### PR TITLE
phase 1.61: substrate-status refresh — 98/98 (#1082)

### DIFF
--- a/bench-results/substrate-status.md
+++ b/bench-results/substrate-status.md
@@ -1,8 +1,11 @@
 # kiln-tensor substrate status
 
-**89 / 89 deliverables shipped** — Phase 4 sampler chain end-to-end
+**98 / 98 deliverables shipped** — Phase 4 sampler chain end-to-end
 complete; **kiln-autograd BackwardOp coverage at 22 / 22 differentiable
-forward ops**.
+forward ops**; **per-backend Allocator + CapturedGraph scaffolds
+shipped for all three GPU backends**; **SGD + AdamW master-write to
+Parameter wired** with anti-pattern 11 preserved across optimizer
+steps.
 
 Regenerate: `scripts/audit-substrate-status.sh --markdown`.
 
@@ -81,7 +84,47 @@ Regenerate: `scripts/audit-substrate-status.sh --markdown`.
 | 1.57 | XTC (Exclude Top Choices) LogitProcessor | ✓ |
 | 1.58 | Gumbel-max categorical sample op (terminal sampler step) | ✓ |
 | 1.59 | full Phase 4 sampler chain integration test | ✓ |
-| 1.60 | substrate-status dashboard refresh (this PR) | ✓ |
+| 1.60 | substrate-status dashboard refresh (Phase 1.52-1.59 + 6a.1-6a.7) | ✓ |
+| 1.61 | substrate-status dashboard refresh (Phase 2.1.1-2.1.2 + 2.5.4 + 5.1 + 6.5.2-6.5.4 + 6a.8-6a.9) | ✓ |
+
+## Phase 2 — kiln-blas / kiln-mps / kiln-vulkan-blas / kiln-param
+
+| Phase | Deliverable | Status |
+|---|---|:-:|
+| 2.1 | kiln-blas production API sketch (AlgoCache + WorkspacePool) | ✓ |
+| 2.1.1 | CudaAllocator scaffold (Owned/Pool/Frozen + warm + reserved-bytes) | ✓ |
+| 2.1.2 | MetalAllocator + VulkanAllocator scaffolds | ✓ |
+| 2.2 | kiln-mps crate scaffold | ✓ |
+| 2.3 | kiln-vulkan-blas crate scaffold | ✓ |
+| 2.5 | kiln-param scaffold (Parameter + AmpPolicy + content hash) | ✓ |
+| 2.5.4 | Parameter::replace_backward_storage (anti-pattern 11 preserving) | ✓ |
+
+## Phase 5 — kiln-graph capture surface
+
+| Phase | Deliverable | Status |
+|---|---|:-:|
+| 5 | kiln-graph crate (CapturedGraph + CaptureSession) | ✓ |
+| 5.1 | kiln-graph-cuda, kiln-graph-metal, kiln-graph-vulkan scaffolds | ✓ |
+
+## Phase 6 — autograd + optim
+
+| Phase | Deliverable | Status |
+|---|---|:-:|
+| 6a | kiln-autograd (Tape + GradStore + BackwardOp) | ✓ |
+| 6a.1 | BackwardOps for add/sub/mul/div + matmul | ✓ |
+| 6a.2 | BackwardOps for sigmoid, silu, softmax | ✓ |
+| 6a.3 | BackwardOps for cross_entropy + embedding | ✓ |
+| 6a.4 | RMSNorm BackwardOp | ✓ |
+| 6a.5 | BackwardOps for index_select, scatter_add, cast | ✓ |
+| 6a.6 | BackwardOps for reduce, masked_fill, l2_norm | ✓ |
+| 6a.7 | BackwardOps for SwiGLU + RoPE | ✓ |
+| 6a.8 | end-to-end Tape integration with real BackwardOps | ✓ |
+| 6a.9 | tiny-net manual-SGD training demo | ✓ |
+| 6.5 | kiln-optim (OptimStep + AdamW CPU) | ✓ |
+| 6.5.1 | Sgd + Lion/Muon scaffolds | ✓ |
+| 6.5.2 | SGD master-write to Parameter | ✓ |
+| 6.5.3 | AdamW master-write to Parameter | ✓ |
+| 6.5.4 | end-to-end Parameter-based training demo | ✓ |
 
 ## Phase 4 sampler chain — 12 / 12 menu items shipped
 
@@ -120,15 +163,13 @@ Each is parity-tested against finite-difference reference values
 where applicable. Non-differentiable ops (argmax, causal_mask, the
 sampler chain) correctly return `bwd: None`.
 
-## Phase 2 / 2.5 / 5 / 6a / 6.5 — new crates
+## What lands next
 
-| Phase | Deliverable | Status |
-|---|---|:-:|
-| 2.1 | kiln-blas production API sketch (AlgoCache + WorkspacePool) | ✓ |
-| 2.2 | kiln-mps crate scaffold | ✓ |
-| 2.3 | kiln-vulkan-blas crate scaffold | ✓ |
-| 2.5 | kiln-param scaffold (Parameter + AmpPolicy + content hash) | ✓ |
-| 5 | kiln-graph crate (CapturedGraph + CaptureSession) | ✓ |
-| 6a | kiln-autograd (Tape + GradStore + BackwardOp) | ✓ |
-| 6.5 | kiln-optim (OptimStep + AdamW CPU) | ✓ |
-| 6.5.1 | Sgd + Lion/Muon scaffolds | ✓ |
+The substrate-side work is complete. Phase 7 is the **real candle
+removal** — replacing the per-backend kernel-crate `Arc<CudaDevice>`
+and `Arc<MetalDevice>` handles with direct cudarc / metal-rs handles,
+and migrating `crates/kiln-train`'s `HashMap<candle_core::TensorId,
+…>` to `kiln_tensor::TensorId`. None of that needs new substrate
+infra — every contract (autograd, parameter slot coherence,
+optimizer master-write, sampler chain) is already settled and
+parity-tested.


### PR DESCRIPTION
Snapshot all substrate work landed in Phase 2.1.1-2.1.2, 2.5.4, 5.1, 6.5.2-6.5.4, and 6a.8-6a.9.

## Highlights

- **98/98 deliverables shipped** (up from 89)
- New per-phase sections for GPU allocators, CapturedGraph scaffolds, optimizer master-write, and backward-op closure
- Removed the stale duplicate "new crates" section
- Added a "What lands next" footer: the substrate-side work is complete, Phase 7 is now strictly a candle-removal refactor

Refs #1082