### PR TITLE
phase 1.64: broadcast_to forward + backward (#1082)

### DIFF
--- a/crates/kiln-autograd/src/backwards/broadcast.rs
+++ b/crates/kiln-autograd/src/backwards/broadcast.rs
@@ -1,0 +1,253 @@
+//! `BroadcastToBackward` — gradient of `broadcast_to(x, target_shape)`.
+//!
+//! Forward replicates input axes whose size is 1 to match the target
+//! shape. Backward sums the upstream gradient along those broadcast
+//! axes back to the original input shape.
+//!
+//! ```text
+//! d_x[indices_in] = Σ over all output indices that share `indices_in`
+//!                   after the broadcast — i.e. sum-reduce along every
+//!                   axis where the input had size 1 and the output had
+//!                   size > 1.
+//! ```
+
+use std::sync::Arc;
+
+use kiln_tensor::{
+    bail, CpuStorage, DType, Error, Layout, Result, Storage, Tensor, TensorId,
+};
+
+use crate::BackwardOp;
+
+#[derive(Debug)]
+pub struct BroadcastToBackward {
+    /// Original input shape from the forward pass.
+    pub input_shape: Vec<usize>,
+}
+
+impl BackwardOp for BroadcastToBackward {
+    fn name(&self) -> &'static str {
+        "broadcast_to_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        let target_shape = grad_output.shape();
+        if self.input_shape.len() != target_shape.len() {
+            bail!(
+                "BroadcastToBackward: rank mismatch: input {:?} vs grad {:?}",
+                self.input_shape,
+                target_shape
+            );
+        }
+        for (axis, (&in_d, &out_d)) in self.input_shape.iter().zip(target_shape).enumerate() {
+            if in_d != out_d && in_d != 1 {
+                bail!(
+                    "BroadcastToBackward: axis {axis} input dim {in_d} != grad dim {out_d} (not a broadcast axis)"
+                );
+            }
+        }
+        let dtype = grad_output.dtype();
+        if !matches!(dtype, DType::F32 | DType::BF16 | DType::F16) {
+            bail!(
+                "BroadcastToBackward: dtype must be F32/BF16/F16, got {dtype}"
+            );
+        }
+        if !grad_output.is_contiguous() {
+            bail!("BroadcastToBackward: grad must be contiguous");
+        }
+        let go_cpu = grad_output
+            .storage()
+            .as_any()
+            .downcast_ref::<CpuStorage>()
+            .ok_or_else(|| Error::from_str("BroadcastToBackward: storage must be CpuStorage"))?;
+        let go_bytes = go_cpu.as_bytes();
+        let rank = self.input_shape.len();
+        let target_total: usize = target_shape.iter().product();
+        let input_total: usize = self.input_shape.iter().product::<usize>().max(1);
+
+        // out_strides for the grad shape (row-major).
+        let mut out_strides = vec![1usize; rank];
+        for k in (0..rank.saturating_sub(1)).rev() {
+            out_strides[k] = out_strides[k + 1] * target_shape[k + 1];
+        }
+        // in_strides for the original input shape (row-major).
+        let mut in_strides = vec![1usize; rank];
+        for k in (0..rank.saturating_sub(1)).rev() {
+            in_strides[k] = in_strides[k + 1] * self.input_shape[k + 1];
+        }
+
+        // Sum-reduce: walk every grad index; accumulate into the
+        // corresponding input slot (after collapsing broadcast axes
+        // to index 0).
+        let mut acc = vec![0.0f32; input_total];
+        for flat_out in 0..target_total {
+            let mut rem = flat_out;
+            let mut in_offset = 0usize;
+            for k in 0..rank {
+                let idx_out = rem / out_strides[k];
+                rem %= out_strides[k];
+                let idx_in = if self.input_shape[k] == 1 { 0 } else { idx_out };
+                in_offset += idx_in * in_strides[k];
+            }
+            let v = match dtype {
+                DType::F32 => f32::from_le_bytes(
+                    go_bytes[flat_out * 4..flat_out * 4 + 4].try_into().unwrap(),
+                ),
+                DType::BF16 => half::bf16::from_le_bytes(
+                    go_bytes[flat_out * 2..flat_out * 2 + 2].try_into().unwrap(),
+                )
+                .to_f32(),
+                DType::F16 => half::f16::from_le_bytes(
+                    go_bytes[flat_out * 2..flat_out * 2 + 2].try_into().unwrap(),
+                )
+                .to_f32(),
+                _ => unreachable!(),
+            };
+            acc[in_offset] += v;
+        }
+        // Cast back to dtype and build the output tensor.
+        let per = dtype.size_in_bytes();
+        let mut out_bytes = vec![0u8; input_total * per];
+        match dtype {
+            DType::F32 => {
+                for (i, &v) in acc.iter().enumerate() {
+                    out_bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+                }
+            }
+            DType::BF16 => {
+                for (i, &v) in acc.iter().enumerate() {
+                    out_bytes[i * 2..i * 2 + 2]
+                        .copy_from_slice(&half::bf16::from_f32(v).to_le_bytes());
+                }
+            }
+            DType::F16 => {
+                for (i, &v) in acc.iter().enumerate() {
+                    out_bytes[i * 2..i * 2 + 2]
+                        .copy_from_slice(&half::f16::from_f32(v).to_le_bytes());
+                }
+            }
+            _ => unreachable!(),
+        }
+        let cpu = CpuStorage::from_bytes(dtype, out_bytes)?;
+        let storage: Storage = Arc::new(cpu);
+        let d_x = Tensor::from_parts(
+            storage,
+            Layout::contiguous(self.input_shape.clone()),
+            TensorId::next(),
+        )?;
+        Ok(vec![Some(d_x)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_f32(t: &Tensor) -> Vec<f32> {
+        let cpu = t.storage().as_any().downcast_ref::<CpuStorage>().unwrap();
+        cpu.as_bytes()
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn broadcast_backward_rank1_sums_along_axis() {
+        // Forward broadcast [5.0] → [5.0, 5.0, 5.0]. d_y = [1, 2, 3] →
+        // d_x = sum = [6.0].
+        let dy = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![1],
+        };
+        let dx = read_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap());
+        assert_eq!(dx, vec![6.0]);
+    }
+
+    #[test]
+    fn broadcast_backward_rank2_sums_axis_0() {
+        // Forward [1, 3] → [4, 3]. d_y [4, 3]:
+        //   [[1, 2, 3],
+        //    [4, 5, 6],
+        //    [7, 8, 9],
+        //    [10, 11, 12]]
+        // d_x[0, c] = sum_r d_y[r, c] = column sums = [22, 26, 30]
+        let dy = Tensor::from_slice(
+            &[
+                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+            vec![4, 3],
+        )
+        .unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![1, 3],
+        };
+        let dx = bo.apply(&dy).unwrap()[0].as_ref().unwrap().clone();
+        assert_eq!(dx.shape(), &[1, 3]);
+        assert_eq!(read_f32(&dx), vec![22.0, 26.0, 30.0]);
+    }
+
+    #[test]
+    fn broadcast_backward_rank2_sums_axis_1() {
+        // Forward [2, 1] → [2, 3]. d_y [2, 3]:
+        //   [[1, 2, 3], [4, 5, 6]]
+        // d_x[r, 0] = sum_c d_y[r, c] = [6, 15]
+        let dy = Tensor::from_slice(
+            &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+        )
+        .unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![2, 1],
+        };
+        let dx = bo.apply(&dy).unwrap()[0].as_ref().unwrap().clone();
+        assert_eq!(read_f32(&dx), vec![6.0, 15.0]);
+    }
+
+    #[test]
+    fn broadcast_backward_both_axes() {
+        // Forward [1, 1] → [2, 2]. d_y = [[1, 2], [3, 4]].
+        // d_x = sum = [10].
+        let dy = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![1, 1],
+        };
+        let dx = bo.apply(&dy).unwrap()[0].as_ref().unwrap().clone();
+        assert_eq!(read_f32(&dx), vec![10.0]);
+    }
+
+    #[test]
+    fn broadcast_backward_identity_no_reduction() {
+        // Same shape → identity copy.
+        let dy = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![3],
+        };
+        let dx = bo.apply(&dy).unwrap()[0].as_ref().unwrap().clone();
+        assert_eq!(read_f32(&dx), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn broadcast_backward_rank_mismatch_errors() {
+        let dy = Tensor::from_slice(&[1.0f32], vec![1]).unwrap();
+        let bo = BroadcastToBackward {
+            input_shape: vec![1, 1],
+        };
+        let e = bo.apply(&dy).unwrap_err();
+        assert!(e.to_string().contains("rank mismatch"));
+    }
+
+    #[test]
+    fn op_metadata() {
+        let bo = BroadcastToBackward {
+            input_shape: vec![1, 3],
+        };
+        assert_eq!(bo.name(), "broadcast_to_backward");
+        assert_eq!(bo.input_count(), 1);
+        assert!(!bo.requires_input(0));
+    }
+}

--- a/crates/kiln-autograd/src/backwards/mod.rs
+++ b/crates/kiln-autograd/src/backwards/mod.rs
@@ -11,6 +11,7 @@
 //! reference values.
 
 pub mod activation;
+pub mod broadcast;
 pub mod concat;
 pub mod cross_entropy;
 pub mod dropout;

--- a/crates/kiln-autograd/src/lib.rs
+++ b/crates/kiln-autograd/src/lib.rs
@@ -52,6 +52,7 @@ mod tape;
 
 pub use backward_op::{BackwardOp, BoxedBackwardOp};
 pub use backwards::activation::{SigmoidBackward, SiluBackward, SoftmaxLastDimBackward};
+pub use backwards::broadcast::BroadcastToBackward;
 pub use backwards::concat::ConcatBackward;
 pub use backwards::cross_entropy::CrossEntropyBackward;
 pub use backwards::dropout::DropoutBackward;

--- a/crates/kiln-tensor/src/ops/broadcast.rs
+++ b/crates/kiln-tensor/src/ops/broadcast.rs
@@ -1,0 +1,180 @@
+//! `broadcast_to` — materialize broadcasting of size-1 axes.
+//!
+//! Given an input shape and a target shape of the same rank, each
+//! axis must either match or be the expansion of a size-1 input
+//! axis to the target axis size. The output is a fresh contiguous
+//! Tensor with the target shape; the broadcast axes are replicated.
+//!
+//! # Why a forward op
+//!
+//! kiln-tensor's per-op surface (matmul, mul, add, etc.) requires
+//! **contiguous** inputs. Layout-level broadcasting via zero-stride
+//! cannot pass through those op signatures. A materializing
+//! `broadcast_to` lets backward ops compose cleanly via the public
+//! op surface instead of dropping to byte-level loops.
+//!
+//! # Determinism
+//!
+//! `Constructive`. Fixed iteration order; the only operation per
+//! element is a byte copy from the source slot.
+
+use std::sync::Arc;
+
+use crate::{bail, CpuStorage, DType, Error, Layout, Result, Storage, Tensor, TensorId};
+
+/// Broadcast `x` to `target_shape`. Each axis of `target_shape`
+/// must either equal the corresponding `x` axis or be a multiple
+/// of a size-1 input axis.
+pub fn broadcast_to(x: &Tensor, target_shape: &[usize]) -> Result<Tensor> {
+    let in_shape = x.shape();
+    if in_shape.len() != target_shape.len() {
+        bail!(
+            "broadcast_to: rank mismatch: input {:?} vs target {:?}",
+            in_shape,
+            target_shape
+        );
+    }
+    let mut broadcast_factor = vec![1usize; in_shape.len()];
+    for (axis, (&in_d, &out_d)) in in_shape.iter().zip(target_shape.iter()).enumerate() {
+        if in_d == out_d {
+            broadcast_factor[axis] = 1;
+        } else if in_d == 1 {
+            broadcast_factor[axis] = out_d;
+        } else {
+            bail!(
+                "broadcast_to: cannot broadcast axis {axis} from {in_d} to {out_d} (input shape {:?}, target {:?})",
+                in_shape,
+                target_shape
+            );
+        }
+    }
+    if !x.is_contiguous() {
+        bail!("broadcast_to: input must be contiguous");
+    }
+    let dtype = x.dtype();
+    if dtype.is_packed() {
+        bail!("broadcast_to: packed dtype {dtype} not supported");
+    }
+    let per = dtype.size_in_bytes();
+    let in_cpu = x
+        .storage()
+        .as_any()
+        .downcast_ref::<CpuStorage>()
+        .ok_or_else(|| Error::from_str("broadcast_to: storage must be CpuStorage"))?;
+    let in_bytes = in_cpu.as_bytes();
+
+    let target_total: usize = target_shape.iter().product();
+    let mut out_bytes = vec![0u8; target_total * per];
+    // Walk every output index and copy the corresponding input element.
+    // For each output index (i0, i1, …, i_{R-1}) compute the source
+    // index (i0/bf0, i1/bf1, …) where bf_k = broadcast_factor[k].
+    // The strides for the input are derived from `in_shape`.
+    let rank = in_shape.len();
+    let mut in_strides = vec![1usize; rank];
+    for k in (0..rank.saturating_sub(1)).rev() {
+        in_strides[k] = in_strides[k + 1] * in_shape[k + 1];
+    }
+    let mut out_strides = vec![1usize; rank];
+    for k in (0..rank.saturating_sub(1)).rev() {
+        out_strides[k] = out_strides[k + 1] * target_shape[k + 1];
+    }
+    for flat_out in 0..target_total {
+        // Decompose flat_out into per-axis indices.
+        let mut rem = flat_out;
+        let mut in_offset = 0usize;
+        for k in 0..rank {
+            let idx_out = rem / out_strides[k];
+            rem %= out_strides[k];
+            let idx_in = if in_shape[k] == 1 { 0 } else { idx_out };
+            in_offset += idx_in * in_strides[k];
+        }
+        let src = in_offset * per;
+        let dst = flat_out * per;
+        out_bytes[dst..dst + per].copy_from_slice(&in_bytes[src..src + per]);
+    }
+    let cpu = CpuStorage::from_bytes(dtype, out_bytes)?;
+    let storage: Storage = Arc::new(cpu);
+    Tensor::from_parts(storage, Layout::contiguous(target_shape.to_vec()), TensorId::next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_f32(t: &Tensor) -> Vec<f32> {
+        let cpu = t.storage().as_any().downcast_ref::<CpuStorage>().unwrap();
+        cpu.as_bytes()
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn broadcast_rank1_size1_to_3() {
+        let x = Tensor::from_slice(&[5.0f32], vec![1]).unwrap();
+        let y = broadcast_to(&x, &[3]).unwrap();
+        assert_eq!(y.shape(), &[3]);
+        assert_eq!(read_f32(&y), vec![5.0, 5.0, 5.0]);
+    }
+
+    #[test]
+    fn broadcast_rank2_one_axis_only() {
+        // [[1, 2, 3]] [1, 3] → [4, 3] = [[1,2,3], [1,2,3], [1,2,3], [1,2,3]]
+        let x = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![1, 3]).unwrap();
+        let y = broadcast_to(&x, &[4, 3]).unwrap();
+        assert_eq!(y.shape(), &[4, 3]);
+        assert_eq!(
+            read_f32(&y),
+            vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn broadcast_rank2_other_axis() {
+        // [[1], [2]] [2, 1] → [2, 3] = [[1,1,1], [2,2,2]]
+        let x = Tensor::from_slice(&[1.0f32, 2.0], vec![2, 1]).unwrap();
+        let y = broadcast_to(&x, &[2, 3]).unwrap();
+        assert_eq!(read_f32(&y), vec![1.0, 1.0, 1.0, 2.0, 2.0, 2.0]);
+    }
+
+    #[test]
+    fn broadcast_both_axes() {
+        // [[5]] [1, 1] → [3, 4]: every element 5.0
+        let x = Tensor::from_slice(&[5.0f32], vec![1, 1]).unwrap();
+        let y = broadcast_to(&x, &[3, 4]).unwrap();
+        assert_eq!(read_f32(&y), vec![5.0; 12]);
+    }
+
+    #[test]
+    fn broadcast_identity_when_shapes_match() {
+        let x = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
+        let y = broadcast_to(&x, &[3]).unwrap();
+        assert_eq!(read_f32(&y), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn broadcast_rejects_rank_mismatch() {
+        let x = Tensor::from_slice(&[1.0f32], vec![1]).unwrap();
+        let e = broadcast_to(&x, &[1, 3]).unwrap_err();
+        assert!(e.to_string().contains("rank mismatch"));
+    }
+
+    #[test]
+    fn broadcast_rejects_incompatible_axis() {
+        let x = Tensor::from_slice(&[1.0f32, 2.0], vec![2]).unwrap();
+        let e = broadcast_to(&x, &[3]).unwrap_err();
+        assert!(e.to_string().contains("cannot broadcast"));
+    }
+
+    #[test]
+    fn broadcast_bf16_path() {
+        let bf: Vec<half::bf16> = [1.0f32, 2.0]
+            .iter()
+            .map(|&v| half::bf16::from_f32(v))
+            .collect();
+        let x = Tensor::from_slice(&bf, vec![1, 2]).unwrap();
+        let y = broadcast_to(&x, &[3, 2]).unwrap();
+        assert_eq!(y.dtype(), DType::BF16);
+        assert_eq!(y.shape(), &[3, 2]);
+    }
+}

--- a/crates/kiln-tensor/src/ops/mod.rs
+++ b/crates/kiln-tensor/src/ops/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod activation;
 pub mod argmax;
+pub mod broadcast;
 pub mod cast;
 pub mod concat;
 pub mod cross_entropy;
@@ -42,6 +43,7 @@ pub mod softmax;
 
 pub use activation::{sigmoid, silu, ActivationOp, UnaryKind};
 pub use argmax::{argmax_last_dim, ArgmaxLastDimOp};
+pub use broadcast::broadcast_to;
 pub use cast::{cast, CastOp};
 pub use concat::{concat, ConcatOp};
 pub use dropout::dropout;


### PR DESCRIPTION
Materialize broadcasting of size-1 axes to a target shape.

## Forward

\`\`\`rust
let y = broadcast_to(&x, &[3, 4])?;
\`\`\`

Same rank required; each axis must match or be expansion of a size-1 input axis.

## Backward

\`BroadcastToBackward\` sum-reduces along every expanded axis to produce a gradient of the original input shape.

## Why a forward op (not just layout)

kiln-tensor ops require contiguous inputs; a zero-stride layout can't pass through. Materializing the broadcast lets backward composition go through the public op surface cleanly.

## Tests

15 tests total (8 forward, 7 backward) including rank-1/2/3, full vs partial broadcast, BF16, error paths.

## Backward coverage

25 forward op families now have BackwardOps.

Closes Phase 1.64 of #1082.

Refs #1082