### PR TITLE
phase 1.66: GELU activation forward + backward (#1082)

### DIFF
--- a/crates/kiln-autograd/src/backwards/activation.rs
+++ b/crates/kiln-autograd/src/backwards/activation.rs
@@ -3,6 +3,8 @@
 //! - **SigmoidBackward** — `dx = dy * y * (1 - y)`. Saves forward `y`.
 //! - **SiluBackward** — `dx = dy * (σ + x*σ*(1-σ))` where `σ = sigmoid(x)`.
 //!   Saves `x`.
+//! - **GeluBackward** — `dx = dy * d(gelu)/dx` (tanh approximation).
+//!   Saves `x` and recomputes `tanh(arg)` in backward.
 //! - **SoftmaxLastDimBackward** — `dx_i = y_i * (dy_i - sum_j(y_j * dy_j))`
 //!   per row over the trailing axis. Saves forward `y`.
 //!
@@ -169,6 +171,57 @@ impl BackwardOp for SiluBackward {
             .map(|(&xi, &dyi)| {
                 let s = sigmoid(xi);
                 dyi * (s + xi * s * (1.0 - s))
+            })
+            .collect();
+        let out = store_f32(self.x.dtype(), self.x.shape(), &dx)?;
+        Ok(vec![Some(out)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+// ----------------------------------------------------------------------
+// GeluBackward
+// ----------------------------------------------------------------------
+
+/// GELU backward (tanh approximation).
+///
+/// Let `c = √(2/π)`, `arg = c * (x + 0.044715*x³)`, `t = tanh(arg)`.
+/// Then `gelu(x) = 0.5 * x * (1 + t)` and:
+///
+/// ```text
+/// d(gelu)/dx = 0.5 * (1 + t) + 0.5 * x * (1 - t²) * c * (1 + 3*0.044715*x²)
+/// ```
+///
+/// `dx = dy * d(gelu)/dx`. Saves `x`; recomputes `t` in backward.
+#[derive(Debug)]
+pub struct GeluBackward {
+    /// Forward input `x` — same shape as output.
+    pub x: Tensor,
+}
+
+impl BackwardOp for GeluBackward {
+    fn name(&self) -> &'static str {
+        "gelu_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.x, grad_output, "GeluBackward")?;
+        let x = load_f32(&self.x)?;
+        let dy = load_f32(grad_output)?;
+        const C: f32 = 0.7978845608_f32; // √(2/π)
+        let dx: Vec<f32> = x
+            .iter()
+            .zip(dy.iter())
+            .map(|(&xi, &dyi)| {
+                let arg = C * (xi + 0.044715 * xi * xi * xi);
+                let t = arg.tanh();
+                let dgdx =
+                    0.5 * (1.0 + t) + 0.5 * xi * (1.0 - t * t) * C * (1.0 + 3.0 * 0.044715 * xi * xi);
+                dyi * dgdx
             })
             .collect();
         let out = store_f32(self.x.dtype(), self.x.shape(), &dx)?;
@@ -352,10 +405,46 @@ mod tests {
     }
 
     #[test]
+    fn gelu_backward_at_zero() {
+        // arg(0) = 0, tanh(0) = 0; d/dx = 0.5 * (1 + 0) + 0 = 0.5.
+        let x = Tensor::from_slice(&[0.0f32, 0.0], vec![2]).unwrap();
+        let dy = Tensor::from_slice(&[1.0f32, 2.0], vec![2]).unwrap();
+        let bo = GeluBackward { x };
+        let dx = load_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap()).unwrap();
+        approx(&dx, &[0.5, 1.0], 1e-6);
+    }
+
+    #[test]
+    fn gelu_backward_finite_difference() {
+        use kiln_tensor::ops::gelu;
+        let x_data = vec![0.5f32, -1.5, 2.0];
+        let x = Tensor::from_slice(&x_data, vec![3]).unwrap();
+        let dy = Tensor::from_slice(&[1.0f32; 3], vec![3]).unwrap();
+        let bo = GeluBackward { x: x.clone() };
+        let dx = load_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap()).unwrap();
+        let loss = |xv: &[f32]| -> f32 {
+            let xt = Tensor::from_slice(xv, vec![3]).unwrap();
+            let y = gelu(&xt).unwrap();
+            load_f32(&y).unwrap().iter().sum()
+        };
+        let step = 1e-3;
+        let mut fd = Vec::with_capacity(3);
+        for i in 0..3 {
+            let mut up = x_data.clone();
+            up[i] += step;
+            let mut dn = x_data.clone();
+            dn[i] -= step;
+            fd.push((loss(&up) - loss(&dn)) / (2.0 * step));
+        }
+        approx(&dx, &fd, 5e-3);
+    }
+
+    #[test]
     fn op_metadata() {
         let one = Tensor::from_slice(&[0.5f32], vec![1]).unwrap();
         assert_eq!(SigmoidBackward { y: one.clone() }.name(), "sigmoid_backward");
         assert_eq!(SiluBackward { x: one.clone() }.name(), "silu_backward");
+        assert_eq!(GeluBackward { x: one.clone() }.name(), "gelu_backward");
         assert_eq!(
             SoftmaxLastDimBackward { y: one.clone() }.name(),
             "softmax_last_dim_backward"

--- a/crates/kiln-autograd/src/lib.rs
+++ b/crates/kiln-autograd/src/lib.rs
@@ -51,7 +51,7 @@ mod grad_store;
 mod tape;
 
 pub use backward_op::{BackwardOp, BoxedBackwardOp};
-pub use backwards::activation::{SigmoidBackward, SiluBackward, SoftmaxLastDimBackward};
+pub use backwards::activation::{GeluBackward, SigmoidBackward, SiluBackward, SoftmaxLastDimBackward};
 pub use backwards::broadcast::BroadcastToBackward;
 pub use backwards::concat::ConcatBackward;
 pub use backwards::cross_entropy::CrossEntropyBackward;

--- a/crates/kiln-tensor/src/ops/activation.rs
+++ b/crates/kiln-tensor/src/ops/activation.rs
@@ -1,14 +1,17 @@
-//! Single-input activation ops: `silu`, `sigmoid`.
+//! Single-input activation ops: `silu`, `sigmoid`, `gelu`.
 //!
-//! Replaces candle's `Tensor::{silu, sigmoid}` and the candle
-//! `Activation::SiLU` enum dispatch.
+//! Replaces candle's `Tensor::{silu, sigmoid, gelu}` and the candle
+//! `Activation::{SiLU, Gelu}` enum dispatch.
 //!
 //! # Semantics
 //!
-//! Both ops are pointwise:
+//! All three are pointwise:
 //!
 //! - `sigmoid(x) = 1 / (1 + exp(-x))`
 //! - `silu(x) = x * sigmoid(x)` (a.k.a. swish)
+//! - `gelu(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))`
+//!   (tanh approximation — the variant used by every modern
+//!   transformer codebase)
 //!
 //! F32-promoted compute for BF16/F16 inputs.
 //!
@@ -29,6 +32,8 @@ pub enum UnaryKind {
     Silu,
     /// `f(x) = 1 / (1 + exp(-x))`
     Sigmoid,
+    /// `f(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715*x^3)))`
+    Gelu,
 }
 
 impl UnaryKind {
@@ -36,6 +41,7 @@ impl UnaryKind {
         match self {
             UnaryKind::Silu => "silu",
             UnaryKind::Sigmoid => "sigmoid",
+            UnaryKind::Gelu => "gelu",
         }
     }
 
@@ -43,6 +49,14 @@ impl UnaryKind {
         match self {
             UnaryKind::Silu => x / (1.0 + (-x).exp()),
             UnaryKind::Sigmoid => 1.0 / (1.0 + (-x).exp()),
+            UnaryKind::Gelu => {
+                // tanh approximation; matches PyTorch's
+                // `F.gelu(x, approximate="tanh")` and candle's
+                // `Activation::Gelu`.
+                const SQRT_2_OVER_PI: f32 = 0.7978845608_f32;
+                let inner = SQRT_2_OVER_PI * (x + 0.044715 * x * x * x);
+                0.5 * x * (1.0 + inner.tanh())
+            }
         }
     }
 }
@@ -127,6 +141,12 @@ pub fn silu(x: &Tensor) -> Result<Tensor> {
 /// `out = 1 / (1 + exp(-x))`.
 pub fn sigmoid(x: &Tensor) -> Result<Tensor> {
     dispatch1(&ActivationOp::new(UnaryKind::Sigmoid), x)
+}
+
+/// `out = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))` —
+/// GELU (tanh approximation).
+pub fn gelu(x: &Tensor) -> Result<Tensor> {
+    dispatch1(&ActivationOp::new(UnaryKind::Gelu), x)
 }
 
 fn validate(x: &Tensor, kind: UnaryKind) -> Result<()> {
@@ -222,6 +242,39 @@ mod tests {
     fn unary_kind_name_strings() {
         assert_eq!(UnaryKind::Silu.name(), "silu");
         assert_eq!(UnaryKind::Sigmoid.name(), "sigmoid");
+        assert_eq!(UnaryKind::Gelu.name(), "gelu");
+    }
+
+    #[test]
+    fn gelu_f32_known_values() {
+        // GELU tanh-approx known references (PyTorch
+        // F.gelu(approximate="tanh") values):
+        // gelu(0)    = 0
+        // gelu(1)    ≈ 0.8412
+        // gelu(-1)   ≈ -0.1588
+        // gelu(2)    ≈ 1.9546
+        // gelu(-2)   ≈ -0.0454
+        let x = Tensor::from_slice(&[0.0f32, 1.0, -1.0, 2.0, -2.0], vec![5]).unwrap();
+        let y = gelu(&x).unwrap();
+        let got = read_f32(&y);
+        let expected = [0.0_f32, 0.8412, -0.1588, 1.9546, -0.0454];
+        for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (g - e).abs() < 1e-3,
+                "gelu[{i}]={g}, expected {e}"
+            );
+        }
+    }
+
+    #[test]
+    fn gelu_bf16_round_trips() {
+        let xv: Vec<half::bf16> = [0.0f32, 1.0, -1.0]
+            .iter()
+            .map(|&v| half::bf16::from_f32(v))
+            .collect();
+        let x = Tensor::from_slice(&xv, vec![3]).unwrap();
+        let y = gelu(&x).unwrap();
+        assert_eq!(y.dtype(), DType::BF16);
     }
 
     #[test]

--- a/crates/kiln-tensor/src/ops/mod.rs
+++ b/crates/kiln-tensor/src/ops/mod.rs
@@ -42,7 +42,7 @@ pub mod scatter_add;
 pub mod silu_mul;
 pub mod softmax;
 
-pub use activation::{sigmoid, silu, ActivationOp, UnaryKind};
+pub use activation::{gelu, sigmoid, silu, ActivationOp, UnaryKind};
 pub use argmax::{argmax_last_dim, ArgmaxLastDimOp};
 pub use broadcast::broadcast_to;
 pub use cast::{cast, CastOp};


### PR DESCRIPTION
GELU tanh approximation — \`F.gelu(approximate="tanh")\`. Used by BERT, GPT-2, and required for candle_nn::Activation::Gelu migration parity.

## Forward

Added to UnaryKind enum + ActivationOp dispatch:

\`\`\`
gelu(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))
\`\`\`

## Backward

GeluBackward saves x; recomputes tanh(arg) in backward via the chain rule:

\`\`\`
dx = dy * (0.5*(1+t) + 0.5*x*(1-t²) * c * (1 + 3*0.044715*x²))
\`\`\`

## Tests

4 new tests including PyTorch-reference closed-form values and finite-difference parity.

## Roll-up

27 forward op families + 27 BackwardOps. The three workhorse activations (silu, sigmoid, gelu) are now complete.

Closes Phase 1.66 of #1082.

Refs #1082