### PR TITLE
phase 1.79: tanh + relu activations + backwards (#1082)

### DIFF
--- a/crates/kiln-autograd/src/backwards/activation.rs
+++ b/crates/kiln-autograd/src/backwards/activation.rs
@@ -5,6 +5,8 @@
 //!   Saves `x`.
 //! - **GeluBackward** — `dx = dy * d(gelu)/dx` (tanh approximation).
 //!   Saves `x` and recomputes `tanh(arg)` in backward.
+//! - **TanhBackward** — `dx = dy * (1 - y²)`. Saves forward `y`.
+//! - **ReluBackward** — `dx = dy * (x > 0 ? 1 : 0)`. Saves forward `x`.
 //! - **SoftmaxLastDimBackward** — `dx_i = y_i * (dy_i - sum_j(y_j * dy_j))`
 //!   per row over the trailing axis. Saves forward `y`.
 //!
@@ -233,6 +235,74 @@ impl BackwardOp for GeluBackward {
 }
 
 // ----------------------------------------------------------------------
+// TanhBackward
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct TanhBackward {
+    /// Forward output `y = tanh(x)`.
+    pub y: Tensor,
+}
+
+impl BackwardOp for TanhBackward {
+    fn name(&self) -> &'static str {
+        "tanh_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.y, grad_output, "TanhBackward")?;
+        let y = load_f32(&self.y)?;
+        let dy = load_f32(grad_output)?;
+        let dx: Vec<f32> = y
+            .iter()
+            .zip(dy.iter())
+            .map(|(&yi, &dyi)| dyi * (1.0 - yi * yi))
+            .collect();
+        let out = store_f32(self.y.dtype(), self.y.shape(), &dx)?;
+        Ok(vec![Some(out)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        false // saves y not x
+    }
+}
+
+// ----------------------------------------------------------------------
+// ReluBackward
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct ReluBackward {
+    /// Forward input `x`.
+    pub x: Tensor,
+}
+
+impl BackwardOp for ReluBackward {
+    fn name(&self) -> &'static str {
+        "relu_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.x, grad_output, "ReluBackward")?;
+        let x = load_f32(&self.x)?;
+        let dy = load_f32(grad_output)?;
+        let dx: Vec<f32> = x
+            .iter()
+            .zip(dy.iter())
+            .map(|(&xi, &dyi)| if xi > 0.0 { dyi } else { 0.0 })
+            .collect();
+        let out = store_f32(self.x.dtype(), self.x.shape(), &dx)?;
+        Ok(vec![Some(out)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+// ----------------------------------------------------------------------
 // SoftmaxLastDimBackward
 // ----------------------------------------------------------------------
 
@@ -440,11 +510,60 @@ mod tests {
     }
 
     #[test]
+    fn tanh_backward_uses_saved_y() {
+        // y = tanh(x); dx = dy * (1 - y²).
+        // At y=0 (x=0): dx = dy.
+        // At y=0.5: dx = dy * (1 - 0.25) = 0.75 * dy.
+        let y = Tensor::from_slice(&[0.0f32, 0.5, -0.5], vec![3]).unwrap();
+        let dy = Tensor::from_slice(&[1.0f32, 1.0, 2.0], vec![3]).unwrap();
+        let bo = TanhBackward { y };
+        let dx = load_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap()).unwrap();
+        approx(&dx, &[1.0, 0.75, 1.5], 1e-6);
+    }
+
+    #[test]
+    fn relu_backward_zeros_negatives() {
+        let x = Tensor::from_slice(&[-1.0f32, 0.0, 1.0, -5.0, 5.0], vec![5]).unwrap();
+        let dy = Tensor::from_slice(&[1.0f32, 1.0, 1.0, 1.0, 1.0], vec![5]).unwrap();
+        let bo = ReluBackward { x };
+        let dx = load_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap()).unwrap();
+        // x=0 is exactly the boundary; subgradient pick is 0 here.
+        assert_eq!(dx, vec![0.0, 0.0, 1.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn tanh_backward_finite_difference() {
+        use kiln_tensor::ops::tanh;
+        let x_data = vec![0.3f32, -0.7, 1.2];
+        let x = Tensor::from_slice(&x_data, vec![3]).unwrap();
+        let y = tanh(&x).unwrap();
+        let dy = Tensor::from_slice(&[1.0f32; 3], vec![3]).unwrap();
+        let bo = TanhBackward { y: y.clone() };
+        let dx = load_f32(bo.apply(&dy).unwrap()[0].as_ref().unwrap()).unwrap();
+        let loss = |xv: &[f32]| -> f32 {
+            let xt = Tensor::from_slice(xv, vec![3]).unwrap();
+            load_f32(&tanh(&xt).unwrap()).unwrap().iter().sum()
+        };
+        let step = 1e-3;
+        let mut fd = Vec::with_capacity(3);
+        for i in 0..3 {
+            let mut up = x_data.clone();
+            up[i] += step;
+            let mut dn = x_data.clone();
+            dn[i] -= step;
+            fd.push((loss(&up) - loss(&dn)) / (2.0 * step));
+        }
+        approx(&dx, &fd, 1e-3);
+    }
+
+    #[test]
     fn op_metadata() {
         let one = Tensor::from_slice(&[0.5f32], vec![1]).unwrap();
         assert_eq!(SigmoidBackward { y: one.clone() }.name(), "sigmoid_backward");
         assert_eq!(SiluBackward { x: one.clone() }.name(), "silu_backward");
         assert_eq!(GeluBackward { x: one.clone() }.name(), "gelu_backward");
+        assert_eq!(TanhBackward { y: one.clone() }.name(), "tanh_backward");
+        assert_eq!(ReluBackward { x: one.clone() }.name(), "relu_backward");
         assert_eq!(
             SoftmaxLastDimBackward { y: one.clone() }.name(),
             "softmax_last_dim_backward"

--- a/crates/kiln-autograd/src/lib.rs
+++ b/crates/kiln-autograd/src/lib.rs
@@ -51,7 +51,9 @@ mod grad_store;
 mod tape;
 
 pub use backward_op::{BackwardOp, BoxedBackwardOp};
-pub use backwards::activation::{GeluBackward, SigmoidBackward, SiluBackward, SoftmaxLastDimBackward};
+pub use backwards::activation::{
+    GeluBackward, ReluBackward, SigmoidBackward, SiluBackward, SoftmaxLastDimBackward, TanhBackward,
+};
 pub use backwards::broadcast::BroadcastToBackward;
 pub use backwards::clamp_pow::{ClampBackward, PowBackward};
 pub use backwards::concat::ConcatBackward;

--- a/crates/kiln-tensor/src/ops/activation.rs
+++ b/crates/kiln-tensor/src/ops/activation.rs
@@ -1,17 +1,18 @@
-//! Single-input activation ops: `silu`, `sigmoid`, `gelu`.
+//! Single-input activation ops: `silu`, `sigmoid`, `gelu`, `tanh`,
+//! `relu`.
 //!
-//! Replaces candle's `Tensor::{silu, sigmoid, gelu}` and the candle
-//! `Activation::{SiLU, Gelu}` enum dispatch.
+//! Replaces candle's `Tensor::{silu, sigmoid, gelu, tanh, relu}` and
+//! the candle `Activation::{SiLU, Gelu, Tanh, Relu}` enum dispatch.
 //!
 //! # Semantics
 //!
-//! All three are pointwise:
+//! All five are pointwise:
 //!
 //! - `sigmoid(x) = 1 / (1 + exp(-x))`
 //! - `silu(x) = x * sigmoid(x)` (a.k.a. swish)
 //! - `gelu(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))`
-//!   (tanh approximation — the variant used by every modern
-//!   transformer codebase)
+//! - `tanh(x) = (e^x - e^-x) / (e^x + e^-x)`
+//! - `relu(x) = max(0, x)`
 //!
 //! F32-promoted compute for BF16/F16 inputs.
 //!
@@ -34,6 +35,10 @@ pub enum UnaryKind {
     Sigmoid,
     /// `f(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715*x^3)))`
     Gelu,
+    /// `f(x) = tanh(x) = (e^x - e^-x) / (e^x + e^-x)`
+    Tanh,
+    /// `f(x) = max(0, x)`
+    Relu,
 }
 
 impl UnaryKind {
@@ -42,6 +47,8 @@ impl UnaryKind {
             UnaryKind::Silu => "silu",
             UnaryKind::Sigmoid => "sigmoid",
             UnaryKind::Gelu => "gelu",
+            UnaryKind::Tanh => "tanh",
+            UnaryKind::Relu => "relu",
         }
     }
 
@@ -57,6 +64,8 @@ impl UnaryKind {
                 let inner = SQRT_2_OVER_PI * (x + 0.044715 * x * x * x);
                 0.5 * x * (1.0 + inner.tanh())
             }
+            UnaryKind::Tanh => x.tanh(),
+            UnaryKind::Relu => x.max(0.0),
         }
     }
 }
@@ -147,6 +156,16 @@ pub fn sigmoid(x: &Tensor) -> Result<Tensor> {
 /// GELU (tanh approximation).
 pub fn gelu(x: &Tensor) -> Result<Tensor> {
     dispatch1(&ActivationOp::new(UnaryKind::Gelu), x)
+}
+
+/// `out = tanh(x) = (e^x - e^-x) / (e^x + e^-x)`.
+pub fn tanh(x: &Tensor) -> Result<Tensor> {
+    dispatch1(&ActivationOp::new(UnaryKind::Tanh), x)
+}
+
+/// `out = max(0, x)` — rectified linear unit.
+pub fn relu(x: &Tensor) -> Result<Tensor> {
+    dispatch1(&ActivationOp::new(UnaryKind::Relu), x)
 }
 
 fn validate(x: &Tensor, kind: UnaryKind) -> Result<()> {
@@ -243,6 +262,40 @@ mod tests {
         assert_eq!(UnaryKind::Silu.name(), "silu");
         assert_eq!(UnaryKind::Sigmoid.name(), "sigmoid");
         assert_eq!(UnaryKind::Gelu.name(), "gelu");
+        assert_eq!(UnaryKind::Tanh.name(), "tanh");
+        assert_eq!(UnaryKind::Relu.name(), "relu");
+    }
+
+    #[test]
+    fn tanh_known_values() {
+        // tanh(0) = 0; tanh(±1) ≈ ±0.7616; tanh(10) ≈ 1; tanh(-10) ≈ -1.
+        let x = Tensor::from_slice(&[0.0f32, 1.0, -1.0, 10.0, -10.0], vec![5]).unwrap();
+        let y = read_f32(&tanh(&x).unwrap());
+        assert!((y[0]).abs() < 1e-6);
+        assert!((y[1] - 0.7616).abs() < 1e-3);
+        assert!((y[2] + 0.7616).abs() < 1e-3);
+        assert!((y[3] - 1.0).abs() < 1e-3);
+        assert!((y[4] + 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn relu_clamps_negatives() {
+        let x = Tensor::from_slice(&[-1.0f32, 0.0, 1.0, -5.0, 5.0], vec![5]).unwrap();
+        let y = read_f32(&relu(&x).unwrap());
+        assert_eq!(y, vec![0.0, 0.0, 1.0, 0.0, 5.0]);
+    }
+
+    #[test]
+    fn tanh_relu_bf16_round_trip() {
+        for op in [UnaryKind::Tanh, UnaryKind::Relu] {
+            let bf: Vec<half::bf16> = [-1.0f32, 0.0, 1.0]
+                .iter()
+                .map(|&v| half::bf16::from_f32(v))
+                .collect();
+            let x = Tensor::from_slice(&bf, vec![3]).unwrap();
+            let y = ActivationOp::new(op).cpu_fwd(&x).unwrap().unwrap();
+            assert_eq!(y.dtype(), DType::BF16);
+        }
     }
 
     #[test]

--- a/crates/kiln-tensor/src/ops/mod.rs
+++ b/crates/kiln-tensor/src/ops/mod.rs
@@ -50,7 +50,7 @@ pub mod trig;
 pub mod unary_arith;
 pub mod where_select;
 
-pub use activation::{gelu, sigmoid, silu, ActivationOp, UnaryKind};
+pub use activation::{gelu, relu, sigmoid, silu, tanh, ActivationOp, UnaryKind};
 pub use argmax::{argmax_last_dim, ArgmaxLastDimOp};
 pub use broadcast::broadcast_to;
 pub use cast::{cast, CastOp};


### PR DESCRIPTION
Two more activations added to UnaryKind + ActivationOp dispatch.

## Forward + Backward

| Op  | Forward | Backward |
|-----|---------|----------|
| tanh | (e^x - e^-x)/(e^x + e^-x) | dx = dy * (1 - y²), saves y |
| relu | max(0, x) | dx = dy * (x > 0 ? 1 : 0), saves x |

## Tests

6 new tests including closed-form values, BF16 round-trip, finite-difference parity for tanh.

## Roll-up

41 forward op families + 41 BackwardOps.

Refs #1082