### PR TITLE
phase 1.86: asin/acos/atan + backwards (#1082)

### DIFF
--- a/crates/kiln-autograd/src/backwards/trig.rs
+++ b/crates/kiln-autograd/src/backwards/trig.rs
@@ -135,6 +135,87 @@ impl BackwardOp for CosBackward {
 }
 
 #[derive(Debug)]
+pub struct AsinBackward {
+    pub x: Tensor,
+}
+impl BackwardOp for AsinBackward {
+    fn name(&self) -> &'static str {
+        "asin_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.x, grad_output, "AsinBackward")?;
+        let x = load_f32(&self.x)?;
+        let dy = load_f32(grad_output)?;
+        let dx: Vec<f32> = x
+            .iter()
+            .zip(dy.iter())
+            .map(|(&xi, &dyi)| dyi / (1.0 - xi * xi).sqrt())
+            .collect();
+        Ok(vec![Some(store_f32(self.x.dtype(), self.x.shape(), &dx)?)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct AcosBackward {
+    pub x: Tensor,
+}
+impl BackwardOp for AcosBackward {
+    fn name(&self) -> &'static str {
+        "acos_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.x, grad_output, "AcosBackward")?;
+        let x = load_f32(&self.x)?;
+        let dy = load_f32(grad_output)?;
+        let dx: Vec<f32> = x
+            .iter()
+            .zip(dy.iter())
+            .map(|(&xi, &dyi)| -dyi / (1.0 - xi * xi).sqrt())
+            .collect();
+        Ok(vec![Some(store_f32(self.x.dtype(), self.x.shape(), &dx)?)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct AtanBackward {
+    pub x: Tensor,
+}
+impl BackwardOp for AtanBackward {
+    fn name(&self) -> &'static str {
+        "atan_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        validate_same(&self.x, grad_output, "AtanBackward")?;
+        let x = load_f32(&self.x)?;
+        let dy = load_f32(grad_output)?;
+        let dx: Vec<f32> = x
+            .iter()
+            .zip(dy.iter())
+            .map(|(&xi, &dyi)| dyi / (1.0 + xi * xi))
+            .collect();
+        Ok(vec![Some(store_f32(self.x.dtype(), self.x.shape(), &dx)?)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
 pub struct TanBackward {
     pub x: Tensor,
 }

--- a/crates/kiln-autograd/src/lib.rs
+++ b/crates/kiln-autograd/src/lib.rs
@@ -73,7 +73,9 @@ pub use backwards::rmsnorm::RmsNormBackward;
 pub use backwards::rope::RopeBackward;
 pub use backwards::stack::StackBackward;
 pub use backwards::swiglu::MulSigmoidGateBackward;
-pub use backwards::trig::{CosBackward, SinBackward, TanBackward};
+pub use backwards::trig::{
+    AcosBackward, AsinBackward, AtanBackward, CosBackward, SinBackward, TanBackward,
+};
 pub use backwards::unary_arith::{AbsBackward, ExpBackward, LnBackward, NegBackward, SqrtBackward};
 pub use backwards::where_select::WhereSelectBackward;
 pub use grad_store::GradStore;

--- a/crates/kiln-tensor/src/ops/mod.rs
+++ b/crates/kiln-tensor/src/ops/mod.rs
@@ -82,6 +82,6 @@ pub use silu_mul::{mul_sigmoid_gate, MulSigmoidGateOp};
 pub use softmax::{softmax_last_dim, SoftmaxLastDimOp};
 pub use stack::stack;
 pub use top_k::top_k;
-pub use trig::{cos, sin, tan, TrigKind};
+pub use trig::{acos, asin, atan, cos, sin, tan, TrigKind};
 pub use unary_arith::{abs, exp, ln, neg, sqrt, UnaryArithKind};
 pub use where_select::where_select;

--- a/crates/kiln-tensor/src/ops/trig.rs
+++ b/crates/kiln-tensor/src/ops/trig.rs
@@ -16,6 +16,9 @@ pub enum TrigKind {
     Sin,
     Cos,
     Tan,
+    Asin,
+    Acos,
+    Atan,
 }
 
 impl TrigKind {
@@ -24,6 +27,9 @@ impl TrigKind {
             TrigKind::Sin => "sin",
             TrigKind::Cos => "cos",
             TrigKind::Tan => "tan",
+            TrigKind::Asin => "asin",
+            TrigKind::Acos => "acos",
+            TrigKind::Atan => "atan",
         }
     }
 
@@ -32,6 +38,9 @@ impl TrigKind {
             TrigKind::Sin => x.sin(),
             TrigKind::Cos => x.cos(),
             TrigKind::Tan => x.tan(),
+            TrigKind::Asin => x.asin(),
+            TrigKind::Acos => x.acos(),
+            TrigKind::Atan => x.atan(),
         }
     }
 }
@@ -89,6 +98,15 @@ pub fn cos(x: &Tensor) -> Result<Tensor> {
 }
 pub fn tan(x: &Tensor) -> Result<Tensor> {
     apply(TrigKind::Tan, x)
+}
+pub fn asin(x: &Tensor) -> Result<Tensor> {
+    apply(TrigKind::Asin, x)
+}
+pub fn acos(x: &Tensor) -> Result<Tensor> {
+    apply(TrigKind::Acos, x)
+}
+pub fn atan(x: &Tensor) -> Result<Tensor> {
+    apply(TrigKind::Atan, x)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
asin, acos, atan ops + matching BackwardOps. d/dx asin = 1/√(1-x²), d/dx acos = -1/√(1-x²), d/dx atan = 1/(1+x²). Refs #1082