### PR TITLE
phase 6.5.7: LR schedules — cosine / linear / linear_warmup_cosine (#1082)

### DIFF
--- a/crates/kiln-optim/src/lib.rs
+++ b/crates/kiln-optim/src/lib.rs
@@ -27,6 +27,7 @@
 
 mod adamw;
 mod lion_muon;
+pub mod lr_schedule;
 mod optim_step;
 mod policy;
 mod sgd;

--- a/crates/kiln-optim/src/lr_schedule.rs
+++ b/crates/kiln-optim/src/lr_schedule.rs
@@ -1,0 +1,110 @@
+//! Learning-rate schedules: `cosine`, `linear`, `linear_warmup_cosine`.
+//!
+//! Pure functions of `(step, total_steps, warmup_steps)`. Plug into
+//! the optimizer by mutating `opt.hp.lr` between steps.
+
+use std::f32::consts::PI;
+
+/// Linear warmup from 0 to `peak_lr` over `warmup` steps, then
+/// cosine-decay from `peak_lr` to `min_lr` over the remaining
+/// `total - warmup` steps.
+pub fn linear_warmup_cosine(step: u64, total: u64, warmup: u64, peak_lr: f32, min_lr: f32) -> f32 {
+    if total == 0 {
+        return peak_lr;
+    }
+    let s = step.min(total);
+    if s < warmup {
+        // Linear warmup.
+        let progress = (s as f32) / (warmup.max(1) as f32);
+        return peak_lr * progress;
+    }
+    let post_warmup = (s - warmup) as f32;
+    let decay_span = (total - warmup) as f32;
+    let progress = if decay_span > 0.0 {
+        post_warmup / decay_span
+    } else {
+        0.0
+    };
+    let cos = 0.5 * (1.0 + (PI * progress).cos());
+    min_lr + (peak_lr - min_lr) * cos
+}
+
+/// Cosine decay from `peak_lr` to `min_lr` over `total` steps.
+/// No warmup.
+pub fn cosine(step: u64, total: u64, peak_lr: f32, min_lr: f32) -> f32 {
+    linear_warmup_cosine(step, total, 0, peak_lr, min_lr)
+}
+
+/// Linear decay from `peak_lr` to `min_lr` over `total` steps.
+pub fn linear(step: u64, total: u64, peak_lr: f32, min_lr: f32) -> f32 {
+    if total == 0 {
+        return peak_lr;
+    }
+    let progress = (step.min(total) as f32) / (total as f32);
+    peak_lr + (min_lr - peak_lr) * progress
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_start_is_peak() {
+        let lr = cosine(0, 100, 1.0, 0.0);
+        assert!((lr - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_end_is_min() {
+        let lr = cosine(100, 100, 1.0, 0.0);
+        assert!(lr.abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_midpoint_is_halfway() {
+        let lr = cosine(50, 100, 1.0, 0.0);
+        // At progress 0.5, cos(π*0.5) = 0; lr = 0.5 * 1 = 0.5.
+        assert!((lr - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_start_is_peak() {
+        assert!((linear(0, 100, 1.0, 0.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_end_is_min() {
+        assert!(linear(100, 100, 1.0, 0.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn linear_midpoint() {
+        assert!((linear(50, 100, 1.0, 0.0) - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn warmup_starts_at_zero() {
+        let lr = linear_warmup_cosine(0, 100, 10, 1.0, 0.0);
+        assert!(lr.abs() < 1e-5);
+    }
+
+    #[test]
+    fn warmup_completes_at_step_n() {
+        let lr = linear_warmup_cosine(10, 100, 10, 1.0, 0.0);
+        // At end of warmup the cosine progress is 0 → lr = peak.
+        assert!((lr - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn warmup_midpoint() {
+        // Step 5 of 10-step warmup → halfway.
+        let lr = linear_warmup_cosine(5, 100, 10, 1.0, 0.0);
+        assert!((lr - 0.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn step_past_total_clamps_to_min() {
+        let lr = linear_warmup_cosine(1000, 100, 10, 1.0, 0.0);
+        assert!(lr.abs() < 1e-5);
+    }
+}


### PR DESCRIPTION
Standard learning-rate schedules. Refs #1082