### PR TITLE
kiln-mps + kiln-vulkan-blas: BackendMatmul impls (Phase 2.2 + 2.3)

### DIFF
--- a/crates/kiln-mps/src/backend_matmul.rs
+++ b/crates/kiln-mps/src/backend_matmul.rs
@@ -1,0 +1,123 @@
+//! Metal-side [`BackendMatmul`] adapter.
+//!
+//! Phase 2.2 of #1082. Ships the backend-agnostic adapter that an
+//! eventual `MPSMatmulHandle` (Phase 2.x, feature-gated) plugs into.
+//! Today the planner returns the **resolved tile policy** from
+//! [`MpsTilePolicy`] — the actual Metal command-queue dispatch
+//! lands when the `--features probe` MPS path comes online.
+//!
+//! # Why a Metal-specific adapter
+//!
+//! Different backends pick algos along different axes — cublasLt
+//! picks an `algo_id` + `workspace_bytes`; MPS picks tile/transpose
+//! configuration. The shared [`BackendMatmul`] trait answers
+//! "give me a plan for this matmul"; this adapter answers it
+//! Metal-side.
+
+use kiln_blas::{
+    AlgoCacheValue, BackendMatmul, MatmulOutcome, MatmulRequest,
+};
+
+use crate::{MpsTilePolicy, MpsUmaHint};
+
+/// Metal-side adapter. Resolves a [`MpsTilePolicy`] for the
+/// requested shape and packs it as the cache `algo_blob`. The
+/// actual Metal dispatch lands behind the `probe` feature when the
+/// `MPSMatmulHandle` ships.
+#[derive(Debug, Default, Clone)]
+pub struct MpsBackendMatmul {
+    /// UMA hint the dispatch path will honor. On M-series this
+    /// picks `MTLStorageModeShared`; on discrete Macs falls back
+    /// to `Private`.
+    pub uma_hint: MpsUmaHint,
+}
+
+impl MpsBackendMatmul {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_uma_hint(uma_hint: MpsUmaHint) -> Self {
+        Self { uma_hint }
+    }
+}
+
+impl BackendMatmul for MpsBackendMatmul {
+    fn backend_name(&self) -> &'static str {
+        "mps"
+    }
+
+    fn plan(&self, req: &MatmulRequest) -> MatmulOutcome {
+        // Resolve a tile policy from the request shape. Heuristic:
+        // small shapes use the GEMV-friendly tile; medium use the
+        // square tile; large use the elongated MLP tile.
+        let policy = MpsTilePolicy::recommended_for(req.m, req.n, req.k);
+        let bytes_per_element: u64 = match req.dtype.as_str() {
+            "f32" => 4,
+            "bf16" | "f16" => 2,
+            "u8" | "f8_e4m3" | "f8_e5m2" => 1,
+            _ => 4,
+        };
+        let bytes_written = req.m * req.n * bytes_per_element;
+        let algo_blob = policy.serialize();
+        MatmulOutcome {
+            bytes_written,
+            elapsed_ms: None,
+            algo_blob: AlgoCacheValue {
+                algo_id: -1,
+                workspace_bytes: 0,
+                recorded_ms: 0.0,
+                algo_blob,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_blas::{Epilogue, MatmulLayout, MatmulRequest};
+
+    fn req(m: u64, n: u64, k: u64) -> MatmulRequest {
+        MatmulRequest {
+            m,
+            n,
+            k,
+            dtype: "bf16".to_string(),
+            a_layout: MatmulLayout::RowMajor,
+            b_layout: MatmulLayout::RowMajor,
+            c_layout: MatmulLayout::RowMajor,
+            epilogue: Epilogue::Identity,
+            concurrent_streams: 1,
+        }
+    }
+
+    #[test]
+    fn backend_name_is_mps() {
+        assert_eq!(MpsBackendMatmul::new().backend_name(), "mps");
+    }
+
+    #[test]
+    fn plan_returns_nonzero_algo_blob() {
+        let h = MpsBackendMatmul::new();
+        let outcome = h.plan(&req(2048, 18432, 2560));
+        assert!(!outcome.algo_blob.algo_blob.is_empty());
+        assert_eq!(outcome.bytes_written, 2048 * 18432 * 2);
+    }
+
+    #[test]
+    fn uma_hint_is_respected() {
+        let h = MpsBackendMatmul::with_uma_hint(MpsUmaHint::ForceShared);
+        assert!(matches!(h.uma_hint, MpsUmaHint::ForceShared));
+    }
+
+    #[test]
+    fn plan_picks_per_shape_policy() {
+        let h = MpsBackendMatmul::new();
+        let small = h.plan(&req(1, 256, 256));
+        let large = h.plan(&req(8192, 18432, 2560));
+        // Different shapes should resolve to different tile policies
+        // → different algo_blob bytes.
+        assert_ne!(small.algo_blob.algo_blob, large.algo_blob.algo_blob);
+    }
+}

--- a/crates/kiln-mps/src/lib.rs
+++ b/crates/kiln-mps/src/lib.rs
@@ -38,9 +38,11 @@
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
+mod backend_matmul;
 mod tile_policy;
 mod uma;
 
+pub use backend_matmul::MpsBackendMatmul;
 pub use tile_policy::MpsTilePolicy;
 pub use uma::MpsUmaHint;
 

--- a/crates/kiln-mps/src/tile_policy.rs
+++ b/crates/kiln-mps/src/tile_policy.rs
@@ -38,6 +38,60 @@ impl MpsTilePolicy {
         transpose_right: false,
     };
 
+    /// Heuristic tile-size pick for an `M x N x K` matmul on Apple
+    /// Silicon. Buckets per the Phase 0.9 `mps_mlp_probe` shape
+    /// sweeps:
+    ///
+    /// - **GEMV-ish** (`M <= 2`) — narrow tile favoring N.
+    /// - **Small square** (`M, N < 512`) — 32 / 32 / 16 tile.
+    /// - **MLP-elongated** (`N > 8 * M`, the gate||up shape) —
+    ///   wide tile favoring N (`128 / 256 / 32`).
+    /// - **Square hot-path** (everything else) — `64 / 64 / 32` tile.
+    ///
+    /// Returned policy still serializes to the same 14-byte blob via
+    /// [`Self::to_blob`].
+    pub fn recommended_for(m: u64, n: u64, k: u64) -> Self {
+        let (tile_m, tile_n, tile_k) = if m <= 2 {
+            // GEMV — let MPS pick the M side; cap N + K.
+            (0, 256, 16)
+        } else if m < 512 && n < 512 {
+            (32, 32, 16)
+        } else if n > 8 * m.max(1) {
+            // Wide / MLP-elongated.
+            (128, 256, 32)
+        } else {
+            (64, 64, 32)
+        };
+        MpsTilePolicy {
+            tile_m,
+            tile_n,
+            tile_k,
+            transpose_left: false,
+            transpose_right: false,
+        }
+        .with_k_hint(k)
+    }
+
+    /// Tweak `tile_k` based on the K axis (the contracted dim).
+    /// Phase 0 mps probe finds the smaller-K shapes prefer 16-element
+    /// tiles; larger ones favor 32.
+    fn with_k_hint(mut self, k: u64) -> Self {
+        if self.tile_k == 0 {
+            return self;
+        }
+        if k < 1024 {
+            self.tile_k = 16;
+        }
+        self
+    }
+
+    /// Alias for [`Self::to_blob`] used by the Phase 2.2
+    /// `MpsBackendMatmul` adapter — `serialize` reads better at the
+    /// call site.
+    pub fn serialize(&self) -> Vec<u8> {
+        self.to_blob()
+    }
+
     /// Serialize to a 14-byte blob:
     /// `[tile_m: u32 LE][tile_n: u32 LE][tile_k: u32 LE][transposes: 2 bytes]`.
     /// Stable across kiln versions.
@@ -117,5 +171,42 @@ mod tests {
         assert!(MpsTilePolicy::from_blob(&[]).is_none());
         assert!(MpsTilePolicy::from_blob(&[0u8; 13]).is_none());
         assert!(MpsTilePolicy::from_blob(&[0u8; 15]).is_none());
+    }
+
+    #[test]
+    fn recommended_picks_distinct_tiles_per_shape() {
+        let gemv = MpsTilePolicy::recommended_for(1, 2560, 18432);
+        let small = MpsTilePolicy::recommended_for(64, 64, 256);
+        let mlp = MpsTilePolicy::recommended_for(2048, 18432, 2560);
+        let square = MpsTilePolicy::recommended_for(2048, 2048, 4096);
+        assert_eq!(gemv.tile_m, 0);
+        assert_eq!(small.tile_m, 32);
+        assert!(mlp.tile_n > mlp.tile_m); // Elongated.
+        assert!(square.tile_m == square.tile_n);
+        // Three distinct policies → three distinct blobs.
+        let blobs = [gemv.to_blob(), small.to_blob(), mlp.to_blob(), square.to_blob()];
+        for i in 0..blobs.len() {
+            for j in i + 1..blobs.len() {
+                assert_ne!(blobs[i], blobs[j], "blob {i} == blob {j}");
+            }
+        }
+    }
+
+    #[test]
+    fn serialize_is_to_blob_alias() {
+        let p = MpsTilePolicy {
+            tile_m: 64,
+            tile_n: 128,
+            tile_k: 32,
+            transpose_left: true,
+            transpose_right: false,
+        };
+        assert_eq!(p.serialize(), p.to_blob());
+    }
+
+    #[test]
+    fn small_k_picks_16_tile() {
+        let p = MpsTilePolicy::recommended_for(2048, 2048, 256);
+        assert_eq!(p.tile_k, 16);
     }
 }

--- a/crates/kiln-vulkan-blas/src/backend_matmul.rs
+++ b/crates/kiln-vulkan-blas/src/backend_matmul.rs
@@ -1,0 +1,171 @@
+//! Vulkan-side [`BackendMatmul`] adapter.
+//!
+//! Phase 2.3 of #1082. Resolves a [`VkWorkgroupConfig`] for the
+//! requested shape and packs it as the cache `algo_blob`. The
+//! actual `vkCmdDispatch` lands behind the Vulkan feature when the
+//! `kiln-vulkan-kernel` matmul wrapper extension ships.
+
+use kiln_blas::{AlgoCacheValue, BackendMatmul, MatmulOutcome, MatmulRequest};
+
+use crate::{VkCooperativeMatrixSupport, VkWorkgroupConfig};
+
+/// Vulkan-side adapter. Knows about cooperative-matrix availability;
+/// the resolved [`VkWorkgroupConfig`] is what runtime dispatch
+/// consumes.
+#[derive(Debug, Clone)]
+pub struct VulkanBackendMatmul {
+    /// What the runtime has detected for cooperative-matrix support.
+    /// On startup, kiln-vulkan-kernel queries
+    /// `vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR` and writes
+    /// the result here.
+    pub coop_matrix: VkCooperativeMatrixSupport,
+}
+
+impl Default for VulkanBackendMatmul {
+    fn default() -> Self {
+        VulkanBackendMatmul {
+            coop_matrix: VkCooperativeMatrixSupport::Unavailable,
+        }
+    }
+}
+
+impl VulkanBackendMatmul {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_coop_matrix(coop: VkCooperativeMatrixSupport) -> Self {
+        VulkanBackendMatmul { coop_matrix: coop }
+    }
+
+    /// Heuristic workgroup pick. When cooperative-matrix is
+    /// available + the shape is large, use a 256-thread workgroup
+    /// with `uses_cooperative_matrix=true`. Smaller / unsupported
+    /// paths use the 64-thread DEFAULT.
+    fn workgroup_for(&self, req: &MatmulRequest) -> VkWorkgroupConfig {
+        let large = req.m * req.n >= 1024 * 1024;
+        let dtype_supported = match req.dtype.as_str() {
+            "bf16" => self.coop_matrix.supports_bf16(),
+            "f16" => self.coop_matrix.supports_fp16(),
+            _ => false,
+        };
+        let use_coop = dtype_supported && large;
+        if use_coop {
+            VkWorkgroupConfig {
+                local_x: 32,
+                local_y: 8,
+                local_z: 1,
+                subgroup_size: 32,
+                uses_cooperative_matrix: true,
+            }
+        } else if large {
+            VkWorkgroupConfig {
+                local_x: 128,
+                local_y: 1,
+                local_z: 1,
+                subgroup_size: 32,
+                uses_cooperative_matrix: false,
+            }
+        } else {
+            VkWorkgroupConfig::DEFAULT
+        }
+    }
+}
+
+impl BackendMatmul for VulkanBackendMatmul {
+    fn backend_name(&self) -> &'static str {
+        "vulkan"
+    }
+
+    fn plan(&self, req: &MatmulRequest) -> MatmulOutcome {
+        let cfg = self.workgroup_for(req);
+        let bytes_per_element: u64 = match req.dtype.as_str() {
+            "f32" => 4,
+            "bf16" | "f16" => 2,
+            "u8" | "f8_e4m3" | "f8_e5m2" => 1,
+            _ => 4,
+        };
+        MatmulOutcome {
+            bytes_written: req.m * req.n * bytes_per_element,
+            elapsed_ms: None,
+            algo_blob: AlgoCacheValue {
+                algo_id: -1,
+                workspace_bytes: 0,
+                recorded_ms: 0.0,
+                algo_blob: cfg.to_blob(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_blas::{Epilogue, MatmulLayout, MatmulRequest};
+
+    fn req(m: u64, n: u64, k: u64) -> MatmulRequest {
+        MatmulRequest {
+            m,
+            n,
+            k,
+            dtype: "bf16".to_string(),
+            a_layout: MatmulLayout::RowMajor,
+            b_layout: MatmulLayout::RowMajor,
+            c_layout: MatmulLayout::RowMajor,
+            epilogue: Epilogue::Identity,
+            concurrent_streams: 1,
+        }
+    }
+
+    #[test]
+    fn backend_name_is_vulkan() {
+        assert_eq!(VulkanBackendMatmul::new().backend_name(), "vulkan");
+    }
+
+    #[test]
+    fn coop_matrix_unsupported_falls_back_to_scalar() {
+        let h = VulkanBackendMatmul::new();
+        let outcome = h.plan(&req(2048, 18432, 2560));
+        let cfg = VkWorkgroupConfig::from_blob(&outcome.algo_blob.algo_blob).unwrap();
+        assert!(!cfg.uses_cooperative_matrix);
+    }
+
+    #[test]
+    fn coop_matrix_supported_uses_it_for_large_bf16_shapes() {
+        let h = VulkanBackendMatmul::with_coop_matrix(
+            VkCooperativeMatrixSupport::Bf16Fp32,
+        );
+        let outcome = h.plan(&req(2048, 18432, 2560));
+        let cfg = VkWorkgroupConfig::from_blob(&outcome.algo_blob.algo_blob).unwrap();
+        assert!(cfg.uses_cooperative_matrix);
+    }
+
+    #[test]
+    fn coop_matrix_supported_skips_coop_for_small_shapes() {
+        let h = VulkanBackendMatmul::with_coop_matrix(
+            VkCooperativeMatrixSupport::Bf16Fp32,
+        );
+        let outcome = h.plan(&req(32, 32, 64));
+        let cfg = VkWorkgroupConfig::from_blob(&outcome.algo_blob.algo_blob).unwrap();
+        assert!(!cfg.uses_cooperative_matrix);
+    }
+
+    #[test]
+    fn coop_matrix_bf16_only_rejects_f16_request() {
+        let h = VulkanBackendMatmul::with_coop_matrix(
+            VkCooperativeMatrixSupport::Bf16Fp32,
+        );
+        let mut r = req(2048, 18432, 2560);
+        r.dtype = "f16".to_string();
+        let outcome = h.plan(&r);
+        let cfg = VkWorkgroupConfig::from_blob(&outcome.algo_blob.algo_blob).unwrap();
+        assert!(!cfg.uses_cooperative_matrix);
+    }
+
+    #[test]
+    fn bytes_written_matches_request_shape() {
+        let h = VulkanBackendMatmul::new();
+        let outcome = h.plan(&req(8, 16, 64));
+        assert_eq!(outcome.bytes_written, 8 * 16 * 2);
+    }
+}

--- a/crates/kiln-vulkan-blas/src/lib.rs
+++ b/crates/kiln-vulkan-blas/src/lib.rs
@@ -36,10 +36,12 @@
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
+mod backend_matmul;
 mod cooperative_matrix;
 mod pipeline_cache;
 mod workgroup;
 
+pub use backend_matmul::VulkanBackendMatmul;
 pub use cooperative_matrix::VkCooperativeMatrixSupport;
 pub use pipeline_cache::VkPipelineCacheKey;
 pub use workgroup::VkWorkgroupConfig;


### PR DESCRIPTION
Per-backend implementations of the BackendMatmul trait shipped in #1286. MpsBackendMatmul resolves a tile policy; VulkanBackendMatmul picks a workgroup config with optional VK_KHR_cooperative_matrix when the extension supports the request dtype. Adds MpsTilePolicy::recommended_for + serialize. 10 unit tests across both crates. Still CPU-buildable; runtime dispatch lands behind --features probe / metal / vulkan in subsequent PRs.