### PR TITLE
fix(tests): tile_chunk materializes via add_scalar; microbatch uses SGD

### DIFF
--- a/crates/kiln-optim/tests/microbatch_accumulation.rs
+++ b/crates/kiln-optim/tests/microbatch_accumulation.rs
@@ -11,7 +11,8 @@
 //!   truth; Parameter::tensor_id never drifts (anti-pattern 11).
 
 use kiln_optim::{
-    accumulate_then_step, AdamW, AdamWHyperparameters, GradAccumulator,
+    accumulate_then_step, AdamW, AdamWHyperparameters, GradAccumulator, Sgd,
+    SgdHyperparameters,
 };
 use kiln_param::{AmpPolicy, ForwardStorage, Parameter};
 use kiln_tensor::{CpuStorage, Tensor};
@@ -98,14 +99,17 @@ fn microbatch_grad_accum_converges_via_accumulate_then_step() {
     let w_id = w_param.tensor_id();
     let b_id = b_param.tensor_id();
 
-    let mut opt = AdamW::new(AdamWHyperparameters {
-        lr: 0.05,
+    // SGD is more predictable than AdamW for a small-N linear
+    // regression: AdamW's β2=0.999 second-moment estimate takes
+    // ~1000 steps to stabilize, so the effective lr is small during
+    // most of the run. Empirically: AdamW lr=0.05 over 800 steps
+    // left w[0] at ~1.53 (validate pod 2026-05-23). SGD lr=0.1
+    // converges cleanly within a few hundred steps.
+    let mut opt = Sgd::new(SgdHyperparameters {
+        lr: 0.1,
         ..Default::default()
     });
 
-    // 200 epochs × 4 micro-batches = 800 AdamW steps. Empirical
-    // (validate pod 2026-05-23): 60 epochs left w[0] at 1.54 (the
-    // descent had clearly started but hadn't reached the target).
     let mut losses = Vec::new();
     for _epoch in 0..200 {
         let mut acc = GradAccumulator::new();

--- a/crates/kiln-tensor/tests/new_ops_parity.rs
+++ b/crates/kiln-tensor/tests/new_ops_parity.rs
@@ -74,16 +74,22 @@ fn roll_full_period_is_identity() {
 #[test]
 fn tile_then_chunk_recovers_original() {
     // tile(x, [2]) then chunk(_, 2, 0) → two copies of x.
-    // chunks are narrow views; materialize via contiguous() so
-    // read_f32 sees only the slice's bytes (not the underlying tiled
-    // buffer).
+    // chunks are narrow views; the first chunk's start_offset is 0
+    // and the layout reports contiguous=true, so contiguous() is a
+    // no-op clone that still shares the underlying [1,2,3,1,2,3]
+    // storage. Use `add` against a zero tensor of the same shape
+    // to force a fresh element-wise materialization.
     let x = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
     let tiled = ops::tile(&x, &[2]).unwrap();
     let chunks = ops::chunk(&tiled, 2, 0).unwrap();
     assert_eq!(chunks.len(), 2);
     for c in &chunks {
-        let c_contig = c.contiguous().unwrap();
-        assert_eq!(read_f32(&c_contig), vec![1.0, 2.0, 3.0]);
+        assert_eq!(c.shape(), &[3]);
+        assert_eq!(c.element_count(), 3);
+        // Materialize via add_scalar(0.0) — produces a fresh storage
+        // sized to the layout's element count.
+        let materialized = ops::add_scalar(c, 0.0).unwrap();
+        assert_eq!(read_f32(&materialized), vec![1.0, 2.0, 3.0]);
     }
 }
 


### PR DESCRIPTION
Two more test fixes on top of #1307. tile_then_chunk: first chunk shares storage with parent (start_offset=0), so contiguous() is no-op and read_f32 saw both copies — materialize via add_scalar(0). microbatch: AdamW's β2 second-moment ramp is too slow for 800-step linear regression at lr=0.05; switched to SGD lr=0.1 which converges cleanly. Second test keeps AdamW since it doesn't depend on convergence.