### PR TITLE
fix(tests): PassthroughBwd second usage in multi-step test

### DIFF
--- a/crates/kiln-optim/tests/full_training_step.rs
+++ b/crates/kiln-optim/tests/full_training_step.rs
@@ -165,7 +165,7 @@ fn multi_step_training_loop_preserves_parameter_identity() {
             &[&weight_fwd],
             Box::new(PassthroughBwd {
                 name: "identity",
-                input_count: 1,
+                input_shapes: vec![weight_fwd.shape().to_vec()],
                 apply_count: apply_count.clone(),
             }),
         );


### PR DESCRIPTION
Compile fix — missed a second PassthroughBwd construction in the multi-step test (line 168) when refactoring input_count → input_shapes in PR #1310.