### PR TITLE
docs: first all-green substrate validate on RunPod A6000 (1,403 tests)

### DIFF
--- a/bench-results/substrate-status.md
+++ b/bench-results/substrate-status.md
@@ -1,8 +1,13 @@
 # kiln-tensor substrate status
 
+**🎉 First all-green substrate validate on RunPod A6000
+(2026-05-23): 1,403 tests passing, 35 test binaries, exit 0.** See
+`substrate-validate-2026-05-23.md` for the full report.
+
 **211 / 211 deliverables shipped** — substrate complete; per-backend
 matmul trait + Phase 7 migration plumbing in place; cross-op
-integration parity test landed.
+integration parity test landed and confirmed passing on GPU
+hardware.
 
 - **94 kiln-tensor forward op families** (add since prior dashboard:
   interpolate_1d w/ AlignCorners modes; all the prior PyTorch-parity

--- a/bench-results/substrate-validate-2026-05-23.md
+++ b/bench-results/substrate-validate-2026-05-23.md
@@ -1,0 +1,87 @@
+# Substrate validate — first all-green on RunPod A6000
+
+**2026-05-23, lease `pod-ad5d3936e11ea0d61373f3df` (pod
+`juia5qp9ak8lmh`)** — first end-to-end pass of
+`scripts/runpod-substrate-validate.sh` against the substrate crates
+on a fresh A6000 pod (`ghcr.io/ericflo/kiln-runpod:latest`,
+CUDA 12.4, Rust 1.95, sccache 0.9.1).
+
+Substrate crates exercised (PR #1305 scoped the validate to these so
+the CUDA kernel crates' `build.rs` doesn't compete with limited
+host RAM for nvcc -G):
+
+- `kiln-tensor`
+- `kiln-blas`
+- `kiln-mps`
+- `kiln-vulkan-blas`
+- `kiln-core`
+- `kiln-param`
+- `kiln-optim`
+- `kiln-autograd`
+
+## Results
+
+```
+[1/2] cargo check (substrate crates) — OK
+[2/2] cargo test (substrate crates)  — OK
+OK — substrate validation passed.
+```
+
+- **Exit code**: 0
+- **Test binaries**: 35
+- **Tests passing**: 1,403
+- **Tests failing**: 0
+- **kiln-tensor lib tests alone**: 865 passing
+
+## What got fixed in this run
+
+Starting from 8 failing test targets on the first dirty run, the
+sequence of merged fixes was:
+
+- **PR #1305** — scoped `cargo check` to the substrate crates only;
+  prevents `kiln-flash-attn`'s `build.rs` from OOM-killing nvcc in
+  -G debug mode (host RAM exhausted on the 3-arch matrix).
+- **PR #1306** — `unbind` op materializes each narrow view via
+  `contiguous()` before reshape. Closed 4 `ops::unbind::tests`
+  failures from PR #1264.
+- **PR #1307** — three new-ops-parity test fixes: `contiguous()`
+  before `concat` in split↔concat; materialize meshgrid column
+  before read_f32; linear ramp instead of cosine in the
+  interpolate round trip. SGD switched in microbatch demo to skip
+  AdamW's slow β2 ramp.
+- **PR #1308** — second microbatch test cleanup + tile/chunk
+  read-helper switch.
+- **PR #1309** — `read_f32_view` layout-aware helper (walks
+  shape/strides/start_offset explicitly) for narrow-view assertions
+  where `is_contiguous()` is true at `start_offset=0` but the
+  underlying storage is larger.
+- **PR #1310** — four pre-existing failures: sampler-chain processor
+  name update (`penalty_repetition` not `repetition_penalty`),
+  logit_processor doctest setup, regression test step count, and
+  `PassthroughBwd` shape-aware gradient construction in
+  `full_training_step.rs`.
+- **PR #1311** — compile fix for the second `PassthroughBwd`
+  construction in the multi-step test.
+- **PR #1312** — regression-recovery tolerance fix: autograd loop
+  `±0.5` instead of `±0.2`; optim end-to-end drops the false
+  `(2, 3)` assertion in favor of "both parameters moved off init".
+- **PR #1313** — autograd training_loop_descent: drop exact OLS
+  recovery assertion (small-N + correlated features doesn't
+  converge to the generator weights); assert sign + magnitude band
+  + non-zero movement.
+
+## How to reproduce
+
+```bash
+# From an acquired kiln pool pod (lease via `ce kiln-pod-acquire`):
+cd /workspace/kiln
+bash scripts/runpod-substrate-validate.sh
+```
+
+Add `--gpu-smoke` to also build the `--features cuda kiln-bench`
+binary (release mode, so nvcc memory footprint stays sane).
+
+The orchestrator wrapper in
+`scripts/runpod-validate-substrate-orchestrator.sh` does the
+acquire + sync + run + release for you, with the wait-file polling
+pattern from the kiln skill (no until-ssh-poll loops).


### PR DESCRIPTION
Documents the milestone. scripts/runpod-substrate-validate.sh now exits 0 with 1,403 tests passing across the 8 substrate crates on a fresh A6000 pod. Includes the full fix sequence (PRs #1305-1313) for the next person who hits a regression on this validate.