### PR TITLE
phase 3: gdn-kernel kt-API — decode_qk_norm_gates_recurrent_rmsnorm_bf16

### DIFF
--- a/crates/kiln-gdn-kernel/src/kt_api.rs
+++ b/crates/kiln-gdn-kernel/src/kt_api.rs
@@ -14,7 +14,10 @@ use candle_core::cuda_backend::cudarc::driver::DevicePtr;
 use kiln_kt_bridge::BridgeError;
 use kiln_tensor::{CudaStorage, DType as KtDType, Tensor as KtTensor};
 
-use crate::{kiln_gdn_forward_substitution, kiln_gdn_recurrent_forward};
+use crate::{
+    kiln_gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16, kiln_gdn_forward_substitution,
+    kiln_gdn_recurrent_forward,
+};
 
 #[derive(Debug)]
 pub enum GdnError {
@@ -261,6 +264,138 @@ pub fn gdn_recurrent_forward_kt(
     };
     if status != 0 {
         return Err(GdnError::Msg(format!("kt-gdn: recurrent FFI returned {status}")));
+    }
+    Ok(out)
+}
+
+/// `gdn_decode_qk_norm_gates_recurrent_rmsnorm` (BF16 q/v variant)
+/// over `kiln_tensor::Tensor` operands.
+///
+/// The hottest decode path on Qwen3.5-4B. Fuses QK-norm + delta-net
+/// gate update + recurrent state advance + RMS-norm of the value
+/// projection in one kernel launch.
+///
+/// Shapes:
+/// - `q`, `k`: BF16 `[B, q_heads, dk]`
+/// - `v`:     BF16 `[B, value_heads, dv]`
+/// - `a`, `b`, `a_log`, `dt_bias`: BF16 (per-head scalars; shape
+///   `[B, q_heads]` for a/b/a_log, `[q_heads]` for dt_bias)
+/// - `state`: BF16 `[B, value_heads, dk, dv]` — mutated in place
+/// - `z`:     BF16 `[B, value_heads, dv]` gate input
+/// - `weight`: F32 `[dv]` RMS-norm gain
+///
+/// Returns BF16 `[B, value_heads, dv]`.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16_kt(
+    q: &KtTensor,
+    k: &KtTensor,
+    v: &KtTensor,
+    a: &KtTensor,
+    b_param: &KtTensor,
+    a_log: &KtTensor,
+    dt_bias: &KtTensor,
+    state: &KtTensor,
+    z: &KtTensor,
+    weight: &KtTensor,
+    q_scale: f32,
+    qk_eps: f32,
+    rms_eps: f32,
+) -> Result<KtTensor, GdnError> {
+    let q_shape = q.shape();
+    if q_shape.len() != 3 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode q must be [B, q_heads, dk], got {q_shape:?}"
+        )));
+    }
+    let (batch, q_heads, dk) = (q_shape[0], q_shape[1], q_shape[2]);
+    if k.shape() != q_shape {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode k {:?} != q {q_shape:?}",
+            k.shape()
+        )));
+    }
+    let v_shape = v.shape();
+    if v_shape.len() != 3 || v_shape[0] != batch {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode v {v_shape:?} != [{batch}, value_heads, dv]"
+        )));
+    }
+    let value_heads = v_shape[1];
+    let dv = v_shape[2];
+
+    let (q_st, q_off) = cuda_storage_and_byte_offset(q, KtDType::BF16, "q")?;
+    let (k_st, k_off) = cuda_storage_and_byte_offset(k, KtDType::BF16, "k")?;
+    let (v_st, v_off) = cuda_storage_and_byte_offset(v, KtDType::BF16, "v")?;
+    let (a_st, a_off) = cuda_storage_and_byte_offset(a, KtDType::BF16, "a")?;
+    let (bp_st, bp_off) = cuda_storage_and_byte_offset(b_param, KtDType::BF16, "b")?;
+    let (al_st, al_off) = cuda_storage_and_byte_offset(a_log, KtDType::BF16, "a_log")?;
+    let (dt_st, dt_off) = cuda_storage_and_byte_offset(dt_bias, KtDType::BF16, "dt_bias")?;
+    let (s_st, s_off) = cuda_storage_and_byte_offset(state, KtDType::BF16, "state")?;
+    let (z_st, z_off) = cuda_storage_and_byte_offset(z, KtDType::BF16, "z")?;
+    let (w_st, w_off) = cuda_storage_and_byte_offset(weight, KtDType::F32, "weight")?;
+
+    let out = alloc_cuda_tensor(q_st, KtDType::BF16, vec![batch, value_heads, dv])?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = q_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let q_slice = q_st.slice().slice(q_off..);
+    let k_slice = k_st.slice().slice(k_off..);
+    let v_slice = v_st.slice().slice(v_off..);
+    let a_slice = a_st.slice().slice(a_off..);
+    let bp_slice = bp_st.slice().slice(bp_off..);
+    let al_slice = al_st.slice().slice(al_off..);
+    let dt_slice = dt_st.slice().slice(dt_off..);
+    let s_slice = s_st.slice().slice(s_off..);
+    let z_slice = z_st.slice().slice(z_off..);
+    let w_slice = w_st.slice().slice(w_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+        let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+        let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+        let (a_ptr, _g4) = a_slice.device_ptr(&stream);
+        let (bp_ptr, _g5) = bp_slice.device_ptr(&stream);
+        let (al_ptr, _g6) = al_slice.device_ptr(&stream);
+        let (dt_ptr, _g7) = dt_slice.device_ptr(&stream);
+        let (s_ptr, _g8) = s_slice.device_ptr(&stream);
+        let (z_ptr, _g9) = z_slice.device_ptr(&stream);
+        let (w_ptr, _g10) = w_slice.device_ptr(&stream);
+        let (o_ptr, _g11) = o_slice.device_ptr(&stream);
+
+        kiln_gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16(
+            q_ptr as *const _,
+            k_ptr as *const _,
+            v_ptr as *const _,
+            a_ptr as *const _,
+            bp_ptr as *const _,
+            al_ptr as *const _,
+            dt_ptr as *const _,
+            s_ptr as *mut _,
+            z_ptr as *const _,
+            w_ptr as *const _,
+            o_ptr as *mut _,
+            batch as i32,
+            q_heads as i32,
+            value_heads as i32,
+            dk as i32,
+            dv as i32,
+            q_scale,
+            qk_eps,
+            rms_eps,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode_qk_norm_rmsnorm FFI returned {status}"
+        )));
     }
     Ok(out)
 }

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -68,7 +68,10 @@ use std::cell::RefCell;
 
 /// kiln-tensor-typed surface alongside candle-typed. Same FFI.
 mod kt_api;
-pub use kt_api::{gdn_forward_substitution_kt, gdn_recurrent_forward_kt, GdnError};
+pub use kt_api::{
+    gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16_kt, gdn_forward_substitution_kt,
+    gdn_recurrent_forward_kt, GdnError,
+};
 
 unsafe extern "C" {
     fn kiln_gdn_forward_substitution(


### PR DESCRIPTION
Production decode hot path port. Fuses QK-norm + delta-net + recurrent + RMS-norm in one kernel. 3 of 17 gdn-kernel FFI entry points now have kt-API surface.