### PR TITLE
phase 3: rmsnorm-kernel kt-API — rotary_qk + mlp_silu_mul

### DIFF
--- a/crates/kiln-rmsnorm-kernel/src/kt_api.rs
+++ b/crates/kiln-rmsnorm-kernel/src/kt_api.rs
@@ -13,7 +13,10 @@ use candle_core::cuda_backend::cudarc::driver::DevicePtr;
 use kiln_kt_bridge::BridgeError;
 use kiln_tensor::{CudaStorage, DType as KtDType, Tensor as KtTensor};
 
-use crate::{kiln_fused_rmsnorm, kiln_fused_rmsnorm_bwd};
+use crate::{
+    kiln_fused_mlp_silu_mul_bf16, kiln_fused_rmsnorm, kiln_fused_rmsnorm_bwd,
+    kiln_fused_rotary_qk,
+};
 
 #[derive(Debug)]
 pub enum RmsNormError {
@@ -216,4 +219,169 @@ pub fn fused_rmsnorm_backward_kt(
         )));
     }
     Ok((grad_x, grad_w_partial))
+}
+
+/// `fused_rotary_qk` over `kiln_tensor::Tensor` operands.
+///
+/// In-place rotary application to Q and K projections. Inputs:
+/// - `q`: BF16 `[batch, seq_len, q_heads, head_dim]`
+/// - `k`: BF16 `[batch, seq_len, k_heads, head_dim]`
+/// - `cos`, `sin`: F32 `[seq_len, rotary_dim]` precomputed tables
+/// - `rotary_dim`: applied head dim slice; must be ≤ head_dim.
+///
+/// Returns `(q_out, k_out)` BF16 tensors of the same shapes as the
+/// inputs.
+#[allow(clippy::too_many_arguments)]
+pub fn fused_rotary_qk_kt(
+    q: &KtTensor,
+    k: &KtTensor,
+    cos: &KtTensor,
+    sin: &KtTensor,
+    rotary_dim: usize,
+) -> Result<(KtTensor, KtTensor), RmsNormError> {
+    let q_shape = q.shape();
+    if q_shape.len() != 4 {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: q must be [B, S, q_heads, head_dim], got {q_shape:?}"
+        )));
+    }
+    let (batch, seq_len, q_heads, head_dim) = (q_shape[0], q_shape[1], q_shape[2], q_shape[3]);
+    let k_shape = k.shape();
+    if k_shape.len() != 4
+        || (k_shape[0], k_shape[1], k_shape[3]) != (batch, seq_len, head_dim)
+    {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: k {k_shape:?} != [{batch}, {seq_len}, k_heads, {head_dim}]"
+        )));
+    }
+    let k_heads = k_shape[2];
+    if rotary_dim > head_dim {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: rotary_dim {rotary_dim} > head_dim {head_dim}"
+        )));
+    }
+    if cos.shape() != [seq_len, rotary_dim] {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: cos {:?} != [{seq_len}, {rotary_dim}]",
+            cos.shape()
+        )));
+    }
+    if sin.shape() != [seq_len, rotary_dim] {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: sin {:?} != [{seq_len}, {rotary_dim}]",
+            sin.shape()
+        )));
+    }
+
+    let (q_st, q_off) = cuda_storage_and_byte_offset(q, KtDType::BF16, "q")?;
+    let (k_st, k_off) = cuda_storage_and_byte_offset(k, KtDType::BF16, "k")?;
+    let (cos_st, cos_off) = cuda_storage_and_byte_offset(cos, KtDType::F32, "cos")?;
+    let (sin_st, sin_off) = cuda_storage_and_byte_offset(sin, KtDType::F32, "sin")?;
+
+    let q_out = alloc_cuda_tensor(q_st, KtDType::BF16, vec![batch, seq_len, q_heads, head_dim])?;
+    let k_out = alloc_cuda_tensor(q_st, KtDType::BF16, vec![batch, seq_len, k_heads, head_dim])?;
+    let qo_cuda = q_out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+    let ko_cuda = k_out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = q_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let q_slice = q_st.slice().slice(q_off..);
+    let k_slice = k_st.slice().slice(k_off..);
+    let cos_slice = cos_st.slice().slice(cos_off..);
+    let sin_slice = sin_st.slice().slice(sin_off..);
+    let qo_slice = qo_cuda.slice().slice(0..);
+    let ko_slice = ko_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+        let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+        let (cos_ptr, _g3) = cos_slice.device_ptr(&stream);
+        let (sin_ptr, _g4) = sin_slice.device_ptr(&stream);
+        let (qo_ptr, _g5) = qo_slice.device_ptr(&stream);
+        let (ko_ptr, _g6) = ko_slice.device_ptr(&stream);
+
+        kiln_fused_rotary_qk(
+            q_ptr as *const _,
+            k_ptr as *const _,
+            cos_ptr as *const f32,
+            sin_ptr as *const f32,
+            qo_ptr as *mut _,
+            ko_ptr as *mut _,
+            batch as i32,
+            seq_len as i32,
+            q_heads as i32,
+            k_heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(RmsNormError::Msg(format!(
+            "kt-rotary: FFI returned {status}"
+        )));
+    }
+    Ok((q_out, k_out))
+}
+
+/// `fused_mlp_silu_mul` over `kiln_tensor::Tensor` operands.
+///
+/// Element-wise: `out = silu(gate) * up`. Both inputs and output
+/// are BF16 of equal element count. Used by the MLP gate||up||silu
+/// fused path.
+pub fn fused_mlp_silu_mul_kt(
+    gate: &KtTensor,
+    up: &KtTensor,
+) -> Result<KtTensor, RmsNormError> {
+    if gate.shape() != up.shape() {
+        return Err(RmsNormError::Msg(format!(
+            "kt-mlp-silu-mul: gate {:?} != up {:?}",
+            gate.shape(),
+            up.shape()
+        )));
+    }
+    let elems = gate.element_count();
+    let shape = gate.shape().to_vec();
+
+    let (g_st, g_off) = cuda_storage_and_byte_offset(gate, KtDType::BF16, "gate")?;
+    let (u_st, u_off) = cuda_storage_and_byte_offset(up, KtDType::BF16, "up")?;
+    let out = alloc_cuda_tensor(g_st, KtDType::BF16, shape)?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = g_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let g_slice = g_st.slice().slice(g_off..);
+    let u_slice = u_st.slice().slice(u_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (g_ptr, _g1) = g_slice.device_ptr(&stream);
+        let (u_ptr, _g2) = u_slice.device_ptr(&stream);
+        let (o_ptr, _g3) = o_slice.device_ptr(&stream);
+        kiln_fused_mlp_silu_mul_bf16(
+            g_ptr as *const _,
+            u_ptr as *const _,
+            o_ptr as *mut _,
+            elems as i64,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(RmsNormError::Msg(format!(
+            "kt-mlp-silu-mul: FFI returned {status}"
+        )));
+    }
+    Ok(out)
 }

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -83,7 +83,10 @@ use std::sync::OnceLock;
 /// kiln-tensor-typed surface alongside candle-typed. Same FFI.
 /// Phase 7 deletes the candle path.
 mod kt_api;
-pub use kt_api::{fused_rmsnorm_backward_kt, fused_rmsnorm_kt, RmsNormError};
+pub use kt_api::{
+    fused_mlp_silu_mul_kt, fused_rmsnorm_backward_kt, fused_rmsnorm_kt, fused_rotary_qk_kt,
+    RmsNormError,
+};
 
 unsafe extern "C" {
     fn kiln_fused_rmsnorm(


### PR DESCRIPTION
Two more entry points in the rmsnorm-kernel kt-API surface. 4 of ~30 FFI functions covered. Same kt-bridge helpers.