### PR TITLE
phase 3: gdn-kernel kt-API — decode_gates_recurrent + decode_qk_norm (non-rmsnorm)

### DIFF
--- a/crates/kiln-gdn-kernel/src/kt_api.rs
+++ b/crates/kiln-gdn-kernel/src/kt_api.rs
@@ -15,6 +15,7 @@ use kiln_kt_bridge::BridgeError;
 use kiln_tensor::{CudaStorage, DType as KtDType, Tensor as KtTensor};
 
 use crate::{
+    kiln_gdn_decode_gates_recurrent_bf16, kiln_gdn_decode_qk_norm_gates_recurrent_bf16,
     kiln_gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16, kiln_gdn_forward_substitution,
     kiln_gdn_full_chunk_forward, kiln_gdn_recurrent_forward,
 };
@@ -558,6 +559,214 @@ pub fn gdn_full_chunk_forward_kt(
     if status != 0 {
         return Err(GdnError::Msg(format!(
             "kt-gdn: full_chunk_forward FFI returned {status}"
+        )));
+    }
+    Ok(out)
+}
+
+/// `gdn_decode_gates_recurrent_bf16` over kt operands.
+///
+/// Decode path WITHOUT QK-norm (the rmsnorm-free variant). Same
+/// shape contract as decode_qk_norm_*_rmsnorm but takes a single
+/// `eps` and a `weight` for the value norm.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_gates_recurrent_bf16_kt(
+    q: &KtTensor,
+    k: &KtTensor,
+    v: &KtTensor,
+    a: &KtTensor,
+    b_param: &KtTensor,
+    a_log: &KtTensor,
+    dt_bias: &KtTensor,
+    state: &KtTensor,
+    z: &KtTensor,
+    weight: &KtTensor,
+    eps: f32,
+) -> Result<KtTensor, GdnError> {
+    let q_shape = q.shape();
+    if q_shape.len() != 3 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode-gates q must be [B, q_heads, dk], got {q_shape:?}"
+        )));
+    }
+    let (batch, q_heads, dk) = (q_shape[0], q_shape[1], q_shape[2]);
+    let v_shape = v.shape();
+    if v_shape.len() != 3 || v_shape[0] != batch {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode-gates v {v_shape:?} != [{batch}, value_heads, dv]"
+        )));
+    }
+    let value_heads = v_shape[1];
+    let dv = v_shape[2];
+
+    let (q_st, q_off) = cuda_storage_and_byte_offset(q, KtDType::BF16, "q")?;
+    let (k_st, k_off) = cuda_storage_and_byte_offset(k, KtDType::BF16, "k")?;
+    let (v_st, v_off) = cuda_storage_and_byte_offset(v, KtDType::BF16, "v")?;
+    let (a_st, a_off) = cuda_storage_and_byte_offset(a, KtDType::BF16, "a")?;
+    let (bp_st, bp_off) = cuda_storage_and_byte_offset(b_param, KtDType::BF16, "b")?;
+    let (al_st, al_off) = cuda_storage_and_byte_offset(a_log, KtDType::BF16, "a_log")?;
+    let (dt_st, dt_off) = cuda_storage_and_byte_offset(dt_bias, KtDType::BF16, "dt_bias")?;
+    let (s_st, s_off) = cuda_storage_and_byte_offset(state, KtDType::BF16, "state")?;
+    let (z_st, z_off) = cuda_storage_and_byte_offset(z, KtDType::BF16, "z")?;
+    let (w_st, w_off) = cuda_storage_and_byte_offset(weight, KtDType::F32, "weight")?;
+
+    let out = alloc_cuda_tensor(q_st, KtDType::BF16, vec![batch, value_heads, dv])?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = q_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let q_slice = q_st.slice().slice(q_off..);
+    let k_slice = k_st.slice().slice(k_off..);
+    let v_slice = v_st.slice().slice(v_off..);
+    let a_slice = a_st.slice().slice(a_off..);
+    let bp_slice = bp_st.slice().slice(bp_off..);
+    let al_slice = al_st.slice().slice(al_off..);
+    let dt_slice = dt_st.slice().slice(dt_off..);
+    let s_slice = s_st.slice().slice(s_off..);
+    let z_slice = z_st.slice().slice(z_off..);
+    let w_slice = w_st.slice().slice(w_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+        let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+        let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+        let (a_ptr, _g4) = a_slice.device_ptr(&stream);
+        let (bp_ptr, _g5) = bp_slice.device_ptr(&stream);
+        let (al_ptr, _g6) = al_slice.device_ptr(&stream);
+        let (dt_ptr, _g7) = dt_slice.device_ptr(&stream);
+        let (s_ptr, _g8) = s_slice.device_ptr(&stream);
+        let (z_ptr, _g9) = z_slice.device_ptr(&stream);
+        let (w_ptr, _g10) = w_slice.device_ptr(&stream);
+        let (o_ptr, _g11) = o_slice.device_ptr(&stream);
+        kiln_gdn_decode_gates_recurrent_bf16(
+            q_ptr as *const _,
+            k_ptr as *const _,
+            v_ptr as *const _,
+            a_ptr as *const _,
+            bp_ptr as *const _,
+            al_ptr as *const _,
+            dt_ptr as *const _,
+            s_ptr as *mut _,
+            z_ptr as *const _,
+            w_ptr as *const _,
+            o_ptr as *mut _,
+            batch as i32,
+            q_heads as i32,
+            value_heads as i32,
+            dk as i32,
+            dv as i32,
+            eps,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode_gates_recurrent FFI returned {status}"
+        )));
+    }
+    Ok(out)
+}
+
+/// `gdn_decode_qk_norm_gates_recurrent_bf16` over kt operands.
+///
+/// QK-norm variant without the rmsnorm output gating. Takes
+/// `(q_scale, qk_eps)` instead of `(q_scale, qk_eps, rms_eps)` +
+/// `weight`. Returns BF16 `[B, value_heads, dv]`.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_qk_norm_gates_recurrent_bf16_kt(
+    q: &KtTensor,
+    k: &KtTensor,
+    v: &KtTensor,
+    a: &KtTensor,
+    b_param: &KtTensor,
+    a_log: &KtTensor,
+    dt_bias: &KtTensor,
+    state: &KtTensor,
+    q_scale: f32,
+    qk_eps: f32,
+) -> Result<KtTensor, GdnError> {
+    let q_shape = q.shape();
+    if q_shape.len() != 3 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode-qk-norm q must be [B, q_heads, dk], got {q_shape:?}"
+        )));
+    }
+    let (batch, q_heads, dk) = (q_shape[0], q_shape[1], q_shape[2]);
+    let v_shape = v.shape();
+    if v_shape.len() != 3 || v_shape[0] != batch {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode-qk-norm v {v_shape:?} != [{batch}, value_heads, dv]"
+        )));
+    }
+    let value_heads = v_shape[1];
+    let dv = v_shape[2];
+
+    let (q_st, q_off) = cuda_storage_and_byte_offset(q, KtDType::BF16, "q")?;
+    let (k_st, k_off) = cuda_storage_and_byte_offset(k, KtDType::BF16, "k")?;
+    let (v_st, v_off) = cuda_storage_and_byte_offset(v, KtDType::BF16, "v")?;
+    let (a_st, a_off) = cuda_storage_and_byte_offset(a, KtDType::BF16, "a")?;
+    let (bp_st, bp_off) = cuda_storage_and_byte_offset(b_param, KtDType::BF16, "b")?;
+    let (al_st, al_off) = cuda_storage_and_byte_offset(a_log, KtDType::BF16, "a_log")?;
+    let (dt_st, dt_off) = cuda_storage_and_byte_offset(dt_bias, KtDType::BF16, "dt_bias")?;
+    let (s_st, s_off) = cuda_storage_and_byte_offset(state, KtDType::BF16, "state")?;
+
+    let out = alloc_cuda_tensor(q_st, KtDType::BF16, vec![batch, value_heads, dv])?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = q_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let q_slice = q_st.slice().slice(q_off..);
+    let k_slice = k_st.slice().slice(k_off..);
+    let v_slice = v_st.slice().slice(v_off..);
+    let a_slice = a_st.slice().slice(a_off..);
+    let bp_slice = bp_st.slice().slice(bp_off..);
+    let al_slice = al_st.slice().slice(al_off..);
+    let dt_slice = dt_st.slice().slice(dt_off..);
+    let s_slice = s_st.slice().slice(s_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+        let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+        let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+        let (a_ptr, _g4) = a_slice.device_ptr(&stream);
+        let (bp_ptr, _g5) = bp_slice.device_ptr(&stream);
+        let (al_ptr, _g6) = al_slice.device_ptr(&stream);
+        let (dt_ptr, _g7) = dt_slice.device_ptr(&stream);
+        let (s_ptr, _g8) = s_slice.device_ptr(&stream);
+        let (o_ptr, _g9) = o_slice.device_ptr(&stream);
+        kiln_gdn_decode_qk_norm_gates_recurrent_bf16(
+            q_ptr as *const _,
+            k_ptr as *const _,
+            v_ptr as *const _,
+            a_ptr as *const _,
+            bp_ptr as *const _,
+            al_ptr as *const _,
+            dt_ptr as *const _,
+            s_ptr as *mut _,
+            o_ptr as *mut _,
+            batch as i32,
+            q_heads as i32,
+            value_heads as i32,
+            dk as i32,
+            dv as i32,
+            q_scale,
+            qk_eps,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: decode_qk_norm_gates_recurrent FFI returned {status}"
         )));
     }
     Ok(out)

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -69,6 +69,7 @@ use std::cell::RefCell;
 /// kiln-tensor-typed surface alongside candle-typed. Same FFI.
 mod kt_api;
 pub use kt_api::{
+    gdn_decode_gates_recurrent_bf16_kt, gdn_decode_qk_norm_gates_recurrent_bf16_kt,
     gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16_kt, gdn_forward_substitution_kt,
     gdn_full_chunk_forward_kt, gdn_recurrent_forward_kt, GdnError,
 };


### PR DESCRIPTION
Two more decode-variant kt-APIs in gdn-kernel. 6 of 17 FFI entry points now covered.