### PR TITLE
docs: substrate-status — Phase 3 kt-API expanded (PRs #1332-#1335)

### DIFF
--- a/bench-results/substrate-status.md
+++ b/bench-results/substrate-status.md
@@ -18,9 +18,9 @@ the candle-typed twins when call sites in `kiln-model` migrate.
 |---|---|---|
 | `kiln-flash-attn` | `flash_attn_fwd_kt`, `flash_attn_bwd_kt`, `flash_attn_paged_decode_kt`, `flash_attn_paged_decode_dyn_seqlen_kt`, `paged_kv_write_token_major_bf16_kt`, `paged_kv_write_token_major_bf16_slot_kt` | 5 of 5 (100%) |
 | `kiln-conv1d-kernel` | `causal_conv1d_update_kt`, `causal_conv1d_prefill_kt` | 2 of 2 (100%) |
-| `kiln-rmsnorm-kernel` | `fused_rmsnorm_kt` + `_backward_kt`, `fused_rotary_qk_kt`, `fused_mlp_silu_mul_kt`, `sgd_step_f32_kt`, `adamw_step_f32_kt`, `lora_decode_hidden_kt`, `lora_decode_add_kt` | 8 of ~30 |
+| `kiln-rmsnorm-kernel` | `fused_rmsnorm_kt` + `_backward_kt`, `fused_rotary_qk_kt` + `_one_kt`, `fused_mlp_silu_mul_kt`, `fused_sigmoid_mul_kt`, `fused_l2_qk_norm_kt` + `_gqa_kt`, `attn_decode_qkv_split_qk_norm_rope_kt` (mega-fused), `sgd_step_f32_kt`, `adamw_step_f32_kt`, `lora_decode_hidden_kt`, `lora_decode_add_kt`, `causal_depthwise_conv1d_kt` + `_inplace_kt` + `_bwd_input_kt` + `_bwd_weight_kt` + `_bwd_state_kt` | 18 of ~30 |
 | `kiln-marlin-gemm` | `marlin_w4a16_gemm_kt` | 1 of 1 (100%) |
-| `kiln-gdn-kernel` | `gdn_forward_substitution_kt`, `gdn_recurrent_forward_kt`, `gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16_kt`, `gdn_full_chunk_forward_kt` | 4 of 17 |
+| `kiln-gdn-kernel` | `gdn_forward_substitution_kt`, `gdn_recurrent_forward_kt`, `gdn_decode_gates_recurrent_bf16_kt`, `gdn_decode_qk_norm_gates_recurrent_bf16_kt`, `gdn_decode_qk_norm_gates_recurrent_rmsnorm_bf16_kt`, `gdn_full_chunk_forward_kt` | 6 of 17 |
 
 **211 / 211 deliverables shipped** — substrate complete; per-backend
 matmul trait + Phase 7 migration plumbing in place; cross-op


### PR DESCRIPTION
rmsnorm-kernel now 18/30 (was 8); gdn-kernel now 6/17 (was 4). Three crates remain at 100% coverage; two have partial coverage growing.