### PR TITLE
phase 3: gdn-kernel kt-API — full_chunk_multiblock + gated_rms_norm

### DIFF
--- a/crates/kiln-gdn-kernel/src/kt_api.rs
+++ b/crates/kiln-gdn-kernel/src/kt_api.rs
@@ -24,7 +24,8 @@ use crate::{
     kiln_gdn_decode_qk_norm_gates_recurrent_rmsnorm_qf32_vf32_bf16,
     kiln_gdn_decode_qk_norm_gates_recurrent_rmsnorm_vf32_bf16,
     kiln_gdn_decode_qk_norm_gates_recurrent_vf32_bf16, kiln_gdn_forward_substitution,
-    kiln_gdn_full_chunk_forward, kiln_gdn_recurrent_forward,
+    kiln_gdn_full_chunk_forward, kiln_gdn_full_chunk_forward_multiblock,
+    kiln_gdn_gated_rms_norm_bf16, kiln_gdn_recurrent_forward,
 };
 
 #[derive(Debug)]
@@ -1494,6 +1495,243 @@ pub fn gdn_decode_qk_norm_gates_recurrent_rmsnorm_qf32_vbf16_bf16_kt(
     if status != 0 {
         return Err(GdnError::Msg(format!(
             "kt-gdn: decode_rmsnorm_qf32_vbf16 FFI returned {status}"
+        )));
+    }
+    Ok(out)
+}
+
+/// `gdn_full_chunk_forward_multiblock` over `kiln_tensor::Tensor` operands.
+///
+/// Multiblock variant of [`gdn_full_chunk_forward_kt`]. Identical
+/// envelope/dtypes; takes an additional `dv_tile` parameter that
+/// controls block tiling along the `dv` axis (used when `dv` exceeds
+/// the single-block kernel's hardware tile).
+///
+/// Returns BF16 `[B, H, C, dv]`.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_full_chunk_forward_multiblock_kt(
+    g: &KtTensor,
+    v: &KtTensor,
+    kkt: &KtTensor,
+    qkt: &KtTensor,
+    ks_entry: &KtTensor,
+    q_s: &KtTensor,
+    beta: &KtTensor,
+    k_t: &KtTensor,
+    state: &KtTensor,
+    dv_tile: usize,
+) -> Result<KtTensor, GdnError> {
+    let g_shape = g.shape();
+    if g_shape.len() != 3 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb g must be [B, H, C], got {g_shape:?}"
+        )));
+    }
+    let (b, h, c) = (g_shape[0], g_shape[1], g_shape[2]);
+
+    let v_shape = v.shape();
+    if v_shape.len() != 4 || (v_shape[0], v_shape[1], v_shape[2]) != (b, h, c) {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb v {v_shape:?} != [{b}, {h}, {c}, dv]"
+        )));
+    }
+    let dv = v_shape[3];
+
+    if kkt.shape() != [b, h, c, c] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb kkt {:?} != [{b}, {h}, {c}, {c}]",
+            kkt.shape()
+        )));
+    }
+    if qkt.shape() != [b, h, c, c] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb qkt {:?} != [{b}, {h}, {c}, {c}]",
+            qkt.shape()
+        )));
+    }
+    if ks_entry.shape() != [b, h, c, dv] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb ks_entry {:?} != [{b}, {h}, {c}, {dv}]",
+            ks_entry.shape()
+        )));
+    }
+    if q_s.shape() != [b, h, c, dv] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb q_s {:?} != [{b}, {h}, {c}, {dv}]",
+            q_s.shape()
+        )));
+    }
+    if beta.shape() != [b, h, c] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb beta {:?} != [{b}, {h}, {c}]",
+            beta.shape()
+        )));
+    }
+    let kt_shape = k_t.shape();
+    if kt_shape.len() != 4
+        || (kt_shape[0], kt_shape[1], kt_shape[3]) != (b, h, c)
+        || kt_shape[2] == 0
+        || kt_shape[2] > 128
+    {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb k_t {kt_shape:?} != [{b}, {h}, dk in 1..=128, {c}]"
+        )));
+    }
+    let dk = kt_shape[2];
+    if state.shape() != [b, h, dk, dv] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb state {:?} != [{b}, {h}, {dk}, {dv}]",
+            state.shape()
+        )));
+    }
+    if dv_tile == 0 || dv_tile > dv {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: chunk-mb dv_tile {dv_tile} must be in 1..={dv}"
+        )));
+    }
+
+    let (g_st, g_off) = cuda_storage_and_byte_offset(g, KtDType::BF16, "g")?;
+    let (v_st, v_off) = cuda_storage_and_byte_offset(v, KtDType::BF16, "v")?;
+    let (kkt_st, kkt_off) = cuda_storage_and_byte_offset(kkt, KtDType::BF16, "kkt")?;
+    let (qkt_st, qkt_off) = cuda_storage_and_byte_offset(qkt, KtDType::BF16, "qkt")?;
+    let (ks_st, ks_off) = cuda_storage_and_byte_offset(ks_entry, KtDType::BF16, "ks_entry")?;
+    let (qs_st, qs_off) = cuda_storage_and_byte_offset(q_s, KtDType::BF16, "q_s")?;
+    let (bt_st, bt_off) = cuda_storage_and_byte_offset(beta, KtDType::BF16, "beta")?;
+    let (kt_st, kt_off) = cuda_storage_and_byte_offset(k_t, KtDType::BF16, "k_t")?;
+    let (s_st, s_off) = cuda_storage_and_byte_offset(state, KtDType::BF16, "state")?;
+
+    let out = alloc_cuda_tensor(g_st, KtDType::BF16, vec![b, h, c, dv])?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = g_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let g_slice = g_st.slice().slice(g_off..);
+    let v_slice = v_st.slice().slice(v_off..);
+    let kkt_slice = kkt_st.slice().slice(kkt_off..);
+    let qkt_slice = qkt_st.slice().slice(qkt_off..);
+    let ks_slice = ks_st.slice().slice(ks_off..);
+    let qs_slice = qs_st.slice().slice(qs_off..);
+    let bt_slice = bt_st.slice().slice(bt_off..);
+    let kt_slice = kt_st.slice().slice(kt_off..);
+    let s_slice = s_st.slice().slice(s_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (g_ptr, _g1) = g_slice.device_ptr(&stream);
+        let (v_ptr, _g2) = v_slice.device_ptr(&stream);
+        let (kkt_ptr, _g3) = kkt_slice.device_ptr(&stream);
+        let (qkt_ptr, _g4) = qkt_slice.device_ptr(&stream);
+        let (ks_ptr, _g5) = ks_slice.device_ptr(&stream);
+        let (qs_ptr, _g6) = qs_slice.device_ptr(&stream);
+        let (bt_ptr, _g7) = bt_slice.device_ptr(&stream);
+        let (kt_ptr, _g8) = kt_slice.device_ptr(&stream);
+        let (s_ptr, _g9) = s_slice.device_ptr(&stream);
+        let (o_ptr, _g10) = o_slice.device_ptr(&stream);
+
+        kiln_gdn_full_chunk_forward_multiblock(
+            g_ptr as *const _,
+            v_ptr as *const _,
+            kkt_ptr as *const _,
+            qkt_ptr as *const _,
+            ks_ptr as *const _,
+            qs_ptr as *const _,
+            bt_ptr as *const _,
+            kt_ptr as *const _,
+            s_ptr as *mut _,
+            o_ptr as *mut _,
+            (b * h) as i32,
+            c as i32,
+            dk as i32,
+            dv as i32,
+            dv_tile as i32,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: full_chunk_forward_multiblock FFI returned {status}"
+        )));
+    }
+    Ok(out)
+}
+
+/// `gdn_gated_rms_norm_bf16` over kt operands.
+///
+/// Fused gated RMS-norm. Inputs:
+/// - `x`:      BF16 `[rows, hidden]` — input activations
+/// - `z`:      BF16 `[rows, hidden]` — gate
+/// - `weight`: F32  `[hidden]` — learned per-channel scale
+///
+/// Returns BF16 `[rows, hidden]`. Computes
+/// `out = (x / rms(x)) * weight * silu(z)` in one pass.
+pub fn gdn_gated_rms_norm_bf16_kt(
+    x: &KtTensor,
+    z: &KtTensor,
+    weight: &KtTensor,
+    eps: f32,
+) -> Result<KtTensor, GdnError> {
+    let x_shape = x.shape();
+    if x_shape.len() != 2 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: gated-rmsnorm x must be [rows, hidden], got {x_shape:?}"
+        )));
+    }
+    let (rows, hidden) = (x_shape[0], x_shape[1]);
+    if z.shape() != x_shape {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: gated-rmsnorm z {:?} != x {x_shape:?}",
+            z.shape()
+        )));
+    }
+    if weight.shape() != [hidden] {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: gated-rmsnorm weight {:?} != [{hidden}]",
+            weight.shape()
+        )));
+    }
+
+    let (x_st, x_off) = cuda_storage_and_byte_offset(x, KtDType::BF16, "x")?;
+    let (z_st, z_off) = cuda_storage_and_byte_offset(z, KtDType::BF16, "z")?;
+    let (w_st, w_off) = cuda_storage_and_byte_offset(weight, KtDType::F32, "weight")?;
+
+    let out = alloc_cuda_tensor(x_st, KtDType::BF16, vec![rows, hidden])?;
+    let out_cuda = out
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .expect("alloc CUDA");
+
+    let stream = x_st.candle_device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let x_slice = x_st.slice().slice(x_off..);
+    let z_slice = z_st.slice().slice(z_off..);
+    let w_slice = w_st.slice().slice(w_off..);
+    let o_slice = out_cuda.slice().slice(0..);
+
+    let status = unsafe {
+        let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+        let (z_ptr, _g2) = z_slice.device_ptr(&stream);
+        let (w_ptr, _g3) = w_slice.device_ptr(&stream);
+        let (o_ptr, _g4) = o_slice.device_ptr(&stream);
+        kiln_gdn_gated_rms_norm_bf16(
+            x_ptr as *const _,
+            z_ptr as *const _,
+            w_ptr as *const _,
+            o_ptr as *mut _,
+            rows as i32,
+            hidden as i32,
+            eps,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(GdnError::Msg(format!(
+            "kt-gdn: gated_rms_norm FFI returned {status}"
         )));
     }
     Ok(out)

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -78,7 +78,8 @@ pub use kt_api::{
     gdn_decode_qk_norm_gates_recurrent_rmsnorm_qf32_vf32_bf16_kt,
     gdn_decode_qk_norm_gates_recurrent_rmsnorm_vf32_bf16_kt,
     gdn_decode_qk_norm_gates_recurrent_vf32_bf16_kt, gdn_forward_substitution_kt,
-    gdn_full_chunk_forward_kt, gdn_recurrent_forward_kt, GdnError,
+    gdn_full_chunk_forward_kt, gdn_full_chunk_forward_multiblock_kt, gdn_gated_rms_norm_bf16_kt,
+    gdn_recurrent_forward_kt, GdnError,
 };
 
 unsafe extern "C" {


### PR DESCRIPTION
Two more kt-API entry points. Coverage now 15/22 FFI symbols. Mechanical pattern, same as previous PRs.