### PR TITLE
phase 7: owner-agnostic device-ptr helpers + first kt-API migration

### DIFF
--- a/crates/kiln-kt-bridge/src/lib.rs
+++ b/crates/kiln-kt-bridge/src/lib.rs
@@ -129,6 +129,50 @@ pub fn cuda_storage_of_output(t: &KtTensor) -> &CudaStorage {
         .expect("kt-bridge: alloc_cuda_tensor output must be CUDA")
 }
 
+/// Owner-agnostic device-pointer extraction for an input kt-Tensor.
+///
+/// Combines [`cuda_storage_and_byte_offset`] (dtype + contiguity +
+/// CUDA-ness check, plus layout-start-offset → bytes conversion) with
+/// the raw-pointer accessor that works for both `Owned` and
+/// `Borrowed` storage (see `kiln_tensor::CudaStorage::device_ptr_raw`).
+///
+/// Returns the absolute device pointer at the tensor's first live
+/// element. Use this in place of the
+/// `st.slice().slice(off..).device_ptr(&stream)` chain when migrating
+/// a kt-API entry point to accept Borrowed storage (Phase 7 v2).
+///
+/// **What this drops vs. the old chain:** the old chain returned a
+/// `SyncOnDrop` guard that recorded the stream's workload to the
+/// `CudaSlice`'s read event on drop, ensuring cross-stream readers of
+/// the same allocation wait for prior writes. The single-stream
+/// kt-API call pattern doesn't depend on this (every op uses the
+/// candle device's default stream), so dropping the guard is safe in
+/// the current call shapes. Future multi-stream kt-API additions
+/// must re-introduce explicit synchronization at the StreamPlanner
+/// layer.
+pub fn cuda_input_device_ptr(
+    t: &KtTensor,
+    expected: KtDType,
+    name: &'static str,
+) -> Result<u64, BridgeError> {
+    let (st, byte_off) = cuda_storage_and_byte_offset(t, expected, name)?;
+    let (base_ptr, byte_len) = st.device_ptr_raw();
+    if byte_off > byte_len {
+        return Err(BridgeError::new(format!(
+            "kt-bridge: {name} byte_off {byte_off} > storage byte_len {byte_len}"
+        )));
+    }
+    Ok(base_ptr + byte_off as u64)
+}
+
+/// Owner-agnostic device-pointer extraction for an output kt-Tensor
+/// (always `Owned` since [`alloc_cuda_tensor`] produces owned
+/// storage). Returns the base pointer; outputs use start_offset=0.
+pub fn cuda_output_device_ptr(t: &KtTensor) -> u64 {
+    let st = cuda_storage_of_output(t);
+    st.device_ptr_raw().0
+}
+
 /// Map candle's `DType` to kiln-tensor's `DType`. Returns
 /// `BridgeError` for variants that have no kt equivalent today.
 ///

--- a/crates/kiln-rmsnorm-kernel/src/kt_api.rs
+++ b/crates/kiln-rmsnorm-kernel/src/kt_api.rs
@@ -905,25 +905,23 @@ pub fn fused_sigmoid_mul_kt(
     let elems = x.element_count();
     let shape = x.shape().to_vec();
 
-    let (x_st, x_off) = cuda_storage_and_byte_offset(x, KtDType::BF16, "x")?;
-    let (g_st, g_off) = cuda_storage_and_byte_offset(gate, KtDType::BF16, "gate")?;
+    // Owner-agnostic input device pointers: works for both Owned and
+    // Borrowed kt storage (Phase 7 v2 — accepts kt-Tensors built via
+    // `kt_tensor_from_candle_cuda_borrow`). This is the migration
+    // template for the rest of the kt-API surface.
+    let x_ptr = kiln_kt_bridge::cuda_input_device_ptr(x, KtDType::BF16, "x")?;
+    let g_ptr = kiln_kt_bridge::cuda_input_device_ptr(gate, KtDType::BF16, "gate")?;
+
+    // Output is always Owned (alloc_cuda_tensor produces owned storage),
+    // so we can reach for the raw pointer the same way.
+    let (x_st, _) = cuda_storage_and_byte_offset(x, KtDType::BF16, "x")?;
     let out = alloc_cuda_tensor(x_st, KtDType::BF16, shape)?;
-    let o_cuda = out
-        .storage()
-        .as_any()
-        .downcast_ref::<CudaStorage>()
-        .expect("alloc CUDA");
+    let o_ptr = kiln_kt_bridge::cuda_output_device_ptr(&out);
 
     let stream = x_st.candle_device().cuda_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
-    let x_slice = x_st.slice().slice(x_off..);
-    let g_slice = g_st.slice().slice(g_off..);
-    let o_slice = o_cuda.slice().slice(0..);
 
     let status = unsafe {
-        let (x_ptr, _g1) = x_slice.device_ptr(&stream);
-        let (g_ptr, _g2) = g_slice.device_ptr(&stream);
-        let (o_ptr, _g3) = o_slice.device_ptr(&stream);
         kiln_fused_sigmoid_mul_bf16(
             x_ptr as *const _,
             g_ptr as *const _,


### PR DESCRIPTION
kt-bridge gets cuda_input_device_ptr + cuda_output_device_ptr; fused_sigmoid_mul_kt is the first migrated kt-API to accept Borrowed storage (zero-copy borrow adapter usable end-to-end).