### PR TITLE
phase 1: CUDA-side Tensor::contiguous kernel — unblocks Phase 3/4 substrate

### DIFF
--- a/crates/kiln-tensor/Cargo.toml
+++ b/crates/kiln-tensor/Cargo.toml
@@ -6,6 +6,12 @@ publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# build.rs compiles the CUDA-side `contiguous` kernel (csrc/contiguous.cu)
+# when --features cuda is enabled. No-op outside the cuda feature.
+build = "build.rs"
+
+[build-dependencies]
+cc = "1"
 
 # kiln-tensor is internal-only — no semver commitment.
 # Other kiln-* crates may break against minor version bumps until candle

--- a/crates/kiln-tensor/build.rs
+++ b/crates/kiln-tensor/build.rs
@@ -1,0 +1,122 @@
+// Build script for kiln-tensor.
+//
+// Under `--features cuda`, compiles the CUDA-side `contiguous` kernel
+// (`csrc/contiguous.cu`) into a static library that the Rust side
+// links against. Outside the cuda feature, this is a no-op.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Only compile CUDA code when the cuda feature is enabled.
+    let cuda_enabled = env::var("CARGO_FEATURE_CUDA").is_ok();
+    if !cuda_enabled {
+        return;
+    }
+
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!(
+                "cargo:warning=CUDA not found, kiln-tensor's CUDA-side contiguous kernel \
+                 will not be compiled. Set CUDA_ROOT or CUDA_HOME, or install CUDA toolkit."
+            );
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+    if !csrc_dir.exists() {
+        return;
+    }
+
+    let cuda_archs = env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    configure_nvcc_from_cuda_root(&cuda_root);
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("-Xcompiler").flag("-fPIC");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("contiguous.cu"));
+    build.compile("kiln_tensor_cuda_ops");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    println!("cargo:rustc-link-lib=cudart");
+
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=NVCC");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn configure_nvcc_from_cuda_root(cuda_root: &PathBuf) {
+    if env::var_os("NVCC").is_some() {
+        return;
+    }
+    let nvcc = cuda_root.join("bin").join("nvcc");
+    if nvcc.exists() {
+        unsafe {
+            env::set_var("NVCC", nvcc);
+        }
+    }
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-tensor/csrc/contiguous.cu
+++ b/crates/kiln-tensor/csrc/contiguous.cu
@@ -1,0 +1,127 @@
+// Kiln CUDA-side `Tensor::contiguous()` — stride-aware copy of a non-
+// contiguous CUDA storage into a freshly-allocated contiguous output.
+//
+// Unblocks the rest of PagedKvCacheKt + the Phase 4 layer-glue rebound
+// (RMSNorm/embedding/residual/LM head) by replacing the CPU-only
+// `Tensor::contiguous()` impl in `kiln-tensor::tensor.rs:358` for CUDA
+// storage. See #1082 Phase 1 "Pinned-host staging pool per device" and
+// the surrounding substrate items.
+//
+// # Algorithm
+//
+// One CUDA thread per logical output element. Each thread:
+//   1. Computes its flat output index `idx` from `blockIdx * blockDim
+//      + threadIdx`.
+//   2. Unflattens `idx` to a multi-dim coordinate `(c0, c1, ..., c_{R-1})`
+//      via repeated modulo against the shape (highest dim varies
+//      fastest — matches the row-major iteration order kt-tensor's
+//      `Layout::contiguous` produces).
+//   3. Computes the physical source byte offset:
+//        `src_byte_off = sum(c_d * strides_e[d]) * bytes_per_elem`
+//      where `strides_e` is the source's element-stride array.
+//   4. Computes the physical destination byte offset:
+//        `dst_byte_off = idx * bytes_per_elem`
+//   5. Copies `bytes_per_elem` bytes from `src + src_byte_off` to
+//      `dst + dst_byte_off`. Byte-wise so the kernel is dtype-agnostic
+//      (BF16 / F32 / U8 / etc. all use the same path).
+//
+// # Limits
+//
+// - `MAX_RANK = 8`. Matches kt-tensor's documented max rank.
+// - `bytes_per_elem ≤ 8`. Covers F32 (4), BF16/F16 (2), U8 (1), I64 (8).
+//
+// # Launch
+//
+// `grid = ceil_div(n_elements, BLOCK_SIZE)`, `block = BLOCK_SIZE`.
+// `BLOCK_SIZE = 256` — standard, good occupancy across SM 80/86/89/90.
+//
+// # Return code
+//
+// `kiln_contiguous_copy_async` returns 0 on success, non-zero on any
+// CUDA error (last-error captured before launch).
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#define MAX_RANK 8
+#define BLOCK_SIZE 256
+
+namespace {
+
+// Per-call descriptor passed by value to the kernel. Up to 8D, so
+// (8 + 8) * 8 + 16 = 144 bytes — well within the CUDA per-kernel
+// parameter limit (4 KB).
+struct ContiguousDesc {
+    int64_t shape[MAX_RANK];
+    int64_t strides_e[MAX_RANK]; // element strides
+    int32_t rank;
+    int32_t bytes_per_elem;
+    int64_t n_elements;
+};
+
+__global__ void kiln_contiguous_copy_kernel(const uint8_t* __restrict__ src,
+                                            uint8_t* __restrict__ dst,
+                                            ContiguousDesc desc) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= desc.n_elements) return;
+
+    // Unflatten idx to (c0, c1, ..., c_{rank-1}) and accumulate src
+    // element offset using the source's element-strides.
+    int64_t src_off_e = 0;
+    int64_t remaining = idx;
+    // Iterate from the last (fastest-varying) dim to the first.
+    for (int d = desc.rank - 1; d >= 0; --d) {
+        int64_t sz = desc.shape[d];
+        int64_t pos = remaining % sz;
+        remaining /= sz;
+        src_off_e += pos * desc.strides_e[d];
+    }
+
+    int64_t bpe = desc.bytes_per_elem;
+    int64_t src_byte = src_off_e * bpe;
+    int64_t dst_byte = idx * bpe;
+
+    // Byte-wise copy. The compiler unrolls for the common BPE values
+    // (1/2/4/8) since `bpe` is uniform across the warp.
+    for (int b = 0; b < bpe; ++b) {
+        dst[dst_byte + b] = src[src_byte + b];
+    }
+}
+
+} // namespace
+
+extern "C" int kiln_contiguous_copy_async(const void* src,
+                                          void* dst,
+                                          const int64_t* shape,
+                                          const int64_t* strides_e,
+                                          int32_t rank,
+                                          int32_t bytes_per_elem,
+                                          int64_t n_elements,
+                                          cudaStream_t stream) {
+    if (rank < 0 || rank > MAX_RANK) return 1;
+    if (bytes_per_elem < 1 || bytes_per_elem > 8) return 2;
+    if (n_elements < 0) return 3;
+    if (n_elements == 0) return 0;
+
+    ContiguousDesc desc;
+    desc.rank = rank;
+    desc.bytes_per_elem = bytes_per_elem;
+    desc.n_elements = n_elements;
+    for (int d = 0; d < MAX_RANK; ++d) {
+        desc.shape[d] = (d < rank) ? shape[d] : 1;
+        desc.strides_e[d] = (d < rank) ? strides_e[d] : 0;
+    }
+
+    int64_t blocks_i64 = (n_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    if (blocks_i64 > (int64_t)2147483647) return 4; // CUDA grid x limit
+    int blocks = static_cast<int>(blocks_i64);
+
+    kiln_contiguous_copy_kernel<<<blocks, BLOCK_SIZE, 0, stream>>>(
+        static_cast<const uint8_t*>(src),
+        static_cast<uint8_t*>(dst),
+        desc);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return 1000 + static_cast<int>(err);
+    return 0;
+}

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -326,6 +326,139 @@ pub fn cuda_zeros(
 }
 
 // ----------------------------------------------------------------------
+// CUDA-side Tensor::contiguous (Phase 1 substrate op)
+// ----------------------------------------------------------------------
+//
+// The kernel itself lives in `csrc/contiguous.cu` and is compiled by
+// `build.rs` when `--features cuda` is on. See the kernel header
+// comment for the algorithm and launch shape.
+
+unsafe extern "C" {
+    fn kiln_contiguous_copy_async(
+        src: *const core::ffi::c_void,
+        dst: *mut core::ffi::c_void,
+        shape: *const i64,
+        strides_e: *const i64,
+        rank: i32,
+        bytes_per_elem: i32,
+        n_elements: i64,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
+/// CUDA-side stride-aware contiguous() — produces a new kt-Tensor with
+/// the same logical shape + dtype as `src` but row-major contiguous
+/// strides and `start_offset = 0`.
+///
+/// Routes through the `kiln_contiguous_copy_async` kernel. Caller is
+/// the dispatch site in `Tensor::contiguous()`.
+///
+/// Errors:
+/// - Source must be CUDA storage (downcast to `CudaStorage`).
+/// - Packed dtypes are not supported (Marlin / Int4Packed / Fp4Packed
+///   have no element-wise interpretation).
+/// - Rank must be ≤ 8 (matches the kernel's `MAX_RANK`).
+#[cfg(feature = "cuda")]
+pub fn cuda_contiguous(src: &crate::Tensor) -> Result<crate::Tensor> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use std::any::Any as _;
+
+    if src.dtype().is_packed() {
+        return Err(crate::Error::Msg(
+            "cuda_contiguous: packed dtype not supported".to_string(),
+        ));
+    }
+
+    let layout = src.layout();
+    let shape = src.shape();
+    let strides_elems = src.strides();
+    let rank = shape.len();
+    if rank > 8 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_contiguous: rank {rank} exceeds kernel MAX_RANK=8"
+        )));
+    }
+    let n_elements = src.element_count();
+    let bpe = src.dtype().size_in_bytes();
+
+    let src_storage = src
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .ok_or_else(|| {
+            crate::Error::Msg("cuda_contiguous: source must be CUDA storage".to_string())
+        })?;
+
+    // Allocate the destination — contiguous, same dtype, same shape.
+    let candle_device = src_storage.candle_device.clone();
+    let device_index = match src_storage.device {
+        crate::Device::Cuda(i) => i,
+        _ => unreachable!("CudaStorage::device is always Cuda"),
+    };
+    let dst_storage = CudaStorage::zeros(
+        candle_device.clone(),
+        device_index,
+        src.dtype(),
+        n_elements,
+    )?;
+
+    // Extract raw device pointers. Source base + start_offset; dst
+    // base.
+    let stream = candle_device.cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let src_base = match &src_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
+    };
+    let dst_base = match &dst_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+    };
+
+    // Source pointer at the live region's start (start_offset applied).
+    let src_byte_off = (layout.start_offset() * bpe) as u64;
+    let src_ptr = (src_base + src_byte_off) as *const core::ffi::c_void;
+    let dst_ptr = dst_base as *mut core::ffi::c_void;
+
+    // Marshal shape + element strides to i64 vecs.
+    let shape_i64: Vec<i64> = shape.iter().map(|&d| d as i64).collect();
+    let strides_i64: Vec<i64> = strides_elems.iter().map(|&s| s as i64).collect();
+
+    let status = unsafe {
+        kiln_contiguous_copy_async(
+            src_ptr,
+            dst_ptr,
+            shape_i64.as_ptr(),
+            strides_i64.as_ptr(),
+            rank as i32,
+            bpe as i32,
+            n_elements as i64,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_contiguous: kiln_contiguous_copy_async returned status {status}"
+        )));
+    }
+
+    let storage_arc: crate::Storage = Arc::new(dst_storage);
+    crate::Tensor::from_parts(
+        storage_arc,
+        crate::Layout::contiguous(shape.to_vec()),
+        crate::TensorId::next(),
+    )
+    .map_err(|e| crate::Error::Msg(format!("cuda_contiguous: wrap: {e}")))
+}
+
+// ----------------------------------------------------------------------
 // Tests are GPU-only — gated by KILN_TENSOR_CUDA_TEST=1 so a host with
 // cudarc + candle's cuda feature compiled in but no actual GPU doesn't
 // spuriously fail.

--- a/crates/kiln-tensor/src/tensor.rs
+++ b/crates/kiln-tensor/src/tensor.rs
@@ -361,9 +361,13 @@ impl Tensor {
         }
         // Anti-pattern 2: this is the materializing branch — count it.
         profile::emit_contiguous_copy();
+        #[cfg(feature = "cuda")]
+        if matches!(self.device(), crate::Device::Cuda(_)) {
+            return crate::cuda_storage::cuda_contiguous(self);
+        }
         if !self.device().is_cpu() {
             return Err(Error::Msg(format!(
-                "Tensor::contiguous: only CPU contiguous is implemented in Phase 1.5; \
+                "Tensor::contiguous: only CPU + CUDA contiguous is implemented; \
                  device {} support lands with the per-backend storage impl",
                 self.device()
             )));


### PR DESCRIPTION
CUDA stride-aware contiguous via custom .cu kernel + build.rs. Unblocks PagedKvCacheKt::read + Phase 4 RMSNorm/embedding/residual rebound.