### PR TITLE
phase 1: CUDA-side index_select(axis=0) kernel — second substrate op

### DIFF
--- a/crates/kiln-tensor/build.rs
+++ b/crates/kiln-tensor/build.rs
@@ -56,6 +56,7 @@ fn main() {
     }
 
     build.file(csrc_dir.join("contiguous.cu"));
+    build.file(csrc_dir.join("index_select.cu"));
     build.compile("kiln_tensor_cuda_ops");
 
     println!(

--- a/crates/kiln-tensor/csrc/index_select.cu
+++ b/crates/kiln-tensor/csrc/index_select.cu
@@ -1,0 +1,86 @@
+// Kiln CUDA-side index_select(src, axis=0, indices) — gather along the
+// outer axis of a CUDA tensor, producing a freshly-allocated output.
+//
+// Unblocks the non-contiguous-slot-run path of
+// `PagedKvCacheKt::read` (#1082 line 110 / 167 / 324) and the
+// generic gather pattern used by RoPE table lookups, embedding
+// lookups, etc.
+//
+// # Algorithm
+//
+// One CUDA block per output row, threads within a block cooperatively
+// copy the row bytes. For `src` of shape `[N, ...inner]` and U32
+// `indices` of shape `[K]`, output is `[K, ...inner]` with
+// `out[i] = src[indices[i]]`.
+//
+//   row_bytes = product(inner_dims) * bytes_per_elem
+//   grid      = K blocks
+//   block     = 256 threads
+//   per thread loop: copy `b in [tid, row_bytes) step blockDim.x`
+//
+// `axis=0` only — kt-tensor's index_select is exposed as a free
+// function with this signature; higher-axis index_select can be
+// expressed via narrow/permute composition.
+//
+// # Bounds
+//
+// Out-of-range indices skip the copy (output row stays zero from
+// `cudaMalloc + memset`). The caller is responsible for valid index
+// values; the kernel does NOT abort the launch on a bad index.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#define BLOCK_SIZE 256
+
+namespace {
+
+__global__ void kiln_index_select_dim0_kernel(const uint8_t* __restrict__ src,
+                                              uint8_t* __restrict__ dst,
+                                              const uint32_t* __restrict__ indices,
+                                              int64_t row_bytes,
+                                              int64_t n_indices,
+                                              int64_t src_n_rows) {
+    int64_t out_row = static_cast<int64_t>(blockIdx.x);
+    if (out_row >= n_indices) return;
+    uint32_t src_row = indices[out_row];
+    if (static_cast<int64_t>(src_row) >= src_n_rows) return;
+
+    int64_t src_off = static_cast<int64_t>(src_row) * row_bytes;
+    int64_t dst_off = out_row * row_bytes;
+
+    int64_t tid = threadIdx.x;
+    int64_t stride = blockDim.x;
+    for (int64_t b = tid; b < row_bytes; b += stride) {
+        dst[dst_off + b] = src[src_off + b];
+    }
+}
+
+} // namespace
+
+extern "C" int kiln_index_select_dim0_async(const void* src,
+                                            void* dst,
+                                            const void* indices_u32,
+                                            int64_t row_bytes,
+                                            int64_t n_indices,
+                                            int64_t src_n_rows,
+                                            cudaStream_t stream) {
+    if (row_bytes < 0 || n_indices < 0 || src_n_rows < 0) return 1;
+    if (n_indices == 0 || row_bytes == 0) return 0;
+
+    int64_t blocks_i64 = n_indices;
+    if (blocks_i64 > (int64_t)2147483647) return 2;
+    int blocks = static_cast<int>(blocks_i64);
+
+    kiln_index_select_dim0_kernel<<<blocks, BLOCK_SIZE, 0, stream>>>(
+        static_cast<const uint8_t*>(src),
+        static_cast<uint8_t*>(dst),
+        static_cast<const uint32_t*>(indices_u32),
+        row_bytes,
+        n_indices,
+        src_n_rows);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return 1000 + static_cast<int>(err);
+    return 0;
+}

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -344,6 +344,16 @@ unsafe extern "C" {
         n_elements: i64,
         stream: *mut core::ffi::c_void,
     ) -> i32;
+
+    fn kiln_index_select_dim0_async(
+        src: *const core::ffi::c_void,
+        dst: *mut core::ffi::c_void,
+        indices_u32: *const core::ffi::c_void,
+        row_bytes: i64,
+        n_indices: i64,
+        src_n_rows: i64,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
 }
 
 /// CUDA-side stride-aware contiguous() — produces a new kt-Tensor with
@@ -456,6 +466,156 @@ pub fn cuda_contiguous(src: &crate::Tensor) -> Result<crate::Tensor> {
         crate::TensorId::next(),
     )
     .map_err(|e| crate::Error::Msg(format!("cuda_contiguous: wrap: {e}")))
+}
+
+/// CUDA-side `index_select(src, axis=0, indices)` — gather along the
+/// outer axis of a CUDA tensor.
+///
+/// Both `src` and `indices` must be CUDA-backed and contiguous.
+/// `indices` must be U32 (the kernel reads it as `*const u32`).
+///
+/// Returns a freshly-allocated contiguous output of shape
+/// `[indices.element_count(), src.shape()[1..]]` with the same dtype
+/// as `src`.
+///
+/// Errors:
+/// - src/indices must be CUDA storage
+/// - src/indices must be contiguous
+/// - src.rank() must be >= 1
+/// - indices.dtype() == U32
+/// - packed dtypes not supported
+#[cfg(feature = "cuda")]
+pub fn cuda_index_select_dim0(
+    src: &crate::Tensor,
+    indices: &crate::Tensor,
+) -> Result<crate::Tensor> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use std::any::Any as _;
+
+    if src.dtype().is_packed() {
+        return Err(crate::Error::Msg(
+            "cuda_index_select_dim0: packed dtype not supported".to_string(),
+        ));
+    }
+    if indices.dtype() != crate::DType::U32 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_index_select_dim0: indices dtype must be U32, got {}",
+            indices.dtype()
+        )));
+    }
+    if !src.is_contiguous() {
+        return Err(crate::Error::Msg(
+            "cuda_index_select_dim0: src must be contiguous (call .contiguous()? first)"
+                .to_string(),
+        ));
+    }
+    if !indices.is_contiguous() {
+        return Err(crate::Error::Msg(
+            "cuda_index_select_dim0: indices must be contiguous".to_string(),
+        ));
+    }
+
+    let src_shape = src.shape();
+    if src_shape.is_empty() {
+        return Err(crate::Error::Msg(
+            "cuda_index_select_dim0: src must have rank >= 1".to_string(),
+        ));
+    }
+    let src_n_rows = src_shape[0];
+    let inner: usize = src_shape[1..].iter().product();
+    let bpe = src.dtype().size_in_bytes();
+    let row_bytes = (inner * bpe) as i64;
+
+    let n_indices = indices.element_count();
+    let mut out_shape = vec![n_indices];
+    out_shape.extend_from_slice(&src_shape[1..]);
+    let n_out_elements = n_indices * inner;
+
+    let src_storage = src
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .ok_or_else(|| {
+            crate::Error::Msg("cuda_index_select_dim0: src must be CUDA storage".to_string())
+        })?;
+    let idx_storage = indices
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .ok_or_else(|| {
+            crate::Error::Msg(
+                "cuda_index_select_dim0: indices must be CUDA storage".to_string(),
+            )
+        })?;
+
+    let candle_device = src_storage.candle_device.clone();
+    let device_index = match src_storage.device {
+        crate::Device::Cuda(i) => i,
+        _ => unreachable!("CudaStorage::device is always Cuda"),
+    };
+    let dst_storage = CudaStorage::zeros(
+        candle_device.clone(),
+        device_index,
+        src.dtype(),
+        n_out_elements,
+    )?;
+
+    let stream = candle_device.cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let src_base = match &src_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
+    };
+    let idx_base = match &idx_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
+    };
+    let dst_base = match &dst_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+    };
+
+    let src_byte_off = (src.layout().start_offset() * bpe) as u64;
+    let idx_byte_off = (indices.layout().start_offset() * crate::DType::U32.size_in_bytes()) as u64;
+
+    let src_ptr = (src_base + src_byte_off) as *const core::ffi::c_void;
+    let idx_ptr = (idx_base + idx_byte_off) as *const core::ffi::c_void;
+    let dst_ptr = dst_base as *mut core::ffi::c_void;
+
+    let status = unsafe {
+        kiln_index_select_dim0_async(
+            src_ptr,
+            dst_ptr,
+            idx_ptr,
+            row_bytes,
+            n_indices as i64,
+            src_n_rows as i64,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_index_select_dim0: FFI returned status {status}"
+        )));
+    }
+
+    let storage_arc: crate::Storage = Arc::new(dst_storage);
+    crate::Tensor::from_parts(
+        storage_arc,
+        crate::Layout::contiguous(out_shape),
+        crate::TensorId::next(),
+    )
+    .map_err(|e| crate::Error::Msg(format!("cuda_index_select_dim0: wrap: {e}")))
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Companion to PR #1374's contiguous kernel. Unblocks PagedKvCacheKt::read non-contiguous slot path + gather patterns generally.