### PR TITLE
phase 1: CUDA-side unary activation kernel — silu/sigmoid/gelu/tanh/relu

### DIFF
--- a/crates/kiln-tensor/build.rs
+++ b/crates/kiln-tensor/build.rs
@@ -58,6 +58,7 @@ fn main() {
     build.file(csrc_dir.join("contiguous.cu"));
     build.file(csrc_dir.join("index_select.cu"));
     build.file(csrc_dir.join("elementwise.cu"));
+    build.file(csrc_dir.join("activation.cu"));
     build.compile("kiln_tensor_cuda_ops");
 
     println!(

--- a/crates/kiln-tensor/csrc/activation.cu
+++ b/crates/kiln-tensor/csrc/activation.cu
@@ -1,0 +1,146 @@
+// Kiln CUDA-side unary activation kernel.
+//
+// Covers silu / sigmoid / gelu / tanh / relu over F32 + BF16 + F16.
+// In-place math in F32 (kiln's numerical-reference convention),
+// narrowed back to the storage dtype on store.
+//
+// Used by Phase 4 layer-glue when no fused kernel is available
+// (the gated MLP path has its own fused silu*mul; standalone silu /
+// sigmoid / gelu hit this kernel).
+//
+// # Algorithm
+//
+// One thread per element. BF16/F16 inputs are loaded, promoted to
+// F32, the activation computed in F32, narrowed back. F32 inputs
+// run directly.
+//
+// # Layout
+//
+// Inputs are *contiguous*. Stride-aware path is a follow-up; the
+// dispatch site can call `.contiguous()` (CUDA contiguous landed
+// in PR #1374).
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <math_constants.h>
+
+#define BLOCK_SIZE 256
+
+// Op kinds — match `UnaryKind` in activation.rs
+#define KIND_SILU    0
+#define KIND_SIGMOID 1
+#define KIND_GELU    2
+#define KIND_TANH    3
+#define KIND_RELU    4
+
+// Dtype tags
+#define DTYPE_F32  0
+#define DTYPE_BF16 1
+#define DTYPE_F16  2
+
+namespace {
+
+__device__ __forceinline__ float apply_unary(int kind, float x) {
+    switch (kind) {
+        case KIND_SILU: {
+            // x / (1 + exp(-x))
+            return x / (1.0f + __expf(-x));
+        }
+        case KIND_SIGMOID: {
+            return 1.0f / (1.0f + __expf(-x));
+        }
+        case KIND_GELU: {
+            // tanh-approximation matching the kt-tensor CPU reference:
+            //   0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+            const float kSqrt2OverPi = 0.7978845608028654f;
+            float inner = kSqrt2OverPi * (x + 0.044715f * x * x * x);
+            return 0.5f * x * (1.0f + tanhf(inner));
+        }
+        case KIND_TANH: {
+            return tanhf(x);
+        }
+        case KIND_RELU: {
+            return fmaxf(0.0f, x);
+        }
+        default:
+            return 0.0f;
+    }
+}
+
+__global__ void kiln_activation_f32(const float* __restrict__ x,
+                                    float* __restrict__ out,
+                                    int64_t n,
+                                    int kind) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    out[idx] = apply_unary(kind, x[idx]);
+}
+
+__global__ void kiln_activation_bf16(const __nv_bfloat16* __restrict__ x,
+                                     __nv_bfloat16* __restrict__ out,
+                                     int64_t n,
+                                     int kind) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    float xv = __bfloat162float(x[idx]);
+    out[idx] = __float2bfloat16(apply_unary(kind, xv));
+}
+
+__global__ void kiln_activation_f16(const __half* __restrict__ x,
+                                    __half* __restrict__ out,
+                                    int64_t n,
+                                    int kind) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    float xv = __half2float(x[idx]);
+    out[idx] = __float2half(apply_unary(kind, xv));
+}
+
+} // namespace
+
+extern "C" int kiln_activation_unary_async(const void* x,
+                                           void* out,
+                                           int64_t n_elements,
+                                           int kind,
+                                           int dtype,
+                                           cudaStream_t stream) {
+    if (n_elements < 0) return 1;
+    if (kind < 0 || kind > 4) return 2;
+    if (n_elements == 0) return 0;
+
+    int64_t blocks_i64 = (n_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    if (blocks_i64 > (int64_t)2147483647) return 3;
+    int blocks = static_cast<int>(blocks_i64);
+
+    switch (dtype) {
+        case DTYPE_F32:
+            kiln_activation_f32<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const float*>(x),
+                static_cast<float*>(out),
+                n_elements,
+                kind);
+            break;
+        case DTYPE_BF16:
+            kiln_activation_bf16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __nv_bfloat16*>(x),
+                static_cast<__nv_bfloat16*>(out),
+                n_elements,
+                kind);
+            break;
+        case DTYPE_F16:
+            kiln_activation_f16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __half*>(x),
+                static_cast<__half*>(out),
+                n_elements,
+                kind);
+            break;
+        default:
+            return 4;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return 1000 + static_cast<int>(err);
+    return 0;
+}

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -364,6 +364,15 @@ unsafe extern "C" {
         dtype: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
+
+    fn kiln_activation_unary_async(
+        x: *const core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        n_elements: i64,
+        kind: i32,
+        dtype: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
 }
 
 /// CUDA-side stride-aware contiguous() — produces a new kt-Tensor with
@@ -758,6 +767,101 @@ pub fn cuda_elementwise_binary(
         crate::TensorId::next(),
     )
     .map_err(|e| crate::Error::Msg(format!("cuda_elementwise_binary: wrap: {e}")))
+}
+
+/// CUDA-side unary activation: `out[i] = activation(x[i])`.
+///
+/// `kind` encodes the op (0=Silu, 1=Sigmoid, 2=Gelu, 3=Tanh, 4=Relu).
+/// Dtype inferred from `x.dtype()`; must be F32/BF16/F16. Input must
+/// be contiguous and on CUDA.
+#[cfg(feature = "cuda")]
+pub fn cuda_activation_unary(x: &crate::Tensor, kind: i32) -> Result<crate::Tensor> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use std::any::Any as _;
+
+    let dtype = x.dtype();
+    let dtype_tag: i32 = match dtype {
+        crate::DType::F32 => 0,
+        crate::DType::BF16 => 1,
+        crate::DType::F16 => 2,
+        other => {
+            return Err(crate::Error::Msg(format!(
+                "cuda_activation_unary: unsupported dtype {other}"
+            )));
+        }
+    };
+    if !x.is_contiguous() {
+        return Err(crate::Error::Msg(
+            "cuda_activation_unary: contiguous input required".to_string(),
+        ));
+    }
+
+    let n = x.element_count();
+    let bpe = dtype.size_in_bytes();
+
+    let x_storage = x
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .ok_or_else(|| crate::Error::Msg("cuda_activation_unary: x must be CUDA".to_string()))?;
+
+    let candle_device = x_storage.candle_device.clone();
+    let device_index = match x_storage.device {
+        crate::Device::Cuda(i) => i,
+        _ => unreachable!(),
+    };
+    let out_storage = CudaStorage::zeros(
+        candle_device.clone(),
+        device_index,
+        dtype,
+        n,
+    )?;
+
+    let stream = candle_device.cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let x_base = match &x_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
+    };
+    let out_base = match &out_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+    };
+
+    let x_off = (x.layout().start_offset() * bpe) as u64;
+    let x_ptr = (x_base + x_off) as *const core::ffi::c_void;
+    let out_ptr = out_base as *mut core::ffi::c_void;
+
+    let status = unsafe {
+        kiln_activation_unary_async(
+            x_ptr,
+            out_ptr,
+            n as i64,
+            kind,
+            dtype_tag,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_activation_unary: FFI returned status {status}"
+        )));
+    }
+
+    let storage_arc: crate::Storage = Arc::new(out_storage);
+    crate::Tensor::from_parts(
+        storage_arc,
+        crate::Layout::contiguous(x.shape().to_vec()),
+        crate::TensorId::next(),
+    )
+    .map_err(|e| crate::Error::Msg(format!("cuda_activation_unary: wrap: {e}")))
 }
 
 // ----------------------------------------------------------------------

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -73,7 +73,8 @@ pub use tensor_id::TensorId;
 pub use cuda_allocator::CudaAllocator;
 #[cfg(feature = "cuda")]
 pub use cuda_storage::{
-    cuda_contiguous, cuda_elementwise_binary, cuda_index_select_dim0, cuda_zeros, CudaStorage,
+    cuda_activation_unary, cuda_contiguous, cuda_elementwise_binary, cuda_index_select_dim0,
+    cuda_zeros, CudaStorage,
 };
 #[cfg(feature = "metal")]
 pub use metal_allocator::MetalAllocator;

--- a/crates/kiln-tensor/src/ops/activation.rs
+++ b/crates/kiln-tensor/src/ops/activation.rs
@@ -137,6 +137,26 @@ impl DeviceOp1 for ActivationOp {
         Ok(Some(t))
     }
 
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(&self, x: &Tensor) -> Result<Option<Tensor>> {
+        validate(x, self.kind)?;
+        let dtype = x.dtype();
+        if !x.is_contiguous() {
+            return Ok(None);
+        }
+        if !matches!(dtype, DType::F32 | DType::BF16 | DType::F16) {
+            return Ok(None);
+        }
+        let kind_tag: i32 = match self.kind {
+            UnaryKind::Silu => 0,
+            UnaryKind::Sigmoid => 1,
+            UnaryKind::Gelu => 2,
+            UnaryKind::Tanh => 3,
+            UnaryKind::Relu => 4,
+        };
+        Ok(Some(crate::cuda_activation_unary(x, kind_tag)?))
+    }
+
     fn bwd(&self) -> Option<Box<dyn BackwardOp>> {
         None
     }


### PR DESCRIPTION
Fourth substrate op (after contiguous + index_select + elementwise binary). Phase 4 enabler for the unfused activation path.