### PR TITLE
phase 1: CUDA-side dtype cast kernel — fifth substrate op

### DIFF
--- a/crates/kiln-tensor/build.rs
+++ b/crates/kiln-tensor/build.rs
@@ -59,6 +59,7 @@ fn main() {
     build.file(csrc_dir.join("index_select.cu"));
     build.file(csrc_dir.join("elementwise.cu"));
     build.file(csrc_dir.join("activation.cu"));
+    build.file(csrc_dir.join("cast.cu"));
     build.compile("kiln_tensor_cuda_ops");
 
     println!(

--- a/crates/kiln-tensor/csrc/cast.cu
+++ b/crates/kiln-tensor/csrc/cast.cu
@@ -1,0 +1,129 @@
+// Kiln CUDA-side dtype cast kernel.
+//
+// Covers the same float↔float matrix as the CPU CastOp:
+//   F32 ↔ BF16 ↔ F16
+// Integer round-trips (U32 ↔ I64) are CPU-only — the few call sites
+// that need them have host data anyway.
+//
+// One thread per element. F32 staging in registers for all
+// conversions (matches the kt-Tensor numerical-reference contract).
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+#define BLOCK_SIZE 256
+
+// (from, to) tag pairs — match the dispatch in cast.rs.
+#define CAST_F32_TO_BF16  0
+#define CAST_F32_TO_F16   1
+#define CAST_BF16_TO_F32  2
+#define CAST_BF16_TO_F16  3
+#define CAST_F16_TO_F32   4
+#define CAST_F16_TO_BF16  5
+
+namespace {
+
+__global__ void kiln_cast_f32_to_bf16(const float* __restrict__ src,
+                                      __nv_bfloat16* __restrict__ dst,
+                                      int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __float2bfloat16(src[idx]);
+}
+
+__global__ void kiln_cast_f32_to_f16(const float* __restrict__ src,
+                                     __half* __restrict__ dst,
+                                     int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __float2half(src[idx]);
+}
+
+__global__ void kiln_cast_bf16_to_f32(const __nv_bfloat16* __restrict__ src,
+                                      float* __restrict__ dst,
+                                      int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __bfloat162float(src[idx]);
+}
+
+__global__ void kiln_cast_bf16_to_f16(const __nv_bfloat16* __restrict__ src,
+                                      __half* __restrict__ dst,
+                                      int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __float2half(__bfloat162float(src[idx]));
+}
+
+__global__ void kiln_cast_f16_to_f32(const __half* __restrict__ src,
+                                     float* __restrict__ dst,
+                                     int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __half2float(src[idx]);
+}
+
+__global__ void kiln_cast_f16_to_bf16(const __half* __restrict__ src,
+                                      __nv_bfloat16* __restrict__ dst,
+                                      int64_t n) {
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    dst[idx] = __float2bfloat16(__half2float(src[idx]));
+}
+
+} // namespace
+
+extern "C" int kiln_cast_async(const void* src,
+                               void* dst,
+                               int64_t n_elements,
+                               int cast_tag,
+                               cudaStream_t stream) {
+    if (n_elements < 0) return 1;
+    if (cast_tag < 0 || cast_tag > 5) return 2;
+    if (n_elements == 0) return 0;
+
+    int64_t blocks_i64 = (n_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    if (blocks_i64 > (int64_t)2147483647) return 3;
+    int blocks = static_cast<int>(blocks_i64);
+
+    switch (cast_tag) {
+        case CAST_F32_TO_BF16:
+            kiln_cast_f32_to_bf16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const float*>(src),
+                static_cast<__nv_bfloat16*>(dst), n_elements);
+            break;
+        case CAST_F32_TO_F16:
+            kiln_cast_f32_to_f16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const float*>(src),
+                static_cast<__half*>(dst), n_elements);
+            break;
+        case CAST_BF16_TO_F32:
+            kiln_cast_bf16_to_f32<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __nv_bfloat16*>(src),
+                static_cast<float*>(dst), n_elements);
+            break;
+        case CAST_BF16_TO_F16:
+            kiln_cast_bf16_to_f16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __nv_bfloat16*>(src),
+                static_cast<__half*>(dst), n_elements);
+            break;
+        case CAST_F16_TO_F32:
+            kiln_cast_f16_to_f32<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __half*>(src),
+                static_cast<float*>(dst), n_elements);
+            break;
+        case CAST_F16_TO_BF16:
+            kiln_cast_f16_to_bf16<<<blocks, BLOCK_SIZE, 0, stream>>>(
+                static_cast<const __half*>(src),
+                static_cast<__nv_bfloat16*>(dst), n_elements);
+            break;
+        default:
+            return 4;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return 1000 + static_cast<int>(err);
+    return 0;
+}

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -373,6 +373,14 @@ unsafe extern "C" {
         dtype: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
+
+    fn kiln_cast_async(
+        src: *const core::ffi::c_void,
+        dst: *mut core::ffi::c_void,
+        n_elements: i64,
+        cast_tag: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
 }
 
 /// CUDA-side stride-aware contiguous() — produces a new kt-Tensor with
@@ -862,6 +870,106 @@ pub fn cuda_activation_unary(x: &crate::Tensor, kind: i32) -> Result<crate::Tens
         crate::TensorId::next(),
     )
     .map_err(|e| crate::Error::Msg(format!("cuda_activation_unary: wrap: {e}")))
+}
+
+/// CUDA-side dtype cast: `dst[i] = (TargetDType)(src[i])`.
+///
+/// Supports the same float↔float matrix as the CPU CastOp:
+/// F32↔BF16↔F16 (6 directions). Integer round-trips (U32↔I64) stay
+/// CPU-only since the few call sites have host data.
+///
+/// Source must be contiguous and CUDA-backed; output is contiguous
+/// with the target dtype.
+#[cfg(feature = "cuda")]
+pub fn cuda_cast(src: &crate::Tensor, target: crate::DType) -> Result<crate::Tensor> {
+    use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+    use std::any::Any as _;
+
+    let from = src.dtype();
+    if from == target {
+        return src
+            .contiguous()
+            .map_err(|e| crate::Error::Msg(format!("cuda_cast: no-op contiguous: {e}")));
+    }
+    let cast_tag: i32 = match (from, target) {
+        (crate::DType::F32, crate::DType::BF16) => 0,
+        (crate::DType::F32, crate::DType::F16) => 1,
+        (crate::DType::BF16, crate::DType::F32) => 2,
+        (crate::DType::BF16, crate::DType::F16) => 3,
+        (crate::DType::F16, crate::DType::F32) => 4,
+        (crate::DType::F16, crate::DType::BF16) => 5,
+        _ => {
+            return Err(crate::Error::Msg(format!(
+                "cuda_cast: unsupported pair {from} -> {target} \
+                 (CUDA path supports F32↔BF16↔F16 only)"
+            )));
+        }
+    };
+    if !src.is_contiguous() {
+        return Err(crate::Error::Msg(
+            "cuda_cast: contiguous input required".to_string(),
+        ));
+    }
+
+    let n = src.element_count();
+    let from_bpe = from.size_in_bytes();
+
+    let src_storage = src
+        .storage()
+        .as_any()
+        .downcast_ref::<CudaStorage>()
+        .ok_or_else(|| crate::Error::Msg("cuda_cast: src must be CUDA".to_string()))?;
+
+    let candle_device = src_storage.candle_device.clone();
+    let device_index = match src_storage.device {
+        crate::Device::Cuda(i) => i,
+        _ => unreachable!(),
+    };
+    let dst_storage = CudaStorage::zeros(
+        candle_device.clone(),
+        device_index,
+        target,
+        n,
+    )?;
+
+    let stream = candle_device.cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+    let src_base = match &src_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
+    };
+    let dst_base = match &dst_storage.slice {
+        SliceOwner::Owned(s) => {
+            let (p, _g) = s.device_ptr(&stream);
+            p
+        }
+        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+    };
+
+    let src_off = (src.layout().start_offset() * from_bpe) as u64;
+    let src_ptr = (src_base + src_off) as *const core::ffi::c_void;
+    let dst_ptr = dst_base as *mut core::ffi::c_void;
+
+    let status = unsafe {
+        kiln_cast_async(src_ptr, dst_ptr, n as i64, cast_tag, raw_stream)
+    };
+    if status != 0 {
+        return Err(crate::Error::Msg(format!(
+            "cuda_cast: FFI returned status {status}"
+        )));
+    }
+
+    let storage_arc: crate::Storage = Arc::new(dst_storage);
+    crate::Tensor::from_parts(
+        storage_arc,
+        crate::Layout::contiguous(src.shape().to_vec()),
+        crate::TensorId::next(),
+    )
+    .map_err(|e| crate::Error::Msg(format!("cuda_cast: wrap: {e}")))
 }
 
 // ----------------------------------------------------------------------

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -73,8 +73,8 @@ pub use tensor_id::TensorId;
 pub use cuda_allocator::CudaAllocator;
 #[cfg(feature = "cuda")]
 pub use cuda_storage::{
-    cuda_activation_unary, cuda_contiguous, cuda_elementwise_binary, cuda_index_select_dim0,
-    cuda_zeros, CudaStorage,
+    cuda_activation_unary, cuda_cast, cuda_contiguous, cuda_elementwise_binary,
+    cuda_index_select_dim0, cuda_zeros, CudaStorage,
 };
 #[cfg(feature = "metal")]
 pub use metal_allocator::MetalAllocator;

--- a/crates/kiln-tensor/src/ops/cast.rs
+++ b/crates/kiln-tensor/src/ops/cast.rs
@@ -102,6 +102,34 @@ impl DeviceOp1 for CastOp {
         Ok(Some(out))
     }
 
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(&self, x: &Tensor) -> Result<Option<Tensor>> {
+        let from = x.dtype();
+        let to = self.target;
+        // CUDA path covers F32 ↔ BF16 ↔ F16. Integer round-trips
+        // stay on the CPU fallback (their few call sites have host
+        // data anyway).
+        let cuda_supported = matches!(
+            (from, to),
+            (DType::F32, DType::BF16)
+                | (DType::F32, DType::F16)
+                | (DType::BF16, DType::F32)
+                | (DType::BF16, DType::F16)
+                | (DType::F16, DType::F32)
+                | (DType::F16, DType::BF16)
+                | (DType::F32, DType::F32)
+                | (DType::BF16, DType::BF16)
+                | (DType::F16, DType::F16)
+        );
+        if !cuda_supported {
+            return Ok(None);
+        }
+        if !x.is_contiguous() {
+            return Ok(None);
+        }
+        Ok(Some(crate::cuda_cast(x, to)?))
+    }
+
     fn bwd(&self) -> Option<Box<dyn BackwardOp>> {
         None
     }


### PR DESCRIPTION
Six dtype-pair specializations covering the float-conversion matrix on CUDA.