### PR TITLE
phase 5: fused batched kv_slot writer kernel (closes #1082 suspect 1)

### DIFF
--- a/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.cu
+++ b/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.cu
@@ -523,6 +523,66 @@ extern "C" kiln_flash_status_t kiln_paged_kv_write_token_major_bf16(
     return err == cudaSuccess ? 0 : -2;
 }
 
+// Fused batched per-row slot writer. Writes `batch` rows from K/V `[batch, num_kv_heads, head_dim]`
+// into K/V pools `[total_slots, num_kv_heads, head_dim]` using a `[batch]` u32 device
+// tensor of per-row destination slot indices. Grid is 2D: blockIdx.y = batch row,
+// blockIdx.x = element within that row. One kernel launch handles all rows — no
+// per-row host loop, no transient device tensors, safe under CUDA graph capture
+// because the only inputs that vary across replays are the device-pointer-backed
+// `slots` table (refreshed via `update_cuda_scalar` outside the captured region).
+// See `bench-results/cuda-graph-bs2-secondary-audit.md` suspect 1 for #1082.
+__global__ void kiln_paged_kv_write_token_major_bf16_batch_slot_kernel(
+    __nv_bfloat16 *k_pool,
+    __nv_bfloat16 *v_pool,
+    const __nv_bfloat16 *k,
+    const __nv_bfloat16 *v,
+    const unsigned int *slots,
+    int batch,
+    int num_kv_heads,
+    int head_dim)
+{
+    int row = blockIdx.y;
+    if (row >= batch) return;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = num_kv_heads * head_dim;
+    if (idx >= total) return;
+    int slot = int(slots[row]);
+    int dst = slot * total + idx;
+    int src = row * total + idx;
+    k_pool[dst] = k[src];
+    v_pool[dst] = v[src];
+}
+
+extern "C" kiln_flash_status_t kiln_paged_kv_write_token_major_bf16_batch_slot(
+    void *k_pool,
+    void *v_pool,
+    const void *k,
+    const void *v,
+    const unsigned int *slots,
+    int batch,
+    int num_kv_heads,
+    int head_dim,
+    void *stream)
+{
+    if (batch <= 0 || num_kv_heads <= 0 || head_dim <= 0) return -1;
+    int total = num_kv_heads * head_dim;
+    int threads = 256;
+    int blocks_x = (total + threads - 1) / threads;
+    dim3 grid(blocks_x, batch, 1);
+    cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    kiln_paged_kv_write_token_major_bf16_batch_slot_kernel<<<grid, threads, 0, cuda_stream>>>(
+        static_cast<__nv_bfloat16 *>(k_pool),
+        static_cast<__nv_bfloat16 *>(v_pool),
+        static_cast<const __nv_bfloat16 *>(k),
+        static_cast<const __nv_bfloat16 *>(v),
+        slots,
+        batch,
+        num_kv_heads,
+        head_dim);
+    cudaError_t err = cudaGetLastError();
+    return err == cudaSuccess ? 0 : -2;
+}
+
 extern "C" kiln_flash_status_t kiln_flash_attn_bwd(
     const void *dout,
     const void *q, const void *k, const void *v,

--- a/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.h
+++ b/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.h
@@ -126,6 +126,23 @@ kiln_flash_status_t kiln_paged_kv_write_token_major_bf16(
     void *stream
 );
 
+// Batched variant: write  token rows into 
+// pools using a  u32 device tensor of per-row destination slots. The K/V
+// inputs are  contiguous bf16. One fused kernel
+// launch handles every row — no per-row host loop, no transient device tensors,
+// safe under CUDA graph capture/replay across different slot indices.
+kiln_flash_status_t kiln_paged_kv_write_token_major_bf16_batch_slot(
+    void *k_pool,
+    void *v_pool,
+    const void *k,
+    const void *v,
+    const unsigned int *slots,
+    int batch,
+    int num_kv_heads,
+    int head_dim,
+    void *stream
+);
+
 // Flash Attention Backward Pass
 //
 // All pointer arguments must be CUDA device pointers.

--- a/crates/kiln-flash-attn/src/lib.rs
+++ b/crates/kiln-flash-attn/src/lib.rs
@@ -101,6 +101,18 @@ unsafe extern "C" {
         stream: *mut core::ffi::c_void,
     ) -> i32;
 
+    fn kiln_paged_kv_write_token_major_bf16_batch_slot(
+        k_pool: *mut core::ffi::c_void,
+        v_pool: *mut core::ffi::c_void,
+        k: *const core::ffi::c_void,
+        v: *const core::ffi::c_void,
+        slots: *const u32,
+        batch: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
     fn kiln_flash_attn_bwd(
         dout: *const core::ffi::c_void,
         q: *const core::ffi::c_void,
@@ -1198,6 +1210,140 @@ pub fn paged_kv_write_token_major_bf16_slot(
         if status != 0 {
             candle_core::bail!(
                 "kiln_paged_kv_write_token_major_bf16_slot failed with status {status}"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Write one decode token per row into a paged K/V pool using a `[batch]` u32
+/// device-side slot tensor. One fused CUDA kernel launch handles every row —
+/// no per-row host loop, no transient device tensors, safe under CUDA graph
+/// capture across different per-replay slot values (`slots` is read from the
+/// runner-owned `kv_slot_buffer`, refreshed via `update_cuda_scalar` before
+/// each replay).
+///
+/// Shapes:
+/// * `k_pool`, `v_pool`: `[total_slots, num_kv_heads, head_dim]` bf16
+/// * `k`, `v`: `[batch, num_kv_heads, head_dim]` (or `[batch, 1, num_kv_heads,
+///   head_dim]` which reshapes contiguously) bf16
+/// * `slots`: `[batch]` u32 device tensor of destination slot indices
+///
+/// Closes suspect 1 in `bench-results/cuda-graph-bs2-secondary-audit.md` for
+/// `#1082`. Caller must hold the contiguity invariant for `k` / `v` / `slots`.
+pub fn paged_kv_write_token_major_bf16_batch_slot(
+    k_pool: &Tensor,
+    v_pool: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    slots: &Tensor,
+) -> Result<()> {
+    let (_, num_kv_heads, head_dim) = k_pool.dims3()?;
+    if v_pool.dims3()? != k_pool.dims3()? {
+        candle_core::bail!("paged_kv_write_token_major_bf16_batch_slot k/v pool dims mismatch");
+    }
+    if k.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || k_pool.dtype() != DType::BF16
+        || v_pool.dtype() != DType::BF16
+    {
+        candle_core::bail!("paged_kv_write_token_major_bf16_batch_slot requires bf16 tensors");
+    }
+    if slots.dtype() != DType::U32 || slots.dims().len() != 1 {
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_batch_slot requires u32 slots shape [batch], got {:?} {:?}",
+            slots.dtype(),
+            slots.dims()
+        );
+    }
+    let batch = slots.dims()[0];
+    if batch == 0 {
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_batch_slot requires a non-empty batch"
+        );
+    }
+    let expected_per_row = num_kv_heads * head_dim;
+    if k.elem_count() != batch * expected_per_row || v.elem_count() != batch * expected_per_row {
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_batch_slot expects batch*({num_kv_heads}*{head_dim})={} elements per K/V, got k={} v={}",
+            batch * expected_per_row,
+            k.elem_count(),
+            v.elem_count()
+        );
+    }
+    let Ok(batch_i32) = i32::try_from(batch) else {
+        candle_core::bail!("paged_kv_write_token_major_bf16_batch_slot batch {batch} exceeds i32");
+    };
+    let Ok(num_kv_heads_i32) = i32::try_from(num_kv_heads) else {
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_batch_slot num_kv_heads {num_kv_heads} exceeds i32"
+        );
+    };
+    let Ok(head_dim_i32) = i32::try_from(head_dim) else {
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_batch_slot head_dim {head_dim} exceeds i32"
+        );
+    };
+
+    let k = k.contiguous()?;
+    let v = v.contiguous()?;
+    let slots = slots.contiguous()?;
+    let (k_storage, k_layout) = k.storage_and_layout();
+    let (v_storage, v_layout) = v.storage_and_layout();
+    let (kp_storage, kp_layout) = k_pool.storage_and_layout();
+    let (vp_storage, vp_layout) = v_pool.storage_and_layout();
+    let (slots_storage, slots_layout) = slots.storage_and_layout();
+
+    macro_rules! cuda {
+        ($s:expr, $name:expr) => {
+            match &*$s {
+                candle_core::Storage::Cuda(c) => c,
+                _ => candle_core::bail!(concat!($name, " must be a CUDA tensor")),
+            }
+        };
+    }
+    let k_cuda = cuda!(k_storage, "k");
+    let v_cuda = cuda!(v_storage, "v");
+    let kp_cuda = cuda!(kp_storage, "k_pool");
+    let vp_cuda = cuda!(vp_storage, "v_pool");
+    let slots_cuda = cuda!(slots_storage, "slots");
+    let stream = k_cuda.device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let k_slice = k_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(k_layout.start_offset()..);
+    let v_slice = v_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(v_layout.start_offset()..);
+    let kp_slice = kp_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(kp_layout.start_offset()..);
+    let vp_slice = vp_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(vp_layout.start_offset()..);
+    let slots_slice = slots_cuda
+        .as_cuda_slice::<u32>()?
+        .slice(slots_layout.start_offset()..);
+    unsafe {
+        let (k_ptr, _g1) = k_slice.device_ptr(&stream);
+        let (v_ptr, _g2) = v_slice.device_ptr(&stream);
+        let (kp_ptr, _g3) = kp_slice.device_ptr(&stream);
+        let (vp_ptr, _g4) = vp_slice.device_ptr(&stream);
+        let (slots_ptr, _g5) = slots_slice.device_ptr(&stream);
+        let status = kiln_paged_kv_write_token_major_bf16_batch_slot(
+            kp_ptr as *mut _,
+            vp_ptr as *mut _,
+            k_ptr as *const _,
+            v_ptr as *const _,
+            slots_ptr as *const u32,
+            batch_i32,
+            num_kv_heads_i32,
+            head_dim_i32,
+            raw_stream,
+        );
+        if status != 0 {
+            candle_core::bail!(
+                "kiln_paged_kv_write_token_major_bf16_batch_slot failed with status {status}"
             );
         }
     }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -17182,6 +17182,21 @@ pub fn gqa_attention_paged_decode_contiguous_batch(
     // `bench-results/cuda-graph-bs2-secondary-audit.md`). `None`
     // reproduces the legacy positions-based per-call build.
     rope_tables: Option<(&Tensor, &Tensor)>,
+    // CUDA-graph-stable `[batch]` u32 per-row KV-write slot tensor. When
+    // `Some` and `kv_fused_batched_enabled()` is true, the per-row KV slot
+    // writer dispatches the fused batched kernel
+    // (`PagedKvCache::write_token_major_native_batch_graph_slot`) instead
+    // of the per-row host loop that calls
+    // `paged_kv_write_token_major_bf16` with a baked-immediate slot.
+    // The baked-immediate form is a CUDA-graph replay-correctness bug:
+    // the captured kernel records the capture-time slot index as a
+    // launch immediate, so replays at a different decode position
+    // write into the wrong KV-cache slot. The fused-slot kernel reads
+    // its destination slots from this device tensor on every replay
+    // (refreshed via `update_cuda_scalar` outside the captured region),
+    // closing suspect 1 in `bench-results/cuda-graph-bs2-secondary-audit.md`
+    // for #1082. `None` reproduces the legacy per-row writer.
+    kv_slot: Option<&Tensor>,
 ) -> Result<Tensor> {
     let (batch, seq_len, _hidden) = x.dims3()?;
     let profile_device = x.device();
@@ -17450,13 +17465,46 @@ pub fn gqa_attention_paged_decode_contiguous_batch(
 
     {
         let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        if !paged_cache.write_token_major_native_batch(
-            full_attn_layer_idx,
-            block_tables,
-            start_positions,
-            &k,
-            &v,
-        )? {
+        let kv_write_done = {
+            #[cfg(feature = "cuda")]
+            {
+                // #1082 suspect 1: when the runner has wired the
+                // `[batch] u32` per-row slot device buffer through
+                // `BatchedPagedDecodeGraphInputs.kv_slot` and the
+                // `KILN_CUDA_GRAPHS_BATCHED_KV_FUSED` gate is on, write
+                // via the fused batched-slot kernel so the captured
+                // graph re-reads fresh slots on every replay. Otherwise
+                // fall back to the legacy per-row writer that bakes
+                // host-immediate slots into kernel args.
+                if let Some(slot_tensor) = kv_slot {
+                    if kv_fused_batched_enabled() {
+                        paged_cache.write_token_major_native_batch_graph_slot(
+                            full_attn_layer_idx,
+                            &k,
+                            &v,
+                            slot_tensor,
+                        )?
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                false
+            }
+        };
+        if !kv_write_done
+            && !paged_cache.write_token_major_native_batch(
+                full_attn_layer_idx,
+                block_tables,
+                start_positions,
+                &k,
+                &v,
+            )?
+        {
             anyhow::bail!("batched contiguous paged attention KV write declined");
         }
         finish_full_attn_stage_profile(
@@ -19492,6 +19540,10 @@ pub fn transformer_block_paged_decode_contiguous_batch(
     // forward path. Forwarded as-is to
     // `gqa_attention_paged_decode_contiguous_batch` (#1082 suspect 2).
     rope_tables: Option<(&Tensor, &Tensor)>,
+    // CUDA-graph-stable `[batch]` u32 per-row KV-write slot tensor.
+    // Forwarded as-is to `gqa_attention_paged_decode_contiguous_batch`
+    // (#1082 suspect 1).
+    kv_slot: Option<&Tensor>,
 ) -> Result<Tensor> {
     let attn_weights = match &layer.attention {
         GpuAttentionWeights::Full(w) => w,
@@ -19540,6 +19592,7 @@ pub fn transformer_block_paged_decode_contiguous_batch(
         cached_meta,
         graph_outputs,
         rope_tables,
+        kv_slot,
     )?;
     let x = {
         kiln_nvtx::range!(c"kiln/residual_batch_decode");
@@ -19608,6 +19661,7 @@ fn model_forward_paged_decode_contiguous_batch_hidden(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -19668,6 +19722,14 @@ fn model_forward_paged_decode_contiguous_batch_hidden_inner(
     // `bench-results/cuda-graph-bs2-secondary-audit.md`).
     stable_rotary_cos_gpu: Option<&Tensor>,
     stable_rotary_sin_gpu: Option<&Tensor>,
+    // CUDA-graph-stable `[batch]` u32 per-row KV-write slot tensor.
+    // When `Some`, the bs>1 KV-write step on the captured path
+    // dispatches the fused batched-slot kernel
+    // (`PagedKvCache::write_token_major_native_batch_graph_slot`) so
+    // every replay re-reads its per-row destination slot from this
+    // runner-owned device tensor instead of baking host-immediate
+    // slots into the captured kernel args. Closes #1082 suspect 1.
+    stable_kv_slot_gpu: Option<&Tensor>,
 ) -> Result<Tensor> {
     let batch = token_ids.len();
     anyhow::ensure!(batch > 0, "batched paged decode requires a non-empty batch");
@@ -19839,6 +19901,7 @@ fn model_forward_paged_decode_contiguous_batch_hidden_inner(
                     cached_paged_meta_ref,
                     layer_graph_outputs,
                     layer_rope_tables,
+                    stable_kv_slot_gpu,
                 )
                 .with_context(|| {
                     format!("batched transformer block {i} (full attention, paged)")
@@ -21462,6 +21525,11 @@ pub(crate) fn model_forward_paged_batched_with_graph_inputs(
         // inside the captured region (#1082 suspect 2).
         Some(graph_inputs.rotary_cos),
         Some(graph_inputs.rotary_sin),
+        // Thread the runner-owned `[batch]` u32 KV-slot buffer
+        // through so the captured KV-write step dispatches the fused
+        // batched-slot kernel instead of baking host-immediate slots
+        // into per-row kernel args (#1082 suspect 1).
+        Some(graph_inputs.kv_slot),
     )?;
     // Compute logits and slice them into the caller-owned stable
     // `output_logits` buffer (`[batch, 1, vocab]`). The captured graph
@@ -21740,6 +21808,7 @@ pub fn model_forward_paged_batched_decode_hidden(
                     &block_table_refs,
                     full_attn_idx,
                     layer_lora,
+                    None,
                     None,
                     None,
                     None,
@@ -25201,6 +25270,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )?;
         device.synchronize()?;
         assert_eq!(batched.dims(), &[batch, 1usize, hidden]);
@@ -25351,6 +25421,7 @@ mod tests {
             &mut batch_cache,
             &block_tables,
             0,
+            None,
             None,
             None,
             None,
@@ -30490,4 +30561,21 @@ mod tests {
             std::env::remove_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD");
         }
     }
+}
+
+
+/// Read the `KILN_CUDA_GRAPHS_BATCHED_KV_FUSED` env var.
+///
+/// When set to `1`/`true`/`yes`/`on`, the bs>1 paged-decode CUDA-graph
+/// path uses the fused batched-slot KV writer kernel
+/// (`PagedKvCache::write_token_major_native_batch_graph_slot`) so the
+/// per-row destination slots are read from a device tensor at replay
+/// time instead of being baked into the captured kernel args.
+/// Closes suspect 1 in `bench-results/cuda-graph-bs2-secondary-audit.md`
+/// for #1082. Defaults to off until validation closes.
+#[cfg(feature = "cuda")]
+fn kv_fused_batched_enabled() -> bool {
+    std::env::var("KILN_CUDA_GRAPHS_BATCHED_KV_FUSED")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
 }

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -1538,6 +1538,126 @@ mod tests {
         Ok(())
     }
 
+    /// Closes suspect 1 in #1082: the fused batched-slot writer must
+    /// land the same byte pattern in the K/V pool as the legacy per-row
+    /// `write_token_major_native_batch` path for every row, with no
+    /// silent off-by-row mistakes from the per-row 2D-grid kernel
+    /// dispatch. Requires CUDA. Skips on CPU-only builds.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_write_token_major_native_batch_graph_slot_matches_per_row() -> Result<()> {
+        let Ok(device) = Device::new_cuda(0) else {
+            eprintln!(
+                "CUDA unavailable, skipping test_write_token_major_native_batch_graph_slot_matches_per_row"
+            );
+            return Ok(());
+        };
+        let batch = 4usize;
+        let heads = 2usize;
+        let head_dim = 8usize;
+        // Distinct slots per row so an off-by-row bug shows up as a
+        // wrong-slot write rather than a silent stomp.
+        let slots: Vec<u32> = vec![1u32, 3, 5, 7];
+        let total_slots = 8usize;
+        let block_size = 1usize;
+        let cache = PagedKvCache::new(
+            1,
+            total_slots,
+            block_size,
+            heads,
+            head_dim,
+            DType::BF16,
+            &device,
+        )?;
+        // Build distinct K/V per row so any row-swap surfaces.
+        let elems = batch * heads * head_dim;
+        let k_data: Vec<f32> = (0..elems)
+            .map(|i| ((i as f32) - (elems as f32) / 2.0) * 0.015625)
+            .collect();
+        let k = Tensor::from_slice(&k_data, (batch, 1usize, heads, head_dim), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let v = (k.to_dtype(DType::F32)? + 50.0)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let slots_t = Tensor::from_slice(slots.as_slice(), batch, &device)?.contiguous()?;
+
+        // Fused-slot writer.
+        let ok = cache.write_token_major_native_batch_graph_slot(0, &k, &v, &slots_t)?;
+        assert!(ok, "batched-graph-slot writer should accept bf16 [batch,1,kv_heads,head_dim]");
+        device.synchronize()?;
+
+        // Reference: per-row write of the same K/V into a fresh cache.
+        let ref_cache = PagedKvCache::new(
+            1,
+            total_slots,
+            block_size,
+            heads,
+            head_dim,
+            DType::BF16,
+            &device,
+        )?;
+        let mut bts: Vec<BlockTable> = (0..batch)
+            .map(|i| {
+                let mut bt = BlockTable::new();
+                bt.push(slots[i]);
+                bt
+            })
+            .collect();
+        let bt_refs: Vec<&BlockTable> = bts.iter_mut().map(|bt| &*bt).collect();
+        let start_positions = vec![0usize; batch];
+        assert!(ref_cache.write_token_major_native_batch(
+            0,
+            &bt_refs,
+            &start_positions,
+            &k,
+            &v,
+        )?);
+        device.synchronize()?;
+
+        // Byte-level equality of the full pool tensor across both caches.
+        let (k_pool_fused, v_pool_fused) = cache
+            .pool_tensors(0)
+            .expect("layer 0 pool tensors");
+        let (k_pool_ref, v_pool_ref) = ref_cache
+            .pool_tensors(0)
+            .expect("ref layer 0 pool tensors");
+        let kf = k_pool_fused
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let kr = k_pool_ref
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let vf = v_pool_fused
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let vr = v_pool_ref
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_eq!(kf.len(), kr.len());
+        for i in 0..kf.len() {
+            assert!(
+                (kf[i] - kr[i]).abs() < 1e-6,
+                "K pool mismatch at {i}: fused={} ref={}",
+                kf[i],
+                kr[i]
+            );
+        }
+        for i in 0..vf.len() {
+            assert!(
+                (vf[i] - vr[i]).abs() < 1e-6,
+                "V pool mismatch at {i}: fused={} ref={}",
+                vf[i],
+                vr[i]
+            );
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_fp8_paged_memory_savings() -> Result<()> {
         let device = Device::Cpu;

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -248,6 +248,58 @@ impl PagedKvCache {
         Ok(true)
     }
 
+    /// Batched graph-slot variant of [`Self::write_token_major_native_graph_slot`].
+    ///
+    /// Writes one decode token per row into the paged K/V pool of `layer_idx`
+    /// using a `[batch]` u32 device tensor of per-row destination slot indices.
+    /// One fused CUDA kernel launch handles every row — safe under CUDA graph
+    /// capture because the only per-replay-varying input is `slots`, which the
+    /// runner refreshes via `update_cuda_scalar` outside the captured region.
+    ///
+    /// Shapes:
+    /// * `k`, `v`: `[batch, 1, num_kv_heads, head_dim]` bf16
+    /// * `slots`: `[batch]` u32 device tensor
+    ///
+    /// Returns `false` when preconditions aren't met (FP8 pool, non-bf16 K/V,
+    /// seq_len != 1, non-CUDA placement) so callers fall back to the slower
+    /// per-row path. Closes suspect 1 in
+    /// `bench-results/cuda-graph-bs2-secondary-audit.md` for `#1082`.
+    #[cfg(feature = "cuda")]
+    pub fn write_token_major_native_batch_graph_slot(
+        &self,
+        layer_idx: usize,
+        k: &Tensor,
+        v: &Tensor,
+        slots: &Tensor,
+    ) -> Result<bool> {
+        if self.fp8 || k.dtype() != DType::BF16 || v.dtype() != DType::BF16 {
+            return Ok(false);
+        }
+        // Expect [batch, 1, num_kv_heads, head_dim].
+        let (batch, seq_len, _heads, _head_dim) = k.dims4()?;
+        if seq_len != 1 {
+            return Ok(false);
+        }
+        if v.dims() != k.dims() {
+            return Ok(false);
+        }
+        if slots.dtype() != DType::U32 || slots.dims() != [batch] {
+            return Ok(false);
+        }
+        let (k_pool, v_pool) = &self.layers[layer_idx];
+        // The fused kernel writes contiguous [batch, num_kv_heads, head_dim].
+        // K/V come in as [batch, 1, kv_heads, head_dim]; collapse the seq_len=1
+        // dim before dispatching. `paged_kv_write_token_major_bf16_batch_slot`
+        // will `.contiguous()?` internally but we squeeze first so the
+        // element_count == batch * kv_heads * head_dim check is exact.
+        let k = k.squeeze(1)?;
+        let v = v.squeeze(1)?;
+        kiln_flash_attn::paged_kv_write_token_major_bf16_batch_slot(
+            k_pool, v_pool, &k, &v, slots,
+        )?;
+        Ok(true)
+    }
+
     pub fn write_token_major_native(
         &self,
         layer_idx: usize,


### PR DESCRIPTION
## Phase 5 final unblock: fused batched kv_slot writer kernel for bs>1 CUDA graphs

Closes **suspect 1** from `bench-results/cuda-graph-bs2-secondary-audit.md` — the last remaining intra-graph alloc/baked-immediate site in the `KILN_CUDA_GRAPHS_BATCHED=1` paged-decode path. Suspects 2, 3, 4 (RoPE cos/sin, attn_out, softmax_lse) already landed.

### The bug shape

The legacy per-row writer (`PagedKvCache::write_token_major_native_batch` → `paged_kv_write_token_major_bf16`) takes a **host** `usize` slot index, converts it to a `u32` immediate kernel arg, and bakes it into the captured CUDA graph node. On replay at a different decode position, the captured kernel writes into the *capture-time* slot — silent KV-cache corruption.

The bs=1 path solves this via `paged_kv_write_token_major_bf16_slot`, which takes a `[1] u32` device tensor refreshed via `update_cuda_scalar` per replay. The runner already pre-allocates `kv_slot_buffer` for the bs>1 case (`cuda_graph.rs:1512`) and threads it through `BatchedPagedDecodeGraphInputs.kv_slot` — but the consumer side was missing.

### Changes

1. **CUDA kernel** (`crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.cu` + `.h`): `kiln_paged_kv_write_token_major_bf16_batch_slot_kernel` — fused 2D-grid kernel. `blockIdx.y` indexes the batch row, `blockIdx.x` indexes the element within `(num_kv_heads × head_dim)`. Per-row destination slot is read from a `[batch]` u32 device tensor. One launch handles every row.

2. **Rust FFI wrapper** (`crates/kiln-flash-attn/src/lib.rs`): `paged_kv_write_token_major_bf16_batch_slot(k_pool, v_pool, k, v, slots)`. Validates shape/dtype, enforces contiguity, dispatches on the current CUDA stream.

3. **PagedKvCache method** (`crates/kiln-model/src/paged_kv_cache.rs`): `write_token_major_native_batch_graph_slot(layer_idx, k, v, slots)`. Mirrors the bs=1 graph-slot writer shape.

4. **Plumbing** (`crates/kiln-model/src/forward.rs`): new `kv_slot: Option<&Tensor>` parameter threaded through:
   - `gqa_attention_paged_decode_contiguous_batch`
   - `transformer_block_paged_decode_contiguous_batch`
   - `model_forward_paged_decode_contiguous_batch_hidden_inner`
   - `model_forward_paged_batched_with_graph_inputs` (consumes `graph_inputs.kv_slot`).
   
   Non-graph callers and test sites pass `None` to preserve existing behavior.

5. **Env gate**: `KILN_CUDA_GRAPHS_BATCHED_KV_FUSED=1` opt-in. Defaults off until full bs>1 graph validation closes. When set + `kv_slot` Some, the GQA function dispatches `write_token_major_native_batch_graph_slot`; otherwise falls back to the legacy per-row writer.

6. **Byte-equality test**: `test_write_token_major_native_batch_graph_slot_matches_per_row` — allocates a 4-row × 8-slot pool, writes distinct K/V into distinct slots `[1,3,5,7]` via the new fused writer, writes the same into a fresh cache via the per-row baseline, and asserts byte-level equality of K and V pool tensors. Catches off-by-row swaps and wrong-slot stomps.

### Validation

- `cargo build --release --features cuda` (full workspace) — clean on A6000 + CUDA 12.4.
- `cargo test --release --features cuda -p kiln-model --lib paged_kv_cache` — **17 passed / 0 failed** (16 pre-existing + new byte-equality test).
- `compute-sanitizer --tool memcheck` on the new kernel via the unit test binary — **0 errors**:
  ```
  test paged_kv_cache::tests::test_write_token_major_native_batch_graph_slot_matches_per_row ... ok
  test result: ok. 1 passed; 0 failed
  ========= ERROR SUMMARY: 0 errors
  ```

### What's left

End-to-end `KILN_CUDA_GRAPHS_BATCHED=1 KILN_CUDA_GRAPHS_BATCHED_KV_FUSED=1` validation against the Qwen3.5-4B server harness from `bench-results/cuda-graph-bs2-memcheck.md` (the 4-row concurrent chat completion driver under compute-sanitizer). The kernel correctness is proven; the remaining work is to land + flip the env-default once the full-stack run is clean. That is gated behind the env-flag here so this PR can land without changing default behavior.

### Commits

- `phase 5: add fused batched kv_slot writer CUDA kernel (#1082)`
- `phase 5: add Rust wrapper paged_kv_write_token_major_bf16_batch_slot (#1082)`
- `phase 5: wire bs>1 graph wrapper to fused batched kv_slot writer (#1082)`
- `phase 5: byte-equality test for batched-slot KV writer vs per-row baseline (#1082)`