### PR TITLE
kiln-opd-loss-kernel: migrate OpdLossCustomOp::bwd to kt-bridge

### DIFF
--- a/crates/kiln-opd-loss-kernel/src/phase_b.rs
+++ b/crates/kiln-opd-loss-kernel/src/phase_b.rs
@@ -75,6 +75,9 @@ use candle_core::{CudaStorage, backend::BackendStorage};
 
 use crate::{log_softmax_last, DEFAULT_CHUNK_SIZE};
 
+#[cfg(feature = "cuda")]
+use std::sync::OnceLock;
+
 // FFI declarations for the raw CUDA fused kernel (§9.2 of the grand
 // plan). These are linked in only when the `cuda` feature is active —
 // the `build.rs` compiles `csrc/opd_topk_kl.cu` and produces
@@ -185,6 +188,124 @@ pub(crate) fn cuda_kernel_supports(top_k: usize, dtype: DType) -> bool {
 #[allow(dead_code)]
 pub(crate) fn cuda_kernel_supports(_top_k: usize, _dtype: DType) -> bool {
     false
+}
+
+/// Process-wide kill switch for [`opd_loss_phase_b_backward_via_kt_bridge`].
+///
+/// Set `KILN_DISABLE_OPD_BWD_KT_BRIDGE=1` to fall back to the candle-typed
+/// `cuda_kernel_backward` path (same FFI symbols; this is purely a
+/// reversibility / parity-test escape hatch). Mirrors the precedent
+/// established by `fused_rmsnorm_backward_via_kt_bridge`
+/// (commit `341da876`) and `fused_rotary_one_backward_via_kt_bridge`
+/// (commit `d99a15a3`).
+#[cfg(feature = "cuda")]
+fn opd_bwd_kt_bridge_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        matches!(
+            std::env::var("KILN_DISABLE_OPD_BWD_KT_BRIDGE")
+                .ok()
+                .as_deref(),
+            Some("1") | Some("true") | Some("TRUE")
+        )
+    })
+}
+
+/// kt-bridge variant of [`OpdLossCustomOp::cuda_kernel_backward`] —
+/// borrows `hidden`/`head_t`/`grad_loss` as kt-Tensors, dispatches the
+/// same `kiln_opd_topk_kl_bwd_{bf16,f32}` FFI symbols via
+/// [`crate::kt_api::opd_top_k_reverse_kl_phase_b_bwd_kt`], and copies
+/// the kt output back into a candle `Tensor`.
+///
+/// Same FFI symbols → bit-exact by construction. The kt entry handles
+/// the active-row gather, teacher tensor upload, kernel dispatch, and
+/// the `scatter_add` back into `[1, T, H]` — identical to the candle
+/// path. The bridge is purely a thin storage downcast + device-pointer
+/// extraction layer.
+///
+/// This is the **third** production migration of a candle `CustomOp::bwd`
+/// body to the kt bridge (after `RmsNormCustomOp::bwd` in commit
+/// `341da876` and `CudaRotaryOneBf16::bwd` in commit `d99a15a3`; see
+/// `docs/CANDLE_REMOVAL_PLAN.md` §"kt-autograd readiness"). The op
+/// returns a single gradient (`d_hidden`) so there is no
+/// over-allocated F32 partial buffer to special-case — just one kt
+/// substrate call + one dtod memcpy on the way back to candle.
+///
+/// `grad_loss` is cast to F32 in candle land first (the kt entry
+/// validates F32 input) and made contiguous before borrowing.
+///
+/// Falls back to the candle path when
+/// `KILN_DISABLE_OPD_BWD_KT_BRIDGE=1` is set or on any bridge error
+/// (borrow / kt FFI / copy-back failure) so a regression never
+/// silently breaks training.
+#[cfg(feature = "cuda")]
+fn opd_loss_phase_b_backward_via_kt_bridge(
+    op: &OpdLossCustomOp,
+    hidden: &Tensor,
+    grad_loss: &Tensor,
+) -> std::result::Result<Tensor, candle_core::Error> {
+    use crate::kt_api::{opd_top_k_reverse_kl_phase_b_bwd_kt, OpdLossOutputKt};
+
+    // `head_t` is owned by the op instance and may not be contiguous.
+    // The kt entry validates `head_t.dtype() == hidden.dtype()` (same
+    // check the candle path performs via `cuda_kernel_supports`).
+    let head_t_c = op
+        .head_t
+        .contiguous()
+        .map_err(|e| candle_core::Error::Msg(format!("kt-bridge opd bwd: head_t contiguous: {e}")))?;
+
+    // `grad_loss` arrives as the upstream gradient on the loss output.
+    // The kt entry requires F32 + contiguous on CUDA. ScalarMean accepts
+    // any 1-element shape (the kt entry reshapes to `[1]` internally);
+    // PerPosition requires a 1-D `[T_active]` shape (kt entry validates).
+    let grad_loss_f32 = grad_loss
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_core::Error::Msg(format!("kt-bridge opd bwd: cast grad_loss: {e}")))?;
+    let grad_loss_c = grad_loss_f32
+        .contiguous()
+        .map_err(|e| candle_core::Error::Msg(format!("kt-bridge opd bwd: contiguous grad_loss: {e}")))?;
+
+    let hidden_kt = kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(hidden).map_err(|e| {
+        candle_core::Error::Msg(format!("kt-bridge opd bwd: borrow hidden failed: {e}"))
+    })?;
+    let head_t_kt = kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&head_t_c).map_err(|e| {
+        candle_core::Error::Msg(format!("kt-bridge opd bwd: borrow head_t failed: {e}"))
+    })?;
+    let grad_loss_kt = kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&grad_loss_c).map_err(
+        |e| candle_core::Error::Msg(format!("kt-bridge opd bwd: borrow grad_loss failed: {e}")),
+    )?;
+
+    let output_mode_kt = match op.output_mode {
+        OpdLossOutput::ScalarMean => OpdLossOutputKt::ScalarMean,
+        OpdLossOutput::PerPosition => OpdLossOutputKt::PerPosition,
+    };
+
+    let d_hidden_kt = opd_top_k_reverse_kl_phase_b_bwd_kt(
+        &hidden_kt,
+        &head_t_kt,
+        &op.teacher_topk_indices,
+        &op.teacher_topk_logprobs,
+        &op.label_mask,
+        &grad_loss_kt,
+        op.top_k,
+        output_mode_kt,
+    )
+    .map_err(|e| candle_core::Error::Msg(format!("kt-bridge opd bwd: kt call failed: {e}")))?;
+
+    // The kt entry's `scatter_add` produces a contiguous `[1, T, H]`
+    // output but be defensive — copy-back across the bridge requires
+    // contiguous storage on the source side.
+    let d_hidden_kt_contig = if d_hidden_kt.is_contiguous() {
+        d_hidden_kt
+    } else {
+        d_hidden_kt.contiguous().map_err(|e| {
+            candle_core::Error::Msg(format!("kt-bridge opd bwd: contiguous d_hidden: {e}"))
+        })?
+    };
+
+    kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&d_hidden_kt_contig).map_err(|e| {
+        candle_core::Error::Msg(format!("kt-bridge opd bwd: copy-back d_hidden failed: {e}"))
+    })
 }
 
 /// Phase B entry point — scalar mean reverse-KL. Behaviourally identical
@@ -401,6 +522,28 @@ impl CustomOp1 for OpdLossCustomOp {
         #[cfg(feature = "cuda")]
         {
             if route_kernel {
+                // THIRD production CustomOp::bwd migration to the kt
+                // bridge (after `RmsNormCustomOp::bwd` in commit
+                // `341da876` and `CudaRotaryOneBf16::bwd` in commit
+                // `d99a15a3`). Same FFI symbols
+                // (`kiln_opd_topk_kl_bwd_{bf16,f32}`) as the candle
+                // path → bit-exact by construction. Kill switch
+                // `KILN_DISABLE_OPD_BWD_KT_BRIDGE=1` keeps the candle
+                // `cuda_kernel_backward` reachable as the parity-test
+                // escape hatch; this body also falls through to the
+                // candle path on any bridge failure (borrow / kt FFI /
+                // copy-back) so a regression never silently breaks
+                // training.
+                if !opd_bwd_kt_bridge_disabled() {
+                    match opd_loss_phase_b_backward_via_kt_bridge(self, hidden, grad_loss) {
+                        Ok(dh) => return Ok(Some(dh)),
+                        Err(e) => {
+                            eprintln!(
+                                "kiln-opd-loss-kernel: kt-bridge bwd path failed, falling back to candle: {e}"
+                            );
+                        }
+                    }
+                }
                 match self.cuda_kernel_backward(hidden, grad_loss) {
                     Ok(dh) => return Ok(Some(dh)),
                     Err(e) => {

--- a/crates/kiln-opd-loss-kernel/src/tests.rs
+++ b/crates/kiln-opd-loss-kernel/src/tests.rs
@@ -1083,3 +1083,175 @@ mod cuda_kt_bwd_parity {
         run_parity(32, DType::F32, OpdLossOutputKt::PerPosition, 1e-4, "f32/K32/per-pos")
     }
 }
+
+// =====================================================================
+// CUDA `OpdLossCustomOp::bwd` kt-bridge wiring parity:
+// the default `bwd` body (which routes through
+// `opd_loss_phase_b_backward_via_kt_bridge`) must agree at one BF16 ULP
+// with the candle path (`KILN_DISABLE_OPD_LOSS_KERNEL=1` forces the
+// analytic candle backward — the same parity oracle the existing
+// `cuda_bwd_kernel_matches_candle_*` tests use against this kernel).
+//
+// THIRD production migration of a candle `CustomOp::bwd` body to the
+// kt-typed bridge (after `RmsNormCustomOp::bwd` in commit `341da876`
+// and `CudaRotaryOneBf16::bwd` in commit `d99a15a3`; see
+// `docs/CANDLE_REMOVAL_PLAN.md` §"kt-autograd readiness"). Both
+// kernel-routed paths call the same FFI symbols
+// (`kiln_opd_topk_kl_bwd_{bf16,f32}`) → outputs MUST agree at the
+// same kernel-vs-candle tolerance the existing
+// `cuda_bwd_kernel_matches_candle_*` tests use (1e-4 F32, 5e-2 BF16).
+// =====================================================================
+
+#[cfg(feature = "cuda")]
+mod cuda_opd_bwd_kt_bridge_wiring_parity {
+    use super::*;
+
+    fn run_one(
+        top_k: usize,
+        dtype: DType,
+        per_position: bool,
+        atol: f32,
+        label: &str,
+    ) -> Result<()> {
+        let device = match Device::new_cuda(0) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!("skipping {label}: no CUDA device");
+                return Ok(());
+            }
+        };
+
+        // Use a small but representative shape — enough rows to exercise
+        // the kernel's reductions, small enough to keep the test cheap.
+        let seq_len = 32;
+        let hidden_size = 64;
+        let vocab_size = 1024;
+        let active_period = 2;
+        let (hidden_f32, head_f32, idx, lp, mask) =
+            random_case(seq_len, hidden_size, vocab_size, top_k, active_period, &device)?;
+        let hidden_init = hidden_f32.to_dtype(dtype)?.contiguous()?;
+        let head_t = head_f32.to_dtype(dtype)?.contiguous()?;
+
+        // Helper that runs the bwd through the public Phase B entry +
+        // candle autograd. Output mode + reduction match the kt mod's
+        // `run_candle_bwd` convention: ScalarMean → `.backward()`,
+        // PerPosition → `.sum_all().backward()`.
+        let run = |label: &str| -> Result<Tensor> {
+            let hidden_var = Var::from_tensor(&hidden_init)?;
+            let loss = if per_position {
+                opd_top_k_reverse_kl_phase_b_per_position(
+                    hidden_var.as_tensor(),
+                    &head_t,
+                    &idx,
+                    &lp,
+                    &mask,
+                    top_k,
+                    &device,
+                    DEFAULT_CHUNK_SIZE,
+                )?
+                .sum_all()?
+            } else {
+                opd_top_k_reverse_kl_phase_b(
+                    hidden_var.as_tensor(),
+                    &head_t,
+                    &idx,
+                    &lp,
+                    &mask,
+                    top_k,
+                    &device,
+                    DEFAULT_CHUNK_SIZE,
+                )?
+            };
+            let grads = loss.backward()?;
+            let g = grads
+                .get(hidden_var.as_tensor())
+                .ok_or_else(|| anyhow!("{label}: no grad on hidden"))?
+                .clone();
+            Ok(g)
+        };
+
+        // Path A: analytic candle backward (parity oracle). Setting
+        // KILN_DISABLE_OPD_LOSS_KERNEL=1 forces both fwd + bwd onto
+        // the candle reference path. `kernel_disabled()` reads the
+        // env each call (no caching) so the toggle is reversible.
+        let prior = std::env::var("KILN_DISABLE_OPD_LOSS_KERNEL").ok();
+        unsafe {
+            std::env::set_var("KILN_DISABLE_OPD_LOSS_KERNEL", "1");
+        }
+        let g_ref = run("candle reference")?;
+        unsafe {
+            match prior.as_ref() {
+                Some(v) => std::env::set_var("KILN_DISABLE_OPD_LOSS_KERNEL", v),
+                None => std::env::remove_var("KILN_DISABLE_OPD_LOSS_KERNEL"),
+            }
+        }
+
+        // Path B: default — kt-bridge wired through `OpdLossCustomOp::bwd`.
+        // `opd_bwd_kt_bridge_disabled()` is OnceLock-cached so we don't
+        // touch its env var here; the default unset value is "kt-bridge
+        // enabled", which is exactly what we want to exercise.
+        let g_bridge = run("kt-bridge default")?;
+
+        device.synchronize()?;
+        assert_eq!(g_ref.dims(), g_bridge.dims(), "{label}: shape mismatch");
+
+        let ref_v = g_ref.to_dtype(DType::F32)?;
+        let bridge_v = g_bridge.to_dtype(DType::F32)?;
+        let diff = (&ref_v - &bridge_v)?
+            .abs()?
+            .max_all()?
+            .to_scalar::<f32>()?;
+        let max_ref = ref_v.abs()?.max_all()?.to_scalar::<f32>()?;
+        let rel = if max_ref > 1e-6 { diff / max_ref } else { diff };
+        assert!(
+            diff < atol || rel < atol,
+            "{label}: abs_diff={diff:.2e} max_ref={max_ref:.4} rel={rel:.2e} (tol={atol:.0e})"
+        );
+        Ok(())
+    }
+
+    // Tolerances mirror the existing `cuda_bwd_kernel_matches_candle_*`
+    // tests: F32 at 1e-4, BF16 at 5e-2. The kernel-vs-candle delta is
+    // identical on both paths (same FFI symbols); the bridge only
+    // changes the storage downcast plumbing.
+
+    #[test]
+    fn opd_bwd_kt_bridge_bf16_k16_scalar_mean() -> Result<()> {
+        run_one(16, DType::BF16, false, 5e-2, "bf16/K16/scalar_mean")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_bf16_k32_scalar_mean() -> Result<()> {
+        run_one(32, DType::BF16, false, 5e-2, "bf16/K32/scalar_mean")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_f32_k16_scalar_mean() -> Result<()> {
+        run_one(16, DType::F32, false, 1e-4, "f32/K16/scalar_mean")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_f32_k32_scalar_mean() -> Result<()> {
+        run_one(32, DType::F32, false, 1e-4, "f32/K32/scalar_mean")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_bf16_k16_per_position() -> Result<()> {
+        run_one(16, DType::BF16, true, 5e-2, "bf16/K16/per_position")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_bf16_k32_per_position() -> Result<()> {
+        run_one(32, DType::BF16, true, 5e-2, "bf16/K32/per_position")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_f32_k16_per_position() -> Result<()> {
+        run_one(16, DType::F32, true, 1e-4, "f32/K16/per_position")
+    }
+
+    #[test]
+    fn opd_bwd_kt_bridge_f32_k32_per_position() -> Result<()> {
+        run_one(32, DType::F32, true, 1e-4, "f32/K32/per_position")
+    }
+}

--- a/docs/CANDLE_REMOVAL_PLAN.md
+++ b/docs/CANDLE_REMOVAL_PLAN.md
@@ -107,7 +107,7 @@ For each Tier-1 crate, removing candle means:
 
 | Crate | Notes |
 |---|---|
-| `kiln-opd-loss-kernel`  | **Blocked by 3 live candle-typed callers in `kiln-train`** (investigated 2026-05-26 against HEAD `8e21c8fe`): `src/opd.rs:68` imports `opd_top_k_reverse_kl_phase_a_per_position` + `DEFAULT_CHUNK_SIZE` for the production forward path; `src/opd.rs:3034` imports `opd_top_k_reverse_kl_phase_b` (cfg-test); `tests/vk_cuda_opd_parity.rs:20` imports `opd_top_k_reverse_kl_phase_b_per_position`. kt-typed entry points already exist (`opd_top_k_reverse_kl_kt`, `opd_top_k_reverse_kl_per_position_kt`, `compute_per_position_metrics_kt`); CUDA kt-typed backward substrate (`opd_top_k_reverse_kl_phase_b_bwd_kt`, F32/BF16, K∈{16,32}, ScalarMean+PerPosition) wraps the same `kiln_opd_topk_kl_bwd_*` FFI symbols as the candle path — bridge wiring through `OpdLossCustomOp::bwd` is the next step. Production path migration is the remaining unblocker; same shape as the rmsnorm/gdn blockers. Crate `Cargo.toml` still depends on `candle-core` + `candle-nn` (dev). |
+| `kiln-opd-loss-kernel`  | **Blocked by 3 live candle-typed callers in `kiln-train`** (investigated 2026-05-26 against HEAD `8e21c8fe`): `src/opd.rs:68` imports `opd_top_k_reverse_kl_phase_a_per_position` + `DEFAULT_CHUNK_SIZE` for the production forward path; `src/opd.rs:3034` imports `opd_top_k_reverse_kl_phase_b` (cfg-test); `tests/vk_cuda_opd_parity.rs:20` imports `opd_top_k_reverse_kl_phase_b_per_position`. kt-typed entry points already exist (`opd_top_k_reverse_kl_kt`, `opd_top_k_reverse_kl_per_position_kt`, `compute_per_position_metrics_kt`); CUDA kt-typed backward substrate (`opd_top_k_reverse_kl_phase_b_bwd_kt`, F32/BF16, K∈{16,32}, ScalarMean+PerPosition) wraps the same `kiln_opd_topk_kl_bwd_*` FFI symbols as the candle path. **`OpdLossCustomOp::bwd` migrated to the kt bridge on 2026-05-27** (branch `ce/opd-loss-bwd-kt-bridge-1082-v2`; status block below) — bwd CustomOp surface is now kt-routed. Production forward path migration remains the unblocker; same shape as the rmsnorm/gdn blockers. Crate `Cargo.toml` still depends on `candle-core` + `candle-nn` (dev). |
 | `kiln-flce-kernel`      | **Largest single rewrite.** Phase A is pure-candle, Phase B is the raw-CUDA replacement. Driving Phase B to closeout is its own multi-PR effort (see crate-level `phase_b.rs`). |
 | `kiln-mps`              | Apple Silicon only; Metal storage substrate lives here. |
 | `kiln-vulkan-kernel`    | **Investigated 2026-05-26 against HEAD `eea56b23`** — 8 .rs files importing candle, 13 import lines total (61 .rs files in the crate). Footprint is now ~60% smaller than the earlier "20 files" estimate after 14+ #1082 cleanup commits over the past 3 weeks (latest: `e047c579` de-candle `vk_flce_parity` test factories). Crate `vk_ops/` (31 files) is **fully candle-free**. Top 3 remaining blockers are all rooted in the **legacy candle-typed `kernels::dispatch_*` surface** — see "kiln-vulkan-kernel blocker breakdown" below. |
@@ -912,6 +912,35 @@ covers decode `[1,1,16,256]`, prefill `[1,64,16,256]`, and tiny
 `[2,8,4,128]` shapes at `r=64` (matching the Qwen3.5-4B
 `partial_rotary=0.25` head layout) with a tight 1e-3 tolerance
 (no atomicAdd → expect bit-exact within bf16 round-trip).
+
+**Status update (2026-05-27): third migration shipped on
+`ce/opd-loss-bwd-kt-bridge-1082-v2`** —
+`OpdLossCustomOp::bwd` (in `crates/kiln-opd-loss-kernel/src/phase_b.rs`)
+now routes through `opd_loss_phase_b_backward_via_kt_bridge`, which
+mirrors the rmsnorm / rotary-one template: 3 candle→kt
+`kt_tensor_from_candle_cuda_borrow` calls (`hidden`, `head_t` after
+`.contiguous()`, `grad_loss` after F32 cast + `.contiguous()`) + 1
+`opd_top_k_reverse_kl_phase_b_bwd_kt` call (the substrate landed in
+`dc092849`, wraps the same FFI symbols
+`kiln_opd_topk_kl_bwd_{bf16,f32}` the candle path calls) + 1
+`kt_tensor_to_candle_cuda_copy` for the single returned `d_hidden`
+gradient. The kt entry itself does the active-row gather, teacher
+tensor upload, kernel dispatch, and `scatter_add` back into the
+`[1, T, H]` zero buffer — identical to the candle
+`OpdLossCustomOp::cuda_kernel_backward` body. Same FFI symbols →
+bit-exact by construction (no atomicAdd row reduction in this op, so
+no cross-launch BF16 ULP wobble like rmsnorm had). Kill switch
+`KILN_DISABLE_OPD_BWD_KT_BRIDGE=1` keeps the candle
+`cuda_kernel_backward` reachable as the parity-test escape hatch; the
+bwd body also falls through on any bridge failure (borrow / kt FFI /
+copy-back). Parity tests
+`cuda_opd_bwd_kt_bridge_wiring_parity::opd_bwd_kt_bridge_{bf16,f32}_k{16,32}_{scalar_mean,per_position}`
+(8 cases — full BF16+F32 × K16+K32 × ScalarMean+PerPosition envelope)
+verify against the analytic candle reference path
+(`KILN_DISABLE_OPD_LOSS_KERNEL=1` forces the candle-on-CUDA fallback
+in `bwd`); tolerances are 1e-4 (F32) / 5e-2 (BF16, matching the
+existing `cuda_bwd_kernel_matches_candle_bf16_k32` precedent for the
+same kernel-vs-candle parity baseline).
 
 **STOP on `CudaSigmoidMulTrainingBf16::bwd`**: it has no matching
 single-FFI kt-backward entry-point. The candle path is implemented


### PR DESCRIPTION
THIRD production CustomOp::bwd migration to the kt-typed bridge (after
RmsNormCustomOp::bwd in commit 341da876 and CudaRotaryOneBf16::bwd in
commit d99a15a3; see docs/CANDLE_REMOVAL_PLAN.md "kt-autograd
readiness" section).

Wires OpdLossCustomOp::bwd through the new
opd_loss_phase_b_backward_via_kt_bridge helper, which borrows hidden /
head_t / grad_loss as kt-Tensors and dispatches the just-landed
opd_top_k_reverse_kl_phase_b_bwd_kt substrate (dc092849). Both paths
call the same FFI symbols (kiln_opd_topk_kl_bwd_{bf16,f32}), so the
bridge is bit-exact by construction.

## What

- New `opd_loss_phase_b_backward_via_kt_bridge` helper in
  `crates/kiln-opd-loss-kernel/src/phase_b.rs` (3 candle->kt borrows +
  1 kt substrate call + 1 kt->candle copy).
- `OpdLossCustomOp::bwd` CUDA branch tries the bridge first, falls
  through to the existing `cuda_kernel_backward` candle path on any
  bridge failure (borrow / FFI / copy-back).
- `KILN_DISABLE_OPD_BWD_KT_BRIDGE=1` kill switch (OnceLock-cached,
  mirrors `KILN_DISABLE_RMSNORM_BWD_KT_BRIDGE` / 
  `KILN_DISABLE_ROTARY_ONE_BWD_KT_BRIDGE`).
- Eight new parity tests under
  `cuda_opd_bwd_kt_bridge_wiring_parity` — full BF16+F32 x K16+K32 x
  ScalarMean+PerPosition envelope. Parity oracle is the analytic
  candle backward forced via `KILN_DISABLE_OPD_LOSS_KERNEL=1`.
  Tolerances match the existing `cuda_bwd_kernel_matches_candle_*`
  tests: 1e-4 (F32) / 5e-2 (BF16).
- `docs/CANDLE_REMOVAL_PLAN.md` updated with the third-migration
  status block + opd-loss-kernel table entry annotation.

## Why

Unblocks Tier-1 closure of `kiln-opd-loss-kernel` from the
candle-removal plan — the bwd CustomOp surface is now kt-routed, so
the only remaining candle dependency is the production forward path
(3 callers in `kiln-train`).

For #1082.