### PR TITLE
kiln-model: migrate BackendRuntime::device() to return kt::Device (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/cpu.rs
+++ b/crates/kiln-model/src/backend/cpu.rs
@@ -9,12 +9,20 @@ use super::BackendRuntime;
 
 #[derive(Debug)]
 pub struct CpuBackend {
+    /// Original candle device the backend was constructed for. Retained
+    /// for kernel trait methods that still take `candle_core::Tensor`
+    /// parameters and may need to compare against the device.
     device: Device,
+    /// `kiln_tensor::Device` form of the same device. Returned by the
+    /// `BackendRuntime::device()` trait method. Cached at construction so
+    /// the hot accessor does not bridge on every call. (#1082)
+    device_kt: kiln_tensor::Device,
 }
 
 impl CpuBackend {
     pub fn new(device: Device) -> Self {
-        Self { device }
+        let device_kt = kiln_kt_bridge::kt_device_from_candle(&device);
+        Self { device, device_kt }
     }
 }
 
@@ -27,7 +35,7 @@ impl BackendRuntime for CpuBackend {
         }
     }
 
-    fn device(&self) -> &Device {
-        &self.device
+    fn device(&self) -> kiln_tensor::Device {
+        self.device_kt
     }
 }

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -110,7 +110,15 @@ fn cuda_optimizer_tensors_supported_for_kt(tensors: &[&Tensor]) -> bool {
 
 #[derive(Debug)]
 pub struct CudaBackend {
+    /// Original candle CUDA device. Kept alongside the kt-typed device so
+    /// the many trait methods that still consume `candle_core::Tensor`
+    /// parameters can pass through to candle without re-bridging. Phase 7
+    /// of #1082 moved the `BackendRuntime::device()` accessor to return
+    /// `kiln_tensor::Device` by value; the candle device is now internal.
     device: Device,
+    /// `kiln_tensor::Device` form of `device`, cached at construction so
+    /// the hot trait accessor does not bridge per call. (#1082)
+    device_kt: kiln_tensor::Device,
     /// Cached at construction: reading env vars per decode step × 24 GDN layers
     /// shows up in decode NVTX captures. Env vars don't change at runtime.
     gdn_enabled: bool,
@@ -220,8 +228,10 @@ impl CudaBackend {
         let lora_decode_add_enabled = std::env::var("KILN_DISABLE_CUDA_LORA_DECODE_ADD").is_err();
         let gdn_full_chunk_forward_multiblock_enabled = gdn_enabled
             && std::env::var("KILN_DISABLE_GDN_FULL_CHUNK_FORWARD_MULTIBLOCK").is_err();
+        let device_kt = kiln_kt_bridge::kt_device_from_candle(&device);
         Self {
             device,
+            device_kt,
             gdn_enabled,
             gdn_gates_enabled,
             gdn_gated_rms_norm_enabled,
@@ -254,8 +264,8 @@ impl BackendRuntime for CudaBackend {
         "cuda"
     }
 
-    fn device(&self) -> &Device {
-        &self.device
+    fn device(&self) -> kiln_tensor::Device {
+        self.device_kt
     }
 
     fn training_capabilities(&self) -> TrainingCapabilities {
@@ -1962,8 +1972,15 @@ mod tests {
     use super::*;
 
     fn test_backend() -> CudaBackend {
+        // Test mock uses a CPU candle device because the unit tests in
+        // this module only exercise the candle-typed surface; the
+        // device_kt field tracks it via the same bridge the production
+        // constructor uses. (#1082)
+        let device = Device::Cpu;
+        let device_kt = kiln_kt_bridge::kt_device_from_candle(&device);
         CudaBackend {
-            device: Device::Cpu,
+            device,
+            device_kt,
             gdn_enabled: false,
             gdn_gates_enabled: false,
             gdn_gated_rms_norm_enabled: false,

--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -116,7 +116,15 @@ impl MetalTransposedCoopGemvTile {
 
 #[derive(Debug)]
 pub struct MetalBackend {
+    /// Original candle Metal device. Retained alongside the kt-typed
+    /// device so trait methods that still consume `candle_core::Tensor`
+    /// parameters continue to dispatch through candle without bridging.
+    /// (#1082)
     device: Device,
+    /// `kiln_tensor::Device` form of `device`, cached at construction so
+    /// the `BackendRuntime::device()` accessor does not bridge per call.
+    /// (#1082)
+    device_kt: kiln_tensor::Device,
     /// Cached at construction to keep env-var reads off per-token support gates.
     disable: MetalKernelDisables,
 }
@@ -155,8 +163,10 @@ impl MetalBackend {
             matches!(device, Device::Metal(_)),
             "MetalBackend created on non-Metal device"
         );
+        let device_kt = kiln_kt_bridge::kt_device_from_candle(&device);
         Self {
             device,
+            device_kt,
             disable: MetalKernelDisables::from_env(),
         }
     }
@@ -258,8 +268,8 @@ impl BackendRuntime for MetalBackend {
         "metal"
     }
 
-    fn device(&self) -> &Device {
-        &self.device
+    fn device(&self) -> kiln_tensor::Device {
+        self.device_kt
     }
 
     fn supports_flash_attn_prefill(&self) -> bool {

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -116,9 +116,17 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
     /// `/health` and logs.
     fn name(&self) -> &'static str;
 
-    /// The candle `Device` this backend drives. All tensors passed to trait
-    /// methods must live on this device.
-    fn device(&self) -> &Device;
+    /// The `kiln_tensor::Device` this backend drives. All tensors passed to
+    /// trait methods must live on this device.
+    ///
+    /// Returned by value: `kiln_tensor::Device` is `Copy` and small (one
+    /// discriminant + a `usize` index). Phase 7 of #1082 migrated the
+    /// return type off `&candle_core::Device` so backend selection no
+    /// longer threads candle types through every trait method. Backends
+    /// that still need a candle `Device` internally (e.g. for the kernel
+    /// trait methods that take `candle_core::Tensor` parameters) keep a
+    /// candle device cached alongside the kt one and bridge as needed.
+    fn device(&self) -> kiln_tensor::Device;
 
     /// `dyn Any` downcast target. Used by the Vulkan-resident decode
     /// fast-path in `transformer_block_paged_with_rope_tables` to recover
@@ -1317,6 +1325,29 @@ mod tests {
             !cuda.supports_resident_decode(),
             "CUDA backend must decline resident decode; gate (c) requires CUDA path unchanged"
         );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cuda_backend_device_accessor_returns_kt() {
+        // #1082 Phase 7: BackendRuntime::device() returns kt::Device by
+        // value. The CUDA backend must round-trip the cuda(i) device
+        // identity through the kt enum without losing the index.
+        let device = match Device::new_cuda(0) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        let cuda = cuda::CudaBackend::new(device);
+        assert_eq!(cuda.device(), kiln_tensor::Device::Cuda(0));
+    }
+
+    #[test]
+    fn cpu_backend_device_accessor_returns_kt() {
+        // Mirrors the CUDA assertion above for the always-available CPU
+        // path. Confirms the trait surface stayed kt-typed even on the
+        // portable fallback. (#1082)
+        let cpu = cpu::CpuBackend::new(Device::Cpu);
+        assert_eq!(cpu.device(), kiln_tensor::Device::Cpu);
     }
 
     #[cfg(feature = "vulkan")]

--- a/crates/kiln-model/src/backend/vulkan.rs
+++ b/crates/kiln-model/src/backend/vulkan.rs
@@ -24,7 +24,18 @@ use crate::forward::{GpuAttentionWeights, GpuWeights};
 /// FlashAttention-2, Gated DeltaNet, and supporting operations.
 #[derive(Debug)]
 pub struct VulkanBackend {
+    /// Candle device the backend was constructed with — always `Device::Cpu`
+    /// today because candle-core has no native Vulkan device. Retained for
+    /// the kernel trait methods that still consume `candle_core::Tensor`
+    /// parameters (they live on this candle CPU device until kt-typed
+    /// siblings land). (#1082)
     device: Device,
+    /// `kiln_tensor::Device` form advertised by `BackendRuntime::device()`.
+    /// `kt::Device::Vulkan(0)` when the Vulkan logical device is up;
+    /// `kt::Device::Cpu` otherwise, matching the CPU-fallback advertised
+    /// by `name()` when `vulkan_device` is `None`. Cached at construction
+    /// so the hot trait accessor does not bridge per call. (#1082)
+    device_kt: kiln_tensor::Device,
     /// Cached at construction: reading env vars per decode step × 24 GDN layers
     /// shows up in decode NVTX captures. Env vars don't change at runtime.
     gdn_enabled: bool,
@@ -345,8 +356,21 @@ impl VulkanBackend {
             }
         };
 
+        // Advertise `kt::Device::Vulkan(0)` when the logical device is up,
+        // matching what `for_device_kt` callers would have constructed.
+        // When the device failed to come up we still need a sensible kt
+        // identity for the BackendRuntime accessor; the CPU fallback path
+        // returns `kt::Device::Cpu` so trait callers consistently see "no
+        // Vulkan" without a separate predicate. (#1082)
+        let device_kt = if vulkan_device.is_some() {
+            kiln_tensor::Device::Vulkan(0)
+        } else {
+            kiln_kt_bridge::kt_device_from_candle(&device)
+        };
+
         Self {
             device,
+            device_kt,
             gdn_enabled,
             gdn_prefill_in_proj_enabled,
             gdn_gates_enabled,
@@ -1010,8 +1034,8 @@ impl BackendRuntime for VulkanBackend {
         if self.has_vulkan() { "vulkan" } else { "cpu" }
     }
 
-    fn device(&self) -> &Device {
-        &self.device
+    fn device(&self) -> kiln_tensor::Device {
+        self.device_kt
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -24623,8 +24623,13 @@ mod tests {
             "fixed-linear-test"
         }
 
-        fn device(&self) -> &Device {
-            &self.device
+        fn device(&self) -> kiln_tensor::Device {
+            // Test mock — synthesizes kt identity from the candle device
+            // held in the struct. Production backends cache this; the
+            // test path bridges per call because the struct existed
+            // before the kt accessor and a field add would churn many
+            // setups. (#1082)
+            kiln_kt_bridge::kt_device_from_candle(&self.device)
         }
 
         fn linear_decode(&self, _x: &Tensor, _weight_t: &Tensor) -> Result<Option<Tensor>> {
@@ -24652,8 +24657,8 @@ mod tests {
             "fixed-mlp-test"
         }
 
-        fn device(&self) -> &Device {
-            &self.device
+        fn device(&self) -> kiln_tensor::Device {
+            kiln_kt_bridge::kt_device_from_candle(&self.device)
         }
 
         fn mlp_decode(

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -2221,15 +2221,15 @@ impl ModelRunner {
         );
 
         let use_greedy_prefill_token = params.is_effectively_greedy()
-            && matches!(self.backend.device(), candle_core::Device::Metal(_))
-            && !streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len());
+            && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
+            && !streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prefill_tokens.len());
         let split_pos =
             strict_prompt_prefix_split_pos(prompt_tokens.len(), cached_tokens, block_size);
         let mut prefill_split_snapshot: Option<RollingPrefixSnapshot> = None;
         let prefill_start = std::time::Instant::now();
         let prefill_source = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prefill_tokens.len()) {
                 if let Some(split_pos) = split_pos {
                     let head_tokens = &prompt_tokens[cached_tokens..split_pos];
                     let _ = model_forward_paged_streaming_with_progress(
@@ -2454,7 +2454,7 @@ impl ModelRunner {
         let prefill_start = std::time::Instant::now();
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prefill_tokens.len()) {
                 if let Some(split_pos) = split_pos {
                     let head_tokens = &prompt_tokens[cached_tokens..split_pos];
                     let _ = model_forward_paged_streaming_with_progress(
@@ -3351,7 +3351,7 @@ impl ModelRunner {
         let _skip_scope =
             crate::forward::VulkanSkipGdnStateReadbackScope::new(skip_gdn_state_readback);
         if params.is_effectively_greedy()
-            && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
         {
             let pc_guard = lock_paged_cache(paged_cache)?;
             let token = model_forward_paged_next_token_greedy(
@@ -3518,7 +3518,7 @@ impl ModelRunner {
 
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming_with_progress(
                     &*self.backend,
                     prompt_tokens,
@@ -3650,7 +3650,7 @@ impl ModelRunner {
         // before the decode loop starts. The decode loop then re-acquires the
         // cache per step.
         let streaming_prefill =
-            streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len());
+            streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len());
         let prefill_source = {
             let pc_guard = lock_paged_cache(paged_cache)?;
             if streaming_prefill {
@@ -3669,7 +3669,7 @@ impl ModelRunner {
                     .context("prefill forward pass (paged, streaming) failed")?,
                 )
             } else if params.is_effectively_greedy()
-                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+                && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
             {
                 PrefillSampleSource::GreedyToken(
                     model_forward_paged_last_token_greedy(
@@ -3762,7 +3762,7 @@ impl ModelRunner {
             }
 
             next_token = if params.is_effectively_greedy()
-                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+                && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
             {
                 // Metal greedy path bypasses the CUDA graph runner entirely.
                 let pc_guard = lock_paged_cache(paged_cache)?;
@@ -3829,7 +3829,7 @@ impl ModelRunner {
 
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -4012,7 +4012,7 @@ impl ModelRunner {
         // Long Metal prompts use tiled streaming prefill by default; env
         // overrides can force either path.
         let streaming_prefill =
-            streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len());
+            streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len());
         let prefill_source = if streaming_prefill {
             PrefillSampleSource::Logits(
                 model_forward_paged_streaming(
@@ -4029,7 +4029,7 @@ impl ModelRunner {
                 .context("prefill forward pass (paged, streaming) failed")?,
             )
         } else if params.is_effectively_greedy()
-            && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
         {
             PrefillSampleSource::GreedyToken(
                 model_forward_paged_last_token_greedy(
@@ -4127,7 +4127,7 @@ impl ModelRunner {
             }
 
             next_token = if params.is_effectively_greedy()
-                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+                && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
             {
                 let token = model_forward_paged_next_token_greedy(
                     &*self.backend,
@@ -4505,7 +4505,7 @@ impl ModelRunner {
         // Prefill: feed the prompt through the base model and capture the
         // post-final-norm last hidden row as the seed `h_prev`.
         let (prefill_logits, mut h_prev) =
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming_last_token_with_last_hidden(
                     &*self.backend,
                     prompt_tokens,
@@ -4952,7 +4952,7 @@ impl ModelRunner {
         let mut linear_state = self.new_linear_state()?;
 
         let (prefill_logits, mut h_prev) =
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming_last_token_with_last_hidden(
                     &*self.backend,
                     &prompt_tokens,
@@ -5226,7 +5226,7 @@ impl ModelRunner {
             let mut linear_state = runner_guard.new_linear_state()?;
             let logits = {
                 let pc_guard = lock_paged_cache(paged_cache.as_ref())?;
-                if streaming_prefill_enabled_for(runner_guard.backend.device(), prompt_tokens.len())
+                if streaming_prefill_enabled_for(runner_guard.weights.embed_tokens.device(), prompt_tokens.len())
                 {
                     model_forward_paged_streaming(
                         &*runner_guard.backend,
@@ -5451,7 +5451,7 @@ impl ModelRunner {
                     let logits = {
                         let pc_guard = lock_paged_cache(paged_cache.as_ref())?;
                         if streaming_prefill_enabled_for(
-                            runner_guard.backend.device(),
+                            runner_guard.weights.embed_tokens.device(),
                             prompt_tokens.len(),
                         ) {
                             if let Some(split_pos) = split_pos {
@@ -5841,7 +5841,7 @@ impl ModelRunner {
         let mut prefill_split_snapshot: Option<RollingPrefixSnapshot> = None;
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 if let Some(split_pos) = split_pos {
                     let head_tokens = &prompt_tokens[cached_tokens..split_pos];
                     let _ = model_forward_paged_streaming(
@@ -5957,7 +5957,7 @@ impl ModelRunner {
 
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -6113,7 +6113,7 @@ impl ModelRunner {
 
         let logits = {
             let pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -6311,7 +6311,7 @@ impl ModelRunner {
         // Prefill. Long Metal prompts use tiled streaming prefill by default;
         // env overrides can force either path.
         let prefill_result =
-            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+            if streaming_prefill_enabled_for(self.weights.embed_tokens.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     &prompt_tokens,
@@ -6414,7 +6414,7 @@ impl ModelRunner {
             }
 
             next_token = if params.is_effectively_greedy()
-                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+                && matches!(self.backend.device(), kiln_tensor::Device::Metal(_))
             {
                 let token = match model_forward_paged_next_token_greedy(
                     &*self.backend,

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -12895,8 +12895,17 @@ mod tests {
             self.name
         }
 
-        fn device(&self) -> &Device {
-            &self.device
+        fn device(&self) -> kiln_tensor::Device {
+            // Test mock always constructs with `Device::Cpu` via
+            // `NamedTestBackend::runtime`, so the kt identity is the
+            // CPU variant. Avoiding the `kiln_kt_bridge` crate keeps
+            // the dep edge to `kiln-train` unchanged for this trait
+            // signature migration. (#1082)
+            debug_assert!(
+                matches!(self.device, Device::Cpu),
+                "NamedTestBackend mock only constructs with Device::Cpu"
+            );
+            kiln_tensor::Device::Cpu
         }
     }
 


### PR DESCRIPTION
Phase 7 of #1082 — Candle removal from `kiln-model`'s backend abstraction. `BackendRuntime::device()` now returns `kiln_tensor::Device` by value instead of `&candle_core::Device`. This drops one of the most-trafficked candle types from the trait seam: every concrete backend selection path through `for_device(_kt)` and every dispatcher inside `forward.rs` / `generate.rs` previously flowed a candle `Device` through the trait surface.

## Trait change

```diff
 pub trait BackendRuntime {
-    fn device(&self) -> &candle_core::Device;
+    fn device(&self) -> kiln_tensor::Device;
 }
```

Returned by value because `kt::Device` is `Copy` and small (one discriminant + a `usize` index).

## Backend implementations

Each concrete backend (`CpuBackend` / `CudaBackend` / `MetalBackend` / `VulkanBackend`) gains a `device_kt: kiln_tensor::Device` field cached at construction so the hot accessor does not bridge per call. The candle `Device` stays alongside as `device` because the rest of the trait surface still consumes `candle_core::Tensor` parameters — only the `device()` getter is migrated in this commit (per Tier-3 incremental policy).

`VulkanBackend` advertises `kt::Device::Vulkan(0)` when the logical device is up and `kt::Device::Cpu` when it falls back, matching the existing `name()` `"vulkan"`/`"cpu"` split. This is the first kt-typed identity for the Vulkan-active sentinel pattern previously carried only through `mark_vulkan_active()`.

## Call-site sweep (kiln-model)

`generate.rs` — 22 `self.backend.device()` consumers updated:
- 7 `matches!(_, candle_core::Device::Metal(_))` predicates → `matches!(_, kiln_tensor::Device::Metal(_))`.
- 15 `streaming_prefill_enabled_for(_, _)` calls migrated to use `self.weights.embed_tokens.device()` (a candle `&Device` directly off the embedding tensor). `streaming_prefill_enabled_for`'s candle-typed signature is unchanged because it is also called from `kiln-train` where the candle device is already in scope.

`forward.rs` — two `#[cfg(test)]` mock backends (`FixedLinearBackend`, `FixedMlpBackend`) updated to the kt-typed accessor; they bridge per call via `kiln_kt_bridge::kt_device_from_candle` so the test struct shape stays unchanged.

## Call-site sweep (kiln-train, unavoidable)

`trainer.rs` — the `NamedTestBackend` mock under `#[cfg(test)]` updated to the kt-typed accessor. The mock always constructs with `Device::Cpu`, so it returns `kiln_tensor::Device::Cpu` directly (no `kiln_kt_bridge` dep edge added to `kiln-train`).

## Tests added

Two regression tests in `backend/mod.rs`:
- `cuda_backend_device_accessor_returns_kt` — round-trips `Device::new_cuda(0)` through `CudaBackend::new` → `device()` and asserts the returned kt value is `Cuda(0)`.
- `cpu_backend_device_accessor_returns_kt` — same shape for the CPU path on the always-available backend.

## Factory functions

`for_device(&candle::Device)` and `for_device_kt(&kt::Device)` retain their candle-typed and kt-typed signatures respectively — many `kiln-train` test sites still construct backends from candle devices, so the factory edge stays dual-typed in this commit.

## Verification

- `cargo check --release --workspace --features cuda` ✅ clean (0 errors) on RTX A6000
- `cargo check --release -p kiln-model -p kiln-train -p kiln-server --features cuda --tests` ✅ clean

## Test plan

- [ ] `cargo check --release --workspace --features cuda` on a CUDA host
- [ ] `cargo nextest run --release -p kiln-model --features cuda backend::tests` (the two new tests)
- [ ] Spot smoke: `kiln-bench --paged --prompt-tokens 64 --max-output-tokens 8` to confirm decode dispatch through the kt-typed accessor is bit-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)