### PR TITLE
kiln-model: metal.rs — migrate mlp family (7 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -7137,13 +7137,29 @@ pub(crate) fn metal_mlp_gate_up_bf16(x: &candle_core::Tensor, gate_t: &candle_co
             _ => anyhow::bail!("metal mlp gate/up out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let gate_buf =
-            buffer_o(gate_metal.buffer(), &gate_layout, gate_t.dtype());
-        let up_buf =
-            buffer_o(up_metal.buffer(), &up_layout, up_t.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        // #1082 Step 4 mlp-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let gate_buf = buffer_o_kt(
+            gate_metal.buffer(),
+            &kt_layout_from_candle(gate_layout),
+            kt_dtype_from_candle(gate_t.dtype()),
+        );
+        let up_buf = buffer_o_kt(
+            up_metal.buffer(),
+            &kt_layout_from_candle(up_layout),
+            kt_dtype_from_candle(up_t.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(gate_buf.buffer), gate_buf.offset_in_bytes);
@@ -7262,12 +7278,24 @@ pub(crate) fn metal_mlp_silu_mul_bf16(gate: &candle_core::Tensor, up: &candle_co
             _ => anyhow::bail!("metal mlp silu*mul out must be on Metal"),
         };
 
-        let gate_buf =
-            buffer_o(gate_metal.buffer(), &gate_layout, gate.dtype());
-        let up_buf =
-            buffer_o(up_metal.buffer(), &up_layout, up.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        // #1082 Step 4 mlp-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let gate_buf = buffer_o_kt(
+            gate_metal.buffer(),
+            &kt_layout_from_candle(gate_layout),
+            kt_dtype_from_candle(gate.dtype()),
+        );
+        let up_buf = buffer_o_kt(
+            up_metal.buffer(),
+            &kt_layout_from_candle(up_layout),
+            kt_dtype_from_candle(up.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(gate_buf.buffer), gate_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(up_buf.buffer), up_buf.offset_in_bytes);


### PR DESCRIPTION
## Summary

Step 4 of the metal_types -> objc2-metal swap plan
(`docs/metal-types-objc2-swap-plan-2026-05-28.md`), second helper-family
slice. Migrates the 7 `buffer_o` call sites inside the mlp data-path
functions to the kt-typed `buffer_o_kt` substrate added in commit
`e82c3017`. Follows the rotary_embedding precedent from #1393 (commit
`5a9b4eb1`).

## Family scope

| Function | Sites |
|---|---|
| `metal_mlp_gate_up_bf16` | 4 (x, gate, up, out) |
| `metal_mlp_silu_mul_bf16` | 3 (gate, up, out) |
| **Total** | **7** |

These are the only two `pub(crate) fn metal_mlp_*` data-path functions
in `kiln-model::backend::metal`; the seven `*_disabled()` env-flag
helpers and three `*_pipeline` builders touch no buffer state. The
intermediate row-group fusion variants (gate_up_pair/triple/quad,
serial_vector_load, serial_dedicated) are inlined inside
`metal_mlp_gate_up_bf16`'s pipeline-selection branch and share the
same 4-buffer call site, so all permutations are covered by the
single set of conversions above.

## Local conversion helpers

Both `kt_layout_from_candle` and `kt_dtype_from_candle` are already
present at the top of `metal.rs` (introduced in #1393 / commit
`5a9b4eb1`). This PR adds zero new helpers — every site uses the same
per-call-site bridging pattern.

## Behavior

`buffer_o_kt` computes `start_offset() * size_in_bytes()` on the kt
types — bit-identical to `buffer_o`'s candle-side computation. The
MSL kernel dispatch downstream is unchanged (`set_buffer(idx, buf,
offset_in_bytes)` accepts the same byte offset regardless of which
Layout/DType type produced it). No runtime behavior change.

## Validation

- `cargo check -p kiln-model` (default features) passes on the agent
  host (3m 00s, single pre-existing unused-variable warning on
  `forward.rs:18203` unrelated to this PR).
- `--features metal` requires Apple Silicon for toolchain reasons
  (objc2 has a `compile_error!` on non-Apple targets); the
  macos-metal CI job at `.github/workflows/ci.yml:25-72` covers that
  path on `macos-14`.
- Pod pool was at capacity at PR time (`metal-lm-head-family-1082`
  and `grpo-bridge-wrap-1082` holding both warm A6000s, third pod
  hibernated and unable to wake due to upstream RunPod capacity
  exhaustion); falling back to PR + CI gates per kiln skill guidance.

## Test plan

- [ ] CI `ci.yml` (Linux + macOS-metal build/test) passes
- [ ] Auto-merge triggers after green checks

## Scope

Single file `crates/kiln-model/src/backend/metal.rs`, +41 / -13. No
`Storage::Metal(s) => s` downcasts changed. No `metal_types.rs`
touched. No helpers added — reuses existing `kt_layout_from_candle` /
`kt_dtype_from_candle` from #1393.

Refs #1082.