### PR TITLE
kiln-model: metal.rs — migrate lm_head family (13 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -6693,11 +6693,24 @@ pub(crate) fn metal_lm_head_bf16(x: &candle_core::Tensor, weight_t: &candle_core
             _ => anyhow::bail!("metal lm head out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &o_layout, out.dtype());
+        // #1082 Step 4 lm_head-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight_t.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(o_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
@@ -6784,21 +6797,35 @@ pub(crate) fn metal_lm_head_argmax_bf16(x: &candle_core::Tensor, weight_t: &cand
             None => None,
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
-        let ps_buf = buffer_o(
-            ps_metal.buffer(),
-            &ps_layout,
-            partial_scores.dtype(),
+        // #1082 Step 4 lm_head-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
         );
-        let pi_buf = buffer_o(
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight_t.dtype()),
+        );
+        let ps_buf = buffer_o_kt(
+            ps_metal.buffer(),
+            &kt_layout_from_candle(ps_layout),
+            kt_dtype_from_candle(partial_scores.dtype()),
+        );
+        let pi_buf = buffer_o_kt(
             pi_metal.buffer(),
-            &pi_layout,
-            partial_indices.dtype(),
+            &kt_layout_from_candle(pi_layout),
+            kt_dtype_from_candle(partial_indices.dtype()),
         );
         let final_buf = final_metal.map(|(storage, layout)| {
-            buffer_o(storage.buffer(), layout, candle_core::DType::F32)
+            buffer_o_kt(
+                storage.buffer(),
+                &kt_layout_from_candle(layout),
+                kt_dtype_from_candle(candle_core::DType::F32),
+            )
         });
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
@@ -6940,21 +6967,35 @@ pub(crate) fn metal_lm_head_argmax_rows_bf16(x: &candle_core::Tensor, weight_t: 
             None => None,
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
-        let ps_buf = buffer_o(
-            ps_metal.buffer(),
-            &ps_layout,
-            partial_scores.dtype(),
+        // #1082 Step 4 lm_head-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
         );
-        let pi_buf = buffer_o(
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight_t.dtype()),
+        );
+        let ps_buf = buffer_o_kt(
+            ps_metal.buffer(),
+            &kt_layout_from_candle(ps_layout),
+            kt_dtype_from_candle(partial_scores.dtype()),
+        );
+        let pi_buf = buffer_o_kt(
             pi_metal.buffer(),
-            &pi_layout,
-            partial_indices.dtype(),
+            &kt_layout_from_candle(pi_layout),
+            kt_dtype_from_candle(partial_indices.dtype()),
         );
         let final_buf = final_metal.map(|(storage, layout)| {
-            buffer_o(storage.buffer(), layout, candle_core::DType::F32)
+            buffer_o_kt(
+                storage.buffer(),
+                &kt_layout_from_candle(layout),
+                kt_dtype_from_candle(candle_core::DType::F32),
+            )
         });
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);


### PR DESCRIPTION
Step 4 of the metal_types -> objc2-metal swap plan
(`docs/metal-types-objc2-swap-plan-2026-05-28.md`), second helper-family
slice (lm_head). Migrates the 13 `buffer_o` call sites across three
lm_head functions to the kt-typed `buffer_o_kt` substrate added in
commit `e82c3017`. Follows the rotary_embedding migration pattern from
PR #1393 / commit `5a9b4eb1`.

## Sites migrated

| Function | Sites |
| --- | --- |
| `metal_lm_head_bf16` | 3 (x_buf, w_buf, out_buf) |
| `metal_lm_head_argmax_bf16` | 5 (x_buf, w_buf, ps_buf, pi_buf, final_buf) |
| `metal_lm_head_argmax_rows_bf16` | 5 (x_buf, w_buf, ps_buf, pi_buf, final_buf) |
| **Total** | **13** |

These three functions cover the full lm_head fan-out in the BF16
forward path: the materialized-logits variant (`metal_lm_head_bf16`),
the single-token argmax fast path (`metal_lm_head_argmax_bf16`), and
the batched per-row argmax variant (`metal_lm_head_argmax_rows_bf16`).
Together they consume the hidden-state activation `x`, the LM-head
weight transpose `weight_t`, and produce either logits or token-id
outputs. The 13-site count matches the swap plan's per-family estimate
exactly.

## Local conversion helpers

The two private helpers added in PR #1393
(`kt_layout_from_candle`, `kt_dtype_from_candle`) at the top of
`metal.rs` already do the candle->kt bridging. This PR reuses them
verbatim — no new helpers, no changes to the import block, no changes
to `kiln-tensor::metal_types`.

## Behavior

`buffer_o_kt` computes `start_offset() * size_in_bytes()` on the kt
types — bit-identical to `buffer_o`'s candle-side computation. The MSL
kernel dispatch downstream is unchanged
(`set_buffer(idx, buf, offset_in_bytes)` accepts the same byte offset
regardless of which Layout/DType type produced it). No runtime
behavior change. The `partial_scores.dtype()` / `partial_indices.dtype()`
arguments to `buffer_o_kt` are F32 in practice (the kernels store
scores+indices as F32 per-chunk), so the `kt_dtype_from_candle`
conversion stays on the F32 arm — identical byte-size math to the
original `buffer_o` path.

## Validation

`cargo check -p kiln-model` (default features) passes on the agent
host (1m11s). `--features metal` requires Apple Silicon for toolchain
reasons (objc2 has a `compile_error!` on non-Apple targets); the
macos-metal CI job at `.github/workflows/ci.yml:25-72` covers that
path on `macos-14`. Wave 13 substrate PRs (#dc8a57e5 etc.) and the
rotary_embedding migration (#1393) used the same validation pattern.
A6000 capacity was exhausted at PR-creation time; per
`runpod-capacity-fallback` the macOS Metal CI is the authoritative
validator for these substrate swaps.

## Touch scope

Single file `crates/kiln-model/src/backend/metal.rs`, +66 / -25. No
`Storage::Metal(s) => s` downcasts changed — those are bundled
separately per the plan. No `metal_types.rs` touched. No helper
functions added or removed; the two helpers from #1393 are reused.

Refs #1082.