### PR TITLE
kiln-model: metal.rs — migrate conv1d family (8 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -13892,12 +13892,29 @@ fn metal_causal_conv1d_prefill_bf16_f32_k4(
             _ => anyhow::bail!("metal conv1d prefill output must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
-        let s_buf =
-            buffer_o(s_metal.buffer(), &s_layout, conv_state.dtype());
-        let o_buf = buffer_o(o_metal.buffer(), &o_layout, out.dtype());
+        // #1082 Step 4 conv1d-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight.dtype()),
+        );
+        let s_buf = buffer_o_kt(
+            s_metal.buffer(),
+            &kt_layout_from_candle(s_layout),
+            kt_dtype_from_candle(conv_state.dtype()),
+        );
+        let o_buf = buffer_o_kt(
+            o_metal.buffer(),
+            &kt_layout_from_candle(o_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
@@ -13984,12 +14001,29 @@ fn metal_causal_conv1d_update_bf16_f32_k4(
             _ => anyhow::bail!("metal conv1d update output must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
-        let s_buf =
-            buffer_o(s_metal.buffer(), &s_layout, conv_state.dtype());
-        let o_buf = buffer_o(o_metal.buffer(), &o_layout, out.dtype());
+        // #1082 Step 4 conv1d-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight.dtype()),
+        );
+        let s_buf = buffer_o_kt(
+            s_metal.buffer(),
+            &kt_layout_from_candle(s_layout),
+            kt_dtype_from_candle(conv_state.dtype()),
+        );
+        let o_buf = buffer_o_kt(
+            o_metal.buffer(),
+            &kt_layout_from_candle(o_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);


### PR DESCRIPTION
## What

Step 4 of the metal_types -> objc2-metal swap plan (docs/metal-types-objc2-swap-plan-2026-05-28.md), fourth helper-family slice. Migrates the 8 `buffer_o` call sites inside the pure conv1d data-path functions to the kt-typed `buffer_o_kt` substrate added in commit e82c3017.

Follows the rotary_embedding / lm_head / rmsnorm / mlp precedents (PRs #1393, #1395, #1396, #1394).

## Family scope

| Function | Sites |
|---|---|
| `metal_causal_conv1d_prefill_bf16_f32_k4` | 4 (x, w, s, o) |
| `metal_causal_conv1d_update_bf16_f32_k4` | 4 (x, w, s, o) |

These are the two pure `metal_causal_conv1d_*` data-path functions in `kiln-model::backend::metal`; the two `*_pipeline` builders (lines 13580, 13630) and two `*_supports` env-flag helpers touch no buffer state.

The gdn-fused conv variants (`metal_gdn_prefill_qkv_conv_split_*` and `metal_gdn_decode_qkv_conv_norm_*`) are explicitly out of scope — they belong to the gdn-family slice handled by a parallel agent.

## Why

Continues the metal_types -> objc2-metal swap by migrating another self-contained helper family from candle `Layout`/`DType` to kt `Layout`/`DType` at the buffer-offset boundary. Bit-identical behavior; sets up the eventual candle-core dep removal.

## Behavior

`buffer_o_kt` computes `start_offset() * size_in_bytes()` on the kt types — bit-identical to `buffer_o`'s candle-side computation. The MSL kernel dispatch downstream is unchanged (`set_buffer(idx, buf, offset_in_bytes)` accepts the same byte offset regardless of which Layout/DType type produced it). No runtime behavior change.

## Local conversion helpers

Both `kt_layout_from_candle` and `kt_dtype_from_candle` are already present at the top of `metal.rs` (introduced in PR #1393 / commit 5a9b4eb1). This PR adds zero new helpers — every site uses the same per-call-site bridging pattern.

## Validation

- `cargo check -p kiln-model` (default features): passes on the agent host (~10s, single pre-existing unused-variable warning on `forward.rs:18203` unrelated to this PR).
- `--features metal`: requires Apple Silicon for toolchain reasons (objc2 has a `compile_error!` on non-Apple targets); the macos-metal CI job at `.github/workflows/ci.yml:25-72` covers that path on `macos-14`.
- `--features cuda`: CUDA toolchain not available on the agent host; covered by sibling slices' parity coverage.

Pod pool was at capacity at PR time (1 leased A6000 holding grpo-bridge-wrap-1082 + 1 hibernated, RunPod upstream reporting `There are no longer any instances available with the requested specifications` on A6000 spec); falling back to PR + CI gates per kiln skill guidance.

## Touch scope

Single file `crates/kiln-model/src/backend/metal.rs`, +46 / -12. No `Storage::Metal(s) => s` downcasts changed. No `metal_types.rs` touched. No helpers added — reuses existing `kt_layout_from_candle` / `kt_dtype_from_candle`.

Refs #1082.