### PR TITLE
kiln-model: metal.rs — migrate gemv/matmul family (13 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -7582,11 +7582,24 @@ fn metal_transposed_coop_gemv_bf16_with_tile(
             _ => anyhow::bail!("metal transposed coop GEMV out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &o_layout, out.dtype());
+        // #1082 Step 5 gemv/matmul-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight_t.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(o_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
@@ -7683,11 +7696,24 @@ fn metal_transposed_coop_gemv_batch_bf16(x: &candle_core::Tensor, weight_t: &can
             _ => anyhow::bail!("metal batch transposed coop GEMV out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &o_layout, out.dtype());
+        // #1082 Step 5 gemv/matmul-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight_t.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(o_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
@@ -7833,24 +7859,43 @@ pub(crate) fn metal_fused_qkv_transposed_coop_gemv_bf16(
             _ => anyhow::bail!("metal fused QKV projection v_out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let q_buf = buffer_o(q_metal.buffer(), &q_layout, q_t.dtype());
-        let k_buf = buffer_o(k_metal.buffer(), &k_layout, k_t.dtype());
-        let v_buf = buffer_o(v_metal.buffer(), &v_layout, v_t.dtype());
-        let q_out_buf = buffer_o(
+        // #1082 Step 5 gemv/matmul-family: `buffer_o` → `buffer_o_kt`.
+        // The kt-typed helper reads `start_offset()` + `size_in_bytes()`
+        // off the kt Layout/DType; everything else is bit-identical.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(x.dtype()),
+        );
+        let q_buf = buffer_o_kt(
+            q_metal.buffer(),
+            &kt_layout_from_candle(q_layout),
+            kt_dtype_from_candle(q_t.dtype()),
+        );
+        let k_buf = buffer_o_kt(
+            k_metal.buffer(),
+            &kt_layout_from_candle(k_layout),
+            kt_dtype_from_candle(k_t.dtype()),
+        );
+        let v_buf = buffer_o_kt(
+            v_metal.buffer(),
+            &kt_layout_from_candle(v_layout),
+            kt_dtype_from_candle(v_t.dtype()),
+        );
+        let q_out_buf = buffer_o_kt(
             q_out_metal.buffer(),
-            &q_out_layout,
-            q_out.dtype(),
+            &kt_layout_from_candle(q_out_layout),
+            kt_dtype_from_candle(q_out.dtype()),
         );
-        let k_out_buf = buffer_o(
+        let k_out_buf = buffer_o_kt(
             k_out_metal.buffer(),
-            &k_out_layout,
-            k_out.dtype(),
+            &kt_layout_from_candle(k_out_layout),
+            kt_dtype_from_candle(k_out.dtype()),
         );
-        let v_out_buf = buffer_o(
+        let v_out_buf = buffer_o_kt(
             v_out_metal.buffer(),
-            &v_out_layout,
-            v_out.dtype(),
+            &kt_layout_from_candle(v_out_layout),
+            kt_dtype_from_candle(v_out.dtype()),
         );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);


### PR DESCRIPTION
## Summary

Step 5 of the metal_types → objc2-metal swap plan
(docs/metal-types-objc2-swap-plan-2026-05-28.md), fifth helper-family
slice. Migrates the 13 `buffer_o` call sites inside the pure gemv /
matmul data-path functions to the kt-typed `buffer_o_kt` substrate
added in commit e82c3017.

Follows the precedent PRs:
- #1393 rotary_embedding (6 sites)
- #1394 mlp (7 sites)
- #1395 lm_head (13 sites)
- #1396 rmsnorm (26 sites)
- #1397 conv1d (8 sites)
- #1398 gdn in-proj (15 sites)

## Family scope

| Function | Sites |
|---|---|
| `metal_transposed_coop_gemv_bf16_with_tile`   | 3 (x, w, out) |
| `metal_transposed_coop_gemv_batch_bf16`       | 3 (x, w, out) |
| `metal_fused_qkv_transposed_coop_gemv_bf16`   | 7 (x, q, k, v, q_out, k_out, v_out) |

These are the three pure gemv data-path functions in
`kiln-model::backend::metal`. The `*_pipeline` builders, `*_supports` /
`*_disabled` env-flag helpers, and the `metal_transposed_coop_gemv_bf16`
dispatcher touch no buffer state. The gdn-family and paged-kv-family
functions are explicitly out of scope — they belong to parallel slices
(gdn in-proj already landed in #1398).

## Helpers

Both `kt_layout_from_candle` and `kt_dtype_from_candle` are already
present at the top of `metal.rs` (introduced in PR #1393 / commit
5a9b4eb1). This PR adds zero new helpers — every site uses the same
per-call-site bridging pattern.

## Behavior

`buffer_o_kt` computes `start_offset() * size_in_bytes()` on the kt
types — bit-identical to `buffer_o`'s candle-side computation. The MSL
kernel dispatch downstream is unchanged (`set_buffer(idx, buf,
offset_in_bytes)` accepts the same byte offset regardless of which
Layout/DType type produced it). No runtime behavior change.

## Validation

- `cargo check -p kiln-model` (default features) passes on the agent
  host (~1m52s cold, single pre-existing unused-variable warning on
  `forward.rs:18203` unrelated to this PR).
- `--features metal` requires Apple Silicon for toolchain reasons (objc2
  has a `compile_error!` on non-Apple targets); the macos-metal CI job
  at `.github/workflows/ci.yml:25-72` covers that path on `macos-14`.
- A6000 capacity was exhausted at PR time (RunPod upstream reporting no
  available instances on the kiln A6000 spec); falling back to PR + CI
  gates per kiln skill guidance.

## Touch scope

Single file `crates/kiln-model/src/backend/metal.rs`, +68 / -23. No
`Storage::Metal(s) => s` downcasts changed. No `metal_types.rs`
touched. No helpers added.

## Remaining buffer_o count

144 (down from 157 after #1398's landing). Subsequent PRs will migrate
the remaining gdn / paged-kv / lora / attention family sites. When all
families are migrated, the `buffer_o` legacy helper can be removed.

Refs #1082.