### PR TITLE
kiln-model: metal.rs — migrate gdn gates family (17 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -10584,15 +10584,37 @@ fn metal_gdn_gates_bf16(
             _ => anyhow::bail!("metal gdn_gates g output must be on Metal"),
         };
 
-        let a_buf = buffer_o(a_metal.buffer(), &a_layout, a.dtype());
-        let b_buf = buffer_o(b_metal.buffer(), &b_layout, b.dtype());
-        let al_buf =
-            buffer_o(al_metal.buffer(), &al_layout, a_log.dtype());
-        let dt_buf =
-            buffer_o(dt_metal.buffer(), &dt_layout, dt_bias.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let g_buf = buffer_o(g_metal.buffer(), &g_layout, g.dtype());
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let a_buf = buffer_o_kt(
+            a_metal.buffer(),
+            &kt_layout_from_candle(a_layout),
+            kt_dtype_from_candle(a.dtype()),
+        );
+        let b_buf = buffer_o_kt(
+            b_metal.buffer(),
+            &kt_layout_from_candle(b_layout),
+            kt_dtype_from_candle(b.dtype()),
+        );
+        let al_buf = buffer_o_kt(
+            al_metal.buffer(),
+            &kt_layout_from_candle(al_layout),
+            kt_dtype_from_candle(a_log.dtype()),
+        );
+        let dt_buf = buffer_o_kt(
+            dt_metal.buffer(),
+            &kt_layout_from_candle(dt_layout),
+            kt_dtype_from_candle(dt_bias.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let g_buf = buffer_o_kt(
+            g_metal.buffer(),
+            &kt_layout_from_candle(g_layout),
+            kt_dtype_from_candle(g.dtype()),
+        );
 
         encoder.set_buffer(0, Some(a_buf.buffer), a_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(b_buf.buffer), b_buf.offset_in_bytes);
@@ -10711,18 +10733,36 @@ pub(crate) fn metal_gdn_gates_decay_bf16(
             _ => anyhow::bail!("metal gdn_gates decay output must be on Metal"),
         };
 
-        let a_buf = buffer_o(a_metal.buffer(), &a_layout, a.dtype());
-        let b_buf = buffer_o(b_metal.buffer(), &b_layout, b.dtype());
-        let al_buf =
-            buffer_o(al_metal.buffer(), &al_layout, a_log.dtype());
-        let dt_buf =
-            buffer_o(dt_metal.buffer(), &dt_layout, dt_bias.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let decay_buf = buffer_o(
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let a_buf = buffer_o_kt(
+            a_metal.buffer(),
+            &kt_layout_from_candle(a_layout),
+            kt_dtype_from_candle(a.dtype()),
+        );
+        let b_buf = buffer_o_kt(
+            b_metal.buffer(),
+            &kt_layout_from_candle(b_layout),
+            kt_dtype_from_candle(b.dtype()),
+        );
+        let al_buf = buffer_o_kt(
+            al_metal.buffer(),
+            &kt_layout_from_candle(al_layout),
+            kt_dtype_from_candle(a_log.dtype()),
+        );
+        let dt_buf = buffer_o_kt(
+            dt_metal.buffer(),
+            &kt_layout_from_candle(dt_layout),
+            kt_dtype_from_candle(dt_bias.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let decay_buf = buffer_o_kt(
             decay_metal.buffer(),
-            &decay_layout,
-            decay.dtype(),
+            &kt_layout_from_candle(decay_layout),
+            kt_dtype_from_candle(decay.dtype()),
         );
 
         encoder.set_buffer(0, Some(a_buf.buffer), a_buf.offset_in_bytes);
@@ -10820,18 +10860,31 @@ pub(crate) fn metal_gdn_gates_decay_ab_bf16(
             _ => anyhow::bail!("metal gdn_gates decay A/B output must be on Metal"),
         };
 
-        let ab_buf =
-            buffer_o(ab_metal.buffer(), &ab_layout, ab.dtype());
-        let al_buf =
-            buffer_o(al_metal.buffer(), &al_layout, a_log.dtype());
-        let dt_buf =
-            buffer_o(dt_metal.buffer(), &dt_layout, dt_bias.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let decay_buf = buffer_o(
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let ab_buf = buffer_o_kt(
+            ab_metal.buffer(),
+            &kt_layout_from_candle(ab_layout),
+            kt_dtype_from_candle(ab.dtype()),
+        );
+        let al_buf = buffer_o_kt(
+            al_metal.buffer(),
+            &kt_layout_from_candle(al_layout),
+            kt_dtype_from_candle(a_log.dtype()),
+        );
+        let dt_buf = buffer_o_kt(
+            dt_metal.buffer(),
+            &kt_layout_from_candle(dt_layout),
+            kt_dtype_from_candle(dt_bias.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let decay_buf = buffer_o_kt(
             decay_metal.buffer(),
-            &decay_layout,
-            decay.dtype(),
+            &kt_layout_from_candle(decay_layout),
+            kt_dtype_from_candle(decay.dtype()),
         );
 
         encoder.set_buffer(0, Some(ab_buf.buffer), ab_buf.offset_in_bytes);


### PR DESCRIPTION
Step 4 of the metal_types -> objc2-metal swap plan
(docs/metal-types-objc2-swap-plan-2026-05-28.md), second gdn sub-family
slice. Migrates the 17 `buffer_o` call sites across the three gdn gates
variants in `kiln-model::backend::metal` to the kt-typed `buffer_o_kt`
substrate. Follows precedent set by PR #1398 (gdn in-proj).

Family scope. Three functions, 17 sites total:
- `metal_gdn_gates_bf16` (6 sites) — base GDN gate computation taking
  a, b, a_log, dt_bias, beta inputs and emitting g.
- `metal_gdn_gates_decay_bf16` (6 sites) — gate computation with decay
  output (replaces beta-with-decay output for prefill paths).
- `metal_gdn_gates_decay_ab_bf16` (5 sites) — fused gates over the
  pre-split ab tensor (a and b on a single allocation).

Local conversion helpers. Reuses the two private bridges introduced in
PR #1393 (`kt_layout_from_candle` and `kt_dtype_from_candle` at the top
of `metal.rs`). No new helpers added.

Behavior. `buffer_o_kt` computes `start_offset() * size_in_bytes()` on
the kt types — bit-identical to `buffer_o`'s candle-side computation.
The MSL kernel dispatch downstream is unchanged. No runtime behavior
change.

Validation. `cargo check -p kiln-model` (default features) passes on
the agent host (~4s after clean, single pre-existing unused-variable
warning on `forward.rs:18203` unrelated to this PR). `--features metal`
requires Apple Silicon for toolchain reasons; the macos-metal CI job at
`.github/workflows/ci.yml:25-72` covers that path on `macos-14`. Pod
pool reports A6000 capacity exhausted on RunPod upstream; falling back
to PR + CI gates per kiln skill guidance.

Touch scope: single file `crates/kiln-model/src/backend/metal.rs`,
+85 / -28. No `Storage::Metal(s) => s` downcasts changed. No
`metal_types.rs` touched.

Refs #1082.