### PR TITLE
kiln-model: metal.rs — migrate gdn decode family (15 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -10224,18 +10224,37 @@ pub(crate) fn metal_gdn_decode_qkv_conv_norm_bf16(
             _ => anyhow::bail!("metal gdn decode qkv conv/norm v_out must be on Metal"),
         };
 
-        let x_buf =
-            buffer_o(x_metal.buffer(), &x_layout, mixed_qkv.dtype());
-        let w_buf =
-            buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
-        let s_buf =
-            buffer_o(s_metal.buffer(), &s_layout, conv_state.dtype());
-        let qo_buf =
-            buffer_o(qo_metal.buffer(), &qo_layout, q_out.dtype());
-        let ko_buf =
-            buffer_o(ko_metal.buffer(), &ko_layout, k_out.dtype());
-        let vo_buf =
-            buffer_o(vo_metal.buffer(), &vo_layout, v_out.dtype());
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let x_buf = buffer_o_kt(
+            x_metal.buffer(),
+            &kt_layout_from_candle(x_layout),
+            kt_dtype_from_candle(mixed_qkv.dtype()),
+        );
+        let w_buf = buffer_o_kt(
+            w_metal.buffer(),
+            &kt_layout_from_candle(w_layout),
+            kt_dtype_from_candle(weight.dtype()),
+        );
+        let s_buf = buffer_o_kt(
+            s_metal.buffer(),
+            &kt_layout_from_candle(s_layout),
+            kt_dtype_from_candle(conv_state.dtype()),
+        );
+        let qo_buf = buffer_o_kt(
+            qo_metal.buffer(),
+            &kt_layout_from_candle(qo_layout),
+            kt_dtype_from_candle(q_out.dtype()),
+        );
+        let ko_buf = buffer_o_kt(
+            ko_metal.buffer(),
+            &kt_layout_from_candle(ko_layout),
+            kt_dtype_from_candle(k_out.dtype()),
+        );
+        let vo_buf = buffer_o_kt(
+            vo_metal.buffer(),
+            &kt_layout_from_candle(vo_layout),
+            kt_dtype_from_candle(v_out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
@@ -11172,22 +11191,52 @@ pub(crate) fn metal_gdn_decode_gates_recurrent_bf16(
             _ => anyhow::bail!("metal gdn decode gates+recurrent out must be on Metal"),
         };
 
-        let q_buf = buffer_o(q_metal.buffer(), &q_layout, q.dtype());
-        let k_buf = buffer_o(k_metal.buffer(), &k_layout, k.dtype());
-        let v_buf = buffer_o(v_metal.buffer(), &v_layout, v.dtype());
-        let a_buf = buffer_o(a_metal.buffer(), &a_layout, a.dtype());
-        let b_buf = buffer_o(b_metal.buffer(), &b_layout, b.dtype());
-        let al_buf =
-            buffer_o(al_metal.buffer(), &al_layout, a_log.dtype());
-        let dt_buf =
-            buffer_o(dt_metal.buffer(), &dt_layout, dt_bias.dtype());
-        let state_buf = buffer_o(
-            state_metal.buffer(),
-            &state_layout,
-            state.dtype(),
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let q_buf = buffer_o_kt(
+            q_metal.buffer(),
+            &kt_layout_from_candle(q_layout),
+            kt_dtype_from_candle(q.dtype()),
         );
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        let k_buf = buffer_o_kt(
+            k_metal.buffer(),
+            &kt_layout_from_candle(k_layout),
+            kt_dtype_from_candle(k.dtype()),
+        );
+        let v_buf = buffer_o_kt(
+            v_metal.buffer(),
+            &kt_layout_from_candle(v_layout),
+            kt_dtype_from_candle(v.dtype()),
+        );
+        let a_buf = buffer_o_kt(
+            a_metal.buffer(),
+            &kt_layout_from_candle(a_layout),
+            kt_dtype_from_candle(a.dtype()),
+        );
+        let b_buf = buffer_o_kt(
+            b_metal.buffer(),
+            &kt_layout_from_candle(b_layout),
+            kt_dtype_from_candle(b.dtype()),
+        );
+        let al_buf = buffer_o_kt(
+            al_metal.buffer(),
+            &kt_layout_from_candle(al_layout),
+            kt_dtype_from_candle(a_log.dtype()),
+        );
+        let dt_buf = buffer_o_kt(
+            dt_metal.buffer(),
+            &kt_layout_from_candle(dt_layout),
+            kt_dtype_from_candle(dt_bias.dtype()),
+        );
+        let state_buf = buffer_o_kt(
+            state_metal.buffer(),
+            &kt_layout_from_candle(state_layout),
+            kt_dtype_from_candle(state.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(q_buf.buffer), q_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(k_buf.buffer), k_buf.offset_in_bytes);


### PR DESCRIPTION
Step 4 of the metal_types -> objc2-metal swap plan
(docs/metal-types-objc2-swap-plan-2026-05-28.md), third gdn sub-family
slice. Migrates the 15 `buffer_o` call sites across the two gdn decode
variants in `kiln-model::backend::metal` to the kt-typed `buffer_o_kt`
substrate. Follows precedent set by PRs #1398 (gdn in-proj) and #1400
(gdn gates).

Family scope. Two functions, 15 sites total:
- `metal_gdn_decode_qkv_conv_norm_bf16` (6 sites) — decode-time fused
  QKV conv1d with RMS norm output (q/k/v_out).
- `metal_gdn_decode_gates_recurrent_bf16` (9 sites) — decode-time fused
  gates + recurrent step (q, k, v, a, b, a_log, dt_bias inputs; state +
  out outputs).

Local conversion helpers. Reuses the two private bridges introduced in
PR #1393 (`kt_layout_from_candle` and `kt_dtype_from_candle` at the top
of `metal.rs`). No new helpers added.

Behavior. `buffer_o_kt` computes `start_offset() * size_in_bytes()` on
the kt types — bit-identical to `buffer_o`'s candle-side computation.
The MSL kernel dispatch downstream is unchanged. No runtime behavior
change.

Validation. `cargo check -p kiln-model` (default features) passes on
the agent host (~4s after clean, single pre-existing unused-variable
warning on `forward.rs:18203` unrelated to this PR). `--features metal`
requires Apple Silicon for toolchain reasons; the macos-metal CI job at
`.github/workflows/ci.yml:25-72` covers that path on `macos-14`. Pod
pool reports A6000 capacity exhausted on RunPod upstream; falling back
to PR + CI gates per kiln skill guidance.

Touch scope: single file `crates/kiln-model/src/backend/metal.rs`,
+75 / -26. No `Storage::Metal(s) => s` downcasts changed. No
`metal_types.rs` touched.

Refs #1082.