### PR TITLE
kiln-model: metal.rs — migrate gdn forward_sub + recurrent (15 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -12468,14 +12468,27 @@ fn metal_gdn_forward_substitution_bf16(
             _ => anyhow::bail!("metal gdn forward-substitution out must be on Metal"),
         };
 
-        let a_buf =
-            buffer_o(a_metal.buffer(), &a_layout, a_strict.dtype());
-        let v_buf =
-            buffer_o(v_metal.buffer(), &v_layout, v_prime.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let a_buf = buffer_o_kt(
+            a_metal.buffer(),
+            &kt_layout_from_candle(a_layout),
+            kt_dtype_from_candle(a_strict.dtype()),
+        );
+        let v_buf = buffer_o_kt(
+            v_metal.buffer(),
+            &kt_layout_from_candle(v_layout),
+            kt_dtype_from_candle(v_prime.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(a_buf.buffer), a_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(v_buf.buffer), v_buf.offset_in_bytes);
@@ -12562,14 +12575,27 @@ fn metal_gdn_forward_substitution_f32(
             _ => anyhow::bail!("metal gdn forward-substitution f32 out must be on Metal"),
         };
 
-        let a_buf =
-            buffer_o(a_metal.buffer(), &a_layout, a_strict.dtype());
-        let v_buf =
-            buffer_o(v_metal.buffer(), &v_layout, v_prime.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let a_buf = buffer_o_kt(
+            a_metal.buffer(),
+            &kt_layout_from_candle(a_layout),
+            kt_dtype_from_candle(a_strict.dtype()),
+        );
+        let v_buf = buffer_o_kt(
+            v_metal.buffer(),
+            &kt_layout_from_candle(v_layout),
+            kt_dtype_from_candle(v_prime.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(a_buf.buffer), a_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(v_buf.buffer), v_buf.offset_in_bytes);
@@ -13236,19 +13262,42 @@ fn metal_gdn_recurrent_bf16(
             _ => anyhow::bail!("metal gdn recurrent out must be on Metal"),
         };
 
-        let q_buf = buffer_o(q_metal.buffer(), &q_layout, q.dtype());
-        let k_buf = buffer_o(k_metal.buffer(), &k_layout, k.dtype());
-        let v_buf = buffer_o(v_metal.buffer(), &v_layout, v.dtype());
-        let beta_buf =
-            buffer_o(beta_metal.buffer(), &beta_layout, beta.dtype());
-        let g_buf = buffer_o(g_metal.buffer(), &g_layout, g.dtype());
-        let state_buf = buffer_o(
-            state_metal.buffer(),
-            &state_layout,
-            state.dtype(),
+        // #1082 Step 4 gdn-family: `buffer_o` → `buffer_o_kt`.
+        let q_buf = buffer_o_kt(
+            q_metal.buffer(),
+            &kt_layout_from_candle(q_layout),
+            kt_dtype_from_candle(q.dtype()),
         );
-        let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+        let k_buf = buffer_o_kt(
+            k_metal.buffer(),
+            &kt_layout_from_candle(k_layout),
+            kt_dtype_from_candle(k.dtype()),
+        );
+        let v_buf = buffer_o_kt(
+            v_metal.buffer(),
+            &kt_layout_from_candle(v_layout),
+            kt_dtype_from_candle(v.dtype()),
+        );
+        let beta_buf = buffer_o_kt(
+            beta_metal.buffer(),
+            &kt_layout_from_candle(beta_layout),
+            kt_dtype_from_candle(beta.dtype()),
+        );
+        let g_buf = buffer_o_kt(
+            g_metal.buffer(),
+            &kt_layout_from_candle(g_layout),
+            kt_dtype_from_candle(g.dtype()),
+        );
+        let state_buf = buffer_o_kt(
+            state_metal.buffer(),
+            &kt_layout_from_candle(state_layout),
+            kt_dtype_from_candle(state.dtype()),
+        );
+        let out_buf = buffer_o_kt(
+            out_metal.buffer(),
+            &kt_layout_from_candle(out_layout),
+            kt_dtype_from_candle(out.dtype()),
+        );
 
         encoder.set_buffer(0, Some(q_buf.buffer), q_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(k_buf.buffer), k_buf.offset_in_bytes);


### PR DESCRIPTION
Step 4 of the metal_types -> objc2-metal swap plan
(docs/metal-types-objc2-swap-plan-2026-05-28.md), fourth gdn sub-family
slice. Migrates the 15 `buffer_o` call sites across the three gdn
forward-substitution + recurrent core variants in
`kiln-model::backend::metal` to the kt-typed `buffer_o_kt` substrate.
Follows precedent set by PRs #1398/#1400/#1402.

Family scope. Three functions, 15 sites total:
- `metal_gdn_forward_substitution_bf16` (4 sites) — BF16 forward
  substitution over (a, v, beta, out).
- `metal_gdn_forward_substitution_f32` (4 sites) — F32 forward
  substitution over the same shape.
- `metal_gdn_recurrent_bf16` (7 sites) — BF16 recurrent state update
  taking (q, k, v, beta, g) inputs and (state, out) outputs.

Local conversion helpers. Reuses the two private bridges introduced in
PR #1393 (`kt_layout_from_candle` and `kt_dtype_from_candle` at the top
of `metal.rs`). No new helpers added.

Behavior. `buffer_o_kt` computes `start_offset() * size_in_bytes()` on
the kt types — bit-identical to `buffer_o`'s candle-side computation.
The MSL kernel dispatch downstream is unchanged. No runtime behavior
change.

Validation. `cargo check -p kiln-model` (default features) passes on
the agent host (~4s after clean, single pre-existing unused-variable
warning on `forward.rs:18203` unrelated to this PR). `--features metal`
requires Apple Silicon; the macos-metal CI job at
`.github/workflows/ci.yml:25-72` covers that path on `macos-14`. Pod
pool reports A6000 capacity exhausted on RunPod upstream; falling back
to PR + CI gates per kiln skill guidance.

Touch scope: single file `crates/kiln-model/src/backend/metal.rs`,
+76 / -27. No `Storage::Metal(s) => s` downcasts changed. No
`metal_types.rs` touched.

Refs #1082.