### PR TITLE
kiln-model: metal.rs — migrate lora_add_decode + attn_gate families (10 sites) to buffer_o_kt (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -7432,11 +7432,11 @@ pub(crate) fn metal_attn_gate_sigmoid_mul_bf16(x: &candle_core::Tensor, gate: &c
             _ => anyhow::bail!("metal attn gate sigmoid/mul out must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
+        let x_buf = buffer_o_kt(x_metal.buffer(), &kt_layout_from_candle(x_layout), kt_dtype_from_candle(x.dtype()));
         let gate_buf =
-            buffer_o(gate_metal.buffer(), &gate_layout, gate.dtype());
+            buffer_o_kt(gate_metal.buffer(), &kt_layout_from_candle(gate_layout), kt_dtype_from_candle(gate.dtype()));
         let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+            buffer_o_kt(out_metal.buffer(), &kt_layout_from_candle(out_layout), kt_dtype_from_candle(out.dtype()));
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(gate_buf.buffer), gate_buf.offset_in_bytes);
@@ -8048,12 +8048,12 @@ pub(crate) fn metal_lora_add_decode_bf16(
             _ => anyhow::bail!("metal LoRA hidden output must be on Metal"),
         };
 
-        let x_buf = buffer_o(x_metal.buffer(), &x_layout, x.dtype());
-        let a_buf = buffer_o(a_metal.buffer(), &a_layout, a.dtype());
-        let hidden_buf = buffer_o(
+        let x_buf = buffer_o_kt(x_metal.buffer(), &kt_layout_from_candle(x_layout), kt_dtype_from_candle(x.dtype()));
+        let a_buf = buffer_o_kt(a_metal.buffer(), &kt_layout_from_candle(a_layout), kt_dtype_from_candle(a.dtype()));
+        let hidden_buf = buffer_o_kt(
             hidden_metal.buffer(),
-            &hidden_layout,
-            hidden.dtype(),
+            &kt_layout_from_candle(hidden_layout),
+            kt_dtype_from_candle(hidden.dtype()),
         );
 
         encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
@@ -8107,16 +8107,16 @@ pub(crate) fn metal_lora_add_decode_bf16(
             _ => anyhow::bail!("metal LoRA add output must be on Metal"),
         };
 
-        let hidden_buf = buffer_o(
+        let hidden_buf = buffer_o_kt(
             hidden_metal.buffer(),
-            &hidden_layout,
-            hidden.dtype(),
+            &kt_layout_from_candle(hidden_layout),
+            kt_dtype_from_candle(hidden.dtype()),
         );
-        let b_buf = buffer_o(b_metal.buffer(), &b_layout, b.dtype());
+        let b_buf = buffer_o_kt(b_metal.buffer(), &kt_layout_from_candle(b_layout), kt_dtype_from_candle(b.dtype()));
         let base_buf =
-            buffer_o(base_metal.buffer(), &base_layout, base.dtype());
+            buffer_o_kt(base_metal.buffer(), &kt_layout_from_candle(base_layout), kt_dtype_from_candle(base.dtype()));
         let out_buf =
-            buffer_o(out_metal.buffer(), &out_layout, out.dtype());
+            buffer_o_kt(out_metal.buffer(), &kt_layout_from_candle(out_layout), kt_dtype_from_candle(out.dtype()));
 
         encoder.set_buffer(0, Some(hidden_buf.buffer), hidden_buf.offset_in_bytes);
         encoder.set_buffer(1, Some(b_buf.buffer), b_buf.offset_in_bytes);


### PR DESCRIPTION
Part of #1082 (removing the `candle-core` dependency).

Migrates 10 candle-typed `buffer_o(...)` call sites to kt-typed `buffer_o_kt(...)` in two functions in `crates/kiln-model/src/backend/metal.rs`:

- `metal_lora_add_decode_bf16` — 7 sites
- `metal_attn_gate_sigmoid_mul_bf16` — 3 sites

Each `buffer_o(BUF, &LAYOUT, X.dtype())` becomes `buffer_o_kt(BUF, &kt_layout_from_candle(LAYOUT), kt_dtype_from_candle(X.dtype()))`, matching the existing migrated pattern. No new helpers; uses `kt_layout_from_candle` / `kt_dtype_from_candle` already present at the top of the file.

`metal_gdn_*` functions were intentionally left untouched (concurrent migration).

## Validation
- `cargo check -p kiln-model` passes (only the pre-existing `forward.rs:18203` unused-variable warning).
- `buffer_o(` count: 78 → 68 (−10); `buffer_o_kt(` count: 154 → 164 (+10).
- macOS Metal CI job validates the Metal path post-merge.