### PR TITLE
kiln-model: metal.rs — fix dead buffer_o import after #1407 (#1082)

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -17,7 +17,7 @@ use super::BackendRuntime;
 // substrate swaps (e.g. candle → objc2-metal) touch this single import
 // block instead of hundreds of scattered fully-qualified references.
 use kiln_tensor::metal_types::{
-    buffer_o, buffer_o_kt, sdpa, ComputePipeline, DeviceId, Library, MetalDevice, Storage,
+    buffer_o_kt, sdpa, ComputePipeline, DeviceId, Library, MetalDevice, Storage,
 };
 
 // Per-function pipeline-cache helpers reach for these std types; hoisted to


### PR DESCRIPTION
## What

Remove `buffer_o` from the module-level chokepoint import at
`metal.rs:20`. PR #1407 deleted the candle-typed `buffer_o` fn from
`metal_types` but left its name in this `use` list, breaking the macOS
Metal build with an unresolved import.

## Why

The macOS Metal job is non-blocking for auto-merge, so #1407 landed on
main with the Metal build red. This restores it. All 232 call sites
already use `buffer_o_kt`; `buffer_o` has no remaining code references
(only doc comments referencing candle's own `buffer_o`).

Part of #1082.