### PR TITLE
kiln-kt-bridge: with_tape_authoritative_scope returns (T, loss, grads) — trainer-flip prep (#1082)

### DIFF
--- a/crates/kiln-kt-bridge/src/tape_bridge.rs
+++ b/crates/kiln-kt-bridge/src/tape_bridge.rs
@@ -289,10 +289,21 @@ pub fn with_io_mapping_scope<R>(f: impl FnOnce() -> R) -> R {
 /// runs `forward` (every `try_tape_*_cuda` adapter records onto the tape and,
 /// via Step-A kt-id reuse, threads its inputs to upstream outputs so the tape
 /// is CONNECTED), then seeds the tape at the returned loss (`dL/dL =
-/// ones_like(loss)`) and walks the connected graph. Returns a map
-/// `{ candle_input_id (raw) → kt grad }` built from the recorded input
-/// mappings, so the trainer can deposit each grad under the matching candle
-/// `TensorId`.
+/// ones_like(loss)`) and walks the connected graph. Returns:
+///
+/// * `T` — the caller's application-specific payload (e.g. the f64 loss value,
+///   metrics, etc.) — same role as the first tuple element of
+///   [`with_tape_scope_emit_to_grad_store`].
+/// * `CandleTensor` — the loss tensor itself. Returned alongside the grad map
+///   so the trainer can build a candle `GradStore` from it (e.g. via
+///   `loss.backward()` to get a near-empty store, then `insert_id` each tape
+///   grad under the matching candle `TensorId` — see the
+///   `kiln-cp4-trainer-flip-gradstore-wrinkle` note for the option (a) path
+///   around candle's private `GradStore::new()`).
+/// * `HashMap<usize, kiln_tensor::Tensor>` — map of
+///   `candle_input_id (raw) → kt grad` built from the recorded input
+///   mappings, so the trainer can deposit each grad under the matching candle
+///   `TensorId`.
 ///
 /// Unlike [`with_tape_scope_emit_to_grad_store`] (candle-authoritative: runs
 /// `loss.backward()` and seeds the tape per-output from candle's `GradStore`,
@@ -300,20 +311,31 @@ pub fn with_io_mapping_scope<R>(f: impl FnOnce() -> R) -> R {
 /// and NO per-output candle grad — only that the loss is itself a tape
 /// adapter output (e.g. the `cross_entropy` adapter recorded it).
 ///
-/// Errors if the returned loss was not produced by a tape adapter in this
-/// scope (i.e. the loss op is not yet tape-routed).
-pub fn with_tape_authoritative_scope<F>(
+/// # Contract
+///
+/// `forward` takes no arguments and must return `(T, CandleTensor)` where the
+/// candle tensor is the loss (must be a tape-adapter output in this scope).
+/// The payload `T` is plumbed through unchanged to the caller.
+///
+/// # Errors
+///
+/// * `forward()` errors. Propagated verbatim.
+/// * The returned loss was not produced by a tape adapter in this scope
+///   (i.e. the loss op is not yet tape-routed).
+/// * Tape walk errors.
+pub fn with_tape_authoritative_scope<T, F>(
     forward: F,
-) -> Result<HashMap<usize, kiln_tensor::Tensor>, BridgeError>
+) -> Result<(T, CandleTensor, HashMap<usize, kiln_tensor::Tensor>), BridgeError>
 where
-    F: FnOnce() -> Result<CandleTensor, BridgeError>,
+    F: FnOnce() -> Result<(T, CandleTensor), BridgeError>,
 {
     with_io_mapping_scope(|| {
         // Run forward under a thread-local tape; the mapping scope stays live
         // for the seed + extract below (with_io_mapping_scope closes it after
         // this closure returns).
-        let (loss_res, tape) = with_thread_local_tape(forward);
-        let loss = loss_res?;
+        let (forward_res, tape): (Result<(T, CandleTensor), BridgeError>, Tape) =
+            with_thread_local_tape(forward);
+        let (payload, loss) = forward_res?;
 
         // The loss must be a tape adapter output — its kt tensor is retained
         // in the mapping scope (via retain_output_for_chaining).
@@ -355,7 +377,7 @@ where
                 out.insert(candle_in_raw, g.clone());
             }
         }
-        Ok(out)
+        Ok((payload, loss, out))
     })
 }
 

--- a/crates/kiln-model/tests/tape_forward_parity.rs
+++ b/crates/kiln-model/tests/tape_forward_parity.rs
@@ -2196,20 +2196,30 @@ fn tape_authoritative_scope_matmul_add_grad_parity() {
     .contiguous()
     .expect("c contig");
 
-    // Path B: tape-authoritative. "loss" = s = a@b + c (seed = ones).
+    // Path B: tape-authoritative. "loss" = s = a@b + c (seed = ones). The
+    // payload exercises the (T, loss) forward shape mirroring
+    // with_tape_scope_emit_to_grad_store — here we use a u32 marker so the
+    // refined signature is type-checked end-to-end. (#1082 CP-4 endgame.)
     let a1 = a.clone();
     let b1 = b.clone();
     let c1 = c.clone();
-    let grads = kiln_kt_bridge::tape_bridge::with_tape_authoritative_scope(move || {
-        let mm = kiln_model::tape_forward::try_tape_matmul_cuda(&a1, &b1)
-            .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("matmul: {e}")))?
-            .ok_or_else(|| kiln_kt_bridge::BridgeError::new("matmul adapter returned None"))?;
-        let s = kiln_model::tape_forward::try_tape_add_cuda(&mm, &c1)
-            .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("add: {e}")))?
-            .ok_or_else(|| kiln_kt_bridge::BridgeError::new("add adapter returned None"))?;
-        Ok(s)
-    })
-    .expect("tape-authoritative scope ok");
+    let (payload, loss_tensor, grads) =
+        kiln_kt_bridge::tape_bridge::with_tape_authoritative_scope(move || {
+            let mm = kiln_model::tape_forward::try_tape_matmul_cuda(&a1, &b1)
+                .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("matmul: {e}")))?
+                .ok_or_else(|| {
+                    kiln_kt_bridge::BridgeError::new("matmul adapter returned None")
+                })?;
+            let s = kiln_model::tape_forward::try_tape_add_cuda(&mm, &c1)
+                .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("add: {e}")))?
+                .ok_or_else(|| kiln_kt_bridge::BridgeError::new("add adapter returned None"))?;
+            Ok((42u32, s))
+        })
+        .expect("tape-authoritative scope ok");
+
+    assert_eq!(payload, 42u32, "payload plumbed through unchanged");
+    assert_eq!(loss_tensor.shape().dims(), &[m, n], "loss tensor shape (a@b+c)");
+    assert!(loss_tensor.device().is_cuda(), "loss tensor stays on CUDA");
 
     // `a.clone()` shares a's candle TensorId, so the grad is keyed by a.id().
     let da_kt = grads


### PR DESCRIPTION
## What

Refines `with_tape_authoritative_scope` so the trainer flip (CP-4 endgame) can plumb a payload through and reach the loss tensor:

```rust
// Before
pub fn with_tape_authoritative_scope<F>(
    forward: F,
) -> Result<HashMap<usize, kiln_tensor::Tensor>, BridgeError>
where
    F: FnOnce() -> Result<CandleTensor, BridgeError>,

// After
pub fn with_tape_authoritative_scope<T, F>(
    forward: F,
) -> Result<(T, CandleTensor, HashMap<usize, kiln_tensor::Tensor>), BridgeError>
where
    F: FnOnce() -> Result<(T, CandleTensor), BridgeError>,
```

- `forward` now returns `(T, CandleTensor)` — mirrors `with_tape_scope_emit_to_grad_store`'s `(payload, loss)` shape, so the caller can keep application-specific data (loss value, metrics, etc.) alongside the loss tensor.
- The bridge returns `(payload, loss_tensor, grads)`. The loss tensor lets the trainer follow option (a) in the GradStore wrinkle: call `loss.backward()` on the detached candle loss to obtain a (near-empty) candle `GradStore`, then `insert_id` each tape grad under the matching candle `TensorId`. (candle's `GradStore::new()` is private — see `vendor/candle-core/src/backprop.rs:708`.)
- The existing `tape_authoritative_scope_matmul_add_grad_parity` test is updated to exercise the new shape end-to-end: forward returns `Ok((42u32, s))`; caller destructures `(payload, loss_tensor, grads)`; asserts `payload == 42`, `loss_tensor.shape().dims() == [m, n]`, and that the loss tensor stays on CUDA.

## Why

Part of #1082 CP-4 endgame (trainer flip to tape-authoritative backward). The previous shape only returned a grad map, but the trainer needs both the loss value (for logging / scheduler / parity assertions) and the loss tensor itself (to seed a candle `GradStore` since `GradStore::new()` is private — only `loss.backward()` returns one). See the `kiln-cp4-trainer-flip-gradstore-wrinkle` agent note for the full wrinkle.

## Verification

A6000 pod (warm sccache):

- `KILN_CUDA_ARCHS=86 cargo check --features cuda -p kiln-kt-bridge` ✅ — lib + lib-test compile cleanly with the new signature.
- `KILN_CUDA_ARCHS=86 cargo check --release --features cuda -p kiln-model --tests` ✅ — exercises the updated `tape_authoritative_scope_matmul_add_grad_parity` integration test.

CPU CI does not exercise the `cuda` feature, so the existing Linux/macOS CI jobs cannot validate this change.

Part of #1082.