### PR TITLE
kiln-model: hub flip regions 1-3 (embedding/lm_head, SwiGLU MLP, GQA-SDPA matmuls) to kt-internal (#1082)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -396,6 +396,48 @@ fn cuda_use_kt_api_swiglu_ffn() -> bool {
     !cuda_kt_api_master_off() && (direct || cuda_use_kt_api_all())
 }
 
+/// Phase 7 default-on (#1082): the two cublasLt batched matmuls of the
+/// GQA full-attention **naive-SDPA fallback** (region 3 of the methodical
+/// kiln-model bare-Tensor migration) through the kt-API + adapters.
+///
+/// This is the region-3 sibling of [`cuda_use_kt_api_embedding`] /
+/// [`cuda_use_kt_api_lm_head`] / [`cuda_use_kt_api_swiglu_ffn`] (regions
+/// 0/1/2). It targets ONLY the score matmul (`q @ kᵀ`) and the value
+/// matmul (`softmax @ v`) of [`gqa_attention_core_prefill`]'s non-flash
+/// fallback — the same `cuda_matmul` (cublasLt) entry the lm_head / SwiGLU
+/// matmul migrations already dispatch to, so it is bit-exact with the
+/// candle `broadcast_matmul` it replaces (both bottom out in cublas GEMM on
+/// the GQA-expanded, head-first operands).
+///
+/// EXTREMELY conservative by design — this is the riskiest forward region
+/// (flash / tape / GQA-expand / flash-decline-counter interactions). The
+/// helper [`try_kt_gqa_sdpa_matmuls`] is invoked ONLY on the plain
+/// inference fallback (head_dim ∉ {128,256}, or no flash backend) and
+/// declines (`Ok(None)`, falling through to candle) on EVERY one of:
+/// - the gate is off (`KILN_DISABLE_KT_API_GQA_SDPA=1` /
+///   `KILN_DISABLE_KT_API_ALL=1`);
+/// - non-CUDA device, or a non-{BF16,F16,F32} / mixed dtype;
+/// - autograd-tracked `q` (candle `loss.backward()` parity oracle must keep
+///   the differentiable composite) OR an active tape recording scope (the
+///   `try_tape_sdpa_fallback_cuda` adapter records the analytic backward on
+///   the candle `attn_output`, so the candle ops must run unchanged).
+///
+/// It deliberately does NOT touch the flash-attn offer/decline ordering,
+/// `cuda_flash_attention_training_bf16`, the `try_tape_*` adapters, or the
+/// scale / causal-mask / softmax ops between the two matmuls (those stay on
+/// their existing candle / kt-softmax-gated path — reproducing the scale
+/// (affine div) and the broadcast `-inf` mask in a different kt kernel
+/// risks rounding divergence from the candle parity oracle and is left
+/// candle on purpose). Escape hatch: `KILN_DISABLE_KT_API_GQA_SDPA=1`.
+/// NVTX range `kiln/gqa_sdpa_kt` brackets the two migrated matmuls.
+#[cfg(feature = "cuda")]
+fn cuda_use_kt_api_gqa_sdpa() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    let direct =
+        *ENABLED.get_or_init(|| std::env::var("KILN_DISABLE_KT_API_GQA_SDPA").is_err());
+    !cuda_kt_api_master_off() && (direct || cuda_use_kt_api_all())
+}
+
 /// Phase 7 (#1082) opt-in: LoRA delta composite
 /// (`(x @ A^T) @ B^T * scale`) through the kt-API + adapters.
 /// Set `KILN_USE_KT_API_LORA_DELTA=1` (or `KILN_USE_KT_API_ALL=1`)
@@ -5043,6 +5085,132 @@ pub struct GpuFullAttentionWeights {
     /// path routes q_proj through the Marlin kernel instead of the BF16
     /// `broadcast_matmul` via `q_proj_t`. LoRA deltas are still applied on top.
     pub q_proj_marlin: Option<crate::marlin_proj::MarlinPackedProj>,
+}
+
+impl GpuFullAttentionWeights {
+    /// kt-native view of the pre-transposed full-attention q projection
+    /// (#1082, GQA full-attention region migration — region 3).
+    ///
+    /// Borrows `q_proj_t` (`[hidden, num_heads * head_dim (+gate)]`,
+    /// contiguous since load) as a `KtTensor` via the zero-copy CUDA bridge,
+    /// mirroring [`GpuFfnWeights::gate_proj_t_kt`] and
+    /// [`GpuWeights::embed_tokens_t_kt`]. Provided for parity with the other
+    /// migrated regions + future consolidation of the q/k/v projections; the
+    /// region-3 SDPA-matmul helper ([`try_kt_gqa_sdpa_matmuls`]) currently
+    /// borrows the activation q/k/v tensors (post-projection, post-RoPE) and
+    /// does not need the weight accessors, but they are kept here so the
+    /// region's candle→kt weight boundary lives in one place. CUDA-only;
+    /// returns a typed error on non-CUDA (the caller falls through to candle).
+    #[cfg(feature = "cuda")]
+    pub fn q_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.q_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "q_proj_t_kt: q_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.q_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .q_proj_t
+            .contiguous()
+            .context("q_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("q_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed full-attention k projection
+    /// (#1082, region 3). Same contiguity / CUDA-only contract as
+    /// [`GpuFullAttentionWeights::q_proj_t_kt`].
+    #[cfg(feature = "cuda")]
+    pub fn k_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.k_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "k_proj_t_kt: k_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.k_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .k_proj_t
+            .contiguous()
+            .context("k_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("k_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed full-attention v projection
+    /// (#1082, region 3). Same contiguity / CUDA-only contract as
+    /// [`GpuFullAttentionWeights::q_proj_t_kt`].
+    #[cfg(feature = "cuda")]
+    pub fn v_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.v_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "v_proj_t_kt: v_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.v_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .v_proj_t
+            .contiguous()
+            .context("v_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("v_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed full-attention output
+    /// projection (#1082, region 3). Shape `[num_heads * head_dim, hidden]`.
+    /// Same contiguity / CUDA-only contract as
+    /// [`GpuFullAttentionWeights::q_proj_t_kt`]; provided for parity with the
+    /// region-1/2 accessors and future consolidation of the o_proj matmul.
+    #[cfg(feature = "cuda")]
+    pub fn o_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.o_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "o_proj_t_kt: o_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.o_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .o_proj_t
+            .contiguous()
+            .context("o_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("o_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the q_norm RMSNorm weight (#1082, region 3).
+    /// Shape `[head_dim]`. Same contiguity / CUDA-only contract as
+    /// [`GpuFullAttentionWeights::q_proj_t_kt`]; provided for parity with the
+    /// region-1/2 accessors (the q/k norm already routes through the
+    /// default-on `rms_norm` kt gate inside the prepare step, so the SDPA
+    /// matmul helper does not need this — it is kept for the future
+    /// consolidation of the prepare region).
+    #[cfg(feature = "cuda")]
+    pub fn q_norm_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.q_norm.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "q_norm_kt: q_norm must be on CUDA for the kt borrow (got {:?})",
+                self.q_norm.device().location()
+            );
+        }
+        let contig = self.q_norm.contiguous().context("q_norm_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("q_norm_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the k_norm RMSNorm weight (#1082, region 3).
+    /// Shape `[head_dim]`. Same contract as
+    /// [`GpuFullAttentionWeights::q_norm_kt`].
+    #[cfg(feature = "cuda")]
+    pub fn k_norm_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.k_norm.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "k_norm_kt: k_norm must be on CUDA for the kt borrow (got {:?})",
+                self.k_norm.device().location()
+            );
+        }
+        let contig = self.k_norm.contiguous().context("k_norm_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("k_norm_kt borrow: {e}"))
+    }
 }
 
 pub struct GpuLinearAttentionWeights {
@@ -18000,6 +18168,163 @@ pub fn gqa_attention_prepare_prefill(
     Ok(GqaAttentionPrepared { q, k, v, gate })
 }
 
+/// Phase 7 default-on (#1082) — region-3 kt-native consolidation of the
+/// GQA full-attention **naive-SDPA fallback**'s two cublasLt matmuls.
+///
+/// Computes the non-flash fallback `attn_output = softmax((q @ kᵀ)/√hd
+/// + causal_mask) @ v` for the GQA-expanded, head-FIRST operands
+/// (`q`/`k`/`v` all `[B, nq, T, hd]`), routing the **score matmul**
+/// (`q @ kᵀ`) and the **value matmul** (`p @ v`) through the kt substrate
+/// (`kiln_tensor::cuda_matmul`, cublasLt) with a single candle→kt borrow at
+/// each matmul's inputs and a kt→candle copy at each output. The scale,
+/// causal mask, and softmax between the two matmuls are computed by the
+/// EXISTING candle / kt-softmax-gated ops (`affine` div, the additive `-inf`
+/// `broadcast_add` mask via [`apply_causal_mask_with_offset`], and
+/// [`cuda_softmax_last_dim`]) — left candle on purpose so the path stays
+/// bit-exact with the candle parity oracle (reproducing the affine div and
+/// the broadcast `-inf` mask in a different kt kernel risks rounding drift).
+///
+/// Returns the head-FIRST `attn_output` `[B, nq, T, hd]` (BEFORE the caller's
+/// transpose+reshape-back and BEFORE the `try_tape_sdpa_fallback_cuda`
+/// adapter) so the caller's tape/decline/reshape logic is byte-for-byte
+/// unchanged. Returns `Ok(None)` — falling through to the caller's existing
+/// candle `broadcast_matmul` pair — on any of:
+/// - the gate is off (`KILN_DISABLE_KT_API_GQA_SDPA=1` /
+///   `KILN_DISABLE_KT_API_ALL=1`);
+/// - non-CUDA device, non-{BF16,F16,F32} / mixed dtype, or a non-contiguous
+///   operand;
+/// - autograd-tracked `q` (the candle `loss.backward()` parity oracle keeps
+///   the differentiable composite) OR an active tape recording scope (so the
+///   caller's `try_tape_sdpa_fallback_cuda` records the analytic backward on
+///   the candle-computed `attn_output`, exactly as today);
+/// - any kt borrow / matmul / copy-back failure (the candle path then runs).
+///
+/// Bit-exact to the candle fallback by construction: each matmul bottoms out
+/// in the SAME cublasLt GEMM the candle `broadcast_matmul` lowers to on CUDA
+/// (and the SAME `cuda_matmul` entry the validated lm_head / SwiGLU matmul
+/// migrations dispatch to); the intervening scale/mask/softmax ops are
+/// physically unchanged candle tensors. NVTX range `kiln/gqa_sdpa_kt`
+/// brackets the migrated region.
+#[cfg(feature = "cuda")]
+fn try_kt_gqa_sdpa_matmuls(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    seq_len: usize,
+    scale: f64,
+) -> Result<Option<Tensor>> {
+    if !cuda_use_kt_api_gqa_sdpa() {
+        return Ok(None);
+    }
+    // The autograd / tape paths must run the candle composite: an
+    // autograd-tracked `q` drives the candle `loss.backward()` parity gate
+    // (a kt copy-out would sever it), and an active tape scope means the
+    // caller's `try_tape_sdpa_fallback_cuda` will record the analytic
+    // backward on the candle `attn_output` — so the candle ops must run.
+    if q.track_op()
+        || (crate::tape_forward::tape_forward_enabled()
+            && kiln_kt_bridge::tape_bridge::bridge_scope_active())
+    {
+        return Ok(None);
+    }
+    // Envelope: head-FIRST, GQA-EXPANDED operands, all [B, nq, T, hd].
+    let (qb, qh, qt, qd) = match q.dims4() {
+        Ok(d) => d,
+        Err(_) => return Ok(None),
+    };
+    let (kb, kh, kt_, kd) = match k.dims4() {
+        Ok(d) => d,
+        Err(_) => return Ok(None),
+    };
+    let (vb, vh, vt, vd) = match v.dims4() {
+        Ok(d) => d,
+        Err(_) => return Ok(None),
+    };
+    // q/k/v must already be GQA-expanded to identical [B, nq, T, hd] shapes
+    // (the caller expands before this call); bail otherwise.
+    if qb != kb
+        || qb != vb
+        || qh != kh
+        || qh != vh
+        || qt != seq_len
+        || kt_ != seq_len
+        || vt != seq_len
+        || qd != kd
+        || qd != vd
+    {
+        return Ok(None);
+    }
+    let dtype = q.dtype();
+    if !matches!(dtype, DType::BF16 | DType::F16 | DType::F32)
+        || k.dtype() != dtype
+        || v.dtype() != dtype
+        || !matches!(q.device(), Device::Cuda(_))
+        || !matches!(k.device(), Device::Cuda(_))
+        || !matches!(v.device(), Device::Cuda(_))
+        || !q.is_contiguous()
+        || !k.is_contiguous()
+        || !v.is_contiguous()
+    {
+        return Ok(None);
+    }
+
+    kiln_nvtx::range!(c"kiln/gqa_sdpa_kt");
+
+    // --- Score matmul: scores = q @ kᵀ, [B, nq, T, T] ---
+    // cublasLt needs contiguous operands; kᵀ ([B, nq, hd, T]) is a transpose
+    // view, so materialize it contiguous (same as the candle path's `k.t()`,
+    // which `broadcast_matmul` also makes contiguous internally on CUDA).
+    let k_t = match k.transpose(2, 3).and_then(|t| t.contiguous()) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let q_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(q) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let k_t_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&k_t) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let scores_kt = match kiln_tensor::cuda_matmul(&q_kt, &k_t_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let attn_scores = match kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&scores_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+
+    // --- Scale + causal mask + softmax: UNCHANGED candle / kt-softmax ops ---
+    // (Left candle on purpose for bit-exactness with the parity oracle.)
+    let attn_scores = (attn_scores / scale)?;
+    let attn_scores = apply_causal_mask_with_offset(&attn_scores, seq_len, seq_len, 0)?;
+    let attn_weights_softmax = cuda_softmax_last_dim(&attn_scores)?;
+
+    // --- Value matmul: attn_output = p @ v, [B, nq, T, hd] ---
+    let p_contig = match attn_weights_softmax.contiguous() {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let p_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&p_contig) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let v_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(v) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let out_kt = match kiln_tensor::cuda_matmul(&p_kt, &v_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let attn_output = match kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&out_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    Ok(Some(attn_output))
+}
+
 pub fn gqa_attention_core_prefill(
     backend: &dyn BackendRuntime,
     prepared: &GqaAttentionPrepared,
@@ -18077,11 +18402,39 @@ pub fn gqa_attention_core_prefill(
     };
 
     let scale = (head_dim as f64).sqrt();
-    let attn_scores = q.broadcast_matmul(&k.t()?)?;
-    let attn_scores = (attn_scores / scale)?;
-    let attn_scores = apply_causal_mask_with_offset(&attn_scores, seq_len, seq_len, 0)?;
-    let attn_weights_softmax = cuda_softmax_last_dim(&attn_scores)?;
-    let attn_output = attn_weights_softmax.broadcast_matmul(&v)?; // [B, nq, T, hd]
+    // #1082 region 3: consolidate the fallback's two cublasLt matmuls
+    // (`q @ kᵀ` and `softmax @ v`) into the kt substrate, keeping the
+    // intervening scale / causal-mask / softmax on candle for bit-exactness.
+    // Fires ONLY on the plain inference path (gate on, !track_op, no tape
+    // scope); declines to `None` otherwise so the candle composite below runs
+    // unchanged — including for the tape/decline paths the adapter relies on.
+    // The helper returns the SAME head-FIRST `[B, nq, T, hd]` `attn_output`,
+    // so the `try_tape_sdpa_fallback_cuda` adapter + transpose/reshape-back
+    // logic below is byte-for-byte identical regardless of which path ran.
+    let attn_output = {
+        #[cfg(feature = "cuda")]
+        {
+            match try_kt_gqa_sdpa_matmuls(&q, &k, &v, seq_len, scale)? {
+                Some(out) => out,
+                None => {
+                    let attn_scores = q.broadcast_matmul(&k.t()?)?;
+                    let attn_scores = (attn_scores / scale)?;
+                    let attn_scores =
+                        apply_causal_mask_with_offset(&attn_scores, seq_len, seq_len, 0)?;
+                    let attn_weights_softmax = cuda_softmax_last_dim(&attn_scores)?;
+                    attn_weights_softmax.broadcast_matmul(&v)? // [B, nq, T, hd]
+                }
+            }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            let attn_scores = q.broadcast_matmul(&k.t()?)?;
+            let attn_scores = (attn_scores / scale)?;
+            let attn_scores = apply_causal_mask_with_offset(&attn_scores, seq_len, seq_len, 0)?;
+            let attn_weights_softmax = cuda_softmax_last_dim(&attn_scores)?;
+            attn_weights_softmax.broadcast_matmul(&v)? // [B, nq, T, hd]
+        }
+    };
 
     // #1082 CP-4: route the GQA SDPA fallback through the kt Tape when
     // KILN_USE_TAPE_SDPA + an active tape scope are set, so a

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -45,6 +45,17 @@ use crate::weights::{DeferredMtpSource, ModelWeights, MtpWeights, TensorDType, W
 
 use kiln_core::block::BlockTable;
 
+/// kt-tensor type alias (#1082). Bare `Tensor` in this file is
+/// `candle_core::Tensor`; `KtTensor` is the kiln-native
+/// `kiln_tensor::Tensor`. Used by the kt-native embedding + lm_head
+/// helpers and the `GpuWeights` kt accessors so the candle↔kt seam
+/// is explicit at the region boundaries while public signatures stay
+/// candle-typed. Always available (the alias itself pulls in no CUDA
+/// toolchain dependency); the accessors and helpers that construct
+/// `KtTensor` device storage are `#[cfg(feature = "cuda")]`.
+#[allow(unused_imports)]
+use kiln_tensor::Tensor as KtTensor;
+
 /// The reduction-axis marker for "the last dimension" — passed to
 /// `Tensor::sum_keepdim` / `max_keepdim` / `mean_keepdim` / `cumsum` /
 /// `narrow` / `Tensor::cat` / `unsqueeze` in this file. Consolidates
@@ -6621,6 +6632,67 @@ impl GpuWeights {
         kiln_kt_bridge::kt_device_from_candle(self.embed_tokens.device())
     }
 
+    /// kt-native view of the token-embedding table (#1082, embedding
+    /// region migration).
+    ///
+    /// Borrows `embed_tokens` ([vocab, hidden]) as a `KtTensor` via the
+    /// zero-copy CUDA bridge so the embedding region can run its gather
+    /// (`kiln_tensor::cuda_index_select_dim0`) on kt storage without the
+    /// caller re-borrowing the candle field each call. `embed_tokens` is
+    /// uploaded contiguous at load (`from_model_weights`), so the
+    /// `contiguous()` here is a cheap Arc clone in the common case; it is
+    /// kept defensively because the bridge borrow requires contiguity.
+    ///
+    /// CUDA-only: the borrow adapter requires a CUDA device. Returns a
+    /// typed error on non-CUDA (callers fall through to the candle
+    /// `index_select` path). Public signatures of the embedding
+    /// functions stay candle-typed — this accessor is the explicit
+    /// candle→kt boundary at the weight side.
+    #[cfg(feature = "cuda")]
+    pub fn embed_tokens_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.embed_tokens.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "embed_tokens_kt: embed_tokens must be on CUDA for the kt borrow \
+                 (got {:?})",
+                self.embed_tokens.device().location()
+            );
+        }
+        let contig = self
+            .embed_tokens
+            .contiguous()
+            .context("embed_tokens_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("embed_tokens_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed token-embedding table
+    /// (#1082, lm_head region migration).
+    ///
+    /// Borrows `embed_tokens_t` ([hidden, vocab], contiguous since load)
+    /// as a `KtTensor` so the lm_head region's final projection
+    /// (`hidden @ embed_tokens_t`) can dispatch through
+    /// `kiln_tensor::cuda_matmul` on kt storage. Same contiguity /
+    /// CUDA-only contract as [`GpuWeights::embed_tokens_kt`].
+    ///
+    /// This is the weight-side candle→kt boundary for the lm_head
+    /// region; the hidden-state side bridges in the lm_head helper.
+    #[cfg(feature = "cuda")]
+    pub fn embed_tokens_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.embed_tokens_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "embed_tokens_t_kt: embed_tokens_t must be on CUDA for the kt borrow \
+                 (got {:?})",
+                self.embed_tokens_t.device().location()
+            );
+        }
+        let contig = self
+            .embed_tokens_t
+            .contiguous()
+            .context("embed_tokens_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("embed_tokens_t_kt borrow: {e}"))
+    }
+
     /// Convert `ModelWeights` (CPU bytes) into candle tensors on the given device.
     ///
     /// `config` is used to precompute the rotary `inv_freq` tensor once so the RoPE
@@ -7130,15 +7202,44 @@ fn embedding_lookup_with_index(index: &Tensor, embed_weights: &Tensor) -> Result
     promote_cpu_activation(embed_weights.index_select(index, 0)?)
 }
 
-/// Phase 7 (#1082) — kt-API embedding-lookup migration helper.
-/// Routes the dim-0 `index_select` underlying token-embedding
-/// gather through `kiln_tensor::cuda_index_select_dim0`.
+/// Phase 7 (#1082) — **kt-native** embedding-lookup core.
+///
+/// Operates entirely on `KtTensor` storage: given the token-embedding
+/// table and the U32 index already borrowed as kt tensors, performs the
+/// dim-0 gather via `kiln_tensor::cuda_index_select_dim0` and returns
+/// the gathered rows as a `KtTensor` (no candle in the signature). This
+/// is the consolidated kt-internal computation for the embedding region;
+/// the candle↔kt bridging lives in the thin
+/// [`try_kt_embedding_lookup`] wrapper (hidden-state side) and the
+/// [`GpuWeights::embed_tokens_kt`] accessor (weight side).
+///
+/// Bit-exact memcpy gather — identical byte output to candle's
+/// `index_select` (no arithmetic, no reordering). The `kiln/embedding_kt`
+/// NVTX range is opened by the calling wrappers
+/// ([`try_kt_embedding_lookup`] and [`try_kt_embedding_lookup_from_weights`])
+/// so it brackets the full migrated computation (borrow-in + gather +
+/// copy-out), matching the pre-refactor trace shape; this core does not
+/// open its own range to avoid a nested duplicate.
+#[cfg(feature = "cuda")]
+fn kt_embedding_lookup_native(
+    embed_weights_kt: &KtTensor,
+    index_kt: &KtTensor,
+) -> Result<KtTensor> {
+    kiln_tensor::cuda_index_select_dim0(embed_weights_kt, index_kt)
+        .map_err(|e| anyhow::anyhow!("kt_embedding_lookup_native: index_select failed: {e}"))
+}
+
+/// Phase 7 (#1082) — kt-API embedding-lookup candle-boundary wrapper.
+/// Borrows the candle `embed_weights` + `index` as kt tensors, runs the
+/// kt-native gather ([`kt_embedding_lookup_native`]), and bridges the kt
+/// output back to a candle `Tensor` so the public
+/// [`embedding_lookup`] / [`embedding_lookup_with_index`] signatures stay
+/// candle-typed. The candle↔kt boundaries are: borrow-in (weight +
+/// index) and dtod-copy-out (gathered rows).
 ///
 /// Returns `Ok(None)` on any incompatibility (gate off, non-CUDA,
 /// non-contiguous, unsupported dtype, indices not U32) so the
-/// caller falls through to candle's `index_select`. NVTX range
-/// `kiln/embedding_kt` brackets the migrated call so nsys traces
-/// separate the path from the candle baseline.
+/// caller falls through to candle's `index_select`.
 #[cfg(feature = "cuda")]
 fn try_kt_embedding_lookup(
     embed_weights: &Tensor,
@@ -7164,6 +7265,7 @@ fn try_kt_embedding_lookup(
 
     kiln_nvtx::range!(c"kiln/embedding_kt");
 
+    // candle→kt boundary (weight + index borrow-in).
     let w_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(embed_weights) {
         Ok(t) => t,
         Err(_) => return Ok(None),
@@ -7172,13 +7274,88 @@ fn try_kt_embedding_lookup(
         Ok(t) => t,
         Err(_) => return Ok(None),
     };
-    let out_kt = match kiln_tensor::cuda_index_select_dim0(&w_kt, &idx_kt) {
+    // kt-internal computation.
+    let out_kt = match kt_embedding_lookup_native(&w_kt, &idx_kt) {
         Ok(t) => t,
         Err(_) => return Ok(None),
     };
+    // kt→candle boundary (gathered rows copy-out).
     let out = kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&out_kt)
         .map_err(|e| anyhow::anyhow!("try_kt_embedding_lookup: candle copy-back failed: {e}"))?;
     Ok(Some(out))
+}
+
+/// Phase 7 (#1082) — weight-aware kt-native embedding lookup at the
+/// embedding→layer0 seam. Borrows the token-embedding table through
+/// [`GpuWeights::embed_tokens_kt`] (the weight-side candle→kt boundary)
+/// and the U32 index through the kt-bridge, runs the kt-native gather
+/// ([`kt_embedding_lookup_native`]), and bridges the gathered rows back
+/// to candle so the still-candle transformer layers consume an
+/// unchanged candle `Tensor`.
+///
+/// This is the consolidated kt-internal embedding path used by the
+/// production `embedding_lookup_from_weights*` callers (the non-stub
+/// `[vocab, hidden]` layout). Returns `Ok(None)` on any
+/// incompatibility (gate off, tape-forward path active, non-CUDA,
+/// non-contiguous, unsupported dtype, indices not U32) so the caller
+/// falls through to the candle `embedding_lookup*` path. The tape path
+/// is intentionally NOT handled here — when `KILN_USE_TAPE_FORWARD` is
+/// active the caller's `embedding_lookup*` candle entry records the
+/// `EmbeddingBackward` node, which this direct accessor path would
+/// bypass; we defer to it by returning `Ok(None)` so behavior is
+/// preserved on the training tape path.
+#[cfg(feature = "cuda")]
+fn try_kt_embedding_lookup_from_weights(
+    index: &Tensor,
+    weights: &GpuWeights,
+) -> Result<Option<Tensor>> {
+    if !cuda_use_kt_api_embedding() {
+        return Ok(None);
+    }
+    // Defer to the candle `embedding_lookup*` entry (which owns the
+    // tape-forward branch) whenever the tape-forward feature is enabled.
+    // That entry records the `EmbeddingBackward` node when a tape scope
+    // is active and otherwise falls through to its own kt path, so
+    // deferring here keeps the training/tape behavior bit-identical.
+    if crate::tape_forward::tape_forward_enabled() {
+        return Ok(None);
+    }
+    if !matches!(weights.embed_tokens.device(), Device::Cuda(_))
+        || !matches!(index.device(), Device::Cuda(_))
+        || !weights.embed_tokens.is_contiguous()
+        || !index.is_contiguous()
+        || index.dtype() != DType::U32
+        || !matches!(
+            weights.embed_tokens.dtype(),
+            DType::F32 | DType::BF16 | DType::F16
+        )
+    {
+        return Ok(None);
+    }
+
+    kiln_nvtx::range!(c"kiln/embedding_kt");
+
+    // candle→kt boundary: weight side via the accessor, index side via
+    // the kt-bridge borrow.
+    let w_kt = match weights.embed_tokens_kt() {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let idx_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(index) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    // kt-internal computation.
+    let out_kt = match kt_embedding_lookup_native(&w_kt, &idx_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    // kt→candle boundary (gathered rows copy-out feeding the candle
+    // transformer layers).
+    let out = kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&out_kt).map_err(|e| {
+        anyhow::anyhow!("try_kt_embedding_lookup_from_weights: candle copy-back failed: {e}")
+    })?;
+    promote_cpu_activation(out).map(Some)
 }
 
 fn embedding_lookup_from_weights(token_ids: &[u32], weights: &GpuWeights) -> Result<Tensor> {
@@ -7187,6 +7364,16 @@ fn embedding_lookup_from_weights(token_ids: &[u32], weights: &GpuWeights) -> Res
         let expected_embed_dims = [t_dims[1], t_dims[0]];
         if weights.embed_tokens.dims() != expected_embed_dims.as_slice() {
             return embedding_lookup_from_transposed(token_ids, &weights.embed_tokens_t);
+        }
+    }
+    // Non-stub `[vocab, hidden]` layout: route the gather through the
+    // weight-aware kt-native path (using `embed_tokens_kt()`) when
+    // eligible; fall through to the candle `embedding_lookup` otherwise.
+    #[cfg(feature = "cuda")]
+    {
+        let index = Tensor::new(token_ids, weights.embed_tokens.device())?;
+        if let Some(out) = try_kt_embedding_lookup_from_weights(&index, weights)? {
+            return Ok(out);
         }
     }
     embedding_lookup(token_ids, &weights.embed_tokens)
@@ -7202,6 +7389,14 @@ fn embedding_lookup_from_weights_with_index(
         if weights.embed_tokens.dims() != expected_embed_dims.as_slice() {
             return embedding_lookup_from_transposed_index(index, &weights.embed_tokens_t);
         }
+    }
+
+    // Non-stub `[vocab, hidden]` layout: route the gather through the
+    // weight-aware kt-native path (using `embed_tokens_kt()`) when
+    // eligible; fall through to the candle `embedding_lookup_with_index`.
+    #[cfg(feature = "cuda")]
+    if let Some(out) = try_kt_embedding_lookup_from_weights(index, weights)? {
+        return Ok(out);
     }
 
     embedding_lookup_with_index(index, &weights.embed_tokens)
@@ -11747,6 +11942,29 @@ fn try_kt_lora_delta(
     Ok(Some(delta2d.reshape(out_shape)?))
 }
 
+/// Phase 7 (#1082) — **kt-native** LM head matmul core.
+///
+/// Operates entirely on `KtTensor` storage: given the flattened
+/// `[lead, K]` hidden state and the `[K, vocab]` transposed embedding,
+/// both already borrowed as kt tensors, performs the final projection
+/// via `kiln_tensor::cuda_matmul` (cublasLt) and returns the
+/// `[lead, vocab]` logits as a `KtTensor`. This is the consolidated
+/// kt-internal computation for the lm_head region; the candle↔kt
+/// bridging (and the captured-graph output-buffer fast path) lives in
+/// the [`try_kt_lm_head`] wrapper.
+///
+/// The matmul is bit-exact to the candle baseline for the LM head
+/// (cublasLt BF16-input + FP32-accumulate, the same intrinsic candle's
+/// matmul dispatches to). The `kiln/lm_head_kt` NVTX range is opened by
+/// the [`try_kt_lm_head`] wrapper (covering both this core and the
+/// captured-graph `cuda_matmul_into` branch), so this core does not open
+/// its own range to avoid a nested duplicate.
+#[cfg(feature = "cuda")]
+fn kt_lm_head_native(lhs_kt: &KtTensor, rhs_kt: &KtTensor) -> Result<KtTensor> {
+    kiln_tensor::cuda_matmul(lhs_kt, rhs_kt)
+        .map_err(|e| anyhow::anyhow!("kt_lm_head_native: matmul failed: {e}"))
+}
+
 /// Phase 7 (#1082) — kt-API LM head migration helper. Routes the
 /// `[B*T, hidden] @ [hidden, vocab] -> [B*T, vocab]` final projection
 /// through `kiln_tensor::cuda_matmul` (cublasLt) directly. The LM
@@ -11757,7 +11975,11 @@ fn try_kt_lora_delta(
 ///
 /// Flattens any leading dims to a 2D `[lead, K]` view before
 /// dispatching to keep the kt path on the `M-N-K` cublasLt entry
-/// shape; reshapes the result back to match the input rank.
+/// shape; reshapes the result back to match the input rank. The
+/// candle↔kt boundaries are: borrow-in (hidden + weight) and
+/// dtod-copy-out (logits) — except on the captured-graph fast path,
+/// which writes the matmul result directly into a pre-allocated,
+/// graph-stable candle output buffer via `cuda_matmul_into`.
 ///
 /// Returns `Ok(None)` on any incompatibility (gate off, non-CUDA,
 /// non-{BF16,F16,F32}, dtype mismatch, non-contiguous,
@@ -11798,6 +12020,7 @@ fn try_kt_lm_head(x: &Tensor, embed_tokens_t: &Tensor) -> Result<Option<Tensor>>
         Err(_) => return Ok(None),
     };
 
+    // candle→kt boundary (hidden + weight borrow-in).
     let lhs_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&x2d) {
         Ok(t) => t,
         Err(_) => return Ok(None),
@@ -11841,10 +12064,12 @@ fn try_kt_lm_head(x: &Tensor, embed_tokens_t: &Tensor) -> Result<Option<Tensor>>
         return Ok(Some(dst_candle));
     }
 
-    let out_kt = match kiln_tensor::cuda_matmul(&lhs_kt, &rhs_kt) {
+    // kt-internal computation (no captured-graph buffer installed).
+    let out_kt = match kt_lm_head_native(&lhs_kt, &rhs_kt) {
         Ok(t) => t,
         Err(_) => return Ok(None),
     };
+    // kt→candle boundary (logits copy-out).
     let out2d = kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&out_kt)
         .map_err(|e| anyhow::anyhow!("try_kt_lm_head: candle copy-back failed: {e}"))?;
     Ok(Some(out2d.reshape(out_shape)?))

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -355,6 +355,47 @@ fn cuda_use_kt_api_lm_head() -> bool {
     !cuda_kt_api_master_off() && (direct || cuda_use_kt_api_all())
 }
 
+/// Phase 7 default-on (#1082): the consolidated SwiGLU FFN region
+/// (`down @ (silu(gate @ x) * (up @ x))`) through the kt-API +
+/// adapters. Routes the whole gate/up/down projection + silu*mul
+/// composite through the kt substrate (`kiln_tensor::cuda_matmul`
+/// for each projection, `kiln_rmsnorm_kernel::fused_mlp_silu_mul_kt`
+/// / `kiln_tensor::ops::mul_sigmoid_gate` for the SwiGLU activation)
+/// keeping the gate/up intermediates as `KtTensor` storage across the
+/// region instead of bridging candle↔kt at every individual op.
+///
+/// This is the region-2 sibling of [`cuda_use_kt_api_embedding`] /
+/// [`cuda_use_kt_api_lm_head`] (regions 0/1): the per-op kt-API gates
+/// ([`cuda_use_kt_api_matmul`] + the inline `fused_mlp_silu_mul_kt`
+/// dispatch) already route the individual MLP ops through kt, but each
+/// op paid a candle↔kt borrow-in + dtod copy-out at its boundary. The
+/// consolidated path collapses the two intermediate dtod copies
+/// (gate/up matmul outputs and the silu*mul output) into a single
+/// candle→kt borrow at the region input and one kt→candle copy at the
+/// region output.
+///
+/// Bit-exact by construction: each sub-op bottoms out in the SAME kt
+/// substrate kernel the per-op gates already dispatch to (cublasLt
+/// matmul; `kiln_fused_mlp_silu_mul_bf16` FFI symbol for the BF16
+/// silu*mul; the `cuda_activation_unary(0)` + `cuda_elementwise_binary(2)`
+/// substrate composite for other dtypes). The only difference is the
+/// elision of the intermediate round-trips through candle storage.
+///
+/// Restricted to the production inference fast path: no LoRA, no
+/// Marlin-packed projections, no autograd-tracked input, and no active
+/// tape recording scope (all those route through the existing candle /
+/// tape-wired path so adapter grads and Marlin int4 dispatch are
+/// preserved). Escape hatch: `KILN_DISABLE_KT_API_SWIGLU_FFN=1`.
+/// NVTX range `kiln/swiglu_ffn_kt` brackets the migrated region so
+/// nsys traces separate it from the candle baseline.
+#[cfg(feature = "cuda")]
+fn cuda_use_kt_api_swiglu_ffn() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    let direct =
+        *ENABLED.get_or_init(|| std::env::var("KILN_DISABLE_KT_API_SWIGLU_FFN").is_err());
+    !cuda_kt_api_master_off() && (direct || cuda_use_kt_api_all())
+}
+
 /// Phase 7 (#1082) opt-in: LoRA delta composite
 /// (`(x @ A^T) @ B^T * scale`) through the kt-API + adapters.
 /// Set `KILN_USE_KT_API_LORA_DELTA=1` (or `KILN_USE_KT_API_ALL=1`)
@@ -5074,6 +5115,80 @@ pub struct GpuFfnWeights {
     pub gate_proj_marlin: Option<crate::marlin_proj::MarlinPackedProj>,
     pub up_proj_marlin: Option<crate::marlin_proj::MarlinPackedProj>,
     pub down_proj_marlin: Option<crate::marlin_proj::MarlinPackedProj>,
+}
+
+impl GpuFfnWeights {
+    /// kt-native view of the pre-transposed SwiGLU gate projection
+    /// (#1082, MLP/FFN region migration — region 2).
+    ///
+    /// Borrows `gate_proj_t` (`[hidden, intermediate]`, contiguous since
+    /// load) as a `KtTensor` via the zero-copy CUDA bridge so the
+    /// consolidated kt-native SwiGLU helper ([`kt_swiglu_ffn_native`])
+    /// can dispatch `x @ gate_proj_t` through `kiln_tensor::cuda_matmul`
+    /// without re-borrowing the candle field each call. `gate_proj_t` is
+    /// uploaded contiguous at load (`from_model_weights`), so the
+    /// `contiguous()` here is a cheap Arc clone in the common case; it is
+    /// kept defensively because the bridge borrow requires contiguity.
+    ///
+    /// CUDA-only and the weight-side candle→kt boundary, mirroring
+    /// [`GpuWeights::embed_tokens_t_kt`]. Returns a typed error on
+    /// non-CUDA (the caller falls through to the candle MLP path).
+    #[cfg(feature = "cuda")]
+    pub fn gate_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.gate_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "gate_proj_t_kt: gate_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.gate_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .gate_proj_t
+            .contiguous()
+            .context("gate_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("gate_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed SwiGLU up projection
+    /// (#1082, MLP/FFN region migration — region 2). Same contiguity /
+    /// CUDA-only contract as [`GpuFfnWeights::gate_proj_t_kt`]; used for
+    /// the `x @ up_proj_t` matmul in [`kt_swiglu_ffn_native`].
+    #[cfg(feature = "cuda")]
+    pub fn up_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.up_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "up_proj_t_kt: up_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.up_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .up_proj_t
+            .contiguous()
+            .context("up_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("up_proj_t_kt borrow: {e}"))
+    }
+
+    /// kt-native view of the pre-transposed SwiGLU down projection
+    /// (#1082, MLP/FFN region migration — region 2). Shape
+    /// `[intermediate, hidden]`. Same contiguity / CUDA-only contract as
+    /// [`GpuFfnWeights::gate_proj_t_kt`]; used for the final
+    /// `hidden @ down_proj_t` matmul in [`kt_swiglu_ffn_native`].
+    #[cfg(feature = "cuda")]
+    pub fn down_proj_t_kt(&self) -> Result<KtTensor> {
+        if !matches!(self.down_proj_t.device(), Device::Cuda(_)) {
+            anyhow::bail!(
+                "down_proj_t_kt: down_proj_t must be on CUDA for the kt borrow (got {:?})",
+                self.down_proj_t.device().location()
+            );
+        }
+        let contig = self
+            .down_proj_t
+            .contiguous()
+            .context("down_proj_t_kt: contiguous")?;
+        kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&contig)
+            .map_err(|e| anyhow::anyhow!("down_proj_t_kt borrow: {e}"))
+    }
 }
 
 /// State for Gated DeltaNet linear attention layers.
@@ -10941,6 +11056,194 @@ fn swiglu_ffn_split_gate_up(
     Ok((gate, up))
 }
 
+/// kt-native SwiGLU FFN core (#1082, MLP/FFN region migration —
+/// region 2). Computes `down @ (silu(gate @ x) * (up @ x))` entirely
+/// over `KtTensor` storage so the gate/up matmul outputs and the
+/// silu*mul result never round-trip through candle. This is the
+/// consolidated kt-internal computation for the MLP region; the
+/// candle↔kt bridging (and all the dispatch-eligibility preconditions)
+/// live in the [`try_kt_swiglu_ffn`] wrapper.
+///
+/// Inputs are all kt 2D views: `x2d` is `[lead, hidden]`, `gate_t` /
+/// `up_t` are `[hidden, intermediate]`, `down_t` is
+/// `[intermediate, hidden]`. Returns the `[lead, hidden]` FFN output as
+/// a `KtTensor`; the wrapper reshapes it back to the input rank.
+///
+/// Bit-exact to the existing per-op kt path:
+/// - each projection is `kiln_tensor::cuda_matmul` (the same cublasLt
+///   entry the per-op [`try_kt_matmul`] gate already dispatches to);
+/// - the SwiGLU activation prefers `fused_mlp_silu_mul_kt` (the exact
+///   `kiln_fused_mlp_silu_mul_bf16` FFI symbol the existing fused fast
+///   path uses) when the BF16 fused kernel supports the operands, and
+///   otherwise falls back to `kiln_tensor::ops::mul_sigmoid_gate`,
+///   whose CUDA fast path composes the same
+///   `cuda_activation_unary(kind=0)` + `cuda_elementwise_binary(kind=2)`
+///   substrate kernels.
+///
+/// The `kiln/swiglu_ffn_kt` NVTX range is opened by the
+/// [`try_kt_swiglu_ffn`] wrapper, so this core does not open its own to
+/// avoid a nested duplicate. The inner `kiln/mlp/{gate,up,down}` ranges
+/// are preserved so nsys per-stage attribution is unchanged.
+#[cfg(feature = "cuda")]
+fn kt_swiglu_ffn_native(
+    x2d: &KtTensor,
+    gate_t: &KtTensor,
+    up_t: &KtTensor,
+    down_t: &KtTensor,
+) -> Result<KtTensor> {
+    let gate = {
+        kiln_nvtx::range!(c"kiln/mlp/gate");
+        kiln_tensor::cuda_matmul(x2d, gate_t)
+            .map_err(|e| anyhow::anyhow!("kt_swiglu_ffn_native: gate matmul: {e}"))?
+    };
+    let up = {
+        kiln_nvtx::range!(c"kiln/mlp/up");
+        kiln_tensor::cuda_matmul(x2d, up_t)
+            .map_err(|e| anyhow::anyhow!("kt_swiglu_ffn_native: up matmul: {e}"))?
+    };
+    let hidden = {
+        kiln_nvtx::range!(c"kiln/mlp/gate_silu_hidden_mul");
+        if kiln_rmsnorm_kernel::supports_mlp_silu_mul_kt(&gate, &up) {
+            // Same fused BF16 kernel (`kiln_fused_mlp_silu_mul_bf16`) the
+            // existing inline fast path uses — bit-exact.
+            kiln_rmsnorm_kernel::fused_mlp_silu_mul_kt(&gate, &up)
+                .map_err(|e| anyhow::anyhow!("kt_swiglu_ffn_native: fused silu*mul: {e}"))?
+        } else {
+            // Non-BF16 (F16/F32) operands: the substrate composite
+            // (silu via cuda_activation_unary(0), then mul via
+            // cuda_elementwise_binary(2)) — identical to the candle
+            // fallback's per-op kt route.
+            kiln_tensor::ops::mul_sigmoid_gate(&gate, &up)
+                .map_err(|e| anyhow::anyhow!("kt_swiglu_ffn_native: mul_sigmoid_gate: {e}"))?
+        }
+    };
+    let out = {
+        kiln_nvtx::range!(c"kiln/mlp/down");
+        kiln_tensor::cuda_matmul(&hidden, down_t)
+            .map_err(|e| anyhow::anyhow!("kt_swiglu_ffn_native: down matmul: {e}"))?
+    };
+    Ok(out)
+}
+
+/// Phase 7 default-on (#1082) — consolidated kt-API SwiGLU FFN
+/// migration wrapper (region 2). Routes the whole
+/// `down @ (silu(gate @ x) * (up @ x))` MLP region through the
+/// kt-native [`kt_swiglu_ffn_native`] core, keeping intermediates as
+/// `KtTensor` storage (one candle→kt borrow at the input, one kt→candle
+/// copy at the output) instead of bridging at every individual op.
+///
+/// Flattens the leading dims of `x` to a 2D `[lead, hidden]` view
+/// before dispatch (mirroring [`matmul_no_broadcast_copy`] /
+/// [`try_kt_lm_head`]) and reshapes the result back to the input rank.
+///
+/// Returns `Ok(None)` — falling through to the existing
+/// projection-by-projection candle path — on any of:
+/// - the gate is off (`KILN_DISABLE_KT_API_SWIGLU_FFN=1` /
+///   `KILN_DISABLE_KT_API_ALL=1`);
+/// - non-CUDA device, or a non-{BF16,F16,F32} / mixed dtype;
+/// - non-contiguous `x` or weights, or weight rank ≠ 2, or a K-dim
+///   mismatch between `x` and the projections;
+/// - autograd-tracked `x` or an active tape recording scope (those must
+///   keep flowing through the candle / tape-wired silu+mul + LoRA path
+///   so adapter grads are not severed);
+/// - any kt borrow / matmul failure (the candle path then runs).
+///
+/// LoRA and Marlin eligibility is checked by the *caller* (the
+/// `!has_mlp_lora && !has_marlin` guard in [`swiglu_ffn_impl_no_chunk`])
+/// before this is invoked, because those need the standalone candle
+/// projections + delta application.
+#[cfg(feature = "cuda")]
+fn try_kt_swiglu_ffn(x: &Tensor, mlp: &GpuFfnWeights) -> Result<Option<Tensor>> {
+    if !cuda_use_kt_api_swiglu_ffn() {
+        return Ok(None);
+    }
+    // The tape-wired path (training) must run through the candle /
+    // tape-forward silu+mul so the gate/up projections' grads chain.
+    if x.track_op()
+        || (crate::tape_forward::tape_forward_enabled()
+            && kiln_kt_bridge::tape_bridge::bridge_scope_active())
+    {
+        return Ok(None);
+    }
+    let x_dims = x.dims();
+    if x_dims.len() < 2 {
+        return Ok(None);
+    }
+    let g_dims = mlp.gate_proj_t.dims();
+    let u_dims = mlp.up_proj_t.dims();
+    let d_dims = mlp.down_proj_t.dims();
+    if g_dims.len() != 2 || u_dims.len() != 2 || d_dims.len() != 2 {
+        return Ok(None);
+    }
+    let hidden = x_dims[x_dims.len() - 1];
+    let intermediate = g_dims[1];
+    // x:[*, hidden] @ gate_t:[hidden, intermediate]; same for up.
+    // hidden_act:[*, intermediate] @ down_t:[intermediate, hidden].
+    if g_dims[0] != hidden
+        || u_dims[0] != hidden
+        || u_dims[1] != intermediate
+        || d_dims[0] != intermediate
+        || d_dims[1] != hidden
+    {
+        return Ok(None);
+    }
+    let dtype = x.dtype();
+    if !matches!(dtype, DType::BF16 | DType::F16 | DType::F32)
+        || mlp.gate_proj_t.dtype() != dtype
+        || mlp.up_proj_t.dtype() != dtype
+        || mlp.down_proj_t.dtype() != dtype
+        || !matches!(x.device(), Device::Cuda(_))
+        || !matches!(mlp.gate_proj_t.device(), Device::Cuda(_))
+        || !matches!(mlp.up_proj_t.device(), Device::Cuda(_))
+        || !matches!(mlp.down_proj_t.device(), Device::Cuda(_))
+        || !x.is_contiguous()
+    {
+        return Ok(None);
+    }
+
+    kiln_nvtx::range!(c"kiln/swiglu_ffn_kt");
+
+    let lead: usize = x_dims[..x_dims.len() - 1].iter().product();
+    let x2d = match x.reshape((lead, hidden)) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+
+    // candle→kt boundary (input borrow-in + weight accessors).
+    let x2d_kt = match kiln_kt_bridge::kt_tensor_from_candle_cuda_borrow(&x2d) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let gate_t_kt = match mlp.gate_proj_t_kt() {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let up_t_kt = match mlp.up_proj_t_kt() {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+    let down_t_kt = match mlp.down_proj_t_kt() {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+
+    // kt-internal computation: gate/up matmuls → silu*mul → down matmul.
+    let out_kt = match kt_swiglu_ffn_native(&x2d_kt, &gate_t_kt, &up_t_kt, &down_t_kt) {
+        Ok(t) => t,
+        Err(_) => return Ok(None),
+    };
+
+    // kt→candle boundary (output copy-out), then restore input rank.
+    let out2d = kiln_kt_bridge::kt_tensor_to_candle_cuda_copy(&out_kt)
+        .map_err(|e| anyhow::anyhow!("try_kt_swiglu_ffn: candle copy-back failed: {e}"))?;
+    let mut out_shape: Vec<usize> = x_dims[..x_dims.len() - 1].to_vec();
+    out_shape.push(hidden);
+    let out = out2d
+        .reshape(out_shape)
+        .context("try_kt_swiglu_ffn: output reshape")?;
+    Ok(Some(out))
+}
+
 fn swiglu_ffn_impl_no_chunk(
     backend: Option<&dyn BackendRuntime>,
     x: &Tensor,
@@ -11146,6 +11449,24 @@ fn swiglu_ffn_impl_no_chunk(
                         }
                     }
                 }
+            }
+        }
+    }
+    // Consolidated kt-native SwiGLU FFN (#1082, region 2). When the
+    // packed `gate_up_proj_t` prefill fast path above did not fire (no
+    // cached fused transpose, or its silu*mul kernel declined) and there
+    // is no MLP LoRA / Marlin, route the entire gate/up/down + silu*mul
+    // region through the kt substrate keeping intermediates as kt storage
+    // (one borrow-in, one copy-out) instead of the per-op candle↔kt
+    // round-trips the legacy `swiglu_ffn_split_gate_up` path pays. Returns
+    // `None` on any incompatibility (tape scope, tracked input, dtype, …)
+    // so the legacy path below runs unchanged. Gated default-on with
+    // escape hatch `KILN_DISABLE_KT_API_SWIGLU_FFN=1`.
+    #[cfg(feature = "cuda")]
+    {
+        if !has_mlp_lora && !has_marlin {
+            if let Some(out) = try_kt_swiglu_ffn(x, mlp)? {
+                return Ok(out);
             }
         }
     }


### PR DESCRIPTION
## What
Hub-migration regions 1–3 of the kiln-model forward.rs candle→kt flip (#1082): consolidate three projection regions to kt-internal compute (`kiln_tensor::cuda_matmul` + kt accessors), bridged, gated **default-ON** behind per-op `cuda_use_kt_api_*` flags that all honor the `KILN_DISABLE_KT_API_ALL` master kill-switch.

- **Region 1** (`879c232f`): embedding + lm_head → kt-internal
- **Region 2** (`3cdfefbb`): SwiGLU MLP/FFN → kt-internal (guarded `!has_mlp_lora && !has_marlin`)
- **Region 3** (`bdc2e2bb`): GQA naive-SDPA-fallback matmuls (q@kᵀ, softmax@v) → `cuda_matmul`

Conservative throughout: candle signatures kept + bridged; the LoRA/Marlin/tape/non-CUDA paths and all fused kernels (GDN recurrent/conv/gates/norms, flash-attn offer/decline, tape adapters) are left byte-for-byte unchanged.

## Validation (H100, arch 90)
Full `kiln-model --features cuda` nextest suite, serialized (`-j1`, per the kt-substrate thread-safety constraint): **465/467 pass**. The 2 failures — `test_causal_conv1d_update_matches_fallback` (kiln-conv1d-kernel numeric tol) and `q_proj_marlin_parity_qwen35_4b` (kiln-marlin-gemm `CUDA_ERROR_ILLEGAL_INSTRUCTION`) — **reproduce identically on `main` (0f77504)** and are pre-existing H100/Hopper vendored-kernel arch issues (production target is A6000/arch-86), untouched by these regions. Every region-relevant test passes: embedding bit-exact parity, swiglu parity, sdpa/flash parity, `model_forward_hybrid_decode/layers/kv_cache_equivalence`, all paged-kv-cache.

Behavior is unchanged when `KILN_DISABLE_KT_API_ALL=1`.