### PR TITLE
kiln-tensor: finish non-autograd method facade + forward.rs type-flip plan (#1082)

### DIFF
--- a/crates/kiln-tensor/src/method_api.rs
+++ b/crates/kiln-tensor/src/method_api.rs
@@ -681,6 +681,95 @@ impl Tensor {
         self.to_vec::<E>()
     }
 
+    /// Read a rank-2 tensor back to a host `Vec<Vec<E>>` (row-major).
+    /// candle: `pub fn to_vec2<S: WithDType>(&self) -> Result<Vec<Vec<S>>>`.
+    ///
+    /// Rank is asserted via [`Tensor::dims2`] (mirrors candle's
+    /// `self.dims2()?` rank-check), then the flat row-major readback from
+    /// kt's existing [`Tensor::to_vec`] is sliced into `dim0` rows of
+    /// `dim1` elements. `to_vec` already returns contiguous row-major
+    /// data, so the row split is a plain chunking — no stride walk.
+    pub fn to_vec2<E: Element>(&self) -> Result<Vec<Vec<E>>> {
+        let (d0, d1) = self.dims2()?;
+        let flat = self.to_vec::<E>()?;
+        let mut rows = Vec::with_capacity(d0);
+        for r in 0..d0 {
+            rows.push(flat[r * d1..(r + 1) * d1].to_vec());
+        }
+        Ok(rows)
+    }
+
+    /// Read a rank-3 tensor back to a host `Vec<Vec<Vec<E>>>` (row-major).
+    /// candle: `pub fn to_vec3<S: WithDType>(&self) -> Result<Vec<Vec<Vec<S>>>>`.
+    ///
+    /// Rank is asserted via [`Tensor::dims3`] (mirrors candle's
+    /// `self.dims3()?`), then the flat contiguous readback from
+    /// [`Tensor::to_vec`] is nested into `d0 × d1 × d2`. Outer index strides
+    /// by `d1 * d2`, middle by `d2`.
+    pub fn to_vec3<E: Element>(&self) -> Result<Vec<Vec<Vec<E>>>> {
+        let (d0, d1, d2) = self.dims3()?;
+        let flat = self.to_vec::<E>()?;
+        let plane = d1 * d2;
+        let mut out = Vec::with_capacity(d0);
+        for i in 0..d0 {
+            let base = i * plane;
+            let mut rows = Vec::with_capacity(d1);
+            for j in 0..d1 {
+                let row_base = base + j * d2;
+                rows.push(flat[row_base..row_base + d2].to_vec());
+            }
+            out.push(rows);
+        }
+        Ok(out)
+    }
+
+    // ==================================================================
+    // Finite / infinite masks — elementwise predicate masks.
+    //
+    // candle-core has NO `is_finite`/`is_infinite` *method* on `Tensor`
+    // (kt previously only had the reduce-to-bool `all_finite()`), so
+    // there is no candle signature to copy here. These follow the
+    // numpy/torch `isfinite`/`isinf` *elementwise-mask* convention the
+    // #1082 flip needs, and the kt `ops::compare` mask convention: a U8
+    // tensor of the same shape, `1` where the predicate holds, `0`
+    // otherwise. Composed entirely from existing kt primitives
+    // (`abs` + a single `lt`/`eq` against a `full_like(±inf)` constant).
+    // ==================================================================
+
+    /// Elementwise finite mask: U8, same shape, `1` where the element is
+    /// finite (not ±inf, not NaN), `0` otherwise.
+    ///
+    /// Composition: `abs(self) < +inf`. IEEE-754 makes this exact in one
+    /// compare — for a finite `v`, `|v| < inf` is true; for `±inf`,
+    /// `inf < inf` is false; for `NaN`, every ordered compare (including
+    /// `NaN < inf`) is false. So no NaN-specific term and no U8 logical-AND
+    /// is needed (kt's `mul`/`minimum` reject U8 anyway). [`ops::abs`]
+    /// materializes a contiguous tensor, so the [`ops::lt`] contiguity
+    /// requirement holds regardless of `self`'s layout.
+    ///
+    /// dtype must be F32/BF16/F16 (the dtypes [`ops::abs`]/[`ops::lt`]
+    /// accept); other dtypes error from the composed ops.
+    pub fn is_finite(&self) -> Result<Self> {
+        let absx = ops::abs(self)?;
+        let inf = ops::full_like(&absx, f32::INFINITY)?;
+        ops::lt(&absx, &inf)
+    }
+
+    /// Elementwise infinite mask: U8, same shape, `1` where the element is
+    /// `+inf` or `-inf`, `0` everywhere else (including NaN).
+    ///
+    /// Composition: `abs(self) == +inf`. For `±inf`, `inf == inf` is true;
+    /// for any finite value the equality is false; for `NaN`, `NaN == inf`
+    /// is false (matching candle/torch `isinf`, which is `0` at NaN).
+    /// Single `eq` against a `full_like(+inf)` constant.
+    ///
+    /// dtype must be F32/BF16/F16; other dtypes error from the composed ops.
+    pub fn is_infinite(&self) -> Result<Self> {
+        let absx = ops::abs(self)?;
+        let inf = ops::full_like(&absx, f32::INFINITY)?;
+        ops::eq(&absx, &inf)
+    }
+
     // ==================================================================
     // Associated constructors — candle: `Tensor::zeros(shape, dt, &dev)`
     // kt Device is `Copy`, so these take `Device` by value (deviation
@@ -1121,6 +1210,122 @@ mod tests {
         assert_eq!(x.to_vec1::<f32>().unwrap(), vec![1.0, 2.0, 3.0]);
         let r2 = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
         assert!(r2.to_vec1::<f32>().is_err());
+    }
+
+    #[test]
+    fn to_vec2_nests_row_major() {
+        // [2,3] -> two rows of three, row-major.
+        let x = t(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+        let nested = x.to_vec2::<f32>().unwrap();
+        assert_eq!(nested, vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+    }
+
+    #[test]
+    fn to_vec2_round_trips_from_known_array() {
+        // Build via from_vec + reshape, read back, assert equal.
+        let known = vec![vec![10.0f32, 20.0], vec![30.0, 40.0], vec![50.0, 60.0]];
+        let flat: Vec<f32> = known.iter().flatten().copied().collect();
+        let x = Tensor::from_vec(flat, vec![3, 2]).unwrap();
+        assert_eq!(x.to_vec2::<f32>().unwrap(), known);
+    }
+
+    #[test]
+    fn to_vec2_rank_mismatch_errors() {
+        let r1 = t(&[1.0, 2.0, 3.0], &[3]);
+        assert!(r1.to_vec2::<f32>().is_err());
+        let r3 = t(&[0.0; 8], &[2, 2, 2]);
+        assert!(r3.to_vec2::<f32>().is_err());
+    }
+
+    #[test]
+    fn to_vec3_nests_row_major() {
+        // [2,2,2] -> 2 planes, each 2 rows of 2, row-major.
+        let x = t(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], &[2, 2, 2]);
+        let nested = x.to_vec3::<f32>().unwrap();
+        assert_eq!(
+            nested,
+            vec![
+                vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+                vec![vec![5.0, 6.0], vec![7.0, 8.0]],
+            ]
+        );
+    }
+
+    #[test]
+    fn to_vec3_round_trips_non_cubic() {
+        // [1,2,3] exercises distinct d0/d1/d2 strides.
+        let known = vec![vec![
+            vec![1.0f32, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+        ]];
+        let flat: Vec<f32> = known
+            .iter()
+            .flatten()
+            .flatten()
+            .copied()
+            .collect();
+        let x = Tensor::from_vec(flat, vec![1, 2, 3]).unwrap();
+        assert_eq!(x.to_vec3::<f32>().unwrap(), known);
+    }
+
+    #[test]
+    fn to_vec3_rank_mismatch_errors() {
+        let r2 = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        assert!(r2.to_vec3::<f32>().is_err());
+        let r1 = t(&[1.0, 2.0], &[2]);
+        assert!(r1.to_vec3::<f32>().is_err());
+    }
+
+    // --- is_finite / is_infinite masks --------------------------------
+
+    fn read_u8(x: &Tensor) -> Vec<u8> {
+        x.to_vec::<u8>().unwrap()
+    }
+
+    #[test]
+    fn is_finite_mask_exact() {
+        // [1.0, 2.0, +inf, -inf, NaN] -> finite mask 1,1,0,0,0.
+        let x = t(
+            &[1.0, 2.0, f32::INFINITY, f32::NEG_INFINITY, f32::NAN],
+            &[5],
+        );
+        let mask = x.is_finite().unwrap();
+        assert_eq!(mask.dtype(), DType::U8);
+        assert_eq!(mask.shape(), &[5]);
+        assert_eq!(read_u8(&mask), vec![1, 1, 0, 0, 0]);
+    }
+
+    #[test]
+    fn is_infinite_mask_exact() {
+        // [1.0, 2.0, +inf, -inf, NaN] -> infinite mask 0,0,1,1,0.
+        let x = t(
+            &[1.0, 2.0, f32::INFINITY, f32::NEG_INFINITY, f32::NAN],
+            &[5],
+        );
+        let mask = x.is_infinite().unwrap();
+        assert_eq!(mask.dtype(), DType::U8);
+        assert_eq!(mask.shape(), &[5]);
+        assert_eq!(read_u8(&mask), vec![0, 0, 1, 1, 0]);
+    }
+
+    #[test]
+    fn is_finite_and_is_infinite_are_complementary_off_nan() {
+        // For non-NaN inputs, finite and infinite masks partition: their
+        // sum is 1 everywhere. (NaN is 0 in both, so it's excluded here.)
+        let x = t(&[0.0, -7.5, f32::INFINITY, f32::NEG_INFINITY], &[4]);
+        let fin = read_u8(&x.is_finite().unwrap());
+        let inf = read_u8(&x.is_infinite().unwrap());
+        for (f, i) in fin.iter().zip(inf.iter()) {
+            assert_eq!(f + i, 1, "finite={f} infinite={i} should partition");
+        }
+    }
+
+    #[test]
+    fn is_finite_preserves_multidim_shape() {
+        let x = t(&[1.0, f32::INFINITY, f32::NAN, -3.0], &[2, 2]);
+        let mask = x.is_finite().unwrap();
+        assert_eq!(mask.shape(), &[2, 2]);
+        assert_eq!(read_u8(&mask), vec![1, 0, 0, 1]);
     }
 
     // --- constructors --------------------------------------------------

--- a/docs/issue-1082-forward-rs-type-flip-plan-2026-05-29.md
+++ b/docs/issue-1082-forward-rs-type-flip-plan-2026-05-29.md
@@ -1,0 +1,136 @@
+# Issue #1082 — `forward.rs` bare-`Tensor` candle→kt type-flip: execution plan
+
+Authoritative roadmap for the *remaining ref-reducing* candle-removal work in
+kiln-model + kiln-train. Grounded in source at HEAD 2026-05-29 (post `fe81330f`).
+Supersedes the looser "type-flip" framing in earlier notes.
+
+## State entering this plan
+
+- **CP-4 tape-authoritative training is DONE + default-on** (`ac3bd054`),
+  finite-diff-validated as *more correct* than candle (candle `loss.backward()`
+  silently drops full-attn + GDN-conv grads).
+- **The method façade is in place** (`fe81330f` + `ce/1082-kt-facade-finish`):
+  `kiln_tensor::Tensor` now has the candle-style method surface
+  (matmul/exp/to_dtype/broadcast_*/dims/sum/keepdim/affine/sqr/is_finite/to_vec2…),
+  so the math/view/ctor/readback surface is **mechanically flippable**.
+- Hub-flip regions 1–3 landed (`d8048283`): embedding/lm_head, SwiGLU MLP, GQA-SDPA
+  matmuls are kt-internal (gated, conservative).
+
+## Two source facts that reframe the work
+
+1. **The candle-autograd "island" (`Var`/`Var::from_tensor`/`.backward()`/`.as_tensor()`)
+   is TEST-ONLY.** It lives entirely in `forward.rs`'s `#[cfg(test)] mod tests`
+   (block at ~26659; `Var` uses 31420–31841). Production `forward.rs` has **zero**
+   `Var`, **zero** real `.backward()` calls (the 8 greps are doc-comments), **zero**
+   `.as_tensor()`. The test mod stays candle (`use candle_core::…Var` locally) and is
+   not part of the production flip.
+2. **`model_forward_kt` (23449) has ZERO production callers.** Every consumer
+   (`generate.rs`, `server/bench.rs`, `trainer.rs`, `opd.rs`, `speculative.rs`) calls
+   the candle `model_forward` (23308) and expects a `candle_core::Tensor`. The public
+   boundary is candle on **both** inference and training sides.
+
+So the real production blockers are: the **`CustomOp{1,2,3}` + `track_op()` +
+`storage_and_layout()` cluster**, the **candle-typed `model_forward` signature**, the
+**`GpuWeights` bare-`Tensor` fields**, and — the deepest one — the **candle `GradStore`
+grad-delivery plumbing** the optimizer still reads.
+
+## ⚠️ The flip is gated on a kt-native training substrate (the true long pole)
+
+Even the **default-on tape-authoritative** path still calls candle `loss.backward()`
+on the *detached* loss to obtain a `GradStore`, then inserts the kt-tape grads keyed by
+each LoRA `Var`'s candle `TensorId` (`trainer.rs:10756–10783`). The kt-native
+`Tape::backward → kt-GradStore` substrate exists (`tape_step.rs`) but is **not wired to
+production `Parameter`s**. The `KILN_USE_TAPE_AUTHORITATIVE=0` opt-out **and the CPU
+device path** (forced regardless of the flag, device-gate at 10809) are pure candle
+`loss.backward()`.
+
+**Consequence:** flipping `forward.rs` to kt severs the candle autograd graph that
+`model_forward`'s candle-typed return feeds into — which breaks *both* the
+candle-authoritative opt-out *and* the current tape path's GradStore harvest. Therefore
+the atomic flip (Increment 4) **cannot land** until the training side is fully
+kt-native (Increment 0 below). DELETE-the-candle-path is **not yet safe**; ISOLATE is.
+
+This is why removing candle from kiln-model/kiln-train is a *training-substrate* project
+as much as a *tensor-type* one.
+
+## Increment sequence
+
+Classification: **[PREP]** still candle, compiles, no behavior change ·
+**[SUBSTRATE]** training-side kt-native wiring · **[ATOMIC]** the coupled type-flip ·
+**[DROP]** removes dep/vendor.
+
+### Increment 0 — [SUBSTRATE] kt-native `Tape::backward → GradStore → Parameter` (THE prerequisite)
+Wire the kt-native tape backward to deliver grads into a kt-keyed `GradStore` consumed
+by the optimizer, removing the candle `loss.backward()` GradStore harvest at
+`trainer.rs:10756–10783`. Then remove the `KILN_USE_TAPE_AUTHORITATIVE=0` opt-out and
+give the CPU training path a kt route (or CUDA-gate it). Files: `trainer.rs:10697–10874`,
+`tape_step.rs`, `cd_types.rs` (GradStore/Var aliases), `kiln-autograd`. **Largest +
+highest-design step; gates everything below.** Validate: CP-4 100-step loss+Adam-moment
+convergence + finite-diff grad gate, fully kt (no candle backward in the loop).
+
+### Increment 1 — [PREP] Migrate the 30 `track_op()` guards to the tape/bridge predicate
+`forward.rs` — centralize through `any_tensor_tracks_op` (2233); rewrite the ~30
+production `!x.track_op()` fast-path guards (94, 2180, 2234, 2709, 3573, 4024-4121,
+7772-7841, 10948-11071, 11330, 11538-11701, 12588, 16215, 16328, 17878, 18224, 22312)
+to the `tape_recording_active = tape_forward_enabled() && bridge_scope_active()` template
+already shipped at 16210. **DO this only after Increment 0** — while the candle-auth path
+exists, `track_op()` legitimately disables fast-paths under candle training, and a naive
+replacement would fire fast-paths on that path. Once candle-auth is gone, `track_op()`
+is dead. Validate: CP-4 parity gate (this changes fast-path selection).
+
+### Increment 2 — [PREP] Un-alias the 7 CUDA + 1 Vulkan `CustomOp` impls to explicit `candle_core::Tensor`
+`forward.rs` — inside `CudaLoraAddF32` (2958), `CudaLoraLinearBf16` (3080),
+`CudaLoraAddBf16` (3331), `CudaSigmoidMulTrainingBf16` (3674),
+`CudaFlashAttentionTrainingBf16` (4520), `CudaRotaryOneBf16` (10683), `VulkanRmsNormOp`
+(8031) and their `apply_op*` wrappers (2750, 2852, 2946, 3075, 3664, 4500, 8218, 8882),
+spell every `Tensor` as `candle_core::Tensor`. Pure type-spelling; isolates them from the
+alias so the flip skips them. (These get DELETED in a later phase once candle-auth is
+fully gone; ISOLATE keeps them compiling meanwhile.) Validate: compiles under
+cuda+vulkan; training smoke.
+
+### Increment 3 — [PREP] Add `GpuLinearAttentionWeights::*_kt` accessors + bridge the 48 BackendRuntime call sites
+`GpuFullAttentionWeights`/`GpuFfnWeights` already have `*_t_kt` accessors (5105–5346);
+**`GpuLinearAttentionWeights` does not** — add `in_proj_*_t_kt`/`out_proj_t_kt`/`conv1d_kt`
+(mirror the 5105 borrow pattern). The `BackendRuntime` trait (`backend/mod.rs`) is fully
+`candle_core::Tensor`-qualified (235 refs, NO alias) so the flip does **not** touch it;
+the 48 forward.rs call sites that cross the seam just need `kt_tensor_to_candle_cuda_copy`
+/ `_borrow` adapters (primitives already used 219× in forward.rs). Validate: decode +
+marlin + resident parity.
+
+### Increment 4 — [ATOMIC] Flip the alias + GpuWeights fields + cd_types + `model_forward` signature (single commit)
+`forward.rs:25/57` (drop `Tensor` from the candle `use`; promote `kiln_tensor::Tensor` to
+bare `Tensor`); GpuWeights/MtpGpuWeights/GpuFullAttentionWeights/GpuLinearAttentionWeights/
+GpuFfnWeights fields → kt; `model_forward` (23308) internals → kt (`model_forward_kt`
+becomes identity); `cd_types.rs:30` aliases + their `vk_train.rs:1683+` field reads →
+kt, lockstep. **Mutually type-dependent — cannot be split.** Test mod stays candle.
+**Single highest-risk step.** Validate: full `cargo nextest -p kiln-model -p kiln-train
+--features cuda` + tape_forward_parity + CP-4 parity + generate/server e2e inference parity.
+
+### Increment 5 — [ATOMIC] Propagate kt through `generate.rs`/`server`/`speculative.rs`
+Flip their `model_forward` consumption to kt (or keep a candle-returning shim and defer).
+Validate: server smoke + inference parity.
+
+### Increment 6 — [ATOMIC] Flip the `BackendRuntime` trait + 4 backends; remove Increment-3 bridges
+`backend/mod.rs` (41 methods) + cpu/cuda/metal/vulkan + vulkan_linear_op.rs/vulkan_lora_op.rs.
+Validate: per-backend parity (vk resident decode, CUDA decode, metal CI).
+
+### Increment 7 — [DROP] Remove candle from kiln-model + kiln-train Cargo.toml; delete vendor
+Gated on Increment 0 (no residual candle `Var`/`backward`/`GradStore`). Delete the candle
+CustomOp impls + test-mod oracles' candle (or keep a kt oracle). Then
+`rm -rf vendor/candle-core`; `cargo tree -i candle-core` empty. Validate: full suite all backends.
+
+## Bottom line
+
+- **Realistic increments: 8** (0–7). Increment **0** (kt-native training substrate) is the
+  true long pole and gates the flip; Increment **4** (alias + GpuWeights + cd_types +
+  model_forward, ~1173 sites) is the coupled-atomic highest-risk type change.
+- Increments **2 + 3** are safe, behavior-preserving PREP that can land anytime
+  (independent of Increment 0).
+- The autograd "island" is test-only; the production gate is Increment 0's GradStore
+  wiring + the 30 `track_op()` guards (Increment 1), for which CP-4 already shipped the
+  replacement pattern.
+
+**Key files:** `crates/kiln-model/src/forward.rs` (25, 57, 2233, 2958–10727, 4758–5346,
+16210, 23308–23474), `crates/kiln-model/src/backend/mod.rs`, `crates/kiln-train/src/{cd_types.rs,
+trainer.rs (10697–10874), vk_train.rs (1683+), tape_step.rs}`, `crates/kiln-kt-bridge/src/{lib.rs,
+tape_bridge.rs (bridge_scope_active)}`, `crates/kiln-autograd/`.


### PR DESCRIPTION
## What
1. **Façade completion** (`crates/kiln-tensor/src/method_api.rs`): adds the two non-autograd candle-API methods PR #1416 skipped — `is_finite`/`is_infinite` (elementwise U8 masks, composed from compare ops) + `to_vec2`/`to_vec3` (nested row-major readback). Completes the non-autograd method surface needed for the forward.rs type-flip. Additive; 10 new CPU unit tests.
2. **Execution plan doc** (`docs/issue-1082-forward-rs-type-flip-plan-2026-05-29.md`): source-grounded 8-increment roadmap for the remaining candle removal, with the key finding that the flip is gated on a kt-native `Tape::backward → GradStore → Parameter` substrate (the default-on tape path still harvests grads via candle `loss.backward()` at trainer.rs:10756).

## Validation
H100/arch-90, `--features cuda`: **1024/1024 kiln-tensor tests pass** (1014 prior + 10 new). Zero dependency changes.