### PR TITLE
kiln-tensor: candle-API operator traits + method/Device gaps for the forward.rs flip (#1082)

### DIFF
--- a/crates/kiln-tensor/src/device.rs
+++ b/crates/kiln-tensor/src/device.rs
@@ -86,6 +86,60 @@ impl Device {
             Device::Vulkan(_) => Backend::Vulkan,
         }
     }
+
+    /// Physical-device locator, mirroring `candle_core::Device::location`.
+    ///
+    /// candle distinguishes a logical [`Device`] (of which several can
+    /// share one physical device, e.g. CUDA streams) from a
+    /// [`DeviceLocation`] (the physical device). `forward.rs` uses
+    /// `device().location()` two ways after the #1082 flip:
+    ///
+    /// 1. In `{:?}` error messages — any `Debug` locator suffices.
+    /// 2. Destructured as `DeviceLocation::Cuda { gpu_id }` to read the
+    ///    GPU index when building the paged KV cache.
+    ///
+    /// To keep both call shapes type-checking, this returns a
+    /// [`DeviceLocation`] whose variants match candle's field-for-field
+    /// (`Cpu`, `Cuda { gpu_id }`, `Metal { gpu_id }`), plus a kt-only
+    /// `Vulkan { gpu_id }` for the fourth backend kt dispatches over.
+    pub const fn location(self) -> DeviceLocation {
+        match self {
+            Device::Cpu => DeviceLocation::Cpu,
+            Device::Cuda(gpu_id) => DeviceLocation::Cuda { gpu_id },
+            Device::Metal(gpu_id) => DeviceLocation::Metal { gpu_id },
+            Device::Vulkan(gpu_id) => DeviceLocation::Vulkan { gpu_id },
+        }
+    }
+}
+
+/// A physical-device locator, mirroring `candle_core::DeviceLocation`.
+///
+/// candle's enum has `Cpu`, `Cuda { gpu_id }`, `Metal { gpu_id }`; kt
+/// adds `Vulkan { gpu_id }` for the fourth backend it dispatches over.
+/// The struct-variant field is named `gpu_id` to match candle exactly
+/// so flip-site destructuring (`DeviceLocation::Cuda { gpu_id }`)
+/// type-checks unchanged. Returned by [`Device::location`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum DeviceLocation {
+    /// The CPU.
+    Cpu,
+    /// A CUDA device, identified by its GPU index.
+    Cuda {
+        /// The CUDA device index.
+        gpu_id: usize,
+    },
+    /// An Apple Metal device, identified by its GPU index.
+    Metal {
+        /// The Metal device index.
+        gpu_id: usize,
+    },
+    /// A Vulkan device, identified by its GPU index (kt-only — candle
+    /// has no Vulkan backend).
+    Vulkan {
+        /// The Vulkan device index.
+        gpu_id: usize,
+    },
 }
 
 impl fmt::Display for Device {
@@ -182,5 +236,44 @@ mod tests {
     fn display_uses_short_name() {
         assert_eq!(format!("{}", Device::Cuda(0)), "cuda:0");
         assert_eq!(format!("{}", Backend::Vulkan), "vulkan");
+    }
+
+    // --- DeviceLocation (#1082 flip gaps) ------------------------------
+
+    #[test]
+    fn location_maps_each_variant() {
+        assert_eq!(Device::Cpu.location(), DeviceLocation::Cpu);
+        assert_eq!(Device::Cuda(0).location(), DeviceLocation::Cuda { gpu_id: 0 });
+        assert_eq!(Device::Cuda(3).location(), DeviceLocation::Cuda { gpu_id: 3 });
+        assert_eq!(Device::Metal(1).location(), DeviceLocation::Metal { gpu_id: 1 });
+        assert_eq!(
+            Device::Vulkan(2).location(),
+            DeviceLocation::Vulkan { gpu_id: 2 }
+        );
+    }
+
+    #[test]
+    fn location_destructures_gpu_id() {
+        // The exact flip-site pattern: `match dev.location() {
+        //   DeviceLocation::Cuda { gpu_id } => ... }`.
+        let gpu_id = match Device::Cuda(5).location() {
+            DeviceLocation::Cuda { gpu_id } => gpu_id,
+            other => panic!("expected Cuda location, got {other:?}"),
+        };
+        assert_eq!(gpu_id, 5);
+    }
+
+    #[test]
+    fn location_is_debug_for_error_messages() {
+        // forward.rs `{:?}`-prints `device().location()` in bail! messages.
+        assert_eq!(format!("{:?}", Device::Cpu.location()), "Cpu");
+        assert_eq!(
+            format!("{:?}", Device::Cuda(0).location()),
+            "Cuda { gpu_id: 0 }"
+        );
+        assert_eq!(
+            format!("{:?}", Device::Metal(2).location()),
+            "Metal { gpu_id: 2 }"
+        );
     }
 }

--- a/crates/kiln-tensor/src/error.rs
+++ b/crates/kiln-tensor/src/error.rs
@@ -209,4 +209,29 @@ mod tests {
             Error::Msg(m) => assert!(m.starts_with("io: ")),
         }
     }
+
+    // #1082 flip prerequisite: `forward.rs` uses `?` into `anyhow::Result`
+    // and `anyhow::Context::context(...)`. Both require
+    // `kiln_tensor::Error: std::error::Error + Send + Sync + 'static`.
+    // thiserror's `#[derive(thiserror::Error)]` on `Error` already
+    // provides the `std::error::Error` impl, and `Error::Msg(String)` is
+    // trivially `Send + Sync + 'static`. These tests lock that in so a
+    // future variant addition that breaks the bound fails CI here rather
+    // than at the (far more numerous) flip call sites.
+    #[test]
+    fn error_is_std_error_send_sync_static() {
+        fn assert_bounds<T: std::error::Error + Send + Sync + 'static>() {}
+        assert_bounds::<Error>();
+    }
+
+    #[test]
+    fn error_boxes_as_dyn_std_error() {
+        let e = Error::from_str("boom");
+        // The exact conversion anyhow relies on: any `std::error::Error`
+        // value can be boxed as `Box<dyn std::error::Error + Send + Sync>`.
+        let boxed: Box<dyn std::error::Error + Send + Sync + 'static> = Box::new(e);
+        assert_eq!(boxed.to_string(), "boom");
+        // `source()` is `None` for the leaf `Msg` variant (no nested cause).
+        assert!(std::error::Error::source(boxed.as_ref()).is_none());
+    }
 }

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -31,6 +31,7 @@ mod element;
 mod error;
 mod layout;
 mod method_api;
+mod operators;
 pub mod ops;
 pub mod probe;
 pub mod profile;
@@ -68,7 +69,7 @@ pub use activation_registry::{
 pub use allocator::{allocator_frozen_error, Allocator, AllocatorMode};
 pub use cpu_allocator::CpuAllocator;
 pub use determinism::{deterministic_enabled, Determinism, DeterministicCache, DETERMINISTIC_CACHED};
-pub use device::{Backend, Device};
+pub use device::{Backend, Device, DeviceLocation};
 pub use device_op::{dispatch1, dispatch2, dispatch3, BackwardOp, DeviceOp1, DeviceOp2, DeviceOp3};
 pub use dtype::DType;
 pub use element::Element;

--- a/crates/kiln-tensor/src/method_api.rs
+++ b/crates/kiln-tensor/src/method_api.rs
@@ -597,6 +597,203 @@ impl Tensor {
     }
 
     // ==================================================================
+    // argmax — candle: `pub fn argmax<D: Dim>(&self, dim: D) -> Result<Self>`
+    // candle squeezes the reduced axis (its `argmax`, *not*
+    // `argmax_keepdim`). kt's [`ops::argmax_last_dim`] already squeezes
+    // the *trailing* axis, so for a general `dim` we move that axis to
+    // the end first (zero-copy permute), reduce, and let the squeeze
+    // drop it — leaving the remaining axes in their original relative
+    // order (exactly candle's output layout). Output dtype is `I64`
+    // (kt's `argmax_last_dim` convention), tie-broken by lowest index
+    // (matches `candle_core::Tensor::argmax`).
+    // ==================================================================
+
+    /// Index of the maximum along `dim`, with `dim` removed from the
+    /// output shape. candle's `argmax` (squeezes the reduced axis).
+    ///
+    /// Delegates to [`ops::argmax_last_dim`] directly when `dim` is the
+    /// last axis; otherwise [`Tensor::move_axis`]es the target axis to
+    /// the end (zero-copy), reduces, and the trailing-axis squeeze
+    /// leaves the other axes in their original order.
+    pub fn argmax<Dm: Dim>(&self, dim: Dm) -> Result<Self> {
+        let rank = self.rank();
+        let axis = dim.to_index(rank, "argmax")?;
+        if axis == rank - 1 {
+            ops::argmax_last_dim(self)
+        } else {
+            // Move `axis` to the trailing position; the squeeze in
+            // argmax_last_dim then drops it, leaving the remaining axes
+            // in their original relative order. `move_axis` is a permute
+            // (non-contiguous view); `ops::argmax_last_dim` requires a
+            // contiguous input, so materialize first.
+            let moved = self.move_axis(axis, rank - 1)?.contiguous()?;
+            ops::argmax_last_dim(&moved)
+        }
+    }
+
+    // ==================================================================
+    // index_add — candle:
+    //   `pub fn index_add<D: Dim>(&self, indexes, source, dim) -> Result<Self>`
+    // candle returns `self` with `source` *added into* `self` at the
+    // positions named by `indexes` along `dim`. kt's
+    // [`ops::scatter_add`] is the "into-zeros" sibling (the
+    // index_select backward): it builds a zero output of the target
+    // shape and scatters `source` in. So candle's index_add is
+    // `self + scatter_add(source, dim, indexes, self.dims()[dim])`.
+    // ==================================================================
+
+    /// Add `source` into a copy of `self` at the rows named by
+    /// `indexes` along `dim`. candle's `index_add` (arg order:
+    /// `indexes`, `source`, `dim`).
+    ///
+    /// Composed as `self + ops::scatter_add(source, dim, indexes,
+    /// self.dims()[dim])`: `scatter_add` produces a zero tensor of
+    /// `self`'s shape with `source` scattered into the indexed
+    /// positions, and the elementwise add folds that onto `self`.
+    pub fn index_add<Dm: Dim>(&self, indexes: &Self, source: &Self, dim: Dm) -> Result<Self> {
+        let axis = dim.to_index(self.rank(), "index_add")?;
+        let target_dim = self.shape()[axis];
+        let scattered = ops::scatter_add(source, axis, indexes, target_dim)?;
+        ops::add(self, &scattered)
+    }
+
+    // ==================================================================
+    // Autograd-free shims — candle methods that interrogate or detach
+    // the computation graph. kt's [`Tensor`] is a pure view/storage
+    // handle with **no autograd graph** (the tape lives in a separate
+    // crate), so these collapse to constants / identity / deep-copy.
+    // ==================================================================
+
+    /// Whether the autograd graph should track ops on this tensor.
+    /// candle: `self.is_variable || self.op.is_some()`.
+    ///
+    /// **Always `false` for kt.** kt's [`Tensor`] carries no autograd
+    /// metadata — it is a storage+layout handle, and gradient tracking
+    /// lives entirely in the separate `kiln-autograd` tape, which is
+    /// keyed off explicit `Var`s rather than a per-tensor `op` field.
+    /// `forward.rs` reads `track_op()` (28 sites) purely to route
+    /// between the autograd-safe slow path and the inference fast path;
+    /// with no in-tensor graph, every kt tensor takes the fast path,
+    /// which is correct because the tape-authoritative training path
+    /// detaches its intermediates (see the `kiln-candle-autograd-drops`
+    /// notes on #1082).
+    pub fn track_op(&self) -> bool {
+        false
+    }
+
+    /// Deep copy — a fresh storage allocation holding the same values.
+    /// candle: `pub fn copy(&self) -> Result<Tensor>` ("copies the
+    /// actual storage but may fail because of running out of memory").
+    ///
+    /// Unlike [`Clone`] (which shares the storage `Arc`) and
+    /// [`Tensor::contiguous`] (which returns a *shared* clone when the
+    /// input is already contiguous), `copy` always materializes a new
+    /// backing buffer, so later in-place mutation of the source does
+    /// not alias the copy. `forward.rs` relies on this to snapshot the
+    /// GDN recurrent / conv states before they are mutated in place.
+    ///
+    /// - CUDA: routes through `cuda_contiguous`, which always allocates
+    ///   a fresh device buffer (even for contiguous inputs).
+    /// - CPU: rebuilds a fresh [`crate::CpuStorage`] from the
+    ///   materialized row-major bytes.
+    /// - Metal / Vulkan: not yet implemented (errors) — no `copy` call
+    ///   site reaches those backends today (#1082).
+    pub fn copy(&self) -> Result<Self> {
+        match self.device() {
+            #[cfg(feature = "cuda")]
+            Device::Cuda(_) => crate::cuda_storage::cuda_contiguous(self),
+            Device::Cpu => {
+                // Materialize a contiguous CPU view, then rebuild fresh
+                // storage from its addressable bytes so the result never
+                // aliases `self`'s buffer.
+                let contig = self.contiguous()?;
+                let per = contig.dtype().size_in_bytes();
+                let n = contig.element_count();
+                let start_bytes = contig.layout().start_offset() * per;
+                let end_bytes = start_bytes + n * per;
+                let storage = contig
+                    .storage()
+                    .as_any()
+                    .downcast_ref::<crate::CpuStorage>()
+                    .ok_or_else(|| {
+                        crate::Error::from_str("Tensor::copy: CPU device must hold CpuStorage")
+                    })?;
+                let bytes = storage.as_bytes();
+                if end_bytes > bytes.len() {
+                    return Err(crate::Error::Msg(format!(
+                        "Tensor::copy: byte range {start_bytes}..{end_bytes} exceeds CPU \
+                         storage length {}",
+                        bytes.len()
+                    )));
+                }
+                let fresh = crate::CpuStorage::from_bytes(
+                    contig.dtype(),
+                    bytes[start_bytes..end_bytes].to_vec(),
+                )?;
+                // Explicit `Storage` (= `Arc<dyn StorageBackend>`) so the
+                // `Arc<CpuStorage>` unsized-coerces at the binding, matching
+                // the `from_slice` constructor pattern.
+                let storage_arc: crate::Storage = std::sync::Arc::new(fresh);
+                Self::from_parts(
+                    storage_arc,
+                    crate::Layout::contiguous(contig.shape().to_vec()),
+                    crate::TensorId::next(),
+                )
+            }
+            other => Err(crate::Error::Msg(format!(
+                "Tensor::copy: deep copy on {other} is not yet implemented (#1082)"
+            ))),
+        }
+    }
+
+    /// Detach from the autograd graph. candle:
+    /// `pub fn detach(&self) -> Tensor` (returns a graph-free view that
+    /// **shares** the storage; identity if already detached).
+    ///
+    /// kt has no in-tensor autograd graph, so detach is a plain
+    /// identity: it returns a `Clone` (shared-storage handle). Matches
+    /// candle's "already detached → same tensor" fast path, and
+    /// candle's by-value `Tensor` return (not `Result`).
+    pub fn detach(&self) -> Self {
+        self.clone()
+    }
+
+    // ==================================================================
+    // Tensor::empty — candle:
+    //   `pub unsafe fn empty<S: Into<Shape>>(shape, dtype, &device)`
+    // candle hands back *uninitialized* memory; kt has no uninitialized
+    // allocator, so this zero-fills (a strictly safer superset — every
+    // candle `empty` call site immediately overwrites the buffer). The
+    // method is still `unsafe` to keep candle's call shape
+    // (`unsafe { Tensor::empty(...) }`) compiling unchanged at the flip
+    // sites.
+    // ==================================================================
+
+    /// Allocate a tensor of `shape`/`dtype` on `device`. candle's
+    /// `Tensor::empty` returns uninitialized memory; kt zero-fills
+    /// instead (no uninit allocator), which is a safe superset since
+    /// callers overwrite the buffer immediately.
+    ///
+    /// # Safety
+    ///
+    /// Kept `unsafe` to mirror candle's signature so flip sites that
+    /// write `unsafe { Tensor::empty(...) }` type-check unchanged. The
+    /// kt impl is in fact memory-safe (it zero-initializes), but the
+    /// `unsafe` marker is part of the API-compat contract.
+    ///
+    /// kt deviation: `device` is taken **by value** (`Device` is
+    /// `Copy`), matching kt's other ctors (`zeros`/`ones`/`arange`);
+    /// candle takes `&Device`. The flip handles the `&`→value at the
+    /// far fewer ctor sites.
+    pub unsafe fn empty(
+        shape: impl Into<Vec<usize>>,
+        dtype: DType,
+        device: Device,
+    ) -> Result<Self> {
+        Self::zeros_on(device, shape.into(), dtype)
+    }
+
+    // ==================================================================
     // Shape accessors — candle name aliases
     // ==================================================================
 
@@ -1378,5 +1575,144 @@ mod tests {
         assert_eq!(a.shape(), &[2, 3]);
         // Fixed seed => reproducible draws.
         assert_eq!(v(&a), v(&b));
+    }
+
+    // --- argmax (#1082 flip gaps) --------------------------------------
+
+    #[test]
+    fn argmax_last_dim_matches_ops_and_squeezes() {
+        // [2,3]; per-row argmax over the last axis -> [2].
+        let x = t(&[1.0, 9.0, 3.0, 4.0, 2.0, 6.0], &[2, 3]);
+        let got = x.argmax(D::Minus1).unwrap();
+        let want = ops::argmax_last_dim(&x).unwrap();
+        assert_eq!(got.dtype(), DType::I64);
+        assert_eq!(got.shape(), &[2]); // last axis dropped
+        assert_eq!(got.to_vec::<i64>().unwrap(), want.to_vec::<i64>().unwrap());
+        // row0 max is 9.0 @ idx 1; row1 max is 6.0 @ idx 2.
+        assert_eq!(got.to_vec::<i64>().unwrap(), vec![1, 2]);
+        // usize axis form for the last axis takes the same fast path.
+        let got_usize = x.argmax(1usize).unwrap();
+        assert_eq!(got_usize.to_vec::<i64>().unwrap(), vec![1, 2]);
+    }
+
+    #[test]
+    fn argmax_rank1_dim0_is_last_axis() {
+        // The dominant forward.rs call shape: argmax(0) on a 1-D tensor.
+        let logits = t(&[0.1, 0.3, 9.9, 0.2], &[4]);
+        let got = logits.argmax(0usize).unwrap();
+        assert_eq!(got.shape(), &[] as &[usize]); // scalar (rank-0)
+        assert_eq!(got.to_vec::<i64>().unwrap(), vec![2]);
+    }
+
+    #[test]
+    fn argmax_non_last_axis_drops_that_axis_in_order() {
+        // [2,3]; argmax over axis 0 -> [3], one winner per column.
+        // col0: max(1,4)=4 @ row1; col1: max(9,2)=9 @ row0; col2: max(3,6)=6 @ row1.
+        let x = t(&[1.0, 9.0, 3.0, 4.0, 2.0, 6.0], &[2, 3]);
+        let got = x.argmax(0usize).unwrap();
+        assert_eq!(got.shape(), &[3]); // axis 0 removed, axis 1 preserved
+        assert_eq!(got.to_vec::<i64>().unwrap(), vec![1, 0, 1]);
+    }
+
+    // --- index_add (#1082 flip gaps) -----------------------------------
+
+    #[test]
+    fn index_add_adds_source_rows_into_self() {
+        // self: [3,2] zeros; add source rows into rows 0 and 2.
+        // candle arg order: index_add(indexes, source, dim).
+        let base = Tensor::zeros(vec![3, 2], DType::F32, Device::Cpu).unwrap();
+        let indexes = Tensor::from_slice(&[0i64, 2i64], vec![2]).unwrap();
+        let source = t(&[10.0, 20.0, 30.0, 40.0], &[2, 2]); // 2 rows of 2
+        let got = base.index_add(&indexes, &source, 0usize).unwrap();
+        assert_eq!(got.shape(), &[3, 2]);
+        // row0 gets [10,20], row1 untouched [0,0], row2 gets [30,40].
+        assert_eq!(v(&got), vec![10.0, 20.0, 0.0, 0.0, 30.0, 40.0]);
+    }
+
+    #[test]
+    fn index_add_folds_onto_existing_self_values() {
+        // Non-zero base verifies the `self + scatter_add(...)` composition.
+        let base = t(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0], &[3, 2]);
+        let indexes = Tensor::from_slice(&[1i64], vec![1]).unwrap();
+        let source = t(&[100.0, 200.0], &[1, 2]);
+        let got = base.index_add(&indexes, &source, 0usize).unwrap();
+        // only row1 changes: [1,1] + [100,200] = [101,201].
+        assert_eq!(v(&got), vec![1.0, 1.0, 101.0, 201.0, 1.0, 1.0]);
+        // Cross-check against the underlying scatter_add composition.
+        let scattered = ops::scatter_add(&source, 0, &indexes, 3).unwrap();
+        let want = ops::add(&base, &scattered).unwrap();
+        assert_eq!(v(&got), v(&want));
+    }
+
+    // --- track_op (#1082 flip gaps) ------------------------------------
+
+    #[test]
+    fn track_op_is_always_false() {
+        let x = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        assert!(!x.track_op());
+        // Derived tensors are equally untracked (no in-tensor graph).
+        let y = x.add(&x).unwrap();
+        assert!(!y.track_op());
+    }
+
+    // --- copy (#1082 flip gaps) ----------------------------------------
+
+    #[test]
+    fn copy_produces_independent_storage() {
+        let x = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        let c = x.copy().unwrap();
+        // Same values + shape + dtype.
+        assert_eq!(c.shape(), x.shape());
+        assert_eq!(c.dtype(), x.dtype());
+        assert_eq!(v(&c), v(&x));
+        // Fresh storage allocation (not aliasing the source Arc), unlike
+        // a plain Clone / contiguous() fast path.
+        assert!(
+            !std::sync::Arc::ptr_eq(c.storage(), x.storage()),
+            "copy must allocate fresh storage, not share the source Arc"
+        );
+    }
+
+    #[test]
+    fn copy_of_noncontiguous_materializes_logical_order() {
+        // Transpose makes a non-contiguous view; copy must read it in
+        // logical (row-major) order, like candle's copy.
+        let x = t(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+        let xt = x.transpose(0, 1).unwrap(); // [3,2], non-contiguous
+        let c = xt.copy().unwrap();
+        assert_eq!(c.shape(), &[3, 2]);
+        // logical order of the transpose: columns of x.
+        assert_eq!(v(&c), vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        assert!(!std::sync::Arc::ptr_eq(c.storage(), xt.storage()));
+    }
+
+    // --- detach (#1082 flip gaps) --------------------------------------
+
+    #[test]
+    fn detach_is_identity_returns_tensor() {
+        let x = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        // candle returns `Tensor` by value (not Result); kt mirrors that.
+        let d: Tensor = x.detach();
+        assert_eq!(v(&d), v(&x));
+        assert_eq!(d.shape(), x.shape());
+        // kt detach is a shared-storage identity (no autograd to sever).
+        assert!(std::sync::Arc::ptr_eq(d.storage(), x.storage()));
+    }
+
+    // --- empty (#1082 flip gaps) ---------------------------------------
+
+    #[test]
+    fn empty_has_requested_shape_and_dtype() {
+        // SAFETY: kt's `empty` zero-fills (safe superset of candle's
+        // uninitialized memory); the `unsafe` is API-compat only.
+        let e = unsafe { Tensor::empty(vec![2, 3], DType::F32, Device::Cpu) }.unwrap();
+        assert_eq!(e.shape(), &[2, 3]);
+        assert_eq!(e.dtype(), DType::F32);
+        // kt zero-fills rather than leaving garbage.
+        assert_eq!(v(&e), vec![0.0; 6]);
+        // BF16 dtype also honored.
+        let eb = unsafe { Tensor::empty(vec![4], DType::BF16, Device::Cpu) }.unwrap();
+        assert_eq!(eb.shape(), &[4]);
+        assert_eq!(eb.dtype(), DType::BF16);
     }
 }

--- a/crates/kiln-tensor/src/operators.rs
+++ b/crates/kiln-tensor/src/operators.rs
@@ -1,0 +1,364 @@
+//! `std::ops::{Add,Sub,Mul,Div,Neg}` trait impls for [`Tensor`] —
+//! the candle-API operator-overload surface the `forward.rs`
+//! candle→kt type-flip relies on (issue #1082).
+//!
+//! # Why this file exists
+//!
+//! candle implements the arithmetic operator traits for `Tensor`,
+//! `&Tensor`, scalar (`f64`) RHS, and even `Result<Tensor>` RHS, all
+//! with **`type Output = Result<Tensor>`**. `forward.rs` writes
+//! `(&a + &b)?`, `x * scale`, `&logits - max`, etc., dozens of times.
+//! A mechanical `s/candle_core::Tensor/kiln_tensor::Tensor/` only
+//! type-checks if `kt::Tensor` answers the same operator overloads.
+//! The error-inventory probe (flipping the `Tensor` alias and
+//! building) attributed ~78 of the 1,450 flip errors to these missing
+//! `impl std::ops::*` blocks — the single biggest mechanical bucket.
+//!
+//! # Faithful mirror of candle's `bin_trait!`
+//!
+//! `vendor/candle-core/src/tensor.rs` defines a `bin_trait!` macro that
+//! emits, for each of `Add/Sub/Mul/Div`:
+//!
+//! - `Tensor      ⊕ B: Borrow<Tensor>` → `Result<Tensor>`
+//! - `&Tensor     ⊕ B: Borrow<Tensor>` → `Result<Tensor>`
+//! - `Result<B>   ⊕ Tensor`            → `Result<Tensor>`
+//! - `Result<B>   ⊕ &Tensor`           → `Result<Tensor>`
+//! - `Tensor      ⊕ Result<B>`         → `Result<Tensor>`
+//! - `&Tensor     ⊕ Result<B>`         → `Result<Tensor>`
+//! - `Tensor      ⊕ f64`               → `Result<Tensor>`
+//! - `&Tensor     ⊕ f64`               → `Result<Tensor>`
+//!
+//! plus standalone `f64 ⊕ Tensor` / `f64 ⊕ &Tensor` impls. This file
+//! reproduces that whole matrix.
+//!
+//! The `B: Borrow<Tensor>` bound is candle's trick that collapses the
+//! `Tensor ⊕ Tensor`, `Tensor ⊕ &Tensor`, `&Tensor ⊕ Tensor`,
+//! `&Tensor ⊕ &Tensor` quartet into two impl blocks (the LHS is the
+//! `self` receiver; the RHS is any `Borrow<Tensor>`). We keep that
+//! exact shape so the same RHS forms callers use compile here too.
+//!
+//! # Delegation
+//!
+//! - Tensor⊕Tensor → the existing free fns
+//!   [`ops::add`] / [`ops::sub`] / [`ops::mul`] / [`ops::div`]
+//!   (via the inherent [`Tensor::add`] … methods in `method_api.rs`,
+//!   which themselves delegate to `ops::`).
+//! - Tensor⊕f64 → candle computes these as `self.affine($mul(rhs),
+//!   $add(rhs))`. kt's inherent [`Tensor::affine`] already exists and
+//!   itself composes [`ops::mul_scalar`] + [`ops::add_scalar`], so we
+//!   delegate to it and stay numerically identical to candle:
+//!     * Add: `affine(1.0, rhs)`   = `x + rhs`   (≡ `ops::add_scalar`)
+//!     * Sub: `affine(1.0, -rhs)`  = `x - rhs`   (≡ `ops::sub_scalar`)
+//!     * Mul: `affine(rhs, 0.0)`   = `x * rhs`   (≡ `ops::mul_scalar`)
+//!     * Div: `affine(1.0/rhs, 0.0)` = `x / rhs` (≡ `ops::div_scalar`)
+//!
+//!   **Deviation note:** kt's scalar `ops::` (and therefore `affine`)
+//!   narrow the `f64` argument to `f32` internally — kt is an f32/bf16
+//!   substrate and has no f64 storage. candle's `affine` keeps the
+//!   `mul`/`add` coefficients in `f64` until the per-element kernel.
+//!   The narrowing is lossless for every coefficient `forward.rs`
+//!   actually uses (small integer / power-of-two scales), and matches
+//!   the pre-existing [`Tensor::powf`] / [`Tensor::clamp`] /
+//!   [`Tensor::affine`] façade convention.
+//!
+//! # `Neg`
+//!
+//! candle does **not** implement `std::ops::Neg` for `Tensor` (it only
+//! has the inherent `Tensor::neg(&self) -> Result<Self>` method, which
+//! kt already mirrors in `method_api.rs`). We therefore do **not** add
+//! a `std::ops::Neg` impl — doing so would *exceed* candle's surface
+//! and could change overload resolution at flip sites that write
+//! `x.neg()?`. See the PR report's "SKIPPED" section.
+//!
+//! # Purely additive
+//!
+//! Nothing in the tree calls these operator overloads yet (the flip is
+//! a separate PR), so this file cannot regress anything. Correctness is
+//! proven by the `#[cfg(test)]` block below.
+
+use crate::{ops, Result, Tensor};
+use std::borrow::Borrow;
+
+// ----------------------------------------------------------------------
+// Tensor ⊕ Tensor (and all &/Borrow combinations) + Result<B> chaining
+// + scalar f64 — one macro invocation per operator, mirroring candle's
+// `bin_trait!`.
+// ----------------------------------------------------------------------
+
+macro_rules! kt_bin_trait {
+    // $trait : the std::ops trait (Add/Sub/Mul/Div)
+    // $fn     : the trait method (add/sub/mul/div) — also the kt free fn
+    // $mul    : f64 -> f64 closure giving the affine multiplier for the scalar form
+    // $add    : f64 -> f64 closure giving the affine addend for the scalar form
+    ($trait:ident, $fn:ident, $mul:expr, $add:expr) => {
+        impl<B: Borrow<Tensor>> std::ops::$trait<B> for Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: B) -> Self::Output {
+                ops::$fn(&self, rhs.borrow())
+            }
+        }
+
+        impl<B: Borrow<Tensor>> std::ops::$trait<B> for &Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: B) -> Self::Output {
+                ops::$fn(self, rhs.borrow())
+            }
+        }
+
+        impl<B: Borrow<Tensor>> std::ops::$trait<Tensor> for Result<B> {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: Tensor) -> Self::Output {
+                ops::$fn(self?.borrow(), &rhs)
+            }
+        }
+
+        impl<B: Borrow<Tensor>> std::ops::$trait<&Tensor> for Result<B> {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: &Tensor) -> Self::Output {
+                ops::$fn(self?.borrow(), rhs)
+            }
+        }
+
+        impl<B: Borrow<Tensor>> std::ops::$trait<Result<B>> for Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: Result<B>) -> Self::Output {
+                ops::$fn(&self, rhs?.borrow())
+            }
+        }
+
+        impl<B: Borrow<Tensor>> std::ops::$trait<Result<B>> for &Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: Result<B>) -> Self::Output {
+                ops::$fn(self, rhs?.borrow())
+            }
+        }
+
+        impl std::ops::$trait<f64> for Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: f64) -> Self::Output {
+                self.affine($mul(rhs), $add(rhs))
+            }
+        }
+
+        impl std::ops::$trait<f64> for &Tensor {
+            type Output = Result<Tensor>;
+
+            fn $fn(self, rhs: f64) -> Self::Output {
+                self.affine($mul(rhs), $add(rhs))
+            }
+        }
+    };
+}
+
+// Same affine coefficients candle uses (`bin_trait!(...)` call sites):
+//   Add: x*1 + rhs           Sub: x*1 + (-rhs)
+//   Mul: x*rhs + 0           Div: x*(1/rhs) + 0
+kt_bin_trait!(Add, add, |_| 1., |v| v);
+kt_bin_trait!(Sub, sub, |_| 1., |v: f64| -v);
+kt_bin_trait!(Mul, mul, |v| v, |_| 0.);
+kt_bin_trait!(Div, div, |v| 1. / v, |_| 0.);
+
+// ----------------------------------------------------------------------
+// f64 ⊕ Tensor — candle's standalone impls (commutative re-dispatch for
+// Add/Mul; explicit affine for the non-commutative Sub/Div).
+// ----------------------------------------------------------------------
+
+impl std::ops::Add<Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    fn add(self, rhs: Tensor) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl std::ops::Add<&Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    fn add(self, rhs: &Tensor) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl std::ops::Mul<Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    fn mul(self, rhs: Tensor) -> Self::Output {
+        rhs * self
+    }
+}
+
+impl std::ops::Mul<&Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    fn mul(self, rhs: &Tensor) -> Self::Output {
+        rhs * self
+    }
+}
+
+impl std::ops::Sub<Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    // candle: `rhs.affine(-1., self)` => `self - rhs` elementwise.
+    fn sub(self, rhs: Tensor) -> Self::Output {
+        rhs.affine(-1., self)
+    }
+}
+
+impl std::ops::Sub<&Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    fn sub(self, rhs: &Tensor) -> Self::Output {
+        rhs.affine(-1., self)
+    }
+}
+
+impl std::ops::Div<Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    // candle: `rhs.recip()? * self` => `self / rhs` elementwise.
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Tensor) -> Self::Output {
+        rhs.recip()? * self
+    }
+}
+
+impl std::ops::Div<&Tensor> for f64 {
+    type Output = Result<Tensor>;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: &Tensor) -> Self::Output {
+        rhs.recip()? * self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ops;
+    use crate::Tensor;
+
+    fn t(data: &[f32], shape: &[usize]) -> Tensor {
+        Tensor::from_slice(data, shape.to_vec()).unwrap()
+    }
+
+    fn v(x: &Tensor) -> Vec<f32> {
+        x.to_vec::<f32>().unwrap()
+    }
+
+    // --- Tensor ⊕ Tensor across all owned/borrowed combinations -------
+
+    #[test]
+    fn add_tensor_tensor_all_ref_combos() {
+        let a = t(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+        let b = t(&[5.0, 6.0, 7.0, 8.0], &[2, 2]);
+        let want = v(&ops::add(&a, &b).unwrap());
+
+        // owned ⊕ owned
+        assert_eq!(v(&(a.clone() + b.clone()).unwrap()), want);
+        // owned ⊕ &
+        assert_eq!(v(&(a.clone() + &b).unwrap()), want);
+        // & ⊕ owned
+        assert_eq!(v(&(&a + b.clone()).unwrap()), want);
+        // & ⊕ &
+        assert_eq!(v(&(&a + &b).unwrap()), want);
+    }
+
+    #[test]
+    fn sub_mul_div_tensor_tensor_match_ops() {
+        let a = t(&[10.0, 20.0, 30.0, 40.0], &[2, 2]);
+        let b = t(&[2.0, 4.0, 5.0, 8.0], &[2, 2]);
+        assert_eq!(v(&(&a - &b).unwrap()), v(&ops::sub(&a, &b).unwrap()));
+        assert_eq!(v(&(&a * &b).unwrap()), v(&ops::mul(&a, &b).unwrap()));
+        assert_eq!(v(&(&a / &b).unwrap()), v(&ops::div(&a, &b).unwrap()));
+    }
+
+    // --- Result<B> chaining: (a + b) + c without intermediate `?` ------
+
+    #[test]
+    fn result_chaining_left_and_right() {
+        let a = t(&[1.0, 1.0], &[2]);
+        let b = t(&[2.0, 2.0], &[2]);
+        let c = t(&[3.0, 3.0], &[2]);
+
+        // Result<Tensor> ⊕ &Tensor  (LHS is the Result)
+        let lhs_result = (&a + &b) + &c; // ((a+b)?) + c
+        assert_eq!(v(&lhs_result.unwrap()), vec![6.0, 6.0]);
+
+        // Tensor ⊕ Result<Tensor>  (RHS is the Result)
+        let rhs_result = a.clone() + (&b + &c); // a + ((b+c)?)
+        assert_eq!(v(&rhs_result.unwrap()), vec![6.0, 6.0]);
+
+        // &Tensor ⊕ Result<Tensor>
+        let ref_rhs_result = &a + (&b + &c);
+        assert_eq!(v(&ref_rhs_result.unwrap()), vec![6.0, 6.0]);
+
+        // Result<Tensor> ⊕ Tensor (owned RHS)
+        let lhs_result_owned = (&a + &b) + c.clone();
+        assert_eq!(v(&lhs_result_owned.unwrap()), vec![6.0, 6.0]);
+    }
+
+    // --- Tensor ⊕ f64 (and &Tensor ⊕ f64), all four operators ---------
+
+    #[test]
+    fn scalar_rhs_matches_scalar_ops() {
+        let a = t(&[2.0, 4.0, 6.0, 8.0], &[2, 2]);
+
+        // Add: x + c  ≡ ops::add_scalar
+        assert_eq!(
+            v(&(a.clone() + 3.0f64).unwrap()),
+            v(&ops::add_scalar(&a, 3.0).unwrap())
+        );
+        assert_eq!(
+            v(&(&a + 3.0f64).unwrap()),
+            v(&ops::add_scalar(&a, 3.0).unwrap())
+        );
+
+        // Sub: x - c  ≡ ops::sub_scalar
+        assert_eq!(
+            v(&(&a - 1.5f64).unwrap()),
+            v(&ops::sub_scalar(&a, 1.5).unwrap())
+        );
+
+        // Mul: x * c  ≡ ops::mul_scalar
+        assert_eq!(
+            v(&(&a * 2.0f64).unwrap()),
+            v(&ops::mul_scalar(&a, 2.0).unwrap())
+        );
+
+        // Div: x / c  ≡ ops::div_scalar
+        assert_eq!(
+            v(&(&a / 2.0f64).unwrap()),
+            v(&ops::div_scalar(&a, 2.0).unwrap())
+        );
+    }
+
+    // --- f64 ⊕ Tensor -------------------------------------------------
+
+    #[test]
+    fn scalar_lhs_add_mul_commute() {
+        let a = t(&[2.0, 4.0], &[2]);
+        // 3 + a == a + 3
+        assert_eq!(v(&(3.0f64 + a.clone()).unwrap()), vec![5.0, 7.0]);
+        assert_eq!(v(&(3.0f64 + &a).unwrap()), vec![5.0, 7.0]);
+        // 2 * a == a * 2
+        assert_eq!(v(&(2.0f64 * a.clone()).unwrap()), vec![4.0, 8.0]);
+        assert_eq!(v(&(2.0f64 * &a).unwrap()), vec![4.0, 8.0]);
+    }
+
+    #[test]
+    fn scalar_lhs_sub_div_are_non_commutative() {
+        let a = t(&[2.0, 4.0], &[2]);
+        // 10 - a == [8, 6]  (NOT a - 10)
+        assert_eq!(v(&(10.0f64 - a.clone()).unwrap()), vec![8.0, 6.0]);
+        assert_eq!(v(&(10.0f64 - &a).unwrap()), vec![8.0, 6.0]);
+        // 8 / a == [4, 2]   (NOT a / 8)
+        assert_eq!(v(&(8.0f64 / a.clone()).unwrap()), vec![4.0, 2.0]);
+        assert_eq!(v(&(8.0f64 / &a).unwrap()), vec![4.0, 2.0]);
+    }
+}


### PR DESCRIPTION
## What
Closes ~240 of the 1450 errors from the forward.rs candle→kt type-flip probe, by adding the candle-API surface `kiln_tensor::Tensor` was missing — all additive, candle-signature-matched, no caller yet (validated by 21 new tests):
- **Operator traits** (`operators.rs`): `Add/Sub/Mul/Div` for `Tensor`/`&Tensor`/`Result<B>`/`f64` (both sides), `Output = Result<Tensor>`, mirroring candle's `bin_trait!` macro exactly — delegates to `ops::`. (~78 flip errors.)
- **Methods**: `track_op()`→false (kt has no in-tensor autograd; 28 sites), `copy()`, `detach()`, `argmax(dim)`, `index_add()`, `empty()`.
- **`Device::location() -> DeviceLocation`** (`Cpu/Cuda{gpu_id}/Metal/Vulkan`, candle's field names; 28 sites).
- Confirmed `kiln_tensor::Error` already impls `std::error::Error + Send + Sync` (thiserror) — anyhow `?`/`.context()` interop works; added bound-pinning tests.

Atomic-flip island (`apply_op*`, `from_storage`, `slice_set`) intentionally untouched.

## Validation
H100/arch-90, `--features cuda`: **1045/1045 kiln-tensor tests pass** (1024 prior + 21 new). The `Result<B>` operator impls compile clean (candle's coherence pattern). Zero dependency changes.