### PR TITLE
kiln-train: re-key OptimizerState.moments to KtTensorId (#1082 Inc0 PR1)

### DIFF
--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -774,7 +774,7 @@ impl TrainableLoraParams {
     /// Returns the [`OptimizerState`] the trainer threads through
     /// `apply_adamw_update`. CPU and GPU paths both consume it.
     pub fn allocate_adamw_state(&self, device: &CdDevice) -> Result<OptimizerState> {
-        let mut moments: HashMap<TensorId, AdamWMoments> = HashMap::new();
+        let mut moments: HashMap<KtTensorId, AdamWMoments> = HashMap::new();
         for var in self.all_vars() {
             let shape = var.as_tensor().shape().clone();
             let dtype = var.as_tensor().dtype();
@@ -782,7 +782,10 @@ impl TrainableLoraParams {
                 .with_context(|| "allocating AdamW first-moment Var")?;
             let v = var_zeros(shape, dtype, device)
                 .with_context(|| "allocating AdamW second-moment Var")?;
-            moments.insert(var.as_tensor().id(), AdamWMoments { m, v });
+            moments.insert(
+                cd_tensor_id_to_kt(var.as_tensor().id()),
+                AdamWMoments { m, v },
+            );
         }
         Ok(OptimizerState { moments, step: 0 })
     }
@@ -811,7 +814,7 @@ pub struct AdamWMoments {
 /// trainer increments `step` *before* dispatching so the first call
 /// sees `step=1`.
 pub struct OptimizerState {
-    pub moments: HashMap<TensorId, AdamWMoments>,
+    pub moments: HashMap<KtTensorId, AdamWMoments>,
     pub step: u32,
 }
 
@@ -7004,12 +7007,15 @@ pub fn optimizer_step(
             let resident_activation = backend.supports_resident_activation();
             for var in params.all_vars() {
                 if let Some(grad) = grads.get(var.as_tensor()) {
-                    let moments = state.moments.get(&var.as_tensor().id()).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "optimizer_step: missing AdamW moments for Var id {:?}",
-                            var.as_tensor().id()
-                        )
-                    })?;
+                    let moments = state
+                        .moments
+                        .get(&cd_tensor_id_to_kt(var.as_tensor().id()))
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "optimizer_step: missing AdamW moments for Var id {:?}",
+                                var.as_tensor().id()
+                            )
+                        })?;
                     apply_adamw_update(
                         backend,
                         var,
@@ -7321,12 +7327,13 @@ pub(crate) fn optimizer_step_from_map(
                     } else {
                         grad.to_device(var.as_tensor().device())?
                     };
-                    let moments = state.moments.get(&id).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "optimizer_step_from_map: missing AdamW moments for Var id {:?}",
-                            id
-                        )
-                    })?;
+                    let moments =
+                        state.moments.get(&cd_tensor_id_to_kt(id)).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "optimizer_step_from_map: missing AdamW moments for Var id {:?}",
+                                id
+                            )
+                        })?;
                     apply_adamw_update(
                         backend,
                         var,


### PR DESCRIPTION
## What
First step of Increment 0 (kt-native training substrate, #1082): flip the AdamW `OptimizerState.moments` map key from candle `TensorId` to kt-native `KtTensorId`, routing every key through the equality-preserving `cd_tensor_id_to_kt` bridge. The candle `GradStore`/`GradMap` grad containers and the LoRA `Var` storage are untouched — only the moment-state keying migrates. Removes the first live consumer of the candle `TensorId` alias from the optimizer path.

## Why
Per `docs/issue-1082-forward-rs-type-flip-plan-2026-05-29.md` Increment 0, the candle dep in kiln-train's training backward is now only the plumbing (GradStore container + Var/TensorId keying). This is the smallest, provably-isolated first step of that migration.

## Sites (all crates/kiln-train/src/trainer.rs)
`OptimizerState.moments` field type; `allocate_adamw_state` local + insert; the two key reads in `optimizer_step` + `optimizer_step_from_map`. `cd_tensor_id_to_kt` is equality-preserving (cd_types.rs, tested), so moment lookups are unchanged.

## Validation (H100, KILN_CUDA_ARCHS=90, release)
- `tape_authoritative_sft_converges_bf16` **PASS** (97s — 100 AdamW steps with the re-keyed moments; the definitive gate for this change).
- `opd_tape_authoritative_grads_reach_lora_bf16` **PASS**, `grpo_tape_authoritative_grads_reach_lora_bf16` **PASS**.
- `tape_authoritative_grads_match_candle_baseline_bf16` + `tape_grad_matches_finite_difference_bf16` fail with a pre-existing `gdn_gates_bf16 FFI 500` in the **candle-baseline forward** (crashes before any optimizer/backward code this PR touches; persists after a full deep clean → environmental, not introduced here). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)