### PR TITLE
kiln-gdn-kernel: fix H100/SM90 dlink-prune of gdn_gates kernels (cudaErrorSymbolNotFound 500) (#1082)

### DIFF
--- a/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
@@ -60,7 +60,20 @@ __device__ __forceinline__ float param_to_float(float x) {
     return x;
 }
 
+}  // namespace (device helpers only)
 
+// #1082 (H100/SM90 dlink-prune fix): the GDN gate `__global__` kernels below
+// have EXTERNAL linkage — they are intentionally NOT inside the anonymous
+// namespace above. Under separable compilation (RDC, `cc::Build::cuda(true)`
+// compiles every .cu with `-dc` then device-links them), `nvcc -dlink`
+// (nvlink) dead-code-eliminates *internal-linkage* `__global__` entry points
+// that have no device-side caller. On SM90 (H100) this silently dropped the
+// entire `gdn_gates.o` device section from `kiln_gdn_kernel_dlink.o`, so the
+// host-side launch resolved no registered device symbol and failed with
+// `cudaErrorSymbolNotFound` (500) — while SM80/SM86 (A100/A6000) happened not
+// to prune them. External linkage marks these as exported entry points that
+// nvlink must keep on every arch. The `__device__` helpers above stay internal
+// (they are inlined into the kernels, so their linkage is irrelevant).
 __global__ void gdn_gate_beta_bf16_kernel(
     const __nv_bfloat16* __restrict__ b,
     __nv_bfloat16* __restrict__ beta_out,
@@ -128,7 +141,20 @@ __global__ void gdn_gates_bf16_kernel(
     g_out[out_idx]    = __float2bfloat16(g_f);
 }
 
-}  // namespace
+// #1082: Explicit template instantiations (external linkage) for the three
+// used type combos (matching kiln_gdn_gates_bf16 / _f32_bf16_params /
+// _f32_params). Forces strong, kept device entry-point symbols so nvlink
+// cannot dead-code-eliminate them at device-link on any arch (SM90 pruned the
+// implicit weak instantiations — see the external-linkage note above).
+template __global__ void gdn_gates_bf16_kernel<__nv_bfloat16, __nv_bfloat16>(
+    const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, int32_t, int32_t, int32_t);
+template __global__ void gdn_gates_bf16_kernel<float, __nv_bfloat16>(
+    const __nv_bfloat16*, const __nv_bfloat16*, const float*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, int32_t, int32_t, int32_t);
+template __global__ void gdn_gates_bf16_kernel<float, float>(
+    const __nv_bfloat16*, const __nv_bfloat16*, const float*, const float*,
+    __nv_bfloat16*, __nv_bfloat16*, int32_t, int32_t, int32_t);
 
 template <typename ALogT, typename DtBiasT>
 int32_t launch_gdn_gates_bf16(


### PR DESCRIPTION
## What
The fused GDN gate kernels (`gdn_gates_bf16_kernel` template + `gdn_gate_beta`/`gdn_gate_g`) lived in `gdn_gates.cu`'s anonymous namespace → **internal linkage**. Under separable compilation (RDC: `cc::Build::cuda(true)` compiles each .cu with `-dc` then `nvcc -dlink`s them), nvlink dead-code-eliminates internal-linkage `__global__` entry points that have no device-side caller. On **SM90 (H100)** this silently dropped the entire `gdn_gates.o` device section from `kiln_gdn_kernel_dlink.o`, so the host launch resolved no registered device symbol and failed at runtime with `cudaErrorSymbolNotFound` (500). SM80/SM86 (A100/A6000) happened not to prune.

## Evidence (cuobjdump, H100)
- Before: `gdn_gates_bf16_kernel` present in `libkiln_gdn_kernel.a` (3 instantiations) but **0** in `kiln_gdn_kernel_dlink.o` and **0** in the final binary; `recurrent`/`chunk`/`gated_rms_norm` survived. dlink.o was freshly built (not stale).
- After: **3** gates instantiations in `dlink.o`.

## Fix
Move the gate `__global__` kernels OUT of the anonymous namespace (external linkage → exported entry points nvlink keeps on every arch) + explicit external template instantiations for the three used type combos (`<bf16,bf16>`, `<f32,bf16>`, `<f32,f32>`) so the weak implicit instantiations can't be pruned either. `__device__` helpers stay internal (inlined).

## Validation (H100, KILN_CUDA_ARCHS=90, release)
All 5 CP-4 bf16 gates **PASS** (previously `tape_authoritative_grads_match_candle_baseline_bf16` + `tape_grad_matches_finite_difference_bf16` failed with the 500): opd/grpo grads_reach_lora, grads_match_candle_baseline, sft_converges (100 steps), finite-difference. Restores candle-baseline + finite-diff parity gates + decode-parity on H100. Correctness on H100/A6000/RTX4090/all is the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)