### PR TITLE
kiln-tensor: alloc_uninit_ctx + uninit matmul output (#1082 perf P0-2)

### DIFF
--- a/crates/kiln-tensor/src/cuda_matmul.rs
+++ b/crates/kiln-tensor/src/cuda_matmul.rs
@@ -225,15 +225,21 @@ pub fn cuda_matmul(a: &Tensor, b: &Tensor) -> Result<Tensor> {
         }
     };
     // ---- allocate output ----
-    // CudaStorage::zeros_ctx (#1082) — the cudarc CudaContext is pulled
-    // directly off a_storage.context(), no .candle_device() read.
+    // CudaStorage::alloc_uninit_ctx (#1082 perf, Pattern A) — the cudarc
+    // CudaContext is pulled directly off a_storage.context(), no
+    // .candle_device() read.
     let ctx = a_storage.context();
     let batch: usize = a_shape[..a_rank - 2].iter().product::<usize>().max(1);
     let mut out_shape = a_shape[..a_rank - 2].to_vec();
     out_shape.push(m);
     out_shape.push(n);
     let out_n_elements = batch * m * n;
-    let out_storage = CudaStorage::zeros_ctx(&ctx, device_index, dtype, out_n_elements)?;
+    // #1082 (perf, Pattern A): this GEMM uses Epilogue::Identity (beta = 0,
+    // pure C = A@B) and the per-batch loop below covers every batch, so all
+    // `batch * m * n` output elements are written before any read. Allocate
+    // uninitialized to skip the cudaMemsetAsync zero-fill (a full-buffer DRAM
+    // write the GEMM immediately overwrites).
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, out_n_elements)?;
 
     // ---- acquire handle ----
     // Cold start passes the cudarc CudaContext through to

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -158,6 +158,45 @@ impl CudaStorage {
         })
     }
 
+    /// (#1082 perf — Pattern A) Allocate `n_elements` of `dtype`
+    /// **UNINITIALIZED** on the cudarc `CudaContext` `ctx`.
+    ///
+    /// Identical to [`Self::zeros_ctx`] except it skips the
+    /// `cudaMemsetAsync` zero-fill (`alloc_zeros` → `alloc`). That zero-fill
+    /// is pure waste whenever the producer overwrites 100% of the buffer —
+    /// e.g. a GEMM with `beta = 0` (`Epilogue::Identity`), or a full-tensor
+    /// elementwise / cast / copy that writes every element. The audit flagged
+    /// "alloc-zeros then fully overwrite" as the highest-frequency baked-in
+    /// waste on the decode + train paths.
+    ///
+    /// # Caller contract
+    /// The returned storage's device bytes are uninitialized; the caller MUST
+    /// fully overwrite the buffer before any read. For accumulation /
+    /// partial-write outputs (read-before-write), use [`Self::zeros_ctx`].
+    pub fn alloc_uninit_ctx(
+        ctx: &Arc<CudaContext>,
+        device_index: usize,
+        dtype: DType,
+        n_elements: usize,
+    ) -> Result<Self> {
+        let byte_len = dtype.packed_buffer_bytes(n_elements);
+        // SAFETY: cudarc's `alloc` returns uninitialized device memory. The
+        // caller contract (documented above) requires a full overwrite before
+        // any read, so the uninitialized contents are never observed.
+        let slice = unsafe { ctx.default_stream().alloc::<u8>(byte_len) }.map_err(|e| {
+            Error::Msg(format!(
+                "CudaStorage::alloc_uninit_ctx: ctx.default_stream().alloc::<u8>({byte_len}) \
+                 failed: {e:?}"
+            ))
+        })?;
+        Ok(CudaStorage {
+            device: Device::Cuda(device_index),
+            dtype,
+            slice: SliceOwner::Owned(slice),
+            ctx: ctx.clone(),
+        })
+    }
+
     /// Wrap an existing `CudaSlice<u8>` allocated by the caller —
     /// **candle-free** entry point.
     ///


### PR DESCRIPTION
## What
Pattern-A perf fix #2 (audited highest-frequency baked-in waste: 'alloc-zeros then fully overwrite'). Adds `CudaStorage::alloc_uninit_ctx` — identical to `zeros_ctx` but skips the `cudaMemsetAsync` zero-fill (`alloc_zeros` → `unsafe alloc`). Wires it into `cuda_matmul`'s output: that GEMM is `Epilogue::Identity` (beta=0, pure C=A@B) and the per-batch loop covers every batch, so all output elements are written before read — the zero-fill was a wasted full-buffer DRAM write the GEMM immediately overwrote.

Caller contract documented (output MUST be fully overwritten before read; accumulation outputs keep `zeros_ctx`). `cuda_matmul_with_bias` (Epilogue::Bias) left on `zeros_ctx` pending separate verification.

## Validation (H100, release)
- kiln-tensor cuda **17/17** matmul tests PASS (matmul_3d_batched, addmm_beta_zero, einsum_matmul — exercise the output alloc).
- **5/5** CP-4 bf16 gates PASS — the candle-baseline full-forward parity gate would fail on any uninit garbage leaking into matmul output; it passes, confirming full overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)