### PR TITLE
kiln-tensor: uninit alloc for cuda_cast output (#1082 perf P0-2b)

### DIFF
--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -1788,11 +1788,10 @@ pub fn cuda_cast(src: &crate::Tensor, target: crate::DType) -> Result<crate::Ten
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
-    let dst_storage = CudaStorage::zeros_ctx(&ctx,
-        device_index,
-        target,
-        n,
-    )?;
+    // #1082 (perf, Pattern A): the cast kernel writes every one of `n` output
+    // elements (`out[i] = cast(src[i])`), so the output is fully overwritten
+    // before any read — allocate uninitialized to skip the cudaMemsetAsync.
+    let dst_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, target, n)?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;


### PR DESCRIPTION
## What
Extends the `alloc_uninit_ctx` perf fix (P0-2) to `cuda_cast`: the cast kernel writes every output element (`out[i] = cast(src[i])`), so the output is fully overwritten before any read — skip the `cudaMemsetAsync` zero-fill. `cuda_cast` runs on the BF16↔F32 conversion path (decode + training).

Follow-up (tracked): extend uninit to the other provably-full-overwrite elementwise/unary/reduction output sites (`cuda_activation_unary`, `cuda_softmax_last_axis`, binary ops, `l2norm`) — each needs per-site full-overwrite verification.

## Validation (H100, release)
**74/74 kiln-tensor cuda tests PASS**, incl. the value-checking `cast_round_trip_through_bf16_preserves_finiteness` (confirms the uninit cast output is correct, no garbage) + all matmul/norm/ops tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)