### PR TITLE
kiln-tensor: uninit alloc sweep for full-overwrite output sites (#1082 perf P0-2c)

### DIFF
--- a/crates/kiln-tensor/src/cuda_matmul.rs
+++ b/crates/kiln-tensor/src/cuda_matmul.rs
@@ -627,15 +627,19 @@ pub fn cuda_matmul_with_bias(
         }
     };
     // ---- allocate output ----
-    // CudaStorage::zeros_ctx (#1082) + .context() default stream — no
-    // .candle_device() read on this matmul path.
+    // .context() default stream — no .candle_device() read on this
+    // matmul path.
     let ctx = a_storage.context();
     let batch: usize = a_shape[..a_rank - 2].iter().product::<usize>().max(1);
     let mut out_shape = a_shape[..a_rank - 2].to_vec();
     out_shape.push(m);
     out_shape.push(n);
     let out_n_elements = batch * m * n;
-    let out_storage = CudaStorage::zeros_ctx(&ctx, device_index, dtype, out_n_elements)?;
+    // #1082 (perf, Pattern A): the cublasLt GEMM runs with beta=0
+    // (handle.matmul hardcodes alpha=1.0/beta=0.0, so C is never read)
+    // and Epilogue::Bias only adds a bias vector — every output element
+    // is written; uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, out_n_elements)?;
 
     // ---- acquire handle ----
     // Cold start passes the cudarc CudaContext through to

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -1328,7 +1328,9 @@ pub fn cuda_elementwise_binary(
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
-    let out_storage = CudaStorage::zeros_ctx(&ctx,
+    // #1082 (perf, Pattern A): elementwise binary writes the full output
+    // (out[i] = op(a[i], b[i]) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx,
         device_index,
         dtype,
         n,
@@ -1356,7 +1358,7 @@ pub fn cuda_elementwise_binary(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let a_off = (a.layout().start_offset() * bpe) as u64;
@@ -1460,7 +1462,9 @@ pub fn cuda_binary_minmax(
         _ => unreachable!(),
     };
     let n = a.element_count();
-    let out_storage = CudaStorage::zeros_ctx(&ctx, device_index, dtype, n)?;
+    // #1082 (perf, Pattern A): binary min/max writes the full output
+    // (out[i] = min/max(a[i], b[i]) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, n)?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -1484,7 +1488,7 @@ pub fn cuda_binary_minmax(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let per = dtype.size_in_bytes();
@@ -1578,7 +1582,9 @@ pub fn cuda_lerp(a: &crate::Tensor, b: &crate::Tensor, weight: f32) -> Result<cr
         _ => unreachable!(),
     };
     let n = a.element_count();
-    let out_storage = CudaStorage::zeros_ctx(&ctx, device_index, dtype, n)?;
+    // #1082 (perf, Pattern A): lerp writes the full output
+    // (out[i] = a[i] + w*(b[i]-a[i]) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, n)?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -1602,7 +1608,7 @@ pub fn cuda_lerp(a: &crate::Tensor, b: &crate::Tensor, weight: f32) -> Result<cr
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let per = dtype.size_in_bytes();
@@ -1682,7 +1688,9 @@ pub fn cuda_activation_unary(x: &crate::Tensor, kind: i32) -> Result<crate::Tens
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
-    let out_storage = CudaStorage::zeros_ctx(&ctx,
+    // #1082 (perf, Pattern A): unary activation writes the full output
+    // (out[i] = f(x[i]) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx,
         device_index,
         dtype,
         n,
@@ -1703,7 +1711,7 @@ pub fn cuda_activation_unary(x: &crate::Tensor, kind: i32) -> Result<crate::Tens
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -2256,8 +2264,11 @@ pub fn cuda_softmax_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
+    // #1082 (perf, Pattern A): softmax writes every element of the
+    // last-axis output (Pass 3 stores out[row, c] for all rows × cols);
+    // uninit skips the memset.
     let out_storage =
-        CudaStorage::zeros_ctx(&ctx, device_index, dtype, x.element_count())?;
+        CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, x.element_count())?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -2274,7 +2285,7 @@ pub fn cuda_softmax_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -2667,7 +2678,11 @@ pub fn cuda_sum_squared_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
         _ => unreachable!(),
     };
     // Output is always F32.
-    let out_storage = CudaStorage::zeros_ctx(&ctx,
+    // #1082 (perf, Pattern A): the sum-of-squares kernel writes every
+    // output row (out[row] = Σ_c x[row,c]^2 for all n_rows rows; lane 0
+    // of each per-row block stores unconditionally) and the output is
+    // exactly n_rows elements; uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx,
         device_index,
         crate::DType::F32,
         n_rows as usize,
@@ -2777,8 +2792,12 @@ pub fn cuda_l2norm_last_axis(x: &crate::Tensor, eps: f32) -> Result<crate::Tenso
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
+    // #1082 (perf, Pattern A): the l2norm-apply kernel writes every
+    // element of the output (out[row, c] = x[row,c] * inv_norm for all
+    // rows × cols) and the output is exactly x.element_count(); uninit
+    // skips the memset.
     let out_storage =
-        CudaStorage::zeros_ctx(&ctx, device_index, dtype, x.element_count())?;
+        CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, x.element_count())?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -2795,14 +2814,14 @@ pub fn cuda_l2norm_last_axis(x: &crate::Tensor, eps: f32) -> Result<crate::Tenso
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
     let out_base = match &out_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -2930,8 +2949,11 @@ pub fn cuda_rmsnorm_last_axis(
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
+    // #1082 (perf, Pattern A): rmsnorm writes every element of the
+    // last-axis output (Pass 2 stores out[row, c] for all rows × cols);
+    // uninit skips the memset.
     let out_storage =
-        CudaStorage::zeros_ctx(&ctx, device_index, dtype, x.element_count())?;
+        CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, x.element_count())?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -3091,8 +3113,11 @@ pub fn cuda_layernorm_last_axis(
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
+    // #1082 (perf, Pattern A): layernorm writes every element of the
+    // last-axis output (Pass 2 stores out[row, c] for all rows × cols);
+    // uninit skips the memset.
     let out_storage =
-        CudaStorage::zeros_ctx(&ctx, device_index, dtype, x.element_count())?;
+        CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, x.element_count())?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -4746,7 +4771,9 @@ pub fn cuda_scalar_op(x: &crate::Tensor, kind: i32, c: f32) -> Result<crate::Ten
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
-    let out_storage = CudaStorage::zeros_ctx(&ctx,
+    // #1082 (perf, Pattern A): scalar op writes the full output
+    // (out[i] = f(x[i], c) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx,
         device_index,
         dtype,
         n,
@@ -4767,7 +4794,7 @@ pub fn cuda_scalar_op(x: &crate::Tensor, kind: i32, c: f32) -> Result<crate::Ten
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -4850,7 +4877,9 @@ pub fn cuda_clamp_pow(
         crate::Device::Cuda(i) => i,
         _ => unreachable!(),
     };
-    let out_storage = CudaStorage::zeros_ctx(&ctx, device_index, dtype, n)?;
+    // #1082 (perf, Pattern A): clamp/pow writes the full output
+    // (out[i] = clamp/pow(x[i]) for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx, device_index, dtype, n)?;
 
     let stream = ctx.default_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
@@ -4867,7 +4896,7 @@ pub fn cuda_clamp_pow(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -4969,7 +4998,9 @@ pub fn cuda_compare(
         _ => unreachable!(),
     };
     // Output is U8 (one byte per element).
-    let out_storage = CudaStorage::zeros_ctx(&ctx,
+    // #1082 (perf, Pattern A): compare writes the full output
+    // (out[i] = cmp(a[i], b[i]) ? 1 : 0 for all n); uninit skips the memset.
+    let out_storage = CudaStorage::alloc_uninit_ctx(&ctx,
         device_index,
         crate::DType::U8,
         n,


### PR DESCRIPTION
## What
Completes the Pattern-A uninit work (audited as the highest-frequency baked-in CUDA waste: 'alloc-zeros then fully overwrite'). Switches **13** output-allocation sites from `zeros_ctx` (alloc + cudaMemsetAsync) to `alloc_uninit_ctx` (alloc only), after verifying each kernel writes 100% of its output before any read (verified by reading the actual .cu kernels):

- Elementwise: `cuda_elementwise_binary`, `cuda_binary_minmax`, `cuda_lerp`, `cuda_activation_unary`, `cuda_scalar_op`, `cuda_clamp_pow`, `cuda_compare`.
- Norms/reductions (write every output row/element): `cuda_softmax_last_axis`, `cuda_sum_squared_last_axis`, `cuda_l2norm_last_axis`, `cuda_rmsnorm_last_axis`, `cuda_layernorm_last_axis`.
- `cuda_matmul_with_bias` (verified `beta=0`; Epilogue::Bias adds a vector, doesn't read C).

**Conservatively KEPT on `zeros_ctx`** (read-before-write / partial-write / padded): `is_finite` (atomicOr), `cross_entropy` intermediates, the arbitrary-axis reduction family (zero-axis early-return-without-launch can leave out_elem≥1 → must stay zeroed), `masked_fill`/`where_select`/`diag_build` (off-diagonal stays 0)/`concat`/`rope`/`dropout`/`scan_axis`/gather paths.

## Validation (H100, release)
**1045/1045 kiln-tensor tests PASS** (full suite, incl. value-checking cuda tests for every switched op — any uninit garbage would fail them).

Authored by an Opus subagent (conservative per-site full-overwrite verification against the .cu kernels) + orchestrator validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)