### PR TITLE
kiln-tensor: cuda op sites handle Borrowed dst (#1082 Phase 7)

### DIFF
--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -937,7 +937,7 @@ pub fn cuda_contiguous(src: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     // Source pointer at the live region's start (start_offset applied).
@@ -1283,7 +1283,7 @@ pub fn cuda_index_select_dim0(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let src_byte_off = (src.layout().start_offset() * bpe) as u64;
@@ -1441,7 +1441,7 @@ pub fn cuda_index_select_axis_n(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let src_byte_off = (src.layout().start_offset() * bpe) as u64;
@@ -1575,7 +1575,7 @@ pub fn cuda_elementwise_binary(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let a_off = (a.layout().start_offset() * bpe) as u64;
@@ -1705,7 +1705,7 @@ pub fn cuda_binary_minmax(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let per = dtype.size_in_bytes();
@@ -1825,7 +1825,7 @@ pub fn cuda_lerp(a: &crate::Tensor, b: &crate::Tensor, weight: f32) -> Result<cr
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let per = dtype.size_in_bytes();
@@ -1928,7 +1928,7 @@ pub fn cuda_activation_unary(x: &crate::Tensor, kind: i32) -> Result<crate::Tens
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -2033,7 +2033,7 @@ pub fn cuda_cast(src: &crate::Tensor, target: crate::DType) -> Result<crate::Ten
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let src_off = (src.layout().start_offset() * from_bpe) as u64;
@@ -2544,7 +2544,7 @@ pub fn cuda_softmax_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -2743,7 +2743,7 @@ pub fn cuda_is_finite(src: &crate::Tensor) -> Result<bool> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     // `cuda_contiguous` produces start_offset == 0, so no byte_off math.
@@ -2965,7 +2965,7 @@ pub fn cuda_sum_squared_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -3076,14 +3076,14 @@ pub fn cuda_l2norm_last_axis(x: &crate::Tensor, eps: f32) -> Result<crate::Tenso
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let out_base = match &out_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -3239,7 +3239,7 @@ pub fn cuda_rmsnorm_last_axis(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -3410,7 +3410,7 @@ pub fn cuda_layernorm_last_axis(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -3540,7 +3540,7 @@ pub fn cuda_masked_fill(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     // mask dtype is U8 → bpe = 1.
@@ -3651,7 +3651,7 @@ pub fn cuda_argmax_last_axis(x: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * in_dtype.size_in_bytes()) as u64;
@@ -3766,14 +3766,14 @@ pub fn cuda_topk_last_axis(x: &crate::Tensor, k: usize) -> Result<(Vec<f32>, Vec
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let idx_base = match &idx_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * in_dtype.size_in_bytes()) as u64;
@@ -3984,21 +3984,21 @@ pub fn cuda_cross_entropy_loss(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let row_err_base = match &row_err_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let out_base = match &out_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let logits_off = (logits.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -4142,7 +4142,7 @@ fn cuda_reduce_last_axis_impl(x: &crate::Tensor, divisor: f32, label: &str) -> R
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -4281,7 +4281,7 @@ fn cuda_reduce_arbitrary_axis_impl(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -4448,7 +4448,7 @@ fn cuda_minmax_arbitrary_axis_impl(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;
@@ -4577,7 +4577,7 @@ pub fn cuda_bool_reduce_axis(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (mask.layout().start_offset() * crate::DType::U8.size_in_bytes()) as u64;
@@ -4749,7 +4749,7 @@ pub fn cuda_concat(inputs: &[&crate::Tensor], axis: usize) -> Result<crate::Tens
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let dst_ptr = dst_base as *mut core::ffi::c_void;
 
@@ -4958,7 +4958,7 @@ pub fn cuda_rope(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * x_bpe) as u64;
@@ -5084,14 +5084,14 @@ pub fn cuda_dropout(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
     let mask_base = match &mask_storage.slice {
         SliceOwner::Owned(s) => {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * x_bpe) as u64;
@@ -5216,7 +5216,7 @@ pub fn cuda_scalar_op(x: &crate::Tensor, kind: i32, c: f32) -> Result<crate::Ten
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -5318,7 +5318,7 @@ pub fn cuda_clamp_pow(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("alloc_uninit produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -5450,7 +5450,7 @@ pub fn cuda_compare(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let a_off = (a.layout().start_offset() * bpe) as u64;
@@ -5586,7 +5586,7 @@ pub fn cuda_where_select(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     // mask is U8 — one byte per element regardless of dtype.
@@ -5685,7 +5685,7 @@ pub fn cuda_diagonal_extract(x: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * bpe) as u64;
@@ -5773,7 +5773,7 @@ pub fn cuda_diag_build(v: &crate::Tensor) -> Result<crate::Tensor> {
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda_zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let v_off = (v.layout().start_offset() * bpe) as u64;
@@ -5899,7 +5899,7 @@ fn cuda_scan_axis_impl(
             let (p, _g) = s.device_ptr(&stream);
             p
         }
-        SliceOwner::Borrowed { .. } => unreachable!("cuda zeros produces Owned"),
+        SliceOwner::Borrowed { ptr, .. } => *ptr,
     };
 
     let x_off = (x.layout().start_offset() * dtype.size_in_bytes()) as u64;


### PR DESCRIPTION
## What
Migrate 37 `cuda_storage` op ptr-extraction sites that assumed a freshly-allocated `dst` is `Owned` (`unreachable!("cuda_zeros produces Owned")`) to handle the `Borrowed` variant by extracting `*ptr` — exactly like the already-migrated src/idx arms.

## Why
Completes the deferred "kernel-crate kt-API sites must migrate to the dtype/owner-aware accessor" work (cuda_storage.rs:258). `Borrowed` storage is produced by the candle→kt zero-copy adapter and by the Phase-5 cuda-graph freeze-pointers capture arena; without this, those ops panic on a Borrowed dst. No behavior change for `Owned` storage.

## Risk
Low — inert for all current `Owned` allocations; only adds correct handling for the `Borrowed` path. Verified to compile under `--features cuda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)