### PR TITLE
kiln-param: atomic Parameter::version epoch counter (#1082 Phase 2.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,10 @@ jobs:
         # the per-crate tests in already-candle-free leaf crates never run
         # in the default job. Test them directly to keep coverage and to
         # validate #1082 box work that lands in them (e.g. the kiln-optim
-        # AdamW stochastic-rounding path). None of these depend on
-        # kiln-model, so they compile and run on a GPU-less runner.
-        run: cargo test --locked -p kiln-optim
+        # AdamW stochastic-rounding path, and the kiln-param Phase 2.7
+        # atomic `Parameter::version` epoch counter). None of these depend
+        # on kiln-model, so they compile and run on a GPU-less runner.
+        run: cargo test --locked -p kiln-optim -p kiln-param
 
   cuda-candle-free:
     name: CUDA dep tree is candle-free (#1082)

--- a/crates/kiln-optim/src/adamw.rs
+++ b/crates/kiln-optim/src/adamw.rs
@@ -201,6 +201,10 @@ impl OptimStep for AdamW {
             step_count,
         )?;
         param.replace_backward_storage(Some(new_master));
+        // #1082 Phase 2.7: end-of-optimizer-step epoch bump. A serving
+        // thread polling `Parameter::version_handle` observes this as
+        // the signal that the master advanced (forward view now stale).
+        param.bump_epoch();
         Ok(())
     }
 

--- a/crates/kiln-optim/src/lion_muon.rs
+++ b/crates/kiln-optim/src/lion_muon.rs
@@ -153,6 +153,8 @@ impl OptimStep for Lion {
         // Write updated master back to the Parameter.
         let new_master = build_master_tensor(policy.master_dtype, master.shape(), &master_f32)?;
         param.replace_backward_storage(Some(new_master));
+        // #1082 Phase 2.7: end-of-optimizer-step epoch bump (see AdamW).
+        param.bump_epoch();
         Ok(())
     }
 
@@ -373,6 +375,8 @@ impl OptimStep for Muon {
 
         let new_master = build_master_tensor(policy.master_dtype, &shape, &master_f32)?;
         param.replace_backward_storage(Some(new_master));
+        // #1082 Phase 2.7: end-of-optimizer-step epoch bump (see AdamW).
+        param.bump_epoch();
         Ok(())
     }
 

--- a/crates/kiln-optim/src/sgd.rs
+++ b/crates/kiln-optim/src/sgd.rs
@@ -170,6 +170,8 @@ impl OptimStep for Sgd {
         // keyed on `param.tensor_id()` (`self.velocities`) survives.
         let new_master = write_f32_to_tensor(policy.master_dtype, master.shape(), &master_f32)?;
         param.replace_backward_storage(Some(new_master));
+        // #1082 Phase 2.7: end-of-optimizer-step epoch bump (see AdamW).
+        param.bump_epoch();
         Ok(())
     }
 

--- a/crates/kiln-optim/tests/epoch_bump.rs
+++ b/crates/kiln-optim/tests/epoch_bump.rs
@@ -1,0 +1,62 @@
+//! #1082 Phase 2.7 — **every** optimizer bumps the `Parameter` epoch
+//! counter at end-of-optimizer-step.
+//!
+//! The epoch counter is the version a live serving thread polls (via
+//! `Parameter::version_handle`) to learn that the master advanced and
+//! its cached forward view is stale. If any `OptimStep` impl finishes a
+//! step without bumping, that signal is silently lost — so this is the
+//! cross-optimizer guard: a future optimizer that forgets
+//! `param.bump_epoch()` fails CI here.
+
+use kiln_optim::{AdamW, AdamWHyperparameters, Lion, Muon, OptimStep, Sgd, SgdHyperparameters};
+use kiln_param::{AmpPolicy, ForwardStorage, Parameter};
+use kiln_tensor::Tensor;
+
+/// 2×2 master so Muon's Newton–Schulz (square-matrix) path is happy;
+/// the elementwise optimizers accept the same shape.
+fn make_param() -> Parameter {
+    let t = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
+    let master = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
+    Parameter::trainable(ForwardStorage::Plain(t), master, AmpPolicy::fp32_reference())
+}
+
+fn grad() -> Tensor {
+    Tensor::from_slice(&[0.1f32, 0.1, 0.1, 0.1], vec![2, 2]).unwrap()
+}
+
+fn assert_steps_bump_epoch(opt: &mut dyn OptimStep, name: &str) {
+    let mut p = make_param();
+    assert_eq!(p.current_epoch(), 0, "{name}: fresh parameter starts at epoch 0");
+    opt.step(&mut p, &grad()).unwrap();
+    assert_eq!(
+        p.current_epoch(),
+        1,
+        "{name}: one optimizer step must bump the epoch to 1"
+    );
+    opt.step(&mut p, &grad()).unwrap();
+    assert_eq!(p.current_epoch(), 2, "{name}: a second step bumps to 2");
+}
+
+#[test]
+fn adamw_step_bumps_epoch() {
+    let mut opt = AdamW::new(AdamWHyperparameters::default());
+    assert_steps_bump_epoch(&mut opt, "AdamW");
+}
+
+#[test]
+fn sgd_step_bumps_epoch() {
+    let mut opt = Sgd::new(SgdHyperparameters::default());
+    assert_steps_bump_epoch(&mut opt, "Sgd");
+}
+
+#[test]
+fn lion_step_bumps_epoch() {
+    let mut opt = Lion::new(1e-3, 0.9, 0.99, 0.0);
+    assert_steps_bump_epoch(&mut opt, "Lion");
+}
+
+#[test]
+fn muon_step_bumps_epoch() {
+    let mut opt = Muon::new(1e-3, 0.9, 5);
+    assert_steps_bump_epoch(&mut opt, "Muon");
+}

--- a/crates/kiln-param/src/parameter.rs
+++ b/crates/kiln-param/src/parameter.rs
@@ -15,6 +15,7 @@
 //! `crates/kiln-train/src/trainer.rs:555,592`) get orphaned on
 //! weight-form transitions.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use kiln_tensor::{Result, Storage, Tensor, TensorId};
@@ -238,7 +239,16 @@ pub struct Parameter {
     ///
     /// Initialized to 0 by both constructors; starts incrementing at
     /// the first optimizer step.
-    epoch: u64,
+    ///
+    /// **Atomic + Arc-shared** (#1082 Phase 2.7): a serving thread
+    /// holding a [`Parameter::version_handle`] reads the live epoch
+    /// lock-free while the trainer mutates this Parameter under its
+    /// own lock and `bump_epoch()`s at end-of-step. `#[derive(Clone)]`
+    /// shares the counter (the live-handle semantic); [`snapshot`]
+    /// detaches it so a snapshot's epoch stays frozen at capture time.
+    ///
+    /// [`snapshot`]: Parameter::snapshot
+    epoch: Arc<AtomicU64>,
 }
 
 impl Parameter {
@@ -255,7 +265,7 @@ impl Parameter {
             amp_policy: AmpPolicy::default(),
             name: None,
             forward_stale: false,
-            epoch: 0,
+            epoch: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -272,7 +282,7 @@ impl Parameter {
             amp_policy: policy,
             name: None,
             forward_stale: false,
-            epoch: 0,
+            epoch: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -317,14 +327,41 @@ impl Parameter {
     /// the snapshot through the Arc-shared storage even as the
     /// master mutates underneath at later epochs.
     pub fn current_epoch(&self) -> u64 {
-        self.epoch
+        self.epoch.load(Ordering::Acquire)
     }
 
     /// Advance the epoch counter — called at end-of-optimizer-step.
-    /// Saturating add: at u64::MAX the counter sticks (in practice
-    /// no training run reaches 2^64 steps).
-    pub fn bump_epoch(&mut self) {
-        self.epoch = self.epoch.saturating_add(1);
+    ///
+    /// Atomic `fetch_add(1, Release)` so a serving thread reading via
+    /// [`Parameter::version_handle`] / [`Parameter::current_epoch`]
+    /// observes the bump **without holding any lock** on the
+    /// Parameter. Takes `&self` (not `&mut self`) precisely so the
+    /// bump composes with a shared/concurrent read path — the trainer
+    /// can bump through a shared reference held alongside serving
+    /// readers. **Saturating** at `u64::MAX` — the counter is
+    /// monotonically non-decreasing, so a stale reader can never be
+    /// fooled into thinking its cached forward view is fresh by a
+    /// wrap-around (in practice no run reaches 2^64 steps anyway).
+    pub fn bump_epoch(&self) {
+        // Atomic saturating add via a CAS loop (`fetch_add` would wrap;
+        // a version counter must stay monotonic — see above).
+        let _ = self.epoch.fetch_update(Ordering::Release, Ordering::Acquire, |v| {
+            Some(v.saturating_add(1))
+        });
+    }
+
+    /// Lock-free reader handle on the live epoch counter (#1082 Phase
+    /// 2.7 "live serve + train coexistence").
+    ///
+    /// A serving thread clones this `Arc<AtomicU64>` once and polls
+    /// `load(Ordering::Acquire)` to observe the trainer's
+    /// [`bump_epoch`](Parameter::bump_epoch) advances without locking
+    /// the Parameter. This is the primitive the next box ("replace the
+    /// whole-GPU `RwLock` with a Parameter-versioned read path") builds
+    /// on: a reader compares the epoch it last quantized against the
+    /// live epoch to decide whether its cached forward view is stale.
+    pub fn version_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.epoch)
     }
 
     /// Phase 2.5 tied-parameter check (#1082 line 288).
@@ -375,7 +412,16 @@ impl Parameter {
     /// **Cost:** O(1). Tensor clones are Arc refcount bumps; no
     /// device-memory copy.
     pub fn snapshot(&self) -> Self {
-        self.clone()
+        // `#[derive(Clone)]` shares the live `Arc<AtomicU64>` epoch (the
+        // live-handle semantic). A snapshot must instead FREEZE the
+        // epoch at capture time so it reports a stable version even as
+        // the master advances under later `bump_epoch()` calls (#1082
+        // Phase 2.7 "eval-while-training via Parameter snapshot"):
+        // detach into an independent counter holding the captured
+        // value.
+        let mut snap = self.clone();
+        snap.epoch = Arc::new(AtomicU64::new(self.current_epoch()));
+        snap
     }
 
     /// Stable identity.
@@ -1020,6 +1066,96 @@ mod tests {
             p.bump_epoch();
         }
         assert_eq!(p.current_epoch(), 1000);
+    }
+
+    #[test]
+    fn bump_epoch_takes_shared_ref() {
+        // #1082 Phase 2.7: `bump_epoch` is `&self` so the trainer can
+        // advance the version through a shared reference held alongside
+        // serving readers — not `&mut self`. Compile-checking shape:
+        // calling it through `&Parameter` must type-check.
+        let fs = plain_f32();
+        let master_tensor = fs.primary_tensor().clone();
+        let p = Parameter::trainable(fs, master_tensor, AmpPolicy::default());
+        let r: &Parameter = &p;
+        r.bump_epoch();
+        r.bump_epoch();
+        assert_eq!(p.current_epoch(), 2);
+    }
+
+    #[test]
+    fn version_handle_observes_live_bumps() {
+        // The lock-free reader handle tracks the LIVE counter: after the
+        // parameter bumps, a previously-taken handle sees the new value
+        // (it is the same Arc<AtomicU64>, not a copy).
+        let fs = plain_f32();
+        let master_tensor = fs.primary_tensor().clone();
+        let p = Parameter::trainable(fs, master_tensor, AmpPolicy::default());
+        let handle = p.version_handle();
+        assert_eq!(handle.load(Ordering::Acquire), 0);
+        p.bump_epoch();
+        p.bump_epoch();
+        p.bump_epoch();
+        assert_eq!(handle.load(Ordering::Acquire), 3);
+        assert_eq!(handle.load(Ordering::Acquire), p.current_epoch());
+    }
+
+    #[test]
+    fn snapshot_version_handle_is_frozen() {
+        // A snapshot's handle is DETACHED: it stays frozen at the
+        // captured epoch even as the parent advances. This is what lets
+        // an eval pass read a consistent version while training rolls on.
+        let fs = plain_f32();
+        let master_tensor = fs.primary_tensor().clone();
+        let p = Parameter::trainable(fs, master_tensor, AmpPolicy::default());
+        p.bump_epoch();
+        let s = p.snapshot();
+        let s_handle = s.version_handle();
+        assert_eq!(s_handle.load(Ordering::Acquire), 1);
+        p.bump_epoch();
+        p.bump_epoch();
+        // Parent moved on; the snapshot's handle is unaffected.
+        assert_eq!(s_handle.load(Ordering::Acquire), 1);
+        assert_eq!(p.current_epoch(), 3);
+    }
+
+    #[test]
+    fn concurrent_read_during_bump_is_safe_and_monotonic() {
+        // The defining Phase 2.7 capability: a serving thread polls the
+        // version lock-free while the trainer bumps it. Only the
+        // Arc<AtomicU64> handle (Send + Sync) crosses to the reader
+        // thread — the Parameter itself stays on the main thread — so
+        // this exercises exactly the serve-while-train read path.
+        use std::sync::atomic::AtomicBool;
+
+        let fs = plain_f32();
+        let master_tensor = fs.primary_tensor().clone();
+        let p = Parameter::trainable(fs, master_tensor, AmpPolicy::default());
+        let handle = p.version_handle();
+        let done = Arc::new(AtomicBool::new(false));
+        let done_reader = Arc::clone(&done);
+
+        let reader = std::thread::spawn(move || {
+            let mut last = 0u64;
+            let mut max_seen = 0u64;
+            while !done_reader.load(Ordering::Acquire) {
+                let v = handle.load(Ordering::Acquire);
+                assert!(v >= last, "version went backwards: {v} < {last}");
+                last = v;
+                max_seen = max_seen.max(v);
+            }
+            // One final read after the writer is done.
+            max_seen.max(handle.load(Ordering::Acquire))
+        });
+
+        for _ in 0..2000 {
+            p.bump_epoch();
+        }
+        done.store(true, Ordering::Release);
+
+        let max_seen = reader.join().unwrap();
+        assert_eq!(p.current_epoch(), 2000);
+        assert!(max_seen <= 2000, "reader saw an impossible epoch {max_seen}");
     }
 
     #[test]


### PR DESCRIPTION
## What

Implements the **Phase 2.7 `Parameter::version` epoch counter** box of #1082 ("live serve + train coexistence").

The field existed but was a plain `u64` mutated through `&mut self` with **zero call sites** — so it was neither concurrent-safe (a serving thread couldn't read the version while the trainer advanced it) nor ever actually bumped. Both gaps are why the box was correctly left unchecked.

- `epoch: u64` → `Arc<AtomicU64>`; `current_epoch()` loads `Acquire`.
- `bump_epoch(&self)`: atomic **saturating** add via a CAS loop — the version stays monotonically non-decreasing (a wrapped epoch would fool a stale reader into thinking its cached forward view is fresh). `&self` so it composes with a concurrent read path.
- `version_handle() -> Arc<AtomicU64>`: lock-free reader handle a serving thread polls without locking the Parameter. This is the primitive the next box ("replace the whole-GPU `RwLock` with a Parameter-versioned read path") builds on. Mirrors the existing `kiln_tensor::Tensor::version_handle`.
- `snapshot()` **detaches** the epoch into a frozen counter, so an eval-while-training / on-policy-GRPO snapshot reports a stable version even as the master rolls on.
- All four `OptimStep` impls (AdamW / Sgd / Lion / Muon) call `param.bump_epoch()` at end-of-step (right after the master swap).

## Why this placement

`bump_epoch` is wired into each `step()` impl, **not** into `replace_backward_storage` — the latter is also called during checkpoint load/init (`trainer.rs:842,1153`), which must not bump.

## Tests (all in the candle-free CI job)

- kiln-param: shared-ref bump, live-handle tracking, **frozen snapshot handle**, and a **concurrent read-during-bump** test (reader thread polls the handle while the main thread bumps 2000×; asserts monotonic + no impossible value).
- kiln-optim `tests/epoch_bump.rs`: cross-optimizer guard so a future optimizer that forgets the bump fails CI.
- `candle-free-crate-tests` now runs `-p kiln-param` alongside `-p kiln-optim`.

No pod / GPU needed — both crates are candle-free leaves validated on the GitHub-hosted runner.