### PR TITLE
ci: validate anomaly/determinism on the candle-free job (#1082, supersedes #1435)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,23 @@ jobs:
         # the per-crate tests in already-candle-free leaf crates never run
         # in the default job. Test them directly to keep coverage and to
         # validate #1082 box work that lands in them (e.g. the kiln-optim
-        # AdamW stochastic-rounding path, and the kiln-param Phase 2.7
-        # atomic `Parameter::version` epoch counter). None of these depend
-        # on kiln-model, so they compile and run on a GPU-less runner.
-        run: cargo test --locked -p kiln-optim -p kiln-param
+        # AdamW stochastic-rounding path, the kiln-param Phase 2.7 atomic
+        # `Parameter::version` epoch counter, and the kiln-autograd tape).
+        # None of these depend on kiln-model, so they compile and run on a
+        # GPU-less runner.
+        run: cargo test --locked -p kiln-optim -p kiln-param -p kiln-autograd
+
+      - name: Validate anomaly trap + deterministic envelope (#1082)
+        # `KILN_DETECT_ANOMALY` (autograd NaN/Inf trap probe, kiln-autograd)
+        # and `KILN_DETERMINISTIC` (deterministic-variant selector,
+        # kiln-tensor) live in candle-free crates, so they validate here
+        # WITHOUT the mid-migration default build that the earlier
+        # training-path approach (PR #1435) depended on and that cannot
+        # compile kiln-model yet. Single-threaded: these tests drive
+        # process-global env vars and must not race each other.
+        run: |
+          KILN_DETECT_ANOMALY=1 cargo test --locked -p kiln-autograd anomaly -- --test-threads=1
+          KILN_DETERMINISTIC=1 cargo test --locked -p kiln-tensor determinism -- --test-threads=1
 
   cuda-candle-free:
     name: CUDA dep tree is candle-free (#1082)


### PR DESCRIPTION
## What

Makes the `KILN_DETECT_ANOMALY` (autograd NaN/Inf trap probe, `kiln-autograd`) and `KILN_DETERMINISTIC` (deterministic-variant selector, `kiln-tensor`) tests **actually run in CI**.

These live in candle-free crates and already have unit tests, but the candle-free job only ran `kiln-optim` + `kiln-param`, so they never executed. **PR #1435** tried to validate them via `cargo test -p kiln-train`, which is dead behind the mid-migration default build (can't compile `kiln-model` yet) — so its step never even reached.

- Add `-p kiln-autograd` to the candle-free leaf-crate test line.
- New step runs the `anomaly` + `determinism` module tests with their env vars set, single-threaded (they drive process-global env state).

No GPU / no `kiln-model` dependency — validated on the GitHub-hosted runner. **Supersedes #1435.**