### PR TITLE
cuda: restore concurrent-decode batching (full-width burst-fill admission) (#1082)

### DIFF
--- a/crates/kiln-kt-bridge/src/lib.rs
+++ b/crates/kiln-kt-bridge/src/lib.rs
@@ -183,9 +183,25 @@ pub fn cuda_input_device_ptr(
 ) -> Result<u64, BridgeError> {
     let (st, byte_off) = cuda_storage_and_byte_offset(t, expected, name)?;
     let (base_ptr, byte_len) = st.device_ptr_raw();
-    if byte_off > byte_len {
+    // #1082 illegal-address localizer: check BOTH ends of the addressable span,
+    // not just the start. A kernel input whose declared shape over-runs its
+    // backing storage (e.g. a batched [batch,...] state cat-assembled to the
+    // wrong batch, or a mis-sized paged-KV/GDN buffer after the candle->kt
+    // migration) otherwise sails past this bridge with a valid start pointer
+    // and faults INSIDE the kernel as an async, sticky CUDA_ERROR_ILLEGAL_ADDRESS
+    // that only surfaces (with a misleading context string) at the next stream
+    // sync — making it nearly impossible to attribute. The end check converts
+    // that into a clean, named Rust error naming the exact input + shape BEFORE
+    // the launch. The tensor is contiguous here (verified in
+    // cuda_storage_and_byte_offset), so addressable_byte_size == element_count *
+    // bytes_per_element. Strictly tighter precondition: a no-op for correctly
+    // sized tensors (the bs=1 and last-known-good paths).
+    let addressable = t.layout().addressable_byte_size(expected.size_in_bytes());
+    if byte_off + addressable > byte_len {
         return Err(BridgeError::new(format!(
-            "kt-bridge: {name} byte_off {byte_off} > storage byte_len {byte_len}"
+            "kt-bridge: {name} OOB: start_offset_bytes {byte_off} + addressable {addressable} \
+             > storage byte_len {byte_len} (shape {:?}, dtype {expected})",
+            t.dims()
         )));
     }
     Ok(base_ptr + byte_off as u64)

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -690,6 +690,9 @@ impl BatchingEngineHandle {
             max_decode_batch,
             env_prefix_aware_admission(),
             env_prefill_admission_quantum_for_backend(max_decode_batch, backend_name),
+            // #1082: CUDA restores the LKG burst-fill admission; Vulkan/Metal
+            // keep their tuned yield-to-ready-rows behavior.
+            matches!(backend_name, Some("cuda")),
         )
     }
 
@@ -698,6 +701,7 @@ impl BatchingEngineHandle {
         max_decode_batch: usize,
         prefix_aware_admission: bool,
         prefill_admission_quantum: usize,
+        burst_refill: bool,
     ) -> Self {
         let (tx, rx) = mpsc::channel(DEFAULT_ENGINE_CHANNEL);
         let actor = BatchingEngineActor::new(
@@ -706,6 +710,7 @@ impl BatchingEngineHandle {
             max_decode_batch.max(1),
             prefix_aware_admission,
             prefill_admission_quantum,
+            burst_refill,
         );
         thread::Builder::new()
             .name("kiln-batching-engine".to_string())
@@ -801,6 +806,16 @@ struct BatchingEngineActor {
     max_decode_batch: usize,
     prefix_aware_admission: bool,
     max_prefill_admissions_per_cycle: usize,
+    // #1082 CUDA concurrency regression: when true, admit_waiting refills the
+    // decode batch toward `max_decode_batch` every cycle (the LKG 2d9d4fc4
+    // burst-fill that scaled CUDA to ~498 tok/s @ bs=64) instead of yielding to
+    // ready decode rows by admitting only 1 prefill/cycle. The `has_ready_decode_row`
+    // 1/cycle yield (added for Vulkan by 2c52565d) starves the SUSTAINED batch
+    // width on CUDA (max_decode_batch=8): inline prefills interleave into every
+    // decode cycle so a wide batch never forms, producing the measured
+    // anti-scaling (n=32 slower than n=8). Set only for CUDA; Vulkan/Metal keep
+    // their tuned yield behavior.
+    burst_refill: bool,
     snapshot: BatchingEngineSnapshot,
 }
 
@@ -811,6 +826,7 @@ impl BatchingEngineActor {
         max_decode_batch: usize,
         prefix_aware_admission: bool,
         prefill_admission_quantum: usize,
+        burst_refill: bool,
     ) -> Self {
         let max_decode_batch = max_decode_batch.max(1);
         let max_prefill_admissions_per_cycle = prefill_admission_quantum.clamp(1, max_decode_batch);
@@ -824,6 +840,7 @@ impl BatchingEngineActor {
             max_decode_batch,
             prefix_aware_admission,
             max_prefill_admissions_per_cycle,
+            burst_refill,
             snapshot: BatchingEngineSnapshot {
                 accepting: true,
                 max_prefill_admission_quantum: max_prefill_admissions_per_cycle,
@@ -937,7 +954,14 @@ impl BatchingEngineActor {
 
     fn admit_waiting(&mut self) {
         let mut admitted = 0usize;
-        let admission_limit = if self.has_ready_decode_row() {
+        // #1082 CUDA concurrency regression fix: CUDA (burst_refill) refills the
+        // batch toward max_decode_batch every cycle — the LKG 2d9d4fc4 burst-fill
+        // that sustained a wide decode batch and scaled to ~498 tok/s @ bs=64.
+        // Vulkan/Metal keep yielding to ready decode rows (admit 1 prefill/cycle
+        // once any row is decoding) — their tuned latency behavior. The while
+        // loop below still caps total active at max_decode_batch, so burst_refill
+        // only ever fills the deficit, never over-admits.
+        let admission_limit = if self.has_ready_decode_row() && !self.burst_refill {
             1
         } else {
             self.max_prefill_admissions_per_cycle
@@ -1606,7 +1630,7 @@ mod tests {
     fn prefill_admission_quantum_limits_each_actor_cycle() {
         let (_tx, rx) = mpsc::channel(DEFAULT_ENGINE_CHANNEL);
         let forward = Arc::new(MockForward::default());
-        let mut actor = BatchingEngineActor::new(rx, forward, 8, false, 3);
+        let mut actor = BatchingEngineActor::new(rx, forward, 8, false, 3, false);
         for idx in 0..8 {
             let (response_tx, _response_rx) = mpsc::channel(DEFAULT_RESPONSE_CHANNEL);
             actor.waiting.push_back(QueuedRequest {
@@ -1636,7 +1660,7 @@ mod tests {
     fn ready_decode_rows_limit_followup_prefill_admission_to_one() {
         let (_tx, rx) = mpsc::channel(DEFAULT_ENGINE_CHANNEL);
         let forward = Arc::new(PendingFirstTokenForward::default());
-        let mut actor = BatchingEngineActor::new(rx, forward.clone(), 8, false, 3);
+        let mut actor = BatchingEngineActor::new(rx, forward.clone(), 8, false, 3, false);
         let mut receivers = Vec::new();
         for idx in 0..6 {
             let (response_tx, response_rx) = mpsc::channel(DEFAULT_RESPONSE_CHANNEL);
@@ -1675,7 +1699,7 @@ mod tests {
     fn admission_emits_prefill_first_tokens_without_model_decode() {
         let (_tx, rx) = mpsc::channel(DEFAULT_ENGINE_CHANNEL);
         let forward = Arc::new(PendingFirstTokenForward::default());
-        let mut actor = BatchingEngineActor::new(rx, forward.clone(), 8, false, 3);
+        let mut actor = BatchingEngineActor::new(rx, forward.clone(), 8, false, 3, false);
         let mut receivers = Vec::new();
         for idx in 0..4 {
             let (response_tx, response_rx) = mpsc::channel(DEFAULT_RESPONSE_CHANNEL);
@@ -1765,7 +1789,7 @@ mod tests {
             reusable_prefixes: true,
             ..MockForward::default()
         });
-        let handle = BatchingEngineHandle::start_with_policy(forward.clone(), 8, true, 8);
+        let handle = BatchingEngineHandle::start_with_policy(forward.clone(), 8, true, 8, false);
 
         let mut prefix_rx = handle
             .enqueue(request_with_tokens(vec![1, 2], 1))

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -75,7 +75,20 @@ pub(crate) fn env_prefill_admission_quantum_for_backend(
         .and_then(|raw| raw.trim().parse::<usize>().ok())
         .filter(|&n| n > 0)
         .unwrap_or_else(|| {
-            if matches!(backend_name, Some("vulkan")) {
+            // #1082 CUDA concurrency regression: this quantum governs how many
+            // waiting requests are prompt-prefilled per actor cycle before the
+            // decode width is reached. At LKG 2d9d4fc4 `admit_waiting`
+            // burst-filled the whole decode width in one cycle and CUDA scaled
+            // ~5.9x to ~498 tok/s @ bs=64. The Vulkan admission-tuning commits
+            // (568d82a4 / 07607d5d) restored that full-width burst ONLY for
+            // Vulkan, leaving CUDA pinned at the latency default (4): the 64
+            // prompt prefills then drained ~1/decode-cycle on the single actor
+            // thread, ballooning TTFT to ~38s and collapsing aggregate
+            // throughput to ~22 tok/s. GPU backends saturate via wide decode
+            // batches, so give CUDA the same full-width quantum as Vulkan; CPU
+            // keeps the latency-oriented default. Per-deploy override:
+            // KILN_BATCH_PREFILL_ADMISSION_QUANTUM.
+            if matches!(backend_name, Some("vulkan") | Some("cuda")) {
                 max_decode_batch
             } else {
                 DEFAULT_PREFILL_ADMISSION_QUANTUM
@@ -1482,9 +1495,20 @@ mod tests {
             env_prefill_admission_quantum_for_backend(64, Some("vulkan")),
             64
         );
+        // #1082: CUDA gets the same full-width quantum as Vulkan (regression fix).
+        assert_eq!(
+            env_prefill_admission_quantum_for_backend(64, Some("cuda")),
+            64
+        );
+        // Metal stays at the latency default (the Metal lane can opt in separately).
         assert_eq!(
             env_prefill_admission_quantum_for_backend(64, Some("metal")),
             4
+        );
+        // CUDA still clamps to demand when the decode width is small.
+        assert_eq!(
+            env_prefill_admission_quantum_for_backend(2, Some("cuda")),
+            2
         );
         assert_eq!(env_prefill_admission_quantum_for_backend(2, None), 2);
         assert_eq!(


### PR DESCRIPTION
Fixes the P0 CUDA concurrent-decode scaling regression: concurrent `/v1/chat/completions` requests stopped co-batching, so aggregate decode throughput went FLAT (and anti-scaled: n=32 slower than n=8) instead of scaling. Root-caused via multi-agent git-archaeology vs the last-known-good commit 2d9d4fc4 (which scaled ~5.9× to 498 tok/s @ bs=64 on A6000).

## Root cause
The `BatchingEngineActor` prefill-admission (`crates/kiln-server/src/batching_engine.rs`) — the production concurrent path. Four "vulkan:" commits edited the **shared, backend-agnostic** actor but only restored full-width admission for Vulkan:
- `env_prefill_admission_quantum_for_backend` gave Vulkan `quantum = max_decode_batch` but pinned CUDA at the latency default (4).
- `admit_waiting`'s `has_ready_decode_row` yield (2c52565d) drops admission to **1 prefill/cycle** once any row is decoding.

At LKG, `admit_waiting` burst-filled the whole decode width every cycle. On current main, CUDA admitted only 4 the first cycle then 1/cycle, so the prompt-prefills (run inline on the single actor thread) interleaved into every decode step and a wide batch never sustained → TTFT ballooned to ~38s and throughput collapsed.

## Fix
1. **Full-width quantum for CUDA** (`env_prefill_admission_quantum_for_backend`): CUDA gets `max_decode_batch` like Vulkan. Metal/CPU unchanged.
2. **Restore LKG burst-fill** (`admit_waiting`): a CUDA-only `burst_refill` flag refills the batch toward `max_decode_batch` every cycle instead of yielding to ready rows. Vulkan/Metal keep their tuned yield. The `while` loop still caps total active at `max_decode_batch` (only fills the deficit).
3. **kt-bridge end-bounds check** (`cuda_input_device_ptr`): defensive hardening — verify `start_offset + addressable_byte_size <= storage byte_len`, not just the start, so a too-large kernel-input shape becomes a named Rust error before the launch instead of a sticky async `CUDA_ERROR_ILLEGAL_ADDRESS`. No-op for correctly-sized tensors.

## Validation (A6000, Qwen3.5-4B, W4A16, canonical `bench-concurrent-batch.py --mode concurrent --warmup`, replay path)
| concurrency | before | after |
|---:|---:|---:|
| 8 | 95 | **140** |
| 16 | — | **192** |
| 32 | 69 (anti-scaling) | **238** |

Monotonic scaling restored (was anti-scaling); 3.4× at n=32. ILLEGAL=0, OOM=0 at ≤32.

## Known follow-ups (separate bugs, NOT fixed here)
- **Eager batched decode (`KILN_CUDA_GRAPHS_BATCHED=0`) CUDA-illegal-addresses at bs>1** — a separate candle-removal memory regression in the contiguous batched primitive (the kt-bridge bounds-check ruled out shape-OOB; needs compute-sanitizer to pin). Tested here on the replay path because eager crashes.
- **bs=64 OOM in the batched cuda-graph path** — the KV auto-sizer doesn't reserve headroom for the graph's resident footprint.
- Absolute parity to ~498/1907 @ bs=64 is gated on those two.
