### PR TITLE
Vulkan BF16 mixed-precision base — train the real BF16 model + halve base VRAM (#1443)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -5696,6 +5696,25 @@ fn gdn_in_proj_matmul(
     x: &Tensor,
     weight_t: &Tensor,
 ) -> Result<Tensor> {
+    // (#1443 step 5) GDN `in_proj_a` / `in_proj_b` are FROZEN base projections
+    // (no LoRA adapter — they are not in DEFAULT_TARGET_MODULES). On Vulkan the
+    // activation `x` is F32 while these base weights are BF16, so the plain
+    // equal-dtype kt `matmul` in `broadcast_matmul_cpu_compatible` cannot run.
+    // Route through the same `try_tape_lora_linear_kt` recorder the qkv/z/out
+    // projections use (with `lora=None`): on Vulkan it dispatches the base
+    // matmul through `vk_matmul_bf16w` (F32 act × BF16 weight) and records the
+    // dx-only `MatmulBf16wBackward`, so dx flows back to `x`/`normed` while the
+    // weight stays frozen BF16. No-op (returns None) off the tape path or on the
+    // equal-dtype path, falling through to the existing dispatch below.
+    #[cfg(any(feature = "cuda", feature = "metal", feature = "vulkan"))]
+    if crate::tape_forward::tape_forward_enabled() {
+        if let Some(out) =
+            crate::tape_forward::try_tape_lora_linear_kt(x, weight_t, None, 0.0)
+                .context("gdn_in_proj_matmul try_tape_lora_linear_kt")?
+        {
+            return Ok(out);
+        }
+    }
     // #1082 item 4: `linear_prefill_apply` is kt-typed — pass kt directly.
     #[cfg(feature = "cuda")]
     {
@@ -6767,6 +6786,28 @@ fn embedding_lookup_from_weights(token_ids: &[u32], weights: &GpuWeights) -> Res
         }
     }
     embedding_lookup(token_ids, &weights.embed_tokens)
+}
+
+/// (#1443 step 3) Vulkan mixed-precision activation cast. The embedding table
+/// (`embed_tokens`) is BF16 on a production BF16 base, so the embedding-lookup
+/// output is BF16. On Vulkan the ACTIVATION dtype is F32 throughout (the
+/// rmsnorm/softmax kernels are F32-only and the base projections consume BF16
+/// weights × F32 activations via `vk_matmul_bf16w`), so the first hidden state
+/// must be cast BF16→F32 before it enters the transformer layers. This is the
+/// single "cast at the start" the mixed-precision design calls for.
+///
+/// No-op (returns the tensor unchanged) unless the tensor is on Vulkan AND BF16:
+///   - CUDA/Metal run BF16 activations end-to-end → untouched.
+///   - An already-F32 Vulkan base (the prior F32-on-Vulkan path) → untouched.
+/// Cheap and idempotent; safe to call on every forward entry point.
+fn vulkan_cast_activation_to_f32(hidden: Tensor) -> Result<Tensor> {
+    #[cfg(feature = "vulkan")]
+    {
+        if matches!(hidden.device(), Device::Vulkan(_)) && hidden.dtype() == DType::BF16 {
+            return Ok(hidden.to_dtype(DType::F32)?);
+        }
+    }
+    Ok(hidden)
 }
 
 fn embedding_lookup_from_weights_with_index(
@@ -23020,7 +23061,10 @@ pub fn model_forward_kt(
     let seq_len = token_ids.len();
 
     // 1. Embedding lookup: [seq_len, hidden_size]
-    let mut hidden = embedding_lookup_from_weights(token_ids, weights)?;
+    // (#1443 step 3) On Vulkan the BF16 embedding output is cast BF16→F32 so the
+    // activation dtype is F32 throughout (base projections consume the BF16 base
+    // weights via `vk_matmul_bf16w`). No-op on CUDA/Metal and on an F32 base.
+    let mut hidden = vulkan_cast_activation_to_f32(embedding_lookup_from_weights(token_ids, weights)?)?;
 
     // Add batch dimension: [1, seq_len, hidden_size]
     hidden = hidden.unsqueeze(0)?;
@@ -23177,7 +23221,7 @@ fn reshape_hole0_4(t: &Tensor, d1: usize, d2: usize, d3: usize) -> Result<Tensor
 /// Returns: [1, seq_len, hidden_size] — output hidden state.
 pub fn model_forward_segment(
     backend: &dyn BackendRuntime,
-    mut hidden: Tensor,
+    hidden: Tensor,
     weights: &GpuWeights,
     config: &kiln_core::config::ModelConfig,
     positions: &[u32],
@@ -23186,6 +23230,11 @@ pub fn model_forward_segment(
     mut linear_state: Option<&mut LinearAttentionState>,
     lora: Option<&LoraWeights>,
 ) -> Result<Tensor> {
+    // (#1443 step 3) Defensive Vulkan BF16→F32 activation cast for direct
+    // callers (gradient-checkpointing recompute) that may hand in a BF16 hidden.
+    // Idempotent no-op when `hidden` is already F32 (the normal path, since
+    // `model_forward_embed` casts) or on CUDA/Metal.
+    let mut hidden = vulkan_cast_activation_to_f32(hidden)?;
     // Count full-attention and linear-attention layers before start_layer
     // so we index into the right KV cache / linear state slots.
     let mut full_attn_idx: usize = (0..start_layer)
@@ -23309,7 +23358,10 @@ pub fn model_forward_segment(
 /// and position indices for RoPE (starting from position 0, no KV cache offset).
 pub fn model_forward_embed(token_ids: &[u32], weights: &GpuWeights) -> Result<(Tensor, Vec<u32>)> {
     let seq_len = token_ids.len();
-    let mut hidden = embedding_lookup_from_weights(token_ids, weights)?;
+    // (#1443 step 3) Cast the BF16 embedding output to F32 on Vulkan so the
+    // transformer-layer activations are F32 (mixed precision: BF16 base weights,
+    // F32 activations). No-op on CUDA/Metal and on an F32 base.
+    let mut hidden = vulkan_cast_activation_to_f32(embedding_lookup_from_weights(token_ids, weights)?)?;
     hidden = hidden.unsqueeze(0)?;
     let positions: Vec<u32> = (0..seq_len).map(|p| p as u32).collect();
     Ok((hidden, positions))

--- a/crates/kiln-model/src/tape_forward.rs
+++ b/crates/kiln-model/src/tape_forward.rs
@@ -353,11 +353,25 @@ pub fn try_tape_rms_norm_kt(
     {
         return Ok(None);
     }
+    // (#1443 step 3) Mixed-precision RMSNorm on Vulkan: F32 ACTIVATION `x` × a
+    // BF16 NORM WEIGHT (production BF16 checkpoints store BF16 norms). The forward
+    // already casts `weight` to `x.dtype()` (F32) internally, and
+    // `RmsNormKtBackward::apply` casts x/weight/grad to F32 throughout, so the
+    // composite handles F32-x/BF16-weight cleanly. The norm weight is FROZEN in
+    // LoRA training (only `dL/dx` matters), so the dw-dtype is irrelevant. Relax
+    // the strict `x.dtype() == weight.dtype()` gate for this Vulkan case ONLY —
+    // CUDA/Metal run x==weight==BF16 end-to-end and keep the strict equality.
+    #[cfg(feature = "vulkan")]
+    let vk_f32x_bf16w = matches!(x.device(), kiln_tensor::Device::Vulkan(_))
+        && x.dtype() == kiln_tensor::DType::F32
+        && weight.dtype() == kiln_tensor::DType::BF16;
+    #[cfg(not(feature = "vulkan"))]
+    let vk_f32x_bf16w = false;
     if weight.rank() != 1
         || x.rank() == 0
         || *x.shape().last().unwrap() != weight.shape()[0]
         || !matches!(x.dtype(), kiln_tensor::DType::BF16 | kiln_tensor::DType::F32)
-        || x.dtype() != weight.dtype()
+        || (x.dtype() != weight.dtype() && !vk_f32x_bf16w)
         || !x.is_contiguous()
         || !weight.is_contiguous()
     {
@@ -1278,7 +1292,21 @@ pub fn try_tape_lora_linear_kt(
     ) {
         return Ok(None);
     }
-    if weight_t.dtype() != x.dtype() {
+    // (#1443 step 2) Mixed-precision base projection on Vulkan: F32 activations ×
+    // a frozen BF16 base weight. The base linear runs through the dedicated
+    // `vk_matmul_bf16w` kernel (recorded with a `MatmulBf16wBackward` dx-only
+    // adjoint) instead of the equal-dtype `MatmulBackward`. Keeping the base
+    // weight BF16 is the VRAM win #1443 buys; the LoRA delta + activations stay
+    // F32 (so the F32-only Vulkan rmsnorm/softmax kernels are untouched). This
+    // branch is Vulkan-only — CUDA/Metal carry their own BF16-base paths and run
+    // BF16 activations end-to-end, so they keep the strict `weight_t == x` gate.
+    #[cfg(feature = "vulkan")]
+    let vk_bf16_base = matches!(x.device(), kiln_tensor::Device::Vulkan(_))
+        && x.dtype() == kiln_tensor::DType::F32
+        && weight_t.dtype() == kiln_tensor::DType::BF16;
+    #[cfg(not(feature = "vulkan"))]
+    let vk_bf16_base = false;
+    if weight_t.dtype() != x.dtype() && !vk_bf16_base {
         return Ok(None);
     }
     let Ok((wk, n)) = weight_t.dims2() else {
@@ -1331,16 +1359,58 @@ pub fn try_tape_lora_linear_kt(
                 input_shape: x.shape().to_vec(),
             }),
         );
-        let base2d = kiln_tensor::ops::matmul(&x2d, weight_t)
-            .map_err(|e| anyhow::anyhow!("kt matmul x2d@w: {e}"))?;
-        tape.record(
-            &base2d,
-            &[&x2d, weight_t],
-            Box::new(MatmulBackward {
-                a: x2d.clone(),
-                b: weight_t.clone(),
-            }),
-        );
+        // (#1443 step 2) Base projection. On the Vulkan mixed-precision path
+        // (`vk_bf16_base`) the frozen base weight is BF16 while `x2d` is F32 — the
+        // equal-dtype kt `matmul` can't run, so route the base linear through the
+        // dedicated `vk_matmul_bf16w` kernel and record a `MatmulBf16wBackward`
+        // (dx only; the weight is frozen, no `dW` edge). Output `base2d` is F32,
+        // so the LoRA delta / residual adds below stay F32-vs-F32. Every other
+        // backend (CUDA/Metal, and the equal-dtype F32/BF16 Vulkan path) keeps
+        // the device-agnostic `MatmulBackward` exactly as before.
+        //
+        // LAYOUT: the production base `weight_t` reaching this recorder is
+        // `[K, N]` = `[in, out]` (the pre-transposed layout `matmul(x2d, weight_t)`
+        // consumes for `x @ W`). The `vk_matmul_bf16w` kernel
+        // (`vk_matmul_bf16w_fwd_rows` / `_bwd_rows`) instead expects the weight in
+        // `[N, K]` = `[out, in]` row-major and computes `x @ W.T`. So transpose
+        // `weight_t` `[K,N]` → `[N,K]` and materialize contiguous before dispatch.
+        // The transient is BF16 (HALF the F32 size) and the RESIDENT base weight
+        // stays BF16 — the #1443 VRAM win is preserved (the only F32 buffers are
+        // the activations, which are F32 on Vulkan by design). The same `[N,K]`
+        // weight is stored in the backward op so `dx = grad_out @ W` is computed
+        // against the matching layout.
+        let base2d = if vk_bf16_base {
+            #[cfg(feature = "vulkan")]
+            {
+                let w_nk = weight_t
+                    .transpose(0, 1)
+                    .map_err(|e| anyhow::anyhow!("kt weight_t.transpose [K,N]->[N,K]: {e}"))?
+                    .contiguous()
+                    .map_err(|e| anyhow::anyhow!("kt weight_nk.contiguous: {e}"))?;
+                let y = kiln_tensor::vulkan_matmul_bf16w(&x2d, &w_nk)
+                    .map_err(|e| anyhow::anyhow!("kt vulkan_matmul_bf16w x2d@w: {e}"))?;
+                tape.record(
+                    &y,
+                    &[&x2d],
+                    Box::new(MatmulBf16wBackward { weight_t: w_nk }),
+                );
+                y
+            }
+            #[cfg(not(feature = "vulkan"))]
+            unreachable!("vk_bf16_base is false without the vulkan feature")
+        } else {
+            let base2d = kiln_tensor::ops::matmul(&x2d, weight_t)
+                .map_err(|e| anyhow::anyhow!("kt matmul x2d@w: {e}"))?;
+            tape.record(
+                &base2d,
+                &[&x2d, weight_t],
+                Box::new(MatmulBackward {
+                    a: x2d.clone(),
+                    b: weight_t.clone(),
+                }),
+            );
+            base2d
+        };
         let out2d = match (lora, a_kt.as_ref(), b_kt.as_ref()) {
             (Some(_proj), Some(a_kt), Some(b_kt)) => {
                 let a_t_kt = a_kt

--- a/crates/kiln-model/src/tape_forward.rs
+++ b/crates/kiln-model/src/tape_forward.rs
@@ -417,6 +417,118 @@ pub fn try_tape_matmul_kt(
     }
 }
 
+/// Tape backward for the Vulkan F32-act × BF16-weight mixed-precision matmul
+/// (#1443 step1). The frozen base weight is in the transposed `[N, K]` BF16
+/// layout; forward computed `out = x @ W.T` (`x` F32 `[rows, K]`). Backward
+/// produces only `dx = grad_out @ W` (F32 `[rows, K]`) via the dedicated
+/// `vk_matmul_bf16w_bwd` kernel — **there is no `dW`**, the weight is frozen.
+///
+/// # Why a bespoke `BackwardOp` (not the device-agnostic `MatmulBackward`)
+///
+/// `kiln_autograd::MatmulBackward` expresses `da`/`db` as
+/// `kiln_tensor::ops::matmul`, which requires **equal input dtypes**. With an
+/// F32 `grad_out` and a BF16 weight that op cannot run; we route `dx` through
+/// the mixed-precision `vk_matmul_bf16w` kernel instead. `input_count() == 1`
+/// because only `x` is differentiable (the weight is not recorded as an input).
+#[cfg(feature = "vulkan")]
+#[derive(Debug)]
+pub(crate) struct MatmulBf16wBackward {
+    /// Frozen BF16 base weight in transposed `[N, K]` layout. FROZEN — no `dW`.
+    pub weight_t: kiln_tensor::Tensor,
+}
+
+#[cfg(feature = "vulkan")]
+impl BackwardOp for MatmulBf16wBackward {
+    fn name(&self) -> &'static str {
+        "matmul_bf16w_backward"
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        // dx needs only grad_out + the (saved) weight; the forward `x`
+        // activation is not read by the backward.
+        false
+    }
+    fn apply(
+        &self,
+        grad_output: &kiln_tensor::Tensor,
+    ) -> kiln_tensor::Result<Vec<Option<kiln_tensor::Tensor>>> {
+        // grad_output may arrive non-contiguous / non-F32 from upstream; the
+        // kernel bridge requires contiguous F32. Materialize before dispatch.
+        let go = if grad_output.dtype() == kiln_tensor::DType::F32 {
+            grad_output.clone()
+        } else {
+            kiln_tensor::ops::cast(grad_output, kiln_tensor::DType::F32)?
+        };
+        let go = if go.is_contiguous() {
+            go
+        } else {
+            go.contiguous()?
+        };
+        let dx = kiln_tensor::vulkan_matmul_bf16w_bwd(&go, &self.weight_t)?;
+        Ok(vec![Some(dx)])
+    }
+}
+
+/// kt-native Vulkan F32-act × BF16-weight matmul tape recorder (#1443 step1).
+///
+/// Records the mixed-precision base projection `out = x @ W.T` (F32 activation
+/// × frozen BF16 weight in transposed `[N, K]` layout) onto the active kt
+/// [`Tape`] with a [`MatmulBf16wBackward`] adjoint (`dx` only — the weight is
+/// frozen). The forward runs on-device via
+/// [`kiln_tensor::vulkan_matmul_bf16w`] (the `vk_matmul_bf16w` kernel bridge),
+/// keeping the data GPU-resident.
+///
+/// This is the recorder the integration step (#1443 step2) routes the base
+/// projection through when `x` is F32 and the base weight is BF16 on Vulkan —
+/// the case the equal-dtype [`try_tape_lora_linear_kt`] base matmul declines
+/// today (its `weight_t.dtype() == x.dtype()` gate). Only `x` is recorded as a
+/// tape input (the weight is frozen, no grad edge).
+///
+/// `Ok(None)` (caller falls through) when tape-forward is off, no tape scope is
+/// active, or the inputs are outside the envelope: Vulkan-resident, `x` rank-2
+/// F32, `weight_t` rank-2 BF16, matching contraction dim `K`.
+#[cfg(feature = "vulkan")]
+pub fn try_tape_matmul_bf16w_kt(
+    x: &kiln_tensor::Tensor,
+    weight_t: &kiln_tensor::Tensor,
+) -> Result<Option<kiln_tensor::Tensor>> {
+    if !tape_forward_enabled() {
+        return Ok(None);
+    }
+    // Vulkan-only: CUDA/Metal carry their own BF16 base-weight paths.
+    if !matches!(x.device(), kiln_tensor::Device::Vulkan(_))
+        || !matches!(weight_t.device(), kiln_tensor::Device::Vulkan(_))
+    {
+        return Ok(None);
+    }
+    if x.dtype() != kiln_tensor::DType::F32 || weight_t.dtype() != kiln_tensor::DType::BF16 {
+        return Ok(None);
+    }
+    if x.rank() != 2 || weight_t.rank() != 2 {
+        return Ok(None);
+    }
+    if x.shape()[1] != weight_t.shape()[1] {
+        return Ok(None);
+    }
+    match with_active_tape(|tape: &mut Tape| -> Result<_> {
+        let y = kiln_tensor::vulkan_matmul_bf16w(x, weight_t)
+            .map_err(|e| anyhow::anyhow!("kt vulkan_matmul_bf16w: {e}"))?;
+        tape.record(
+            &y,
+            &[x],
+            Box::new(MatmulBf16wBackward {
+                weight_t: weight_t.clone(),
+            }),
+        );
+        Ok(y)
+    }) {
+        Some(result) => Ok(Some(result?)),
+        None => Ok(None),
+    }
+}
+
 /// kt-native embedding tape recorder (#1082 seam flip) — the kt-native embedding tape recorder. Records `EmbeddingBackward` directly from kt
 /// inputs. `Ok(None)` outside the rank-2-weights envelope.
 pub fn try_tape_embedding_kt(

--- a/crates/kiln-model/tests/vk_tape_record_proof.rs
+++ b/crates/kiln-model/tests/vk_tape_record_proof.rs
@@ -53,9 +53,9 @@
 #![cfg(feature = "vulkan")]
 
 use kiln_model::tape_forward::{
-    try_tape_add_kt, try_tape_rms_norm_kt, with_thread_local_tape,
+    try_tape_add_kt, try_tape_matmul_bf16w_kt, try_tape_rms_norm_kt, with_thread_local_tape,
 };
-use kiln_tensor::{ops, Device, Tensor};
+use kiln_tensor::{ops, DType, Device, Tensor};
 use kiln_vulkan_kernel::VulkanDevice;
 
 // ----------------------------------------------------------------------------
@@ -188,6 +188,96 @@ fn vk_tape_add_records_and_backprops() {
         bwd_err,
         da_err,
         db_err
+    );
+}
+
+// ----------------------------------------------------------------------------
+// #1443 step1 — F32-act × BF16-weight matmul recorder + recorded dx backward.
+// ----------------------------------------------------------------------------
+
+/// #1443 step1 proof: `try_tape_matmul_bf16w_kt` on `Device::Vulkan(0)` RECORDS
+/// the mixed-precision base projection (`out = x @ W.T`, F32 activation × frozen
+/// BF16 weight) onto the kt `Tape` as exactly ONE node, its forward matches a
+/// BF16-cast F32 reference (`vulkan_matmul`) to BF16 tolerance, and
+/// `Tape::backward` produces the correct `dL/dx` over Vulkan storage via the
+/// recorded `MatmulBf16wBackward`. Critically: the WEIGHT IS FROZEN — it is not
+/// recorded as a tape input, so `grads` carries a key for `x` but NOT for the
+/// weight (`input_count() == 1`, no `dW`).
+///
+/// Single-shot, tiny (rows=4, K=8, N=6), GPU-gated.
+#[test]
+fn vk_tape_matmul_bf16w_records_and_backprops() {
+    let test_name = "vk_tape_matmul_bf16w_records_and_backprops";
+    if !vk_enabled(test_name) {
+        return;
+    }
+    let (rows, k, n) = (4usize, 8usize, 6usize);
+    let x_data: Vec<f32> = (0..rows * k).map(|i| (i as f32) * 0.07 - 0.9).collect();
+    let w_data: Vec<f32> = (0..n * k).map(|i| ((i % 5) as f32) * 0.2 - 0.3).collect();
+
+    let x = Tensor::from_vec_on(Device::Vulkan(0), x_data.clone(), vec![rows, k])
+        .expect("build x on Vulkan");
+    // Frozen BF16 base weight [N, K] (transposed-weight layout).
+    let w_f32 = Tensor::from_vec_on(Device::Vulkan(0), w_data.clone(), vec![n, k])
+        .expect("build weight on Vulkan");
+    let w_bf16 = kiln_tensor::vulkan_cast(&w_f32, DType::BF16).expect("cast weight -> BF16");
+
+    let ((y, x_id, w_id), tape) = with_thread_local_tape(|| {
+        let y = try_tape_matmul_bf16w_kt(&x, &w_bf16)
+            .expect("try_tape_matmul_bf16w_kt errored")
+            .expect("try_tape_matmul_bf16w_kt returned None — recorder did NOT record on Vulkan");
+        (y, x.id(), w_bf16.id())
+    });
+
+    // (1) ANTI-SILENT-DROP: exactly one node recorded.
+    assert_eq!(tape.len(), 1, "bf16w recorder recorded {} nodes, expected 1", tape.len());
+    assert_eq!(y.device(), Device::Vulkan(0), "forward output left Vulkan");
+    assert_eq!(y.shape(), &[rows, n]);
+    assert_eq!(y.dtype(), DType::F32);
+
+    // (2) FORWARD PARITY: vs the same BF16 weight cast back to F32 then F32 matmul.
+    let w_f32_ref = kiln_tensor::vulkan_cast(&w_bf16, DType::F32).expect("bf16->f32 ref");
+    let w_t_ref = w_f32_ref.transpose(0, 1).unwrap().contiguous().unwrap();
+    let ref_fwd = read_host_f32(&kiln_tensor::vulkan_matmul(&x, &w_t_ref).expect("ref matmul"));
+    let vk_fwd = read_host_f32(&y);
+    let fwd_err = max_abs_err(&vk_fwd, &ref_fwd);
+    assert!(fwd_err < 2e-2, "forward parity FAILED: max_abs_err={fwd_err}");
+
+    // (3) BACKWARD: seed dL/dy = ones. dx = grad_out @ W (frozen weight).
+    let seed = Tensor::from_vec_on(Device::Vulkan(0), vec![1.0_f32; rows * n], vec![rows, n])
+        .expect("seed on Vulkan");
+    let grads = tape
+        .backward(y.id(), seed, |g, z| ops::add(g, z))
+        .expect("Tape::backward errored on bf16w Vulkan graph");
+
+    // dx is keyed on x.id(); the FROZEN weight has NO grad key (not a tape input).
+    let dx = grads.get(x_id).expect("no grad keyed on x.id()");
+    assert_eq!(dx.shape(), &[rows, k], "dL/dx wrong shape");
+    assert!(
+        grads.get(w_id).is_none(),
+        "FROZEN weight must have NO gradient, but a dW was recorded"
+    );
+
+    // Analytic dx straight from the kernel bridge: must match the recorded one.
+    let dx_v = read_host_f32(dx);
+    let analytic = read_host_f32(
+        &kiln_tensor::vulkan_matmul_bf16w_bwd(
+            &Tensor::from_vec_on(Device::Vulkan(0), vec![1.0_f32; rows * n], vec![rows, n]).unwrap(),
+            &w_bf16,
+        )
+        .expect("analytic dx"),
+    );
+    assert!(dx_v.iter().all(|v| v.is_finite()), "non-finite dx: {dx_v:?}");
+    let dx_err = max_abs_err(&dx_v, &analytic);
+    assert!(dx_err < 2e-2, "recorded dx != analytic dx: max_abs_err={dx_err}");
+
+    eprintln!(
+        "[#1443 step1 PROOF] Device::Vulkan(0): tape.len()={} | fwd max_abs_err vs F32-cast ref={:.3e} | \
+         dx max_abs_err vs analytic={:.3e} | weight FROZEN (no dW): {}",
+        tape.len(),
+        fwd_err,
+        dx_err,
+        grads.get(w_id).is_none()
     );
 }
 

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -92,7 +92,7 @@ regex = "1"
 [features]
 cuda = ["kiln-model/cuda", "kiln-tensor/cuda", "kiln-train/cuda", "kiln-kt-bridge/cuda"]
 metal = ["kiln-model/metal", "kiln-tensor/metal", "kiln-kt-bridge/metal", "kiln-train/metal"]
-vulkan = ["kiln-model/vulkan", "kiln-train/vulkan"]
+vulkan = ["kiln-model/vulkan", "kiln-tensor/vulkan", "kiln-train/vulkan", "kiln-kt-bridge/vulkan"]
 # Forward kiln-model's NVTX feature so kiln-bench / kiln binaries emit ranges
 # under nsys for per-call-site attribution. No effect without --features cuda.
 nvtx = ["kiln-model/nvtx"]

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -160,6 +160,7 @@ pub use vulkan_storage::{
     host_to_vulkan_copy, kt_tensor_from_vk, primary_vulkan_device, vulkan_activation_unary,
     vulkan_argmax_last_axis, vulkan_cast, vulkan_elementwise_binary,
     vulkan_index_select_dim0, vulkan_l2norm_last_axis, vulkan_masked_fill, vulkan_matmul,
-    vulkan_mean_all, vulkan_rmsnorm_last_axis, vulkan_scale, vulkan_softmax_last_axis,
+    vulkan_matmul_bf16w, vulkan_matmul_bf16w_bwd, vulkan_mean_all, vulkan_rmsnorm_last_axis,
+    vulkan_scale, vulkan_softmax_last_axis,
     vulkan_sum_all, vulkan_to_host_copy, vulkan_zeros, vk_tensor_from_kt, VulkanStorage,
 };

--- a/crates/kiln-tensor/src/vulkan_storage.rs
+++ b/crates/kiln-tensor/src/vulkan_storage.rs
@@ -425,6 +425,140 @@ pub fn vulkan_matmul(a: &crate::Tensor, b: &crate::Tensor) -> Result<crate::Tens
 }
 
 // ----------------------------------------------------------------------
+// vulkan_matmul_bf16w — #1443 step1: F32-act × BF16-weight mixed-precision GEMM
+// ----------------------------------------------------------------------
+
+/// Vulkan mixed-precision linear `out = x @ W.T` where `x` is an F32
+/// activation `[rows, K]` and `W` is a **frozen** BF16-packed weight in the
+/// transposed `[N, K]` layout (`N = out_dim`, `K = hidden`). Returns an F32
+/// `[rows, N]` tensor.
+///
+/// This is the foundational kt-level op for #1443 (store frozen base weights
+/// in BF16 on Vulkan to halve base VRAM, keeping activations/LoRA/grads F32).
+/// The kt [`crate::ops::matmul`] requires equal input dtypes, so F32-act ×
+/// BF16-weight cannot run through it; this bridge fills that gap by calling the
+/// dedicated `vk_matmul_bf16w` kernels.
+///
+/// Bridges both inputs to `VkTensor` zero-copy ([`vk_tensor_from_kt`]) — the
+/// BF16 weight bridges cleanly because the PR3b bridge already gates F32|BF16 —
+/// dispatches `kiln_vulkan_kernel::vk_ops::matmul_bf16w::vk_matmul_bf16w_no_grad`
+/// (which tiles general PREFILL row counts internally via the
+/// `vk_matmul_bf16w_fwd_rows` shader), and bridges the F32 result back zero-copy
+/// ([`kt_tensor_from_vk`], which records the **logical** byte length, not the
+/// pool-rounded physical allocation). No D2H/H2D round-trip.
+///
+/// # Requirements
+///
+/// - `x` and `weight_t` both backed by [`VulkanStorage`] (same device)
+/// - `x.dtype() == F32`, `weight_t.dtype() == BF16`
+/// - both rank-2 and contiguous (`start_offset == 0`), with
+///   `x.shape()[1] == weight_t.shape()[1]` (shared contraction dim `K`)
+///
+/// # Errors
+///
+/// Returns [`Error::Msg`] on non-Vulkan storage, dtype/shape violations, or
+/// kernel dispatch failure.
+pub fn vulkan_matmul_bf16w(x: &crate::Tensor, weight_t: &crate::Tensor) -> Result<crate::Tensor> {
+    use kiln_vulkan_kernel::vk_ops::matmul_bf16w::vk_matmul_bf16w_no_grad;
+
+    if x.dtype() != DType::F32 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w: x must be F32 (got {})",
+            x.dtype()
+        )));
+    }
+    if weight_t.dtype() != DType::BF16 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w: weight must be BF16 (got {})",
+            weight_t.dtype()
+        )));
+    }
+    if x.rank() != 2 || weight_t.rank() != 2 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w: rank-2 only (got x.rank={}, weight.rank={})",
+            x.rank(),
+            weight_t.rank()
+        )));
+    }
+    if x.shape()[1] != weight_t.shape()[1] {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w: contraction dim mismatch: x.shape[1]={} vs weight.shape[1]={}",
+            x.shape()[1],
+            weight_t.shape()[1]
+        )));
+    }
+    let device_index = vulkan_device_index(x, "vulkan_matmul_bf16w")?;
+
+    let vk_x = vk_tensor_from_kt(x)?;
+    let vk_w = vk_tensor_from_kt(weight_t)?;
+    let vk_out = vk_matmul_bf16w_no_grad(&vk_x, &vk_w)
+        .map_err(|e| Error::Msg(format!("vulkan_matmul_bf16w: kernel dispatch failed: {e}")))?;
+    kt_tensor_from_vk(&vk_out, device_index)
+}
+
+/// Vulkan mixed-precision linear backward `dx = grad_out @ W` for the frozen
+/// BF16 weight `W` shaped `[N, K]`. Companion to [`vulkan_matmul_bf16w`]: given
+/// the upstream F32 gradient `grad_out` `[rows, N]`, returns `dx` `[rows, K]`
+/// F32. The weight is FROZEN — there is **no** `dW` (the recorder returns
+/// `None` for the weight slot).
+///
+/// Bridges both inputs to `VkTensor` zero-copy, dispatches
+/// `vk_matmul_bf16w_bwd_no_grad` (tiled over prefill rows internally), and
+/// bridges `dx` back zero-copy.
+///
+/// # Requirements
+///
+/// - `grad_out` and `weight_t` both [`VulkanStorage`]-backed (same device)
+/// - `grad_out.dtype() == F32`, `weight_t.dtype() == BF16`
+/// - both rank-2 and contiguous (`start_offset == 0`), with
+///   `grad_out.shape()[1] == weight_t.shape()[0]` (shared `N = out_dim`)
+///
+/// # Errors
+///
+/// Returns [`Error::Msg`] on non-Vulkan storage, dtype/shape violations, or
+/// kernel dispatch failure.
+pub fn vulkan_matmul_bf16w_bwd(
+    grad_out: &crate::Tensor,
+    weight_t: &crate::Tensor,
+) -> Result<crate::Tensor> {
+    use kiln_vulkan_kernel::vk_ops::matmul_bf16w::vk_matmul_bf16w_bwd_no_grad;
+
+    if grad_out.dtype() != DType::F32 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w_bwd: grad_out must be F32 (got {})",
+            grad_out.dtype()
+        )));
+    }
+    if weight_t.dtype() != DType::BF16 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w_bwd: weight must be BF16 (got {})",
+            weight_t.dtype()
+        )));
+    }
+    if grad_out.rank() != 2 || weight_t.rank() != 2 {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w_bwd: rank-2 only (got grad_out.rank={}, weight.rank={})",
+            grad_out.rank(),
+            weight_t.rank()
+        )));
+    }
+    if grad_out.shape()[1] != weight_t.shape()[0] {
+        return Err(Error::Msg(format!(
+            "vulkan_matmul_bf16w_bwd: dim mismatch: grad_out.shape[1]={} vs weight.shape[0]={}",
+            grad_out.shape()[1],
+            weight_t.shape()[0]
+        )));
+    }
+    let device_index = vulkan_device_index(grad_out, "vulkan_matmul_bf16w_bwd")?;
+
+    let vk_grad = vk_tensor_from_kt(grad_out)?;
+    let vk_w = vk_tensor_from_kt(weight_t)?;
+    let vk_dx = vk_matmul_bf16w_bwd_no_grad(&vk_grad, &vk_w)
+        .map_err(|e| Error::Msg(format!("vulkan_matmul_bf16w_bwd: kernel dispatch failed: {e}")))?;
+    kt_tensor_from_vk(&vk_dx, device_index)
+}
+
+// ----------------------------------------------------------------------
 // vulkan_scale — Phase 3c hot-op port: tensor * scalar (#1082)
 // ----------------------------------------------------------------------
 
@@ -2445,5 +2579,113 @@ mod tests {
         let err = max_abs_err(&got, &want);
         eprintln!("vulkan_elementwise_add_pool_overflow_parity: max_abs_err = {err:e}");
         assert!(err < 1e-5, "add max_abs_err {err} too large; got={got:?} want={want:?}");
+    }
+
+    // ------------------------------------------------------------------
+    // #1443 step1: F32-act × BF16-weight mixed-precision matmul.
+    //
+    // `vulkan_matmul_bf16w(x, W)` computes `out = x @ W.T` for an F32
+    // activation `x [rows, K]` and a frozen BF16 weight `W [N, K]`. The
+    // reference is the SAME BF16 weight cast back to F32 (so both paths see
+    // the same BF16-rounded weight values), transposed to `[K, N]`, then run
+    // through the F32 `vulkan_matmul` (PR3b). Tolerance ~2e-2 covers the BF16
+    // weight precision. Bounded, single-shot tiny GPU test.
+    // ------------------------------------------------------------------
+
+    /// Build a BF16 Vulkan weight from F32 host data of shape `[n, k]`.
+    fn vk_bf16_weight(data: Vec<f32>, n: usize, k: usize) -> crate::Tensor {
+        let w_f32 = vk_f32(data, vec![n, k]);
+        super::vulkan_cast(&w_f32, DType::BF16).expect("vulkan_cast f32->bf16 weight")
+    }
+
+    #[test]
+    fn vulkan_matmul_bf16w_parity_2d() {
+        if maybe_vulkan_device().is_none() {
+            eprintln!("skip: KILN_TENSOR_VULKAN_TEST unset or no Vulkan device");
+            return;
+        }
+        // x [rows=4, K=8] F32, W [N=6, K=8] BF16. out = x @ W.T = [4, 6].
+        let (rows, k, n) = (4usize, 8usize, 6usize);
+        let x_data: Vec<f32> = (0..rows * k).map(|i| (i as f32) * 0.1 - 1.3).collect();
+        let w_data: Vec<f32> = (0..n * k).map(|i| ((i % 7) as f32) * 0.25 - 0.5).collect();
+
+        let x = vk_f32(x_data.clone(), vec![rows, k]);
+        let w_bf16 = vk_bf16_weight(w_data.clone(), n, k);
+        assert_eq!(w_bf16.dtype(), DType::BF16);
+
+        // Mixed-precision path under test.
+        let out = super::vulkan_matmul_bf16w(&x, &w_bf16).expect("vulkan_matmul_bf16w");
+        assert_eq!(out.shape(), &[rows, n]);
+        assert_eq!(out.dtype(), DType::F32);
+        assert_eq!(out.device(), Device::Vulkan(0), "result must stay on Vulkan");
+        let got = read_vk_f32(&out);
+
+        // Reference: same BF16 weight cast back to F32, transposed to [K, N],
+        // then F32 vulkan_matmul (PR3b). This sees the identical BF16-rounded
+        // weight, so any residual error is the bf16w kernel's accumulation.
+        let w_f32_ref = super::vulkan_cast(&w_bf16, DType::F32).expect("vulkan_cast bf16->f32 ref");
+        let w_t_ref = w_f32_ref
+            .transpose(0, 1)
+            .expect("transpose [N,K]->[K,N]")
+            .contiguous()
+            .expect("contiguous w_t");
+        let ref_out = super::vulkan_matmul(&x, &w_t_ref).expect("vulkan_matmul reference");
+        let want = read_vk_f32(&ref_out);
+
+        assert!(got.iter().all(|v| v.is_finite()), "bf16w out not finite: {got:?}");
+        let err = max_abs_err(&got, &want);
+        eprintln!("vulkan_matmul_bf16w_parity_2d: max_abs_err = {err:e}");
+        assert!(
+            err < 2e-2,
+            "bf16w matmul diverges from F32-cast reference: max_abs_err={err}; got={got:?} want={want:?}"
+        );
+    }
+
+    /// FD gradient check: central-difference `dL/dx` (loss = sum(out)) vs the
+    /// `vulkan_matmul_bf16w_bwd` adjoint `dx = grad_out @ W` (grad_out = ones).
+    /// Confirms the recorded backward's dx is correct. The weight is frozen —
+    /// there is no `dW` to check (the recorder returns `None` for it).
+    #[test]
+    fn vulkan_matmul_bf16w_fd_dx() {
+        if maybe_vulkan_device().is_none() {
+            eprintln!("skip: KILN_TENSOR_VULKAN_TEST unset or no Vulkan device");
+            return;
+        }
+        let (rows, k, n) = (4usize, 8usize, 6usize);
+        let x_data: Vec<f32> = (0..rows * k).map(|i| (i as f32) * 0.07 - 0.9).collect();
+        let w_data: Vec<f32> = (0..n * k).map(|i| ((i % 5) as f32) * 0.2 - 0.3).collect();
+
+        let w_bf16 = vk_bf16_weight(w_data.clone(), n, k);
+
+        // Analytic dx via the backward kernel. loss = sum(out) => grad_out = ones.
+        let grad_out = vk_f32(vec![1.0f32; rows * n], vec![rows, n]);
+        let dx = super::vulkan_matmul_bf16w_bwd(&grad_out, &w_bf16).expect("vulkan_matmul_bf16w_bwd");
+        assert_eq!(dx.shape(), &[rows, k]);
+        assert_eq!(dx.device(), Device::Vulkan(0));
+        let dx_v = read_vk_f32(&dx);
+
+        // Central-difference each x element through the forward.
+        let eps = 1e-2f32;
+        let loss_at = |xd: &[f32]| -> f32 {
+            let x = vk_f32(xd.to_vec(), vec![rows, k]);
+            let out = super::vulkan_matmul_bf16w(&x, &w_bf16).expect("fd forward");
+            read_vk_f32(&out).iter().sum()
+        };
+        let mut fd = vec![0.0f32; rows * k];
+        for i in 0..rows * k {
+            let mut xp = x_data.clone();
+            let mut xm = x_data.clone();
+            xp[i] += eps;
+            xm[i] -= eps;
+            fd[i] = (loss_at(&xp) - loss_at(&xm)) / (2.0 * eps);
+        }
+
+        let err = max_abs_err(&dx_v, &fd);
+        eprintln!("vulkan_matmul_bf16w_fd_dx: max_abs_err = {err:e}");
+        assert!(dx_v.iter().all(|v| v.is_finite()), "dx not finite: {dx_v:?}");
+        assert!(
+            err < 2e-2,
+            "bf16w dx diverges from finite-difference: max_abs_err={err}; analytic={dx_v:?} fd={fd:?}"
+        );
     }
 }

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -4337,4 +4337,155 @@ mod tests {
              did not connect through the F32 model to any LoRA leaf"
         );
     }
+
+    /// (#1443 step 4) OPD on a BF16 BASE on Vulkan through the REAL
+    /// `opd_step_forward_backward_tape_authoritative` entry point must produce a
+    /// non-empty, finite F32 LoRA grad store, with the base projection weights
+    /// staying BF16 (the VRAM win). Mixed precision: BF16 base weights, F32
+    /// activations — the base linear runs `vk_matmul_bf16w`, the embedding is
+    /// cast BF16→F32 at the head of the forward, and LoRA A/B are F32. Uses the
+    /// GDN-bearing BF16 `tiny_config_bf16` so the GDN BF16-weight path is driven.
+    ///
+    /// HOST-SAFETY: ONE forward+loss+backward over the tiny 4-layer model.
+    /// Self-skips unless `KILN_TENSOR_VULKAN_TEST=1` AND a Vulkan device is
+    /// present. Run single-shot, one at a time.
+    #[cfg(feature = "vulkan")]
+    #[test]
+    fn vk_bf16_opd_grads_nonempty() {
+        use crate::trainer::tests::{tiny_config_bf16, tiny_weights_bf16};
+        use crate::trainer::TrainableLoraParams;
+
+        let test_name = "vk_bf16_opd_grads_nonempty";
+        if std::env::var("KILN_TENSOR_VULKAN_TEST").ok().as_deref() != Some("1") {
+            eprintln!("skip {test_name}: KILN_TENSOR_VULKAN_TEST unset");
+            return;
+        }
+        if !kiln_model::backend::vulkan::vulkan_is_available() {
+            eprintln!("skip {test_name}: no Vulkan device");
+            return;
+        }
+        unsafe {
+            std::env::set_var("KILN_USE_TAPE_FORWARD", "1");
+            std::env::set_var("KILN_USE_TAPE_LORA_ADD", "1");
+            std::env::set_var("KILN_USE_TAPE_FLASH_ATTN", "1");
+            std::env::set_var("KILN_USE_TAPE_SDPA", "1");
+            std::env::set_var("KILN_USE_TAPE_GDN", "1");
+            std::env::set_var("KILN_USE_TAPE_GDN_GATED_NORM", "1");
+            std::env::set_var("KILN_USE_TAPE_GDN_QK_NORM", "1");
+            std::env::set_var("KILN_USE_TAPE_GDN_CONV", "1");
+        }
+
+        let device = Device::Vulkan(0);
+        let config = tiny_config_bf16(); // BF16 base, GDN-bearing
+        let weights = tiny_weights_bf16(&config, &device).expect("bf16 tiny weights on Vulkan");
+        assert_eq!(
+            weights.embed_tokens.dtype(),
+            DType::BF16,
+            "OPD BF16 Vulkan: config must be BF16"
+        );
+        // Base projection weights stay BF16 (the #1443 VRAM win).
+        assert_eq!(
+            weights.embed_tokens_t.dtype(),
+            DType::BF16,
+            "lm_head (embed_tokens_t) base weight must stay BF16 (the #1443 VRAM win)"
+        );
+
+        let params =
+            TrainableLoraParams::initialize_seeded(&config, &weights, 4, 8.0, &device, Some(7))
+                .expect("LoRA params");
+        // Mixed precision: LoRA is F32 on Vulkan even on a BF16 base.
+        assert_eq!(
+            params.all_params()[0]
+                .forward_storage()
+                .primary_tensor()
+                .dtype(),
+            kiln_tensor::DType::F32,
+            "LoRA param dtype must be F32 on Vulkan even on a BF16 base (mixed precision)"
+        );
+
+        // head_t = tied BF16 LM head; the OPD scalar loss consumes F32 activations
+        // (post embed BF16→F32 cast) and the BF16 head via `vk_matmul_bf16w`.
+        let head_t = weights.embed_tokens_t.clone();
+        assert_eq!(head_t.dtype(), DType::BF16, "head_t must be BF16 here");
+
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2, 8];
+        let active_positions: Vec<usize> = vec![2, 3, 4, 5];
+        let top_k = 16usize; // in the kt backward envelope {16,32}, <= vocab=32
+        let teacher: Arc<dyn LogitSource> = Arc::new(
+            crate::logit_source::DeterministicUniformLogitSource::new(
+                "vk-opd-bf16-test",
+                config.vocab_size,
+                top_k,
+            ),
+        );
+
+        let backend = kiln_model::backend::for_device_kt(&device);
+        let (loss_val, active_count, grads) = opd_step_forward_backward_tape_authoritative(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            &params,
+            &device,
+            &head_t,
+            teacher,
+            &active_positions,
+            OpdLossGranularity::TeacherTopK,
+            top_k,
+            None,
+            None,
+        )
+        .expect("opd_step_forward_backward_tape_authoritative (BF16 Vulkan OPD)");
+
+        assert_eq!(active_count, active_positions.len());
+        assert!(
+            loss_val.is_finite(),
+            "OPD BF16 Vulkan loss {loss_val} is not finite"
+        );
+
+        // Per-module coverage bisection + finite-F32 grad check.
+        let mut present = 0usize;
+        let mut max_norm = 0.0_f32;
+        let mut missing = 0usize;
+        for p in params.all_params() {
+            match grads.get(p.tensor_id()) {
+                Some(g) => {
+                    assert_eq!(
+                        g.dtype(),
+                        kiln_tensor::DType::F32,
+                        "OPD BF16 Vulkan LoRA grad must be F32 (mixed precision)"
+                    );
+                    let host = g
+                        .to_device(kiln_tensor::Device::Cpu)
+                        .and_then(|t| t.to_dtype(kiln_tensor::DType::F32))
+                        .and_then(|t| t.to_vec::<f32>())
+                        .unwrap_or_default();
+                    assert!(
+                        host.iter().all(|v| v.is_finite()),
+                        "OPD BF16 Vulkan LoRA grad non-finite"
+                    );
+                    let norm = host.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    max_norm = max_norm.max(norm);
+                    present += 1;
+                }
+                None => missing += 1,
+            }
+        }
+        eprintln!(
+            "[OPD BF16 Vulkan] loss={loss_val:.6} store.len()={} present={present} \
+             absent={missing} max_norm={max_norm:.6} (base BF16, LoRA F32)",
+            grads.len()
+        );
+        assert!(
+            !grads.is_empty() && present > 0 && max_norm > 0.0,
+            "BF16 Vulkan OPD produced EMPTY/zero LoRA grads — the OPD-KL tape root \
+             did not connect through the BF16 model to any LoRA leaf"
+        );
+        // Re-confirm the base weight is STILL BF16 after the step.
+        assert_eq!(
+            weights.embed_tokens_t.dtype(),
+            DType::BF16,
+            "lm_head base weight must stay BF16 after the OPD step (the #1443 VRAM win)"
+        );
+    }
 }

--- a/crates/kiln-train/src/opd_tape_shim.rs
+++ b/crates/kiln-train/src/opd_tape_shim.rs
@@ -113,6 +113,34 @@ pub fn try_tape_opd_scalar_mean_cuda_kt(
         return Ok(None);
     }
 
+    // (#1443 step 3/5) Mixed-precision OPD on Vulkan: the model activations are
+    // F32 (post embed BF16→F32 cast) so `hidden` is F32, but the tied lm_head
+    // `head_t` is BF16 on a BF16 base. The OPD top-K reverse-KL kernel's envelope
+    // requires `hidden.dtype() == head_t.dtype()` (it runs an internal
+    // `hidden @ head_t` and the fused/composite backward assumes one dtype). The
+    // kernel has no bf16w-style mixed path, so cast the FROZEN `head_t` to F32 for
+    // this OPD-loss compute. The RESIDENT `embed_tokens_t` stays BF16 (the #1443
+    // VRAM win for SFT/GRPO via the bf16w lm_head); this is only a per-step
+    // transient F32 head used by the OPD loss — which already reads the full head
+    // for its matmul. Vulkan-only + F32-hidden/BF16-head only; CUDA/Metal (BF16
+    // hidden == BF16 head) and the F32-base Vulkan path are untouched.
+    #[cfg(feature = "vulkan")]
+    let head_owned;
+    #[cfg(feature = "vulkan")]
+    let head_t: &kiln_tensor::Tensor = if matches!(
+        hidden.device(),
+        kiln_tensor::Device::Vulkan(_)
+    ) && hidden.dtype() == kiln_tensor::DType::F32
+        && head_t.dtype() == kiln_tensor::DType::BF16
+    {
+        head_owned = head_t
+            .to_dtype(kiln_tensor::DType::F32)
+            .context("opd shim: cast BF16 head_t -> F32 for the OPD loss (Vulkan mixed precision)")?;
+        &head_owned
+    } else {
+        head_t
+    };
+
     // Record the SCALAR-mean OPD loss onto the active tape. The kt `hidden` is
     // the final-RMSNorm tape node output (passed straight through by
     // `opd_step_forward_backward_tape_authoritative`), so the recorded node's

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -652,13 +652,26 @@ impl TrainableLoraParams {
         let hidden = config.hidden_size;
         let intermediate = config.intermediate_size;
 
-        // (#1082) LoRA-param dtype FOLLOWS the base/activation dtype. On a BF16
-        // base (CUDA/Metal, and the default Vulkan path) this resolves to BF16
-        // — a byte-for-byte no-op vs. the old hardcoded `DType::BF16`. On an F32
-        // base (Vulkan-only, user-approved) the LoRA A/B now match the F32
-        // activations so `try_tape_lora_linear_kt` fires instead of declining on
-        // a dtype mismatch (`proj.a.dtype() != x.dtype()` → `Ok(None)`).
-        let lora_dtype = weights.embed_tokens.dtype();
+        // (#1082) LoRA-param dtype FOLLOWS the base/activation dtype on
+        // CUDA/Metal: BF16 base ⇒ BF16 LoRA (byte-for-byte no-op vs. the old
+        // hardcoded `DType::BF16`). On an F32 Vulkan base the LoRA A/B match the
+        // F32 activations so `try_tape_lora_linear_kt` fires instead of
+        // declining on a dtype mismatch (`proj.a.dtype() != x.dtype()`).
+        //
+        // (#1443 step 2) On Vulkan the ACTIVATION dtype is F32 regardless of the
+        // base WEIGHT dtype — the mixed-precision design keeps base projection
+        // weights BF16 (the VRAM win) but runs F32 activations through the
+        // F32-only Vulkan rmsnorm/softmax kernels, and the embedding output is
+        // cast BF16→F32 at the head of the forward. So on Vulkan LoRA A/B are
+        // ALWAYS F32 (matching the F32 activations / LoRA delta path) even on a
+        // BF16 base; otherwise a BF16 LoRA on a BF16 base would mismatch the F32
+        // `x2d` in `try_tape_lora_linear_kt`'s LoRA branch and decline. CUDA/Metal
+        // keep `embed_tokens.dtype()` (BF16 activations end-to-end) unchanged.
+        let lora_dtype = if is_vulkan_device(device) {
+            kiln_tensor::DType::F32
+        } else {
+            weights.embed_tokens.dtype()
+        };
 
         // Kaiming uniform bound: sqrt(1 / in_features) for A
         let bound_hidden = (1.0 / hidden as f64).sqrt();
@@ -9731,6 +9744,21 @@ pub(crate) mod tests {
         }
     }
 
+    /// Full-attention-only BF16 config (`full_attention_interval = 1`, no GDN
+    /// layers). (#1443 step 4) The primary bar for the BF16-base mixed-precision
+    /// Vulkan tests: exercises SFT/GRPO/OPD grad delivery through the
+    /// q/k/v/o_proj + MLP LoRA modules on a BF16 base independently of the GDN
+    /// tape wiring. `pub(crate)` so `opd.rs`'s BF16 OPD test can reuse it.
+    // Only the `vulkan`-gated BF16 validation tests consume this today; the
+    // CUDA/Metal BF16 coverage uses the GDN-bearing `tiny_config_bf16`.
+    #[cfg_attr(not(feature = "vulkan"), allow(dead_code))]
+    pub(crate) fn tiny_config_full_attn_bf16() -> ModelConfig {
+        ModelConfig {
+            dtype: kiln_core::config::DType::BF16,
+            ..tiny_config_full_attn()
+        }
+    }
+
     /// BF16 twin of [`tiny_weights`]. Builds the F32 fixture via
     /// `tiny_weights_with_seed` (so the seeded init / shape logic stays in one
     /// place) then casts every candle `Tensor` in the `GpuWeights` to BF16 —
@@ -11826,5 +11854,246 @@ pub(crate) mod tests {
              root did not connect through the F32 model to any LoRA leaf"
         );
         eprintln!("[GRPO F32 Vulkan] loss={loss_val:.6} grad_leaves={present}");
+    }
+
+    // ====================================================================
+    // (#1443 step 4) BF16-base MIXED-PRECISION Vulkan validation.
+    //
+    // The bar: SFT/GRPO/OPD on a BF16 base on Vulkan must produce non-empty,
+    // finite F32 LoRA grads, AND the base projection weights must STAY BF16
+    // (the VRAM win). Mixed precision: BF16 base weights, F32 activations — the
+    // base linear runs `vk_matmul_bf16w(x_f32, weight_bf16)`; LoRA A/B + the
+    // delta + activations are F32; the embedding output is cast BF16→F32 at the
+    // head of the forward.
+    //
+    // Same host-safety contract as the F32 tests: ONE bounded forward+backward
+    // over the tiny 4-layer model, self-skips unless KILN_TENSOR_VULKAN_TEST=1,
+    // run single-shot one at a time.
+    // ====================================================================
+
+    /// Assert a representative BASE projection weight is still BF16 (the VRAM
+    /// win) — the whole point of #1443. Checks a full-attention layer's q_proj_t
+    /// (or in_proj_qkv_t on a GDN layer) plus the tied lm_head (embed_tokens_t).
+    #[cfg(feature = "vulkan")]
+    fn assert_base_weights_bf16(weights: &GpuWeights) {
+        assert_eq!(
+            weights.embed_tokens_t.dtype(),
+            kiln_tensor::DType::BF16,
+            "lm_head (embed_tokens_t) base weight must stay BF16 (the #1443 VRAM win)"
+        );
+        let mut checked_a_projection = false;
+        for layer in &weights.layers {
+            match &layer.attention {
+                kiln_model::forward::GpuAttentionWeights::Full(full) => {
+                    assert_eq!(
+                        full.q_proj_t.dtype(),
+                        kiln_tensor::DType::BF16,
+                        "q_proj_t base weight must stay BF16 (the #1443 VRAM win)"
+                    );
+                    checked_a_projection = true;
+                    break;
+                }
+                kiln_model::forward::GpuAttentionWeights::Linear(lin) => {
+                    assert_eq!(
+                        lin.in_proj_qkv_t.dtype(),
+                        kiln_tensor::DType::BF16,
+                        "in_proj_qkv_t base weight must stay BF16 (the #1443 VRAM win)"
+                    );
+                    assert_eq!(
+                        lin.in_proj_a_t.dtype(),
+                        kiln_tensor::DType::BF16,
+                        "GDN in_proj_a_t base weight must stay BF16 (the #1443 VRAM win)"
+                    );
+                    checked_a_projection = true;
+                    break;
+                }
+            }
+        }
+        assert!(checked_a_projection, "no projection weight found to verify BF16");
+    }
+
+    /// Run ONE SFT forward+backward through `standard_forward_backward` on a
+    /// BF16 base on Vulkan, asserting: (1) LoRA params are F32 (the
+    /// mixed-precision rule — activations are F32 even on a BF16 base), (2) the
+    /// base projection weights stay BF16, (3) a non-empty, finite F32 grad store.
+    #[cfg(feature = "vulkan")]
+    fn run_vk_bf16_sft(label: &str, config: &ModelConfig, device: &Device) -> usize {
+        let weights = tiny_weights_bf16(config, device).expect("bf16 tiny weights on Vulkan");
+        assert_eq!(
+            weights.embed_tokens.dtype(),
+            kiln_tensor::DType::BF16,
+            "config must be BF16 to exercise the BF16-base mixed-precision path"
+        );
+        // The base projection weights are BF16 (the VRAM win we must preserve).
+        assert_base_weights_bf16(&weights);
+
+        let params =
+            TrainableLoraParams::initialize_seeded(config, &weights, 4, 8.0, device, Some(7))
+                .expect("LoRA params");
+        // The mixed-precision rule under test: on Vulkan the LoRA dtype is F32
+        // (matching the F32 activations) even on a BF16 base.
+        assert_eq!(
+            params.all_params()[0]
+                .forward_storage()
+                .primary_tensor()
+                .dtype(),
+            kiln_tensor::DType::F32,
+            "LoRA param dtype must be F32 on Vulkan even on a BF16 base (mixed precision)"
+        );
+
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2, 8];
+        let label_mask = vec![false, false, true, true, true, true, false];
+        let backend = backend::for_device_kt(device);
+
+        let (loss_val, grad_src) = standard_forward_backward(
+            &*backend,
+            &input_ids,
+            &weights,
+            config,
+            &params,
+            &label_mask,
+            device,
+        )
+        .expect("standard_forward_backward (BF16 Vulkan SFT)");
+
+        assert!(loss_val.is_finite(), "SFT loss not finite: {loss_val}");
+        let grads = grad_src.kt();
+        let present = vk_report_grad_coverage(label, &params, grads);
+        // Every delivered grad must be finite F32.
+        for p in params.all_params() {
+            if let Some(g) = grads.get(p.tensor_id()) {
+                assert_eq!(
+                    g.dtype(),
+                    kiln_tensor::DType::F32,
+                    "LoRA grad on a BF16 base must be F32 (mixed precision)"
+                );
+            }
+        }
+        assert!(
+            !grads.is_empty() && present > 0,
+            "BF16 Vulkan SFT ({label}) produced EMPTY/zero LoRA grads — the tape \
+             chain did not connect through the BF16 model to any LoRA leaf"
+        );
+        // Re-confirm the base weights are STILL BF16 after the step (no path
+        // silently up-cast them to F32 — that cast is the VRAM waste #1443 kills).
+        assert_base_weights_bf16(&weights);
+        eprintln!("[{label}] loss={loss_val:.6} grad_leaves={present} (base BF16, LoRA F32)");
+        present
+    }
+
+    /// SFT on a BF16 base on Vulkan (full-attention-only) — the primary bar.
+    /// Non-empty finite F32 LoRA grads, base projections stay BF16.
+    #[cfg(feature = "vulkan")]
+    #[test]
+    fn vk_bf16_sft_grads_nonempty() {
+        let test_name = "vk_bf16_sft_grads_nonempty";
+        if !vk_validation_enabled(test_name) {
+            return;
+        }
+        vk_set_all_tape_gates();
+        let device = Device::Vulkan(0);
+        run_vk_bf16_sft("SFT/full-attn BF16", &tiny_config_full_attn_bf16(), &device);
+    }
+
+    /// SFT on the GDN-bearing BF16 config (3 linear-attention + 1 full-attention
+    /// layer) — exercises the GDN in_proj_a/b BF16-weight matmuls routed through
+    /// `vk_matmul_bf16w` in addition to the qkv/z/out projections.
+    #[cfg(feature = "vulkan")]
+    #[test]
+    fn vk_bf16_sft_grads_nonempty_gdn() {
+        let test_name = "vk_bf16_sft_grads_nonempty_gdn";
+        if !vk_validation_enabled(test_name) {
+            return;
+        }
+        vk_set_all_tape_gates();
+        let device = Device::Vulkan(0);
+        run_vk_bf16_sft("SFT/gdn BF16", &tiny_config_bf16(), &device);
+    }
+
+    /// GRPO on a BF16 base on Vulkan through the REAL
+    /// `grpo_step_forward_backward_tape_authoritative_kt` step producer.
+    /// Non-empty finite F32 LoRA grads, base projections stay BF16.
+    #[cfg(feature = "vulkan")]
+    #[test]
+    fn vk_bf16_grpo_grads_nonempty() {
+        let test_name = "vk_bf16_grpo_grads_nonempty";
+        if !vk_validation_enabled(test_name) {
+            return;
+        }
+        vk_set_all_tape_gates();
+
+        let device = Device::Vulkan(0);
+        let config = tiny_config_full_attn_bf16(); // BF16 base, full-attn-only
+        let weights = tiny_weights_bf16(&config, &device).expect("bf16 tiny weights on Vulkan");
+        assert_base_weights_bf16(&weights);
+        let params =
+            TrainableLoraParams::initialize_seeded(&config, &weights, 4, 8.0, &device, Some(7))
+                .expect("LoRA params");
+        assert_eq!(
+            params.all_params()[0]
+                .forward_storage()
+                .primary_tensor()
+                .dtype(),
+            kiln_tensor::DType::F32,
+            "LoRA param dtype must be F32 on Vulkan even on a BF16 base (mixed precision)"
+        );
+
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2, 8];
+        let action_mask = vec![false, false, true, true, true, true, true];
+        let num_active = action_mask[1..].iter().filter(|&&m| m).count();
+
+        let ref_log_probs = zeros_f32_on(num_active, &device)
+            .expect("ref_log_probs placeholder")
+            .detach();
+        let loss_params = GrpoLossParams {
+            advantage: 1.0,
+            clip_low: 0.8,
+            clip_high: 1.2,
+            kl_coeff: 0.0,
+            kl_estimator: KlEstimator::None,
+            loss_normalizer: 1.0 / (num_active.max(1) as f64),
+            is_level: IsLevel::Token,
+            reinforce: true,
+            entropy_aware_kl_quantile: None,
+        };
+
+        let backend = backend::for_device_kt(&device);
+        let (loss_val, grads) = grpo_step_forward_backward_tape_authoritative_kt(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            &params,
+            &action_mask,
+            &ref_log_probs,
+            loss_params,
+            &device,
+            0,
+            num_active,
+            0,
+            0,
+            0,
+            None,
+        )
+        .expect("grpo_step_forward_backward_tape_authoritative_kt (BF16 Vulkan GRPO)");
+
+        assert!(loss_val.is_finite(), "GRPO loss not finite: {loss_val}");
+        let present = vk_report_grad_coverage("GRPO BF16", &params, &grads);
+        for p in params.all_params() {
+            if let Some(g) = grads.get(p.tensor_id()) {
+                assert_eq!(
+                    g.dtype(),
+                    kiln_tensor::DType::F32,
+                    "LoRA grad on a BF16 base must be F32 (mixed precision)"
+                );
+            }
+        }
+        assert!(
+            !grads.is_empty() && present > 0,
+            "BF16 Vulkan GRPO produced EMPTY/zero LoRA grads — the PG-loss tape \
+             root did not connect through the BF16 model to any LoRA leaf"
+        );
+        assert_base_weights_bf16(&weights);
+        eprintln!("[GRPO BF16 Vulkan] loss={loss_val:.6} grad_leaves={present} (base BF16, LoRA F32)");
     }
 }


### PR DESCRIPTION
## Summary

Implements **#1443 — BF16 mixed-precision base on Vulkan**: frozen base weights stay **BF16** (the VRAM win) while activations / LoRA / grads run **F32**, so the F32-only Vulkan kernels (rmsnorm/softmax) are untouched and only the base projections consume BF16 weights via `vk_matmul_bf16w`. This both halves base VRAM **and** is what lets the real BF16 Qwen3.5-4B train on Vulkan (the F32-only path only handled F32 fixtures).

Built on the merged kt-tape harmonization (#1441). 3 commits:
- **step 1** (`9c48b317`): kt-level F32-activation × BF16-weight matmul on Vulkan (bridge to `vk_matmul_bf16w`) + recorded dx backward (weight frozen). Parity `2.4e-7`, FD dx `4.6e-5`.
- **steps 2-4** (`25239646`): route the training base projections through the bf16w path; LoRA stays F32 on Vulkan even on a BF16 base; BF16 embedding → F32 cast; keep base weights BF16. Validated: SFT/GRPO/OPD (incl. GDN) on a BF16 base → non-empty finite grads.
- **cargo fix** (`45dc4ae9`): kiln-server `vulkan` feature explicitly activates `kiln-tensor/vulkan` + `kiln-kt-bridge/vulkan` (matches the cuda/metal lanes).

## Validation (real GPU, RADV Strix Halo)
- bf16w matmul parity + FD dx + recorder proof (weight frozen, no dW). ✓
- `vk_bf16_sft_grads_nonempty` (+ `_gdn`), `vk_bf16_grpo_`, `vk_bf16_opd_` — all PASS (non-empty finite F32 grads on a BF16 base). ✓
- F32 Vulkan training tests still PASS (no regression). ✓
- kiln-tensor/kiln-model/kiln-train/kiln-server build under `--features vulkan` and default; CUDA/Metal BF16 default tests unchanged (244 / 290).
- **Real Qwen3.5-4B loads + `kiln serve` reaches Ready on Vulkan** (8GB BF16 upload, harmonized `trainer.rs` path active).

## Known issue (NOT introduced here; tracked separately)
**Inference generation hangs** on the real model (the `/v1/chat/completions` decode forward via the batching actor / paged-KV path times out — no token). This path is untouched by the training work and was already broken (inference on Vulkan has been down since the candle-removal broke the model *load*, which this series fixes). Being investigated next as a separate effort.

## Merge caveats (same as #1441, accepted)
- `--features cuda` / `--features metal` not compile-verified on the dev host (no nvcc / no Apple Silicon); all edits are additive/device-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
