### PR TITLE
cuda: block_size=64 + stable paged-metadata — recover bs=64 concurrent decode baseline (#1082)

### DIFF
--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -138,9 +138,15 @@ impl CudaGraphKey {
     fn new(block_table: &BlockTable, paged_cache: &PagedKvCacheKt, seq_len: usize) -> Self {
         let stable_metadata = Self::stable_paged_metadata_enabled();
         let attention_len = seq_len + 1;
-        let max_seqlen_k = attention_len.div_ceil(128) * 128;
-        let pages_per_chunk = 128 / paged_cache.block_size();
-        let max_blocks_per_seq = (max_seqlen_k / 128) * pages_per_chunk;
+        // #1082: bucket + size by FA2_KBLOCK_N (=64 for hdim256), NOT a hardcoded
+        // 128. Must match `forward.rs::try_flash_attn_paged_decode`'s K_BLOCK_N
+        // exactly — otherwise the captured graph's block-table buffer is sized
+        // differently from the table the forward actually builds, and replay
+        // reads OOB → CUDA_ERROR_ILLEGAL_ADDRESS (the block_size=64 graph crash).
+        let kblock_n = crate::generate::FA2_KBLOCK_N;
+        let max_seqlen_k = attention_len.div_ceil(kblock_n) * kblock_n;
+        let pages_per_chunk = kblock_n / paged_cache.block_size();
+        let max_blocks_per_seq = (max_seqlen_k / kblock_n) * pages_per_chunk;
         Self {
             stable_metadata,
             seq_len: if stable_metadata { 0 } else { seq_len },
@@ -256,9 +262,15 @@ impl CudaBatchedGraphKey {
     ) -> Self {
         let stable_metadata = CudaGraphKey::stable_paged_metadata_enabled();
         let attention_len = max_seq_len + 1;
-        let max_seqlen_k = attention_len.div_ceil(128) * 128;
-        let pages_per_chunk = 128 / paged_cache.block_size();
-        let max_blocks_per_seq = (max_seqlen_k / 128) * pages_per_chunk;
+        // #1082: bucket + size by FA2_KBLOCK_N (=64 for hdim256), NOT a hardcoded
+        // 128. Must match `forward.rs::try_flash_attn_paged_decode`'s K_BLOCK_N
+        // exactly — otherwise the captured graph's block-table buffer is sized
+        // differently from the table the forward actually builds, and replay
+        // reads OOB → CUDA_ERROR_ILLEGAL_ADDRESS (the block_size=64 graph crash).
+        let kblock_n = crate::generate::FA2_KBLOCK_N;
+        let max_seqlen_k = attention_len.div_ceil(kblock_n) * kblock_n;
+        let pages_per_chunk = kblock_n / paged_cache.block_size();
+        let max_blocks_per_seq = (max_seqlen_k / kblock_n) * pages_per_chunk;
         Self {
             stable_metadata,
             batch_size,
@@ -2551,8 +2563,12 @@ impl CudaGraphRunner {
         max_seqlen_k: usize,
     ) -> Result<Vec<u32>> {
         let block_size = paged_cache.block_size();
-        let pages_per_chunk = 128 / block_size;
-        let max_blocks_per_seq = (max_seqlen_k / 128) * pages_per_chunk;
+        // #1082: FA2_KBLOCK_N (=64 hdim256), matching the CudaGraphKey sizing
+        // above + forward.rs's K_BLOCK_N. `max_seqlen_k` arrives already bucketed
+        // to a multiple of FA2_KBLOCK_N by the key, so this divides cleanly.
+        let kblock_n = crate::generate::FA2_KBLOCK_N;
+        let pages_per_chunk = kblock_n / block_size;
+        let max_blocks_per_seq = (max_seqlen_k / kblock_n) * pages_per_chunk;
         let take = max_blocks_per_seq.min(block_table.blocks.len());
         let mut padded = Vec::with_capacity(max_blocks_per_seq);
         padded.extend_from_slice(&block_table.blocks[..take]);

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -161,9 +161,16 @@ impl CudaGraphKey {
     }
 
     fn stable_paged_metadata_enabled() -> bool {
+        // #1082: default ON. The persistent block-table buffer (refreshed in
+        // place per replay) reads the CURRENT block table, so it does NOT race
+        // with concurrent block recycling — required for correctness with the
+        // #1082 default block_size=64 (the old transient captured table races
+        // → CUDA_ERROR_ILLEGAL_ADDRESS under concurrent decode) and strictly
+        // more correct for capture/replay at any block_size. Opt out with
+        // KILN_CUDA_GRAPH_STABLE_PAGED_METADATA=0.
         std::env::var("KILN_CUDA_GRAPH_STABLE_PAGED_METADATA")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
-            .unwrap_or(false)
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on" | "ON"))
+            .unwrap_or(true)
     }
 }
 

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -18688,9 +18688,20 @@ fn try_flash_attn_paged_decode(
     if padded.is_empty() {
         return Ok(None);
     }
+    // #1082: pad the tail by REPEATING the last real block id, never `last + 1`.
+    // At block_size >= kBlockN (the #1082 default 64) pages_per_chunk = 1, so the
+    // FA2 split-KV kernel reads EVERY block_table entry [0..n_block_max-1] as a
+    // raw physical page id. An incrementing pad off the last real page can exceed
+    // num_blocks (~12174 at block_size=64) — harmless when rebuilt eagerly each
+    // step, but FATAL once baked into a captured CUDA graph (CUDA_ERROR_ILLEGAL_
+    // ADDRESS on the first replay under concurrency, where blocks.len() <
+    // max_blocks_per_seq so padding is actually appended). Repeat-last keeps every
+    // entry a valid in-pool page; the padded tail is beyond actual_seqlen_k so it
+    // is masked and never semantically read. Matches the box-102 fix in
+    // cuda_graph.rs::padded_block_table.
+    let pad_block = *padded.last().expect("padded is non-empty (checked above)");
     while padded.len() < max_blocks_per_seq {
-        let next = padded.last().copied().unwrap_or(0).wrapping_add(1);
-        padded.push(next);
+        padded.push(pad_block);
     }
 
     let device = q.device();

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -18375,12 +18375,14 @@ pub(crate) struct BatchedPagedDecodeGraphInputs<'a> {
 /// materializing slow path).
 ///
 /// ### Preconditions checked here
-///   * `block_size` divides `kBlockN = 128`
+///   * `block_size` divides `kBlockN` (`FA2_KBLOCK_N` = 64 for the hdim256
+///     model — see its doc in generate.rs)
 ///   * Within each `kBlockN`-wide chunk of the block table, the underlying
 ///     physical pages are contiguous in the pool. The FA2 splitkv paged kernel
 ///     reads only one block-table entry per kBlockN chunk and assumes the next
 ///     `kBlockN / block_size` pages are physically contiguous (see
-///     `flash_fwd_kernel.h` lines 587-596 and 770-779).
+///     `flash_fwd_kernel.h` lines 587-596 and 770-779). With the #1082 default
+///     `block_size = 64` this is one page per chunk → vacuously satisfied.
 ///
 /// ### Output
 /// `[batch, 1, num_heads * head_dim]` after o_proj (matches the slow path).
@@ -18413,7 +18415,8 @@ fn try_flash_attn_paged_decode(
         &crate::paged_kv_cache_kt::PagedKvCacheKt,
     >,
 ) -> Result<Option<Tensor>> {
-    const K_BLOCK_N: usize = 128;
+    // #1082: the real FA2 tile width for hdim256 (was a conservative 128).
+    const K_BLOCK_N: usize = crate::generate::FA2_KBLOCK_N;
 
     #[cfg(feature = "cuda")]
     let block_size =

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -145,11 +145,25 @@ fn profile_decode_batcher_stages_enabled() -> bool {
 /// intervening entries). When a fragmented free list hands the kernel
 /// non-adjacent pages it reads a foreign page / off the pool →
 /// CUDA_ERROR_ILLEGAL_ADDRESS. Mirrors the bs=1 check in
-/// `forward.rs::try_flash_attn_paged_decode` (~18605). Uses the CONSERVATIVE
-/// 128-token chunk (pages_per_chunk = 128/block_size): the hdim256 model uses
-/// kBlockN=64 (4 pages) and hdim128 uses kBlockN=128 (8 pages), and 128-token
-/// contiguity is a superset of both, so this never under-checks. Returns true
-/// → caller must route to the contiguity-safe per-row decode.
+/// `forward.rs::try_flash_attn_paged_decode`.
+///
+/// Chunk = `FA2_KBLOCK_N` tokens. Qwen3.5-4B's GQA full-attn is head_dim=256
+/// only, so kBlockN = 64 (`flash_fwd_launch_template.h:170`: hd>128 → 64). A
+/// 64-token tile spans `64/block_size` pages, which is the run that must be
+/// physically adjacent. With the #1082 default `block_size = 64` this is ONE
+/// page per tile → every block_table is trivially "contiguous" → no row ever
+/// routes to the slow per-row loop for FA2 reasons (the n=64 fix). At the old
+/// `block_size = 16` it is 4 pages/tile. (If a head_dim=128 model is ever
+/// served — kiln is Qwen3.5-4B-only today — kBlockN would be 128; bump
+/// `FA2_KBLOCK_N` or thread head_dim before then.) Returns true → caller must
+/// route to the contiguity-safe per-row decode.
+/// FA2 split-KV decode tile width (tokens) for Qwen3.5-4B's head_dim=256 GQA
+/// full-attn (`flash_fwd_launch_template.h:170`: hd>128 → 64). The K/V pages
+/// backing one tile must be physically adjacent; with `block_size >= 64` a tile
+/// is one page so the requirement is vacuous. kiln is Qwen3.5-4B-only (hd=256);
+/// a head_dim=128 model would need 128 here (or head_dim threaded through).
+pub(crate) const FA2_KBLOCK_N: usize = 64;
+
 pub(crate) fn batch_has_noncontiguous_kv_tiles(
     block_tables: &[&BlockTable],
     seq_lens: &[usize],
@@ -177,7 +191,7 @@ pub(crate) fn row_has_noncontiguous_kv_tiles(
     if block_size == 0 {
         return false;
     }
-    let pages_per_chunk = (128 / block_size).max(1);
+    let pages_per_chunk = (FA2_KBLOCK_N / block_size).max(1);
     // Only the pages actually covering live tokens are read by the kernel.
     let n_pages = seqlen.div_ceil(block_size).min(blocks.len());
     let mut c = 0usize;
@@ -5554,8 +5568,9 @@ impl ModelRunner {
             "generate_mtp_speculative currently only supports greedy decoding (temperature == 0)"
         );
 
-        // Block size matches the kiln-core default + the bench convention.
-        const BLOCK_SIZE: usize = 16;
+        // Block size matches the kiln-core default + the bench convention
+        // (#1082: 16 -> 64 so each FA2 kBlockN=64 tile is one physical page).
+        const BLOCK_SIZE: usize = 64;
 
         let max_total = prompt_tokens.len() + params.max_tokens;
         // (#1082) kt-native paged cache — `PagedKvCacheKt::new` allocates pools
@@ -6009,7 +6024,8 @@ impl ModelRunner {
              (temperature == 0)"
         );
 
-        const BLOCK_SIZE: usize = 16;
+        // #1082: 16 -> 64 so each FA2 kBlockN=64 tile is one physical page.
+        const BLOCK_SIZE: usize = 64;
 
         let max_total = prompt_tokens.len() + params.max_tokens;
         // (#1082) kt-native paged cache — kt `DType` + runtime `Device`.
@@ -7690,24 +7706,25 @@ mod tests {
 
     #[test]
     fn noncontiguous_kv_tiles_detection() {
-        // #1082 crasher fix: block_size=16 → pages_per_chunk = 128/16 = 8.
-        // CONTIGUOUS within each 8-page chunk → safe (false).
+        // #1082: FA2_KBLOCK_N=64 (hdim256). At block_size=16 → pages_per_chunk
+        // = 64/16 = 4. CONTIGUOUS within each 4-page chunk → safe (false).
         let bt_contig = block_table_with(&[100, 101, 102, 103, 104, 105, 106, 107, 200, 201]);
         assert!(
             !batch_has_noncontiguous_kv_tiles(&[&bt_contig], &[160], 16),
             "physically-contiguous pages within a tile must NOT force the row-loop"
         );
-        // A gap INSIDE the first 8-page chunk (104 -> 999) → non-contiguous (true).
+        // A gap (999) starting the 2nd 4-page chunk: base=999 then 105 != 1000
+        // → non-contiguous (true).
         let bt_frag = block_table_with(&[100, 101, 102, 103, 999, 105, 106, 107]);
         assert!(
             batch_has_noncontiguous_kv_tiles(&[&bt_frag], &[128], 16),
             "a fragmented page inside a tile must force the contiguity-safe row-loop"
         );
-        // Chunk BOUNDARY discontinuity (idx 8 starts a new chunk) is allowed —
-        // the kernel re-reads block_table at chunk starts (200 != 107+1 is fine).
+        // Chunk BOUNDARY discontinuity (idx 8 starts a new 4-page chunk) is
+        // allowed — the kernel re-reads block_table at chunk starts.
         assert!(
             !batch_has_noncontiguous_kv_tiles(&[&bt_contig], &[144], 16),
-            "discontinuity at a chunk boundary (every 8 pages) is allowed"
+            "discontinuity at a chunk boundary (every 4 pages) is allowed"
         );
         // bs=1 short row (1 page) is trivially contiguous.
         let bt_one = block_table_with(&[42]);
@@ -7724,6 +7741,16 @@ mod tests {
         assert!(
             !batch_has_noncontiguous_kv_tiles(&[&bt_tail_frag], &[20], 16),
             "fragmentation beyond the live window (seqlen=20 → 2 pages) is not read"
+        );
+        // #1082 KEY: at the new default block_size=64, pages_per_chunk =
+        // FA2_KBLOCK_N/64 = 1, so each FA2 tile is exactly one page and the
+        // kernel looks it up independently. Arbitrarily strided (non-adjacent)
+        // blocks that WOULD trip at block_size=16 are safe at 64 → the row-loop
+        // never fires for FA2 reasons (this is what restores bs=64 concurrent).
+        let bt_strided = block_table_with(&[5, 7, 9, 11]);
+        assert!(
+            !batch_has_noncontiguous_kv_tiles(&[&bt_strided], &[256], 64),
+            "block_size>=kBlockN makes every FA2 tile one page → no fragmentation trips"
         );
     }
 

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -25,7 +25,13 @@ use crate::metrics::Metrics;
 use crate::recent_requests::{DEFAULT_CAPACITY as RECENT_REQUESTS_CAPACITY, RecentRequestsRing};
 use crate::training_queue::{SharedTrainingQueue, ShutdownFlag};
 
-const DEFAULT_BLOCK_SIZE: usize = 16;
+// #1082: 64 (was 16) so each FA2 split-KV decode tile (kBlockN=64 for the
+// hdim256 GQA full-attn — flash_fwd_launch_template.h:170) maps to exactly ONE
+// physical page. That makes the kernel's per-tile block_table lookup
+// per-page-correct and removes the intra-tile physical-contiguity requirement
+// entirely — so concurrent decode no longer fragments into the slow per-row
+// loop (the n=64 cliff). 64 >= max kBlockN and divides cleanly everywhere.
+const DEFAULT_BLOCK_SIZE: usize = 64;
 const MIN_AUTO_KV_BLOCKS: usize = 64;
 const METAL_AUTO_MAX_KV_BLOCKS_LOW_MEM: usize = 512; // 8K tokens at block_size=16.
 const METAL_AUTO_MAX_KV_BLOCKS_MID_MEM: usize = 1024; // 16K tokens at block_size=16.

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -4420,8 +4420,10 @@ fn jsonl_byte_progress(total_bytes: u64, offset: u64) -> (usize, usize, f32) {
 }
 
 /// Page size used by the GRPO shared-prompt-prefix paged cache. Matches the
-/// production server / bench setting so the same FA fast paths fire.
-const GRPO_REF_PAGED_BLOCK_SIZE: usize = 16;
+/// production server / bench setting so the same FA fast paths fire (#1082:
+/// 16 -> 64 so each FA2 kBlockN=64 tile is one page; keeps parity with
+/// `DEFAULT_BLOCK_SIZE`).
+const GRPO_REF_PAGED_BLOCK_SIZE: usize = 64;
 
 /// Compute the reference-policy log probs for every completion in a GRPO
 /// group, sharing the prompt-prefix forward across all completions.


### PR DESCRIPTION
## What
Recovers the **bs=64 concurrent decode baseline** (the documented ~1181 tok/s) from the **11 tok/s row-loop cliff**, and fixes two CUDA_ERROR_ILLEGAL_ADDRESS crashes — all rooted in the vendored FA2 split-KV kernel's intra-tile page-contiguity assumption.

For hdim256, FA2 `kBlockN=64` (`flash_fwd_launch_template.h:170`). At the old `block_size=16` a 64-token tile spans 4 pages the kernel assumes are physically adjacent; under interleaved concurrent allocation they fragment → row-loop serialization (the n=64 cliff) or ILLEGAL. **Raising `block_size` to 64 makes each tile exactly one page**, so the kernel's per-tile `block_table` lookup is per-page-correct and the contiguity requirement vanishes — no cutlass changes.

Five coordinated changes:
1. `DEFAULT_BLOCK_SIZE`/GRPO-ref/MTP `block_size` **16 → 64**.
2. New `FA2_KBLOCK_N=64` const; the Rust contiguity checks (`generate.rs` row/batch + `forward.rs` bs=1) use it instead of a conservative `128` (which over-fired and still row-looped *pairs* at block_size=64).
3. `cuda_graph.rs` block-table sizing uses `FA2_KBLOCK_N` too (was a hardcoded 128 → mismatched `forward.rs` → captured-buffer/forward size disagreement).
4. **Repeat-last block-table pad** in `forward.rs` (was `last.wrapping_add(1)`, which can exceed `num_blocks` and OOB once baked into a captured graph).
5. **Default `KILN_CUDA_GRAPH_STABLE_PAGED_METADATA` ON** — the persistent block-table buffer (refreshed in place per replay) reads the *current* table, eliminating the concurrent-graph-capture **race** (a Heisenbug: vanishes under `CUDA_LAUNCH_BLOCKING`) that the transient captured table hit under async n=64.

## Validation (A6000, default config — no env flags)
- Builds (release + test); contiguity unit tests pass (incl. new block_size=64 strided→false assertion).
- Graphs-on bs=64 concurrent: **0 ILLEGAL**, coherent output, 64/64 success.
- **Marginal decode rate ~1155 tok/s** (prefill-subtracted: (16384−4096)/(49.86−39.22)) ≈ the documented 1181 baseline, up from the 11 tok/s row-loop cliff.
- Eager (graphs off) also 0 ILLEGAL, 147 tok/s @ mt=64.

## Honest scope (residual to vLLM 1907)
The lower *aggregate* tok/s at short `max_tokens` (105 @ mt=64 → 330 @ mt=256 → 499 @ mt=512) is **serial-prefill domination** (the engine prefills concurrent admits one-at-a-time), not the decode rate. Closing the aggregate to ~1181 needs a batched/chunked-prefill primitive; closing ~1155 → 1907 needs the decode-kernel levers (Phase 8 GDN) + bs>1 graph replay (#1440). This PR recovers the **decode baseline** + removes the crashes; those two are tracked follow-ups on #1082.

Rollback: revert; PR #1446's row-loop remains crash-safe at block_size=16. Opt-out: `KILN_CUDA_GRAPH_STABLE_PAGED_METADATA=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)