### PR TITLE
fix(test): gate stale Metal NYI assertions behind not(feature = metal)

### DIFF
--- a/crates/kiln-tensor/src/tensor.rs
+++ b/crates/kiln-tensor/src/tensor.rs
@@ -1534,9 +1534,14 @@ mod tests {
         // Per-backend Metal branch stays Err in a no-feature build;
         // callers that hit it should see an explicit error instead of a
         // silent CPU fallback that would later trip a device-mismatch
-        // assert.
-        let e = Tensor::zeros_on(Device::Metal(0), vec![2], DType::F32).unwrap_err();
-        assert!(e.to_string().contains("metal:0"));
+        // assert. With the `metal` feature the substrate has landed and the
+        // branch builds a real `MetalStorage` — so the NYI-error contract
+        // only holds WITHOUT the feature (mirrors the `vulkan` gating below).
+        #[cfg(not(feature = "metal"))]
+        {
+            let e = Tensor::zeros_on(Device::Metal(0), vec![2], DType::F32).unwrap_err();
+            assert!(e.to_string().contains("metal:0"));
+        }
         // Vulkan is first-class once the `vulkan` feature lands (PR2,
         // #1082); without the feature it errors with the device name.
         #[cfg(not(feature = "vulkan"))]
@@ -1548,8 +1553,11 @@ mod tests {
 
     #[test]
     fn from_vec_on_metal_errors_until_substrate_lands() {
-        let e = Tensor::from_vec_on(Device::Metal(0), vec![1.0f32], vec![1]).unwrap_err();
-        assert!(e.to_string().contains("metal:0"));
+        #[cfg(not(feature = "metal"))]
+        {
+            let e = Tensor::from_vec_on(Device::Metal(0), vec![1.0f32], vec![1]).unwrap_err();
+            assert!(e.to_string().contains("metal:0"));
+        }
         #[cfg(not(feature = "vulkan"))]
         {
             let e = Tensor::from_vec_on(Device::Vulkan(0), vec![1.0f32], vec![1]).unwrap_err();


### PR DESCRIPTION
## Problem

Main CI has been red on the **macOS / Metal** job (exit 101) across many recent commits. The failing tests:

- `tensor::tests::zeros_on_metal_errors_until_substrate_lands`
- `tensor::tests::from_vec_on_metal_errors_until_substrate_lands`

Both assert that constructing a `Device::Metal(0)` tensor **errors** with a `"metal:0"` not-yet-implemented message. That contract was true before the Metal substrate landed — but with the `metal` feature, `zeros_on`/`from_vec_on` now build a real `MetalStorage` (#1082), so the NYI-error assertion fires and panics.

The Linux/default and Linux/Vulkan jobs stay green because they build without the `metal` feature, where the NYI-error contract still holds.

## Fix

Gate the Metal assertion behind `#[cfg(not(feature = "metal"))]`, exactly mirroring the `#[cfg(not(feature = "vulkan"))]` gating already present on the Vulkan half of these same tests.

- **No-feature / Vulkan jobs:** unchanged — still assert the NYI error.
- **Metal job:** the stale assertion no longer runs; the real Metal construction path is covered by the metal GPU test suite (292 metal tests pass).

Test-only change, one file. Verified `cargo test -p kiln-tensor metal_errors_until_substrate_lands` passes on the no-feature build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)