### PR TITLE
feat(vulkan): de-bytes the last 3 host bounces — resident rmsnorm, buffer SDPA, BF16 batched matmul

### DIFF
--- a/crates/kiln-model/src/backend/vulkan.rs
+++ b/crates/kiln-model/src/backend/vulkan.rs
@@ -684,6 +684,56 @@ fn kt_tensor_to_f32_bytes_with_shape(
     Ok((bytemuck::cast_slice(&f32_data).to_vec(), shape))
 }
 
+/// Resident single-sequence (batch==1) causal prefill SDPA — the buffer-based,
+/// fully on-device replacement for the bytes path in `flash_attn_prefill_vulkan`.
+///
+/// q/k/v arrive `[1, seq_len, num_heads, head_dim]` (k/v already GQA-expanded
+/// to `num_heads` by the caller). Squeeze the batch axis to the rank-3
+/// `[seq, heads, head_dim]` layout `vk_sdpa_prefill` consumes, bridge zero-copy
+/// (F32, contiguous, whole-buffer), run the fused on-device SDPA, bridge the
+/// result back, and restore the `[1, seq, heads, head_dim]` shape + input
+/// dtype. No D2H/H2D round-trip.
+#[allow(clippy::too_many_arguments)]
+fn resident_sdpa_prefill_b1(
+    q: &kiln_tensor::Tensor,
+    k: &kiln_tensor::Tensor,
+    v: &kiln_tensor::Tensor,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f32,
+) -> Result<kiln_tensor::Tensor> {
+    use kiln_tensor::{kt_tensor_from_vk, vk_tensor_from_kt, DType, Device};
+
+    // F32, [seq, heads, head_dim], contiguous, start_offset==0 (the bridge
+    // contract). `to_dtype`/`contiguous` are resident on Vulkan (no host hop);
+    // both are no-ops when the activation is already F32 + contiguous.
+    let prep = |t: &kiln_tensor::Tensor| -> Result<kiln_tensor::Tensor> {
+        Ok(t.to_dtype(DType::F32)?
+            .reshape((seq_len, num_heads, head_dim))?
+            .contiguous()?)
+    };
+    let qf = prep(q)?;
+    let kf = prep(k)?;
+    let vf = prep(v)?;
+    let device_index = match qf.device() {
+        Device::Vulkan(i) => i,
+        _ => anyhow::bail!("resident_sdpa_prefill_b1: not Vulkan-resident after prep"),
+    };
+
+    let vk_q = vk_tensor_from_kt(&qf)?;
+    let vk_k = vk_tensor_from_kt(&kf)?;
+    let vk_v = vk_tensor_from_kt(&vf)?;
+    let vk_out = kiln_vulkan_kernel::vk_ops::attention::vk_sdpa_prefill(&vk_q, &vk_k, &vk_v, scale)?;
+    let out =
+        kt_tensor_from_vk(&vk_out, device_index)?.reshape((1usize, seq_len, num_heads, head_dim))?;
+    Ok(if q.dtype() == DType::F32 {
+        out
+    } else {
+        out.to_dtype(q.dtype())?
+    })
+}
+
 /// kt-native: wrap f32 bytes as a kt tensor
 /// (CPU-host, the Vulkan activation residency), no candle bridge. (#1082)
 #[inline]
@@ -1733,6 +1783,28 @@ impl VulkanBackend {
             || v_head_dim != head_dim
         {
             return Ok(None);
+        }
+
+        // Resident buffer-based SDPA for the common single-sequence causal
+        // case: zero-copy bridge q/k/v → fused on-device `vk_sdpa_prefill`
+        // (permute → batched matmul → scale → causal-mask → softmax → matmul,
+        // all resident) → bridge back. No host round-trip. batch>1 (the kernel
+        // flattens query rows to one sequence, so cross-batch attention would
+        // be wrong) and non-causal fall through to the bytes path below.
+        if causal
+            && batch == 1
+            && matches!(q.device(), kiln_tensor::Device::Vulkan(_))
+            && matches!(k.device(), kiln_tensor::Device::Vulkan(_))
+            && matches!(v.device(), kiln_tensor::Device::Vulkan(_))
+        {
+            match resident_sdpa_prefill_b1(q, k, v, seq_len, num_heads, head_dim, softmax_scale) {
+                Ok(out) => return Ok(Some(out)),
+                Err(e) => {
+                    if std::env::var("KILN_VK_TRACE").is_ok() {
+                        eprintln!("[vk] resident sdpa_prefill fell back to bytes: {e}");
+                    }
+                }
+            }
         }
 
         let in_dtype = q.dtype();

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -7036,6 +7036,35 @@ pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
         // training branch: training is CUDA-BF16 / kt-tape only now; Vulkan is
         // inference-only.
     }
+    // Resident Vulkan RMSNorm: when the activation `x` is already
+    // Vulkan-backed (the resident inference path — activations are F32 via
+    // `vulkan_cast_activation_to_f32`), run the fused `qwen_rmsnorm_forward`
+    // kernel zero-copy via `vulkan_rmsnorm_last_axis` instead of the
+    // multi-dispatch `rms_norm_fallback` (mean/rsqrt/mul) or the CPU-input
+    // bytes path above. Identical `(1+w)*x*rsqrt(mean(x^2)+eps)` Qwen
+    // semantics (same shader). The kernel is F32-only, so cast x/weight to F32
+    // (a no-op on the F32 activation path) and back — keeping BF16 supported
+    // for free. The weight is a small `[hidden]` vector; aligning it to the
+    // device is a no-op once the model is resident.
+    #[cfg(feature = "vulkan")]
+    if crate::backend::vulkan_active()
+        && matches!(x.device(), Device::Vulkan(_))
+        && !x.track_op()
+        && !weight.track_op()
+    {
+        let in_dtype = x.dtype();
+        let x32 = x.contiguous()?.to_dtype(DType::F32)?;
+        let w32 = weight
+            .to_device(x.device())?
+            .contiguous()?
+            .to_dtype(DType::F32)?;
+        let out32 = kiln_tensor::vulkan_rmsnorm_last_axis(&x32, &w32, eps as f32)?;
+        return if in_dtype == DType::F32 {
+            Ok(out32)
+        } else {
+            Ok(out32.to_dtype(in_dtype)?)
+        };
+    }
     rms_norm_fallback(x, weight, eps)
 }
 

--- a/crates/kiln-tensor/src/ops/matmul.rs
+++ b/crates/kiln-tensor/src/ops/matmul.rs
@@ -167,7 +167,8 @@ impl DeviceOp2 for MatmulOp {
         // unequal/sub-matrix ranks, or non-Vulkan storage — returns Ok(None)
         // so `dispatch2` runs the CPU reference and copies the result back to
         // Vulkan (correct, slower).
-        if a.dtype() != DType::F32 || b.dtype() != DType::F32 {
+        let dt = a.dtype();
+        if !matches!(dt, DType::F32 | DType::BF16) || b.dtype() != dt {
             return Ok(None);
         }
         if !a.is_contiguous() || !b.is_contiguous() {
@@ -190,6 +191,13 @@ impl DeviceOp2 for MatmulOp {
         if ar < 2 || ar != br {
             // Sub-matrix or unequal ranks: `validate()` would bail; let the
             // host reference report the error instead.
+            return Ok(None);
+        }
+        // The rank-2 GEMM (`vulkan_matmul`) is F32-only; BF16 rank-2 has no
+        // resident kernel here, so fall back to the host reference. BF16
+        // rank≥3 (the attention-core / GDN batched GEMMs for the BF16 model)
+        // routes through the batched kernel.
+        if dt == DType::BF16 && ar == 2 {
             return Ok(None);
         }
         // Re-validate the full shape/dtype contract (contraction dim,
@@ -626,6 +634,73 @@ mod tests {
         assert!(
             max_abs_err < 1e-4,
             "rank-4 batched matmul diverges from CPU ref: max_abs_err={max_abs_err}"
+        );
+    }
+
+    /// Batched BF16 matmul (the attention-core path for the BF16 model) must
+    /// match the CPU BF16 reference and stay Vulkan-resident. Inputs are
+    /// small integers exactly representable in BF16, with the accumulation
+    /// kept small enough that the result is exact in BF16 — so the on-device
+    /// (bf16-read, F32-accumulate, F32-out → cast BF16) path is byte-exact
+    /// with the host (F32-accumulate → cast BF16) reference.
+    #[cfg(feature = "vulkan")]
+    #[test]
+    fn matmul_vulkan_batched_bf16_parity_rank4() {
+        if !vulkan_test_enabled() {
+            eprintln!("skip: KILN_TENSOR_VULKAN_TEST unset");
+            return;
+        }
+        if crate::primary_vulkan_device(0).is_err() {
+            eprintln!("skip: no Vulkan device");
+            return;
+        }
+        let dev = crate::Device::Vulkan(0);
+
+        // [B=2, H=2, S=3, D=4] @ [2,2,4,5] = [2,2,3,5]. Small ints (0..3).
+        let (b_, h, s, d, n) = (2usize, 2usize, 3usize, 4usize, 5usize);
+        let a_data: Vec<f32> = (0..b_ * h * s * d).map(|i| (i % 4) as f32).collect();
+        let b_data: Vec<f32> = (0..b_ * h * d * n).map(|i| (i % 3) as f32).collect();
+
+        let a_cpu = Tensor::from_slice(&a_data, vec![b_, h, s, d])
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let b_cpu = Tensor::from_slice(&b_data, vec![b_, h, d, n])
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let ref_vals = read_f32(&matmul(&a_cpu, &b_cpu).unwrap().to_dtype(DType::F32).unwrap());
+
+        let a_vk = Tensor::from_vec_on(dev, a_data.clone(), vec![b_, h, s, d])
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let b_vk = Tensor::from_vec_on(dev, b_data.clone(), vec![b_, h, d, n])
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let accepted = MatmulOp.vulkan_fwd(&a_vk, &b_vk).unwrap();
+        assert!(accepted.is_some(), "BF16 batched matmul must run resident");
+
+        let c_vk = matmul(&a_vk, &b_vk).unwrap();
+        assert_eq!(c_vk.shape(), &[b_, h, s, n]);
+        assert_eq!(c_vk.device(), dev, "BF16 result must stay on Vulkan");
+        assert_eq!(c_vk.dtype(), DType::BF16, "BF16 in → BF16 out");
+        let got = c_vk
+            .to_device(crate::Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .to_vec::<f32>()
+            .unwrap();
+        let mut max_abs_err = 0.0f32;
+        for (g, r) in got.iter().zip(ref_vals.iter()) {
+            max_abs_err = max_abs_err.max((g - r).abs());
+        }
+        eprintln!("matmul_vulkan_batched_bf16_parity_rank4: max_abs_err = {max_abs_err:e}");
+        assert!(
+            max_abs_err < 0.5,
+            "BF16 batched matmul diverges from CPU ref: max_abs_err={max_abs_err}"
         );
     }
 }

--- a/crates/kiln-tensor/src/vulkan_storage.rs
+++ b/crates/kiln-tensor/src/vulkan_storage.rs
@@ -459,16 +459,24 @@ pub fn vulkan_matmul(a: &crate::Tensor, b: &crate::Tensor) -> Result<crate::Tens
 /// Returns [`Error::Msg`] on non-Vulkan storage, dtype/rank/shape
 /// violations, or kernel dispatch failure.
 pub fn vulkan_matmul_batched(a: &crate::Tensor, b: &crate::Tensor) -> Result<crate::Tensor> {
-    use kiln_vulkan_kernel::vk_ops::matmul_batched::vk_matmul_batched_no_grad;
+    use kiln_vulkan_kernel::vk_ops::matmul_batched::{
+        vk_matmul_batched_bf16_no_grad, vk_matmul_batched_no_grad,
+    };
     use kiln_vulkan_kernel::vk_tensor::{VkDType, VkTensor};
 
-    if a.dtype() != DType::F32 || b.dtype() != DType::F32 {
+    let dtype = a.dtype();
+    if !matches!(dtype, DType::F32 | DType::BF16) || b.dtype() != dtype {
         return Err(Error::Msg(format!(
-            "vulkan_matmul_batched: F32-only kernel (got a={}, b={})",
+            "vulkan_matmul_batched: F32/BF16 equal-dtype kernel (got a={}, b={})",
             a.dtype(),
             b.dtype()
         )));
     }
+    let vk_dtype = match dtype {
+        DType::F32 => VkDType::F32,
+        DType::BF16 => VkDType::Bf16,
+        _ => unreachable!("dtype gated to F32/BF16 above"),
+    };
     let (ar, br) = (a.rank(), b.rank());
     if ar < 3 || br != ar {
         return Err(Error::Msg(format!(
@@ -528,23 +536,34 @@ pub fn vulkan_matmul_batched(a: &crate::Tensor, b: &crate::Tensor) -> Result<cra
     let vk_a = VkTensor::from_buffer(
         a_vk.buffer_arc(),
         vec![batch_a, m, k],
-        VkDType::F32,
+        vk_dtype,
         Arc::clone(a_vk.vulkan_device()),
     );
     let vk_b = VkTensor::from_buffer(
         b_vk.buffer_arc(),
         vec![batch_b, kk, n],
-        VkDType::F32,
+        vk_dtype,
         Arc::clone(b_vk.vulkan_device()),
     );
-    let vk_out = vk_matmul_batched_no_grad(&vk_a, &vk_b)
-        .map_err(|e| Error::Msg(format!("vulkan_matmul_batched: kernel dispatch failed: {e}")))?;
-    // vk_out is [batch, m, n]; restore the caller's leading axes.
+    // Both kernels accumulate in F32 and return an F32 [batch, m, n] result;
+    // the BF16 kernel reads bf16-packed inputs and writes F32 (no write race).
+    let vk_out = match dtype {
+        DType::F32 => vk_matmul_batched_no_grad(&vk_a, &vk_b),
+        DType::BF16 => vk_matmul_batched_bf16_no_grad(&vk_a, &vk_b),
+        _ => unreachable!("dtype gated to F32/BF16 above"),
+    }
+    .map_err(|e| Error::Msg(format!("vulkan_matmul_batched: kernel dispatch failed: {e}")))?;
+    // vk_out is F32 [batch, m, n]; restore the caller's leading axes.
     let mut out_shape: Vec<usize> = a_shape[..ar - 2].to_vec();
     out_shape.push(m);
     out_shape.push(n);
-    let out = kt_tensor_from_vk(&vk_out, device_index)?;
-    out.reshape(out_shape)
+    let out_f32 = kt_tensor_from_vk(&vk_out, device_index)?.reshape(out_shape)?;
+    // Match the input dtype: BF16 inputs → BF16 output (resident vulkan_cast).
+    match dtype {
+        DType::F32 => Ok(out_f32),
+        DType::BF16 => out_f32.to_dtype(DType::BF16),
+        _ => unreachable!("dtype gated to F32/BF16 above"),
+    }
 }
 
 // ----------------------------------------------------------------------

--- a/crates/kiln-vulkan-kernel/build.rs
+++ b/crates/kiln-vulkan-kernel/build.rs
@@ -380,6 +380,7 @@ const SHADERS: &[(&str, &str)] = &[
         "SPIR_V_VK_SCALE_INPLACE_F32_OFFSET",
     ),
     ("vk_matmul_batched_f32", "SPIR_V_VK_MATMUL_BATCHED_F32"),
+    ("vk_matmul_batched_bf16", "SPIR_V_VK_MATMUL_BATCHED_BF16"),
     ("vk_transpose_3d_f32", "SPIR_V_VK_TRANSPOSE_3D_F32"),
     (
         "vk_gather_contiguous_f32",

--- a/crates/kiln-vulkan-kernel/csrc/shaders/vk_matmul_batched_bf16.comp
+++ b/crates/kiln-vulkan-kernel/csrc/shaders/vk_matmul_batched_bf16.comp
@@ -1,0 +1,85 @@
+// Batched BF16 matmul: C[b, m, n] = sum_k A[b, m, k] * B[b, k, n]
+//
+// BF16 twin of vk_matmul_batched_f32. Inputs A,B are BF16 (u16 packed two
+// per u32 word, low lane = even logical index); accumulation is F32; the
+// OUTPUT is F32 (one full float per invocation, so there is no inter-lane
+// write race — the caller casts F32→BF16 resident afterwards). This is the
+// attention-core GEMM (Q·Kᵀ, scores·V) for the BF16 inference model.
+//
+// Per-batch [M, K] @ [K, N] → [M, N]. Workgroup grid: (N/16, M/16, batch).
+//
+// Push constants: [batch, M, N, K]
+
+#version 450
+#extension GL_EXT_control_flow_attributes : enable
+
+const uint TILE = 16;
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(push_constant) uniform Parameters {
+    uint batch;
+    uint M;
+    uint N;
+    uint K;
+};
+
+layout(binding = 0) readonly  buffer ABuf { uint a[]; };   // BF16 packed
+layout(binding = 1) readonly  buffer BBuf { uint b[]; };   // BF16 packed
+layout(binding = 2) writeonly buffer CBuf { float c[]; };  // F32 output
+
+shared float tile_a[TILE][TILE];
+shared float tile_b[TILE][TILE];
+
+// Decode the BF16 element at logical index `elem_idx` to F32. BF16 is the
+// high 16 bits of the IEEE-754 F32 bit pattern (so f32 = bits << 16).
+float load_a(uint elem_idx) {
+    uint word = a[elem_idx >> 1u];
+    uint h = ((elem_idx & 1u) == 0u) ? (word & 0xffffu) : (word >> 16u);
+    return uintBitsToFloat(h << 16u);
+}
+
+float load_b(uint elem_idx) {
+    uint word = b[elem_idx >> 1u];
+    uint h = ((elem_idx & 1u) == 0u) ? (word & 0xffffu) : (word >> 16u);
+    return uintBitsToFloat(h << 16u);
+}
+
+void main() {
+    uint bx = gl_WorkGroupID.z;
+    if (bx >= batch) return;
+    uint global_row = gl_GlobalInvocationID.y;
+    uint global_col = gl_GlobalInvocationID.x;
+    uint local_row = gl_LocalInvocationID.y;
+    uint local_col = gl_LocalInvocationID.x;
+
+    uint a_base = bx * M * K;
+    uint b_base = bx * K * N;
+    uint c_base = bx * M * N;
+
+    float acc = 0.0;
+    uint num_tiles = (K + TILE - 1u) / TILE;
+    for (uint t = 0u; t < num_tiles; ++t) {
+        uint a_col = t * TILE + local_col;
+        uint b_row = t * TILE + local_row;
+        if (global_row < M && a_col < K) {
+            tile_a[local_row][local_col] = load_a(a_base + global_row * K + a_col);
+        } else {
+            tile_a[local_row][local_col] = 0.0;
+        }
+        if (b_row < K && global_col < N) {
+            tile_b[local_row][local_col] = load_b(b_base + b_row * N + global_col);
+        } else {
+            tile_b[local_row][local_col] = 0.0;
+        }
+        barrier();
+        [[unroll]] for (uint k = 0u; k < TILE; ++k) {
+            acc += tile_a[local_row][k] * tile_b[k][local_col];
+        }
+        barrier();
+    }
+
+    if (global_row < M && global_col < N) {
+        c[c_base + global_row * N + global_col] = acc;
+    }
+}

--- a/crates/kiln-vulkan-kernel/src/pipeline.rs
+++ b/crates/kiln-vulkan-kernel/src/pipeline.rs
@@ -381,6 +381,7 @@ const SHADER_SPIRVS: &[(&str, &[u8])] = &[
         SPIR_V_VK_SCALE_INPLACE_F32_OFFSET,
     ),
     ("vk_matmul_batched_f32", SPIR_V_VK_MATMUL_BATCHED_F32),
+    ("vk_matmul_batched_bf16", SPIR_V_VK_MATMUL_BATCHED_BF16),
     ("vk_transpose_3d_f32", SPIR_V_VK_TRANSPOSE_3D_F32),
     ("vk_gather_contiguous_f32", SPIR_V_VK_GATHER_CONTIGUOUS_F32),
     ("vk_gather_contiguous_bf16", SPIR_V_VK_GATHER_CONTIGUOUS_BF16),

--- a/crates/kiln-vulkan-kernel/src/vk_ops/matmul_batched.rs
+++ b/crates/kiln-vulkan-kernel/src/vk_ops/matmul_batched.rs
@@ -110,6 +110,69 @@ pub fn vk_matmul_batched_no_grad(a: &VkTensor, b: &VkTensor) -> Result<VkTensor>
     ))
 }
 
+fn dispatch_matmul_batched_bf16(
+    device: &VulkanDevice,
+    a: &VulkanBuffer,
+    b: &VulkanBuffer,
+    out: &VulkanBuffer,
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<()> {
+    let wg_x = ((n + 15) / 16) as u32;
+    let wg_y = ((m + 15) / 16) as u32;
+    let wg_z = batch as u32;
+    let push = [batch as u32, m as u32, n as u32, k as u32];
+    dispatch_3d(
+        device,
+        "vk_matmul_batched_bf16",
+        &[a.handle(), b.handle(), out.handle()],
+        &push,
+        (wg_x, wg_y, wg_z),
+    )
+}
+
+fn check_batched_matmul_bf16(a: &VkTensor, b: &VkTensor) -> Result<(usize, usize, usize, usize)> {
+    anyhow::ensure!(
+        a.shape().len() == 3 && b.shape().len() == 3,
+        "vk_matmul_batched_bf16: rank-3 required, got {:?}/{:?}",
+        a.shape(),
+        b.shape()
+    );
+    anyhow::ensure!(
+        a.dtype() == VkDType::Bf16 && b.dtype() == VkDType::Bf16,
+        "vk_matmul_batched_bf16: BF16-only"
+    );
+    let ba = a.shape()[0];
+    let m = a.shape()[1];
+    let k = a.shape()[2];
+    let bb = b.shape()[0];
+    let kk = b.shape()[1];
+    let n = b.shape()[2];
+    anyhow::ensure!(ba == bb, "batch mismatch: {ba} vs {bb}");
+    anyhow::ensure!(k == kk, "inner-dim mismatch: {k} vs {kk}");
+    Ok((ba, m, n, k))
+}
+
+/// Batched BF16 GEMM: `a`,`b` BF16 `[B,M,K]@[B,K,N]`, returns an **F32**
+/// `[B,M,N]`. BF16 inputs are read (and accumulated) as F32 in-shader; the
+/// output is F32 to avoid an inter-lane write race on the packed BF16 words.
+/// The caller casts F32→BF16 resident (`vulkan_cast`) when a BF16 result is
+/// required — keeping the attention-core GEMM off the host for the BF16
+/// inference model.
+pub fn vk_matmul_batched_bf16_no_grad(a: &VkTensor, b: &VkTensor) -> Result<VkTensor> {
+    let (batch, m, n, k) = check_batched_matmul_bf16(a, b)?;
+    let out = alloc_f32(a.device(), batch * m * n)?;
+    dispatch_matmul_batched_bf16(a.device(), a.buffer(), b.buffer(), &out, batch, m, n, k)?;
+    Ok(VkTensor::from_buffer(
+        out,
+        vec![batch, m, n],
+        VkDType::F32,
+        Arc::clone(a.device()),
+    ))
+}
+
 pub fn vk_transpose_batched_2d_no_grad(t: &VkTensor) -> Result<VkTensor> {
     anyhow::ensure!(
         t.shape().len() == 3,


### PR DESCRIPTION
Removes the last three CPU/bytes round-trips on the Vulkan inference path. Each reuses a proven kernel via the zero-copy `VulkanStorage`↔`VkTensor` bridge — no D2H/H2D.

## What was bouncing → resident

1. **BF16 batched matmul.** `MatmulOp::vulkan_fwd` fell back to CPU for BF16 batched GEMMs. New `vk_matmul_batched_bf16` shader (bf16-packed reads, F32 accumulate, **F32 output** → no inter-lane write race); `vulkan_matmul_batched` casts the F32 result back to BF16 resident; rank≥3 BF16 routes through it.
2. **RMSNorm.** Added a resident arm to `rms_norm`: when the activation is Vulkan-backed, run the fused `qwen_rmsnorm_forward` kernel zero-copy via `vulkan_rmsnorm_last_axis` instead of the CPU-input bytes path (`try_vulkan_rmsnorm_forward`, gated on x-on-CPU) or the multi-dispatch `rms_norm_fallback`. **Same `(1+w)·x·rsqrt(mean(x²)+eps)` shader → bit-identical.**
3. **Prefill SDPA.** `flash_attn_prefill_vulkan` bounced q/k/v to host bytes. For the common single-sequence causal case (batch==1) it now bridges q/k/v zero-copy and runs the fully on-device `vk_sdpa_prefill` (permute → batched matmul → scale → causal-mask → softmax → matmul). batch>1 / non-causal keep the bytes path as a safety net (→ caller's resident naive SDPA on `None`).

## GPU-validated (RTX 3090, driver 580.65.06, NVIDIA Vulkan)

| Kernel | Result |
|---|---|
| BF16 batched matmul (rank-4 attention shape) | `max_abs_err = 0e0` (byte-exact) |
| `qwen_rmsnorm_forward` (rmsnorm tests) | 9 passed |
| `vk_sdpa_prefill` (head_dim 64/128/256 vs CPU) | 3 passed |
| Full kiln-tensor gated suite | **991 passed / 0 failed** |

The wiring is compile-verified and reuses these validated kernels via the same bridge proven in the prior residency PR (#1450). Vulkan-path-only; CPU/CUDA/Metal untouched.

Context: the Vulkan activation path is F32 (`vulkan_cast_activation_to_f32`), so the attention/rmsnorm hot path is F32 (the F32 batched matmul already covers it); the BF16 matmul closes the remaining BF16 batched-GEMM gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)