### PR TITLE
feat(memory): cross-engine dynamic memory governance — driver-counter awareness, governor, reclaim, observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,9 @@ dependencies = [
 [[package]]
 name = "kiln-memory"
 version = "0.2.19"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "kiln-model"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "kiln-hip",
  "kiln-kt-bridge",
  "kiln-marlin-gemm",
+ "kiln-memory",
  "kiln-nvtx",
  "kiln-rmsnorm-kernel",
  "kiln-tensor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "kiln-autograd",
  "kiln-blas",
  "kiln-hip",
+ "kiln-memory",
  "kiln-rocblas",
  "kiln-tensor-id",
  "kiln-vulkan-kernel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiln-memory"
+version = "0.2.19"
+
+[[package]]
 name = "kiln-model"
 version = "0.2.19"
 dependencies = [
@@ -1514,6 +1518,7 @@ dependencies = [
  "kiln-core",
  "kiln-eval",
  "kiln-kt-bridge",
+ "kiln-memory",
  "kiln-model",
  "kiln-scheduler",
  "kiln-tensor",
@@ -1581,6 +1586,7 @@ dependencies = [
  "kiln-eval",
  "kiln-flce-kernel",
  "kiln-kt-bridge",
+ "kiln-memory",
  "kiln-model",
  "kiln-opd-loss-kernel",
  "kiln-optim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/kiln-gdn-kernel",
     "crates/kiln-kt-bridge",
     "crates/kiln-marlin-gemm",
+    "crates/kiln-memory",
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-autograd",
@@ -65,6 +66,7 @@ default-members = [
     # now an optional (default-on) feature so candle-free consumers can
     # opt out with `default-features = false`. (#1082)
     "crates/kiln-kt-bridge",
+    "crates/kiln-memory",
     "crates/kiln-model",
     "crates/kiln-mps",
     "crates/kiln-nvtx",
@@ -159,6 +161,7 @@ kiln-hip = { path = "crates/kiln-hip" }
 kiln-rocblas = { path = "crates/kiln-rocblas" }
 kiln-kt-bridge = { path = "crates/kiln-kt-bridge" }
 kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }
+kiln-memory = { path = "crates/kiln-memory" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }
 kiln-opd-loss-kernel = { path = "crates/kiln-opd-loss-kernel" }
 kiln-rmsnorm-kernel = { path = "crates/kiln-rmsnorm-kernel" }

--- a/crates/kiln-core/src/block.rs
+++ b/crates/kiln-core/src/block.rs
@@ -85,26 +85,109 @@ impl BlockManager {
         let in_circulation = self.num_blocks - self.retired_blocks.len();
         if in_circulation > target {
             // Shrink: retire free blocks (in-use ones retire on free in free_one).
+            // Retire the HIGHEST free block IDs first so the pool's tail clears,
+            // making a subsequent physical truncate (#26 `physical_truncate`)
+            // possible — the dead region we hand back to the OS must be the tail
+            // `[new_num_blocks, num_blocks)`, never a hole in the middle.
             let to_retire = (in_circulation - target).min(self.free_blocks.len());
-            for _ in 0..to_retire {
-                if let Some(id) = self.free_blocks.pop_front() {
+            if to_retire > 0 {
+                let mut ids: Vec<u32> = self.free_blocks.iter().copied().collect();
+                ids.sort_unstable();
+                let keep = ids.len() - to_retire;
+                for &id in &ids[keep..] {
                     self.retired_blocks.push_back(id);
                 }
+                // Keep the free list low-ID-biased so allocation reuses low
+                // blocks first, which also helps keep the tail clear.
+                self.free_blocks = ids[..keep].iter().copied().collect();
             }
         } else if in_circulation < target {
-            // Grow: bring retired blocks back into circulation.
+            // Grow: bring retired blocks back into circulation, lowest IDs first
+            // so the usable range extends contiguously up from the live region.
             let to_restore = target - in_circulation;
-            for _ in 0..to_restore {
-                if let Some(id) = self.retired_blocks.pop_front() {
+            if to_restore > 0 && !self.retired_blocks.is_empty() {
+                let mut ids: Vec<u32> = self.retired_blocks.iter().copied().collect();
+                ids.sort_unstable();
+                let restore = to_restore.min(ids.len());
+                for &id in &ids[..restore] {
                     self.free_blocks.push_back(id);
-                } else {
-                    break;
                 }
+                self.retired_blocks = ids[restore..].iter().copied().collect();
             }
         }
         // After a shrink that couldn't fully complete (in-use > target), the
         // effective ceiling is what's actually in circulation.
         (self.num_blocks - self.retired_blocks.len()).max(in_use)
+    }
+
+    /// Highest physical block ID currently held by a live request (in-use),
+    /// or `None` if nothing is in use. In-use blocks are those neither free nor
+    /// retired. This is the high-water mark that bounds how far the physical
+    /// pool may be truncated — the tensor tail above this ID holds no live KV.
+    pub fn highest_in_use_block(&self) -> Option<u32> {
+        if self.num_used() == 0 {
+            return None;
+        }
+        let free: std::collections::HashSet<u32> = self.free_blocks.iter().copied().collect();
+        let retired: std::collections::HashSet<u32> =
+            self.retired_blocks.iter().copied().collect();
+        (0..self.num_blocks as u32)
+            .rev()
+            .find(|id| !free.contains(id) && !retired.contains(id))
+    }
+
+    /// Smallest `num_blocks` the physical pool could shrink to RIGHT NOW without
+    /// dropping any live KV: `highest_in_use_block + 1` (0 if nothing is in use).
+    /// A physical truncate to any value `>=` this floor is sound; below it would
+    /// orphan a live request's blocks. Distinct from `target_usable` (logical).
+    pub fn physical_floor(&self) -> usize {
+        self.highest_in_use_block().map_or(0, |id| id as usize + 1)
+    }
+
+    /// Physically shrink the manager's block space to `new_num_blocks`, dropping
+    /// the tail `[new_num_blocks, num_blocks)` from the free/retired lists. The
+    /// CALLER must realloc the backing KV pool tensor to match in lockstep
+    /// ([`PagedKvCacheKt::physical_resize_to`]).
+    ///
+    /// Sound only when the tail holds no live request — fails with `OutOfMemory`
+    /// (repurposed: "tail still in use") if `physical_floor() > new_num_blocks`.
+    /// Drive a logical [`set_target_usable`] shrink first and let it drain, then
+    /// truncate once `physical_floor()` has dropped to the target.
+    pub fn physical_truncate(&mut self, new_num_blocks: usize) -> Result<(), BlockError> {
+        if new_num_blocks >= self.num_blocks {
+            return Ok(());
+        }
+        let floor = self.physical_floor();
+        if floor > new_num_blocks {
+            return Err(BlockError::OutOfMemory {
+                needed: floor,
+                available: new_num_blocks,
+            });
+        }
+        let cap = new_num_blocks as u32;
+        self.free_blocks.retain(|&id| id < cap);
+        self.retired_blocks.retain(|&id| id < cap);
+        self.num_blocks = new_num_blocks;
+        self.target_usable = self.target_usable.min(new_num_blocks);
+        Ok(())
+    }
+
+    /// Physically grow the block space to `new_num_blocks`, adding the new tail
+    /// `[num_blocks, new_num_blocks)` as free (or retired, if above the current
+    /// `target_usable` ceiling). The CALLER must realloc the KV pool tensor to
+    /// match in lockstep. No-op if `new_num_blocks <= num_blocks`.
+    pub fn physical_grow(&mut self, new_num_blocks: usize) {
+        if new_num_blocks <= self.num_blocks {
+            return;
+        }
+        for id in self.num_blocks as u32..new_num_blocks as u32 {
+            if (id as usize) < self.target_usable {
+                self.free_blocks.push_back(id);
+            } else {
+                self.retired_blocks.push_back(id);
+            }
+        }
+        self.num_blocks = new_num_blocks;
     }
 
     /// Allocate a single block. Returns the physical block ID.
@@ -357,6 +440,61 @@ mod tests {
         assert_eq!(bm.num_retired(), 6);
         assert_eq!(bm.num_free(), 4);
         assert_eq!(bm.num_used(), 0);
+    }
+
+    #[test]
+    fn shrink_retires_highest_ids_so_tail_clears() {
+        let mut bm = BlockManager::new(10, 16);
+        // All 10 free. Shrink to 6 must retire the HIGHEST 4 ids (6,7,8,9) so
+        // the pool tail clears and a physical truncate to 6 becomes sound.
+        bm.set_target_usable(6);
+        assert_eq!(bm.num_retired(), 4);
+        // Nothing in use, so the physical floor is 0 and we can truncate to 6.
+        assert_eq!(bm.physical_floor(), 0);
+        bm.physical_truncate(6).expect("tail is clear");
+        assert_eq!(bm.num_blocks(), 6);
+        assert_eq!(bm.num_retired(), 0); // retired ids 6..10 dropped with the tail
+        assert_eq!(bm.num_free(), 6);
+        // Every surviving id is < 6 — no orphaned high block.
+        for _ in 0..6 {
+            assert!(bm.allocate_one().unwrap() < 6);
+        }
+    }
+
+    #[test]
+    fn physical_truncate_blocked_by_live_tail_then_succeeds_after_drain() {
+        let mut bm = BlockManager::new(8, 16);
+        // Hold ids 0..6 (front-pop), leaving 6,7 free.
+        let held = bm.allocate(6).unwrap();
+        // Logical shrink to 4: retire the highest free ids (6,7).
+        bm.set_target_usable(4);
+        assert_eq!(bm.num_retired(), 2);
+        // A live block still sits at id 5 → floor is 6, can't truncate to 4 yet.
+        assert_eq!(bm.physical_floor(), 6);
+        assert!(bm.physical_truncate(4).is_err());
+        // Drain the high holders (ids 4,5) — they retire (target not yet met).
+        bm.free_all(&held[4..6]);
+        assert_eq!(bm.physical_floor(), 4); // ids 0..4 still live
+        bm.physical_truncate(4).expect("tail clear after drain");
+        assert_eq!(bm.num_blocks(), 4);
+        assert_eq!(bm.num_used(), 4);
+    }
+
+    #[test]
+    fn physical_grow_restores_capacity_and_round_trips() {
+        let mut bm = BlockManager::new(6, 16);
+        bm.set_target_usable(4);
+        bm.physical_truncate(4).unwrap();
+        assert_eq!(bm.num_blocks(), 4);
+        // Grow back to 10: add physical capacity FIRST (set_target_usable is
+        // clamped to num_blocks), then raise the logical ceiling to make the new
+        // blocks usable. The new ids 4..10 land retired (above the old ceiling),
+        // then the ceiling-raise un-retires them into the free list.
+        bm.physical_grow(10);
+        assert_eq!(bm.num_blocks(), 10);
+        bm.set_target_usable(10);
+        assert_eq!(bm.num_retired(), 0);
+        assert!(bm.can_allocate(10));
     }
 
     #[test]

--- a/crates/kiln-core/src/block.rs
+++ b/crates/kiln-core/src/block.rs
@@ -17,6 +17,14 @@ pub struct BlockManager {
     block_size: usize,
     num_blocks: usize,
     free_blocks: VecDeque<u32>,
+    /// Blocks taken OUT of circulation by a dynamic shrink (the memory governor
+    /// lowering the inference KV footprint so a coexisting job / training run can
+    /// use that VRAM). They are neither free nor in-use — `set_target_usable`
+    /// restores them when memory pressure eases. Empty in steady state.
+    retired_blocks: VecDeque<u32>,
+    /// The dynamic logical capacity: at most this many blocks may be in
+    /// circulation (free + in-use). `<= num_blocks`; defaults to `num_blocks`.
+    target_usable: usize,
 }
 
 impl BlockManager {
@@ -26,6 +34,8 @@ impl BlockManager {
             block_size,
             num_blocks,
             free_blocks,
+            retired_blocks: VecDeque::new(),
+            target_usable: num_blocks,
         }
     }
 
@@ -42,7 +52,59 @@ impl BlockManager {
     }
 
     pub fn num_used(&self) -> usize {
-        self.num_blocks - self.free_blocks.len()
+        self.num_blocks - self.free_blocks.len() - self.retired_blocks.len()
+    }
+
+    /// Blocks currently retired (out of circulation) by a dynamic shrink.
+    pub fn num_retired(&self) -> usize {
+        self.retired_blocks.len()
+    }
+
+    /// Current dynamic capacity (free + in-use ceiling). `<= num_blocks`.
+    pub fn target_usable(&self) -> usize {
+        self.target_usable
+    }
+
+    /// Dynamically resize the inference KV footprint to `target` usable blocks
+    /// (clamped to `[blocks_in_use, num_blocks]` — we never retire a block a live
+    /// request still holds). SHRINK retires free blocks immediately; any excess
+    /// in-use blocks retire automatically as their request frees them. GROW
+    /// returns retired blocks to the free list. Returns the achieved
+    /// `target_usable` (may exceed `target` if in-use blocks block a full shrink).
+    ///
+    /// This is the actuator the memory governor drives: under pressure it shrinks
+    /// so kiln hands VRAM back; when pressure eases it grows again. Safe to call
+    /// concurrently with serving — in-flight requests are never disrupted.
+    pub fn set_target_usable(&mut self, target: usize) -> usize {
+        let in_use = self.num_used();
+        // Store the REQUESTED target (only bounded by num_blocks) so a shrink
+        // below the current in-use count keeps retiring blocks as requests drain,
+        // via free_one/free_all — rather than being lost to an up-front clamp.
+        let target = target.min(self.num_blocks);
+        self.target_usable = target;
+        let in_circulation = self.num_blocks - self.retired_blocks.len();
+        if in_circulation > target {
+            // Shrink: retire free blocks (in-use ones retire on free in free_one).
+            let to_retire = (in_circulation - target).min(self.free_blocks.len());
+            for _ in 0..to_retire {
+                if let Some(id) = self.free_blocks.pop_front() {
+                    self.retired_blocks.push_back(id);
+                }
+            }
+        } else if in_circulation < target {
+            // Grow: bring retired blocks back into circulation.
+            let to_restore = target - in_circulation;
+            for _ in 0..to_restore {
+                if let Some(id) = self.retired_blocks.pop_front() {
+                    self.free_blocks.push_back(id);
+                } else {
+                    break;
+                }
+            }
+        }
+        // After a shrink that couldn't fully complete (in-use > target), the
+        // effective ceiling is what's actually in circulation.
+        (self.num_blocks - self.retired_blocks.len()).max(in_use)
     }
 
     /// Allocate a single block. Returns the physical block ID.
@@ -67,9 +129,16 @@ impl BlockManager {
             .collect())
     }
 
-    /// Free a single block, returning it to the free list.
+    /// Free a single block. Normally returns it to the free list, but if a
+    /// pending dynamic shrink left circulation above `target_usable`, the block
+    /// is RETIRED instead (this is how an in-use-blocked shrink completes as
+    /// requests drain).
     pub fn free_one(&mut self, block_id: u32) {
-        self.free_blocks.push_back(block_id);
+        if self.num_blocks - self.retired_blocks.len() > self.target_usable {
+            self.retired_blocks.push_back(block_id);
+        } else {
+            self.free_blocks.push_back(block_id);
+        }
     }
 
     /// Free multiple blocks.
@@ -94,7 +163,13 @@ impl BlockManager {
             "BlockManager::free_all called with block IDs already on the free list: incoming={block_ids:?}",
         );
         for &id in block_ids {
-            self.free_blocks.push_back(id);
+            // Retire instead of free while a pending shrink keeps circulation
+            // above the target (see free_one).
+            if self.num_blocks - self.retired_blocks.len() > self.target_usable {
+                self.retired_blocks.push_back(id);
+            } else {
+                self.free_blocks.push_back(id);
+            }
         }
     }
 
@@ -243,6 +318,45 @@ mod tests {
 
         bm.free_all(&blocks);
         assert_eq!(bm.num_free(), 10);
+    }
+
+    #[test]
+    fn dynamic_shrink_retires_free_blocks_and_grow_restores() {
+        let mut bm = BlockManager::new(10, 16);
+        // Shrink to 6 usable: 4 free blocks retired, only 6 allocatable.
+        let achieved = bm.set_target_usable(6);
+        assert_eq!(achieved, 6);
+        assert_eq!(bm.num_retired(), 4);
+        assert_eq!(bm.num_free(), 6);
+        assert!(!bm.can_allocate(7));
+        assert!(bm.can_allocate(6));
+        // Grow back to 10: retired blocks return to free.
+        let achieved = bm.set_target_usable(10);
+        assert_eq!(achieved, 10);
+        assert_eq!(bm.num_retired(), 0);
+        assert_eq!(bm.num_free(), 10);
+    }
+
+    #[test]
+    fn dynamic_shrink_blocked_by_in_use_completes_as_requests_drain() {
+        let mut bm = BlockManager::new(10, 16);
+        // 8 blocks in use, 2 free. Ask to shrink to 4 — we can only retire the
+        // 2 free now; the in-use blocks retire as they free (never yanked).
+        let held = bm.allocate(8).unwrap();
+        let achieved = bm.set_target_usable(4);
+        assert_eq!(achieved, 8, "can't go below in-use count yet");
+        assert_eq!(bm.num_retired(), 2); // the 2 free blocks retired immediately
+        assert_eq!(bm.num_free(), 0);
+        // Drain 4 of the held blocks -> they retire (not freed) until target met.
+        bm.free_all(&held[0..4]);
+        assert_eq!(bm.num_retired(), 6); // 2 + 4 retired -> circulation now 4
+        assert_eq!(bm.num_used(), 4);
+        assert_eq!(bm.num_free(), 0);
+        // Freeing the rest now returns to the free list (target reached).
+        bm.free_all(&held[4..8]);
+        assert_eq!(bm.num_retired(), 6);
+        assert_eq!(bm.num_free(), 4);
+        assert_eq!(bm.num_used(), 0);
     }
 
     #[test]

--- a/crates/kiln-core/src/lib.rs
+++ b/crates/kiln-core/src/lib.rs
@@ -8,7 +8,6 @@ pub mod request;
 pub mod sampling;
 pub mod token;
 pub mod tokenizer;
-pub mod vram;
 
 pub use block::{BlockManager, BlockTable};
 pub use config::ModelConfig;

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -344,6 +344,109 @@ pub fn detect_used_vram_bytes() -> Option<u64> {
     (info.used_bytes > 0).then_some(info.used_bytes)
 }
 
+/// A point-in-time snapshot of the memory pool the accelerator actually
+/// allocates from — the single backend-agnostic primitive kiln's memory
+/// awareness is built on. Every engine (CUDA / ROCm / Metal / Vulkan) consults
+/// the SAME probe, so the system is uniformly aware regardless of which backend
+/// is compiled in.
+///
+/// The crucial nuance is `unified`: on a discrete GPU `free_bytes` is the GPU's
+/// own VRAM headroom, but on a unified-memory APU (AMD Strix Halo) or Apple
+/// Silicon, GPU allocations come out of **system RAM**, so the meaningful free
+/// figure is the host's `MemAvailable`, not a BIOS-reported VRAM carveout. Sizing
+/// against the carveout there would happily over-commit system RAM and OOM the
+/// box. This probe gets that right so "be mindful of VRAM on whatever the user
+/// is running" holds on every device class.
+#[derive(Debug, Clone, Copy)]
+pub struct MemorySnapshot {
+    /// Total memory addressable by the accelerator (unified-corrected on APUs).
+    pub total_bytes: u64,
+    /// Currently-used bytes (`total - free`).
+    pub used_bytes: u64,
+    /// Free bytes available to allocate RIGHT NOW.
+    pub free_bytes: u64,
+    /// Provenance of the figures.
+    pub source: VramSource,
+    /// Whether the accelerator shares system RAM (APU / Apple Silicon). When
+    /// true, `free_bytes` tracks host `MemAvailable` and allocations contend
+    /// with the rest of the OS.
+    pub unified: bool,
+}
+
+/// Take a live snapshot of accelerator memory: total, used, and free, with the
+/// unified-memory correction applied. This is the keystone of kiln's dynamic
+/// memory awareness — KV-cache sizing, graph-capture headroom checks, the
+/// training/inference budget arbiter, and allocator pressure response all read
+/// from here, so the whole system reacts to the SAME live figure on every
+/// backend (including coexisting GPU workloads, since the probe is OS-level).
+pub fn current_memory_snapshot() -> MemorySnapshot {
+    let total = detect_vram();
+    let unified = matches!(
+        total.source,
+        VramSource::LinuxDrmSysfsUnified | VramSource::AppleSilicon
+    );
+
+    // Unified memory: free is the host's available RAM (capped at our corrected
+    // budget), because GPU allocations are system-RAM allocations there.
+    if unified {
+        #[cfg(target_os = "linux")]
+        if let Some(avail) =
+            query_meminfo_available_bytes_at(std::path::Path::new("/proc/meminfo"))
+        {
+            let free = avail.min(total.total_bytes);
+            return MemorySnapshot {
+                total_bytes: total.total_bytes,
+                used_bytes: total.total_bytes.saturating_sub(free),
+                free_bytes: free,
+                source: total.source,
+                unified: true,
+            };
+        }
+        // macOS unified / meminfo unavailable: fall through to the used-probe.
+    }
+
+    // Discrete GPU (or unified fallback): free = total − currently-used.
+    let used = detect_used_vram();
+    let used_bytes = used.used_bytes;
+    let free = total.total_bytes.saturating_sub(used_bytes);
+    MemorySnapshot {
+        total_bytes: total.total_bytes,
+        used_bytes,
+        free_bytes: free,
+        source: if used.source != VramSource::None {
+            used.source
+        } else {
+            total.source
+        },
+        unified,
+    }
+}
+
+/// Free accelerator memory in bytes right now (0 if undetectable). Thin
+/// convenience over [`current_memory_snapshot`].
+pub fn current_free_bytes() -> u64 {
+    current_memory_snapshot().free_bytes
+}
+
+/// Read `MemAvailable` (the kernel's estimate of allocatable RAM without
+/// swapping) from a `/proc/meminfo`-format file. This is the right "free"
+/// figure for unified-memory accelerators, where GPU buffers are backed by
+/// system RAM.
+#[cfg(target_os = "linux")]
+fn query_meminfo_available_bytes_at(path: &std::path::Path) -> Option<u64> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            let kib: u64 = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse().ok())?;
+            return Some(kib * 1024);
+        }
+    }
+    None
+}
+
 /// Query total GPU memory via nvidia-smi.
 ///
 /// Runs `nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits`
@@ -1330,6 +1433,39 @@ mod tests {
             Some(32_479_448u64 * 1024)
         );
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_meminfo_available_parser() {
+        let path = std::env::temp_dir().join(format!(
+            "kiln-meminfo-avail-test-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(
+            &path,
+            "MemTotal:       32479448 kB\nMemFree:  1000000 kB\nMemAvailable:   27571892 kB\n",
+        )
+        .unwrap();
+        assert_eq!(
+            query_meminfo_available_bytes_at(&path),
+            Some(27_571_892u64 * 1024)
+        );
+        // Missing MemAvailable -> None (older kernels; caller falls back).
+        std::fs::write(&path, "MemTotal: 100 kB\n").unwrap();
+        assert_eq!(query_meminfo_available_bytes_at(&path), None);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn current_memory_snapshot_is_internally_consistent() {
+        // Whatever the host reports, the snapshot's arithmetic must hold:
+        // used + free == total, and free <= total. (On CI runners with no GPU
+        // total may be 0, in which case all three are 0 — still consistent.)
+        let s = current_memory_snapshot();
+        assert_eq!(s.used_bytes.saturating_add(s.free_bytes), s.total_bytes);
+        assert!(s.free_bytes <= s.total_bytes);
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/kiln-hip/src/lib.rs
+++ b/crates/kiln-hip/src/lib.rs
@@ -206,6 +206,46 @@ impl RocmContext {
         Ok(())
     }
 
+    /// `(reserved, used)` bytes of THIS device's default stream-ordered memory
+    /// pool: `reserved` = total VRAM the pool currently holds from the OS (its
+    /// high-water mark, since we pin the release threshold), `used` = bytes
+    /// actively allocated out of it right now. `reserved - used` is pooled-free
+    /// memory available for reuse WITHOUT a new OS reservation.
+    ///
+    /// Unlike the DRM/`hipMemGetInfo` counters, these are PROCESS-ISOLATED — they
+    /// measure only kiln's pool, immune to a coexisting llama-server etc. This is
+    /// the right signal for "did a freed KV pool get reused vs grow our
+    /// footprint": a reuse leaves `reserved` flat; a leak grows it. Returns
+    /// `(0,0)` if the runtime lacks mempools.
+    pub fn pool_stats(&self) -> Result<(u64, u64)> {
+        self.bind_to_thread()?;
+        const HIP_MEM_POOL_ATTR_RESERVED_MEM_CURRENT: c_uint = 5;
+        const HIP_MEM_POOL_ATTR_USED_MEM_CURRENT: c_uint = 7;
+        let mut pool: *mut c_void = ptr::null_mut();
+        if unsafe { sys::hipDeviceGetDefaultMemPool(&mut pool, self.ordinal) } != sys::HIP_SUCCESS
+            || pool.is_null()
+        {
+            return Ok((0, 0));
+        }
+        let mut reserved: u64 = 0;
+        let mut used: u64 = 0;
+        let _ = unsafe {
+            sys::hipMemPoolGetAttribute(
+                pool,
+                HIP_MEM_POOL_ATTR_RESERVED_MEM_CURRENT,
+                &mut reserved as *mut u64 as *mut c_void,
+            )
+        };
+        let _ = unsafe {
+            sys::hipMemPoolGetAttribute(
+                pool,
+                HIP_MEM_POOL_ATTR_USED_MEM_CURRENT,
+                &mut used as *mut u64 as *mut c_void,
+            )
+        };
+        Ok((reserved, used))
+    }
+
     /// Device-reported `(free, total)` bytes via `hipMemGetInfo`. On a discrete
     /// GPU this is the driver's own view; on a unified APU it reflects the GTT
     /// budget and is best cross-checked against the OS-level `kiln-memory` probe.

--- a/crates/kiln-hip/src/lib.rs
+++ b/crates/kiln-hip/src/lib.rs
@@ -183,6 +183,43 @@ impl RocmContext {
         self.default_stream.clone()
     }
 
+    /// Return pooled-but-unused VRAM to the OS, keeping at least
+    /// `min_keep_bytes` cached for fast reuse. This is how kiln gives memory
+    /// back when a coexisting process needs it (the pool otherwise hoards freed
+    /// blocks via the release-threshold pin, by design, to avoid the async-free
+    /// decode race).
+    ///
+    /// **Synchronizes the device first** so no in-flight kernel is reading a
+    /// block being released — that's what makes the trim race-free, unlike the
+    /// automatic threshold-0 release the pin disables. Best-effort: a no-op if
+    /// the runtime lacks mempools.
+    pub fn trim_pool(&self, min_keep_bytes: usize) -> Result<()> {
+        self.bind_to_thread()?;
+        // Drain in-flight work so freed pages aren't yanked from under a kernel.
+        check(unsafe { sys::hipDeviceSynchronize() }, "hipDeviceSynchronize")?;
+        let mut pool: *mut c_void = ptr::null_mut();
+        if unsafe { sys::hipDeviceGetDefaultMemPool(&mut pool, self.ordinal) } == sys::HIP_SUCCESS
+            && !pool.is_null()
+        {
+            let _ = unsafe { sys::hipMemPoolTrimTo(pool, min_keep_bytes) };
+        }
+        Ok(())
+    }
+
+    /// Device-reported `(free, total)` bytes via `hipMemGetInfo`. On a discrete
+    /// GPU this is the driver's own view; on a unified APU it reflects the GTT
+    /// budget and is best cross-checked against the OS-level `kiln-memory` probe.
+    pub fn mem_get_info(&self) -> Result<(usize, usize)> {
+        self.bind_to_thread()?;
+        let mut free: usize = 0;
+        let mut total: usize = 0;
+        check(
+            unsafe { sys::hipMemGetInfo(&mut free, &mut total) },
+            "hipMemGetInfo",
+        )?;
+        Ok((free, total))
+    }
+
     /// Create a fresh non-blocking stream bound to this device.
     pub fn new_stream(&self) -> Result<Arc<RocmStream>> {
         self.bind_to_thread()?;

--- a/crates/kiln-hip/src/sys.rs
+++ b/crates/kiln-hip/src/sys.rs
@@ -68,6 +68,14 @@ unsafe extern "C" {
         attr: c_uint,
         value: *mut c_void,
     ) -> hipError_t;
+    // Read a pool attribute (e.g. ReservedMemCurrent / UsedMemCurrent). The
+    // process-isolated way to measure how much VRAM kiln's own pool reserves vs
+    // actively uses — immune to coexisting processes (unlike the DRM counters).
+    pub fn hipMemPoolGetAttribute(
+        pool: *mut c_void,
+        attr: c_uint,
+        value: *mut c_void,
+    ) -> hipError_t;
     // Release pooled-but-unused memory back to the OS, keeping at least
     // `min_bytes_to_hold` cached. Safe to call only when no in-flight work is
     // touching the freed blocks (i.e. after a device/stream sync) — that's how

--- a/crates/kiln-hip/src/sys.rs
+++ b/crates/kiln-hip/src/sys.rs
@@ -68,6 +68,15 @@ unsafe extern "C" {
         attr: c_uint,
         value: *mut c_void,
     ) -> hipError_t;
+    // Release pooled-but-unused memory back to the OS, keeping at least
+    // `min_bytes_to_hold` cached. Safe to call only when no in-flight work is
+    // touching the freed blocks (i.e. after a device/stream sync) — that's how
+    // we return VRAM to the OS / a coexisting process without re-introducing the
+    // async-free decode race that the release-threshold pin prevents.
+    pub fn hipMemPoolTrimTo(pool: *mut c_void, min_bytes_to_hold: usize) -> hipError_t;
+    // Free/total device memory (the device-API counterpart to the OS-level
+    // sysfs probe). Useful for a discrete-GPU cross-check.
+    pub fn hipMemGetInfo(free: *mut usize, total: *mut usize) -> hipError_t;
     pub fn hipMemcpyHtoDAsync(
         dst: *mut c_void,
         src: *mut c_void,

--- a/crates/kiln-memory/Cargo.toml
+++ b/crates/kiln-memory/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kiln-memory"
+description = "Kiln's cross-engine memory awareness — VRAM/RAM probing, the memory governor, pressure signals, and the training/inference budget arbiter. Backend-agnostic by design (OS-level probes), so every engine reads the same live figures."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+
+# Deliberately dependency-light: the memory probes are pure std (sysfs /
+# nvidia-smi / sysctl), so this crate sits at the very bottom of the workspace
+# graph and can be depended on by kiln-tensor / kiln-model / kiln-train /
+# kiln-server without cycles.
+[dependencies]

--- a/crates/kiln-memory/Cargo.toml
+++ b/crates/kiln-memory/Cargo.toml
@@ -7,7 +7,9 @@ edition.workspace = true
 license.workspace = true
 
 # Deliberately dependency-light: the memory probes are pure std (sysfs /
-# nvidia-smi / sysctl), so this crate sits at the very bottom of the workspace
-# graph and can be depended on by kiln-tensor / kiln-model / kiln-train /
-# kiln-server without cycles.
+# nvidia-smi / sysctl). `tracing` is the one dep (ubiquitous, no kiln edges) so
+# the governor's background pressure monitor can log reclaim events. The crate
+# still sits at the bottom of the workspace graph — depended on by kiln-tensor /
+# kiln-model / kiln-train / kiln-server without cycles.
 [dependencies]
+tracing = { workspace = true }

--- a/crates/kiln-memory/src/governor.rs
+++ b/crates/kiln-memory/src/governor.rs
@@ -18,9 +18,14 @@
 //! is available via [`MemoryGovernor::global`] so the allocator and other
 //! deep-in-the-stack callers can consult it without threading an `Arc` around.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
+
+/// A reclaim hook: "release up to `target` bytes of pooled/cached device memory
+/// back to the OS; return how much you freed (0 if unknown/none)." Registered by
+/// the allocator layer; invoked by the governor under memory pressure.
+pub type Reclaimer = Box<dyn Fn(u64) -> u64 + Send + Sync>;
 
 use crate::vram::{current_memory_snapshot, MemorySnapshot};
 
@@ -130,6 +135,11 @@ pub struct MemoryGovernor {
     /// subtracted from `available_bytes` so two consumers can't both plan to
     /// use the same free bytes. Released via the [`Reservation`] guard.
     soft_reserved: AtomicU64,
+    /// Reclaim hooks registered by the allocator layer (return pooled VRAM to
+    /// the OS). Invoked under pressure by [`Self::reclaim`] / the monitor.
+    reclaimers: Mutex<Vec<Reclaimer>>,
+    /// Guards [`Self::start_monitor`] against spawning more than one thread.
+    monitor_started: AtomicBool,
 }
 
 impl MemoryGovernor {
@@ -145,6 +155,8 @@ impl MemoryGovernor {
                 sampled_at: Instant::now(),
             }),
             soft_reserved: AtomicU64::new(0),
+            reclaimers: Mutex::new(Vec::new()),
+            monitor_started: AtomicBool::new(false),
         }
     }
 
@@ -231,6 +243,80 @@ impl MemoryGovernor {
 
     pub fn config(&self) -> &GovernorConfig {
         &self.cfg
+    }
+
+    /// Register a reclaim hook (the allocator layer's "return pooled VRAM to the
+    /// OS" function). Invoked under memory pressure so kiln gives memory back to
+    /// a coexisting process instead of hoarding it. Multiple hooks may register
+    /// (e.g. one per device pool); they're called in registration order.
+    pub fn register_reclaimer<F: Fn(u64) -> u64 + Send + Sync + 'static>(&self, f: F) {
+        self.reclaimers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(Box::new(f));
+    }
+
+    /// Invoke registered reclaimers to free up to `target_bytes`, then re-probe.
+    /// Returns total bytes freed (best-effort; a hook may report 0 if it can't
+    /// measure). A no-op with no reclaimers registered.
+    pub fn reclaim(&self, target_bytes: u64) -> u64 {
+        let mut freed = 0u64;
+        {
+            let hooks = self.reclaimers.lock().unwrap_or_else(|e| e.into_inner());
+            for hook in hooks.iter() {
+                if freed >= target_bytes {
+                    break;
+                }
+                freed = freed.saturating_add(hook(target_bytes.saturating_sub(freed)));
+            }
+        }
+        if freed > 0 {
+            self.refresh(); // ground truth after returning memory to the OS
+        }
+        freed
+    }
+
+    /// Reclaim only if under memory pressure (Tight/Critical) — the policy the
+    /// background monitor applies. Targets enough to climb back to the
+    /// comfortable free fraction. Returns bytes freed (0 if not needed).
+    pub fn maybe_reclaim(&self) -> u64 {
+        if !self.pressure().should_reclaim() {
+            return 0;
+        }
+        let s = self.snapshot();
+        let want_free = ((s.total_bytes as f64) * self.cfg.comfortable_frac) as u64;
+        let target = want_free.saturating_sub(s.free_bytes).max(1);
+        self.reclaim(target)
+    }
+
+    /// Spawn a background thread that watches pressure and auto-reclaims, turning
+    /// the one-shot probe into *continuous* self-adjustment: if a coexisting job
+    /// (or kiln itself) drives memory tight, kiln returns pooled VRAM to the OS
+    /// without anyone asking. Idempotent — starts at most one thread. Requires a
+    /// `'static` governor (use [`MemoryGovernor::global`]).
+    pub fn start_monitor(&'static self) {
+        if self.monitor_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let interval = self.cfg.ttl.max(Duration::from_secs(2));
+        std::thread::Builder::new()
+            .name("kiln-mem-governor".into())
+            .spawn(move || loop {
+                std::thread::sleep(interval);
+                let pressure = self.pressure();
+                if pressure.should_reclaim() {
+                    let freed = self.maybe_reclaim();
+                    let s = self.snapshot();
+                    tracing::info!(
+                        ?pressure,
+                        freed_mb = freed / (1024 * 1024),
+                        free_gb = s.free_bytes as f64 / 1e9,
+                        total_gb = s.total_bytes as f64 / 1e9,
+                        "memory governor: reclaimed under pressure"
+                    );
+                }
+            })
+            .ok();
     }
 }
 
@@ -401,6 +487,44 @@ mod tests {
         assert_eq!(g.pressure(), MemoryPressure::Tight); // 2/24 = 8.3% <= 10%
         assert!(g.pressure().should_reclaim());
         assert!(!g.can_fit(5 * GB));
+    }
+
+    #[test]
+    fn reclaim_invokes_hooks_under_pressure_and_recovers() {
+        let src = std::sync::Arc::new(Fixed::new(24 * GB, GB)); // 1/24 ≈ 4% -> Critical
+        struct Shared(std::sync::Arc<Fixed>);
+        impl MemorySource for Shared {
+            fn probe(&self) -> MemorySnapshot {
+                self.0.probe()
+            }
+        }
+        let cfg = GovernorConfig {
+            ttl: Duration::from_millis(0),
+            ..GovernorConfig::default()
+        };
+        let g = MemoryGovernor::with_source(Box::new(Shared(src.clone())), cfg);
+        assert!(g.pressure().should_reclaim());
+
+        // A reclaimer that "returns memory to the OS" — modelled as free jumping
+        // back up — and reports the bytes it freed.
+        let calls = std::sync::Arc::new(AtomicU64::new(0));
+        let (src2, calls2) = (src.clone(), calls.clone());
+        g.register_reclaimer(move |target| {
+            calls2.fetch_add(1, Ordering::SeqCst);
+            src2.set_free(12 * GB);
+            target
+        });
+
+        let freed = g.maybe_reclaim();
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "reclaimer must be invoked");
+        assert!(freed > 0);
+        // The post-reclaim re-probe sees the freed memory -> back to comfortable.
+        assert_eq!(g.pressure(), MemoryPressure::Comfortable);
+
+        // No pressure -> reclaimer NOT called again.
+        let freed2 = g.maybe_reclaim();
+        assert_eq!(freed2, 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/kiln-memory/src/governor.rs
+++ b/crates/kiln-memory/src/governor.rs
@@ -1,0 +1,426 @@
+//! The [`MemoryGovernor`] — continuous, cross-engine memory awareness.
+//!
+//! [`crate::vram::current_memory_snapshot`] answers "how much memory is free
+//! *right now*", but calling it on every allocation would be wasteful (it spawns
+//! `nvidia-smi` / reads sysfs). The governor wraps it in a cheap-to-read,
+//! TTL-cached view and layers on the two things every other subsystem needs:
+//!
+//! * a **pressure level** ([`MemoryPressure`]) derived from the live free
+//!   fraction, so allocators / the KV sizer / the arbiter can react *before*
+//!   they hit an OOM, and
+//! * an **available-budget** calculation that respects a safety floor and any
+//!   *soft reservations* — memory a consumer has announced it's about to need
+//!   (e.g. a training job's activation peak) but hasn't allocated yet, so it
+//!   doesn't get double-handed-out to inference in the meantime.
+//!
+//! It is backend-agnostic: it only ever reads [`MemorySnapshot`]s, which are
+//! themselves OS-level and unified-memory-aware. A single process-wide instance
+//! is available via [`MemoryGovernor::global`] so the allocator and other
+//! deep-in-the-stack callers can consult it without threading an `Arc` around.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::vram::{current_memory_snapshot, MemorySnapshot};
+
+/// Source of [`MemorySnapshot`]s. Abstracted so tests can drive the governor
+/// with synthetic memory states (no GPU required) and so an integration could
+/// later swap in a device-API probe (`hipMemGetInfo`/`cudaMemGetInfo`) without
+/// touching the governor itself.
+pub trait MemorySource: Send + Sync {
+    fn probe(&self) -> MemorySnapshot;
+}
+
+/// Default source: the OS-level [`current_memory_snapshot`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OsProbe;
+
+impl MemorySource for OsProbe {
+    fn probe(&self) -> MemorySnapshot {
+        current_memory_snapshot()
+    }
+}
+
+/// How tight memory is right now, as a coarse signal for policy decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryPressure {
+    /// Plenty of headroom — grow freely, capture graphs, skip checkpointing.
+    Comfortable,
+    /// Getting full — stop growing, prefer modest allocations.
+    Moderate,
+    /// Nearly full — shrink caches, return pool memory, engage checkpointing.
+    Tight,
+    /// On the edge — refuse new non-essential allocations, evict aggressively.
+    Critical,
+}
+
+impl MemoryPressure {
+    /// True once the system should start *releasing* memory (Tight or worse).
+    pub fn should_reclaim(self) -> bool {
+        matches!(self, MemoryPressure::Tight | MemoryPressure::Critical)
+    }
+}
+
+/// Governor tuning. Defaults are conservative and env-overridable via
+/// [`GovernorConfig::from_env`].
+#[derive(Debug, Clone, Copy)]
+pub struct GovernorConfig {
+    /// Minimum interval between OS probes; reads inside this window return the
+    /// cached snapshot. Keeps `nvidia-smi`/sysfs probing off the hot path.
+    pub ttl: Duration,
+    /// Bytes never handed out — headroom left for the OS, other apps, and
+    /// allocator fragmentation slack. `available_bytes` subtracts this.
+    pub floor_bytes: u64,
+    /// `free/total` at/below which pressure is [`MemoryPressure::Tight`].
+    pub tight_frac: f64,
+    /// `free/total` at/below which pressure is [`MemoryPressure::Critical`].
+    pub critical_frac: f64,
+    /// `free/total` at/above which pressure is [`MemoryPressure::Comfortable`].
+    pub comfortable_frac: f64,
+}
+
+impl Default for GovernorConfig {
+    fn default() -> Self {
+        GovernorConfig {
+            ttl: Duration::from_millis(500),
+            floor_bytes: 1024 * 1024 * 1024, // 1 GiB
+            critical_frac: 0.05,
+            tight_frac: 0.10,
+            comfortable_frac: 0.25,
+        }
+    }
+}
+
+impl GovernorConfig {
+    /// Build from defaults with optional env overrides:
+    /// * `KILN_MEMORY_FLOOR_GB` — safety floor in GiB.
+    /// * `KILN_MEMORY_PROBE_MS` — probe TTL in milliseconds.
+    pub fn from_env() -> Self {
+        let mut cfg = GovernorConfig::default();
+        if let Ok(v) = std::env::var("KILN_MEMORY_FLOOR_GB") {
+            if let Ok(gb) = v.parse::<f64>() {
+                cfg.floor_bytes = (gb * 1024.0 * 1024.0 * 1024.0) as u64;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_MEMORY_PROBE_MS") {
+            if let Ok(ms) = v.parse::<u64>() {
+                cfg.ttl = Duration::from_millis(ms);
+            }
+        }
+        cfg
+    }
+}
+
+struct State {
+    cached: MemorySnapshot,
+    sampled_at: Instant,
+}
+
+/// Continuous, shared memory-awareness for the whole process.
+///
+/// Cheap to read (TTL-cached), backend-agnostic, and the single source every
+/// dynamic-memory consumer should consult. Construct one and share it via
+/// `Arc`, or use [`MemoryGovernor::global`] for the process-wide default.
+pub struct MemoryGovernor {
+    source: Box<dyn MemorySource>,
+    cfg: GovernorConfig,
+    state: Mutex<State>,
+    /// Soft reservations: memory announced-but-not-yet-allocated. Summed and
+    /// subtracted from `available_bytes` so two consumers can't both plan to
+    /// use the same free bytes. Released via the [`Reservation`] guard.
+    soft_reserved: AtomicU64,
+}
+
+impl MemoryGovernor {
+    /// Construct with an explicit source + config (used by tests and custom
+    /// integrations).
+    pub fn with_source(source: Box<dyn MemorySource>, cfg: GovernorConfig) -> Self {
+        let cached = source.probe();
+        MemoryGovernor {
+            source,
+            cfg,
+            state: Mutex::new(State {
+                cached,
+                sampled_at: Instant::now(),
+            }),
+            soft_reserved: AtomicU64::new(0),
+        }
+    }
+
+    /// The default governor: OS probe + env-tuned config.
+    pub fn new() -> Self {
+        Self::with_source(Box::new(OsProbe), GovernorConfig::from_env())
+    }
+
+    /// The process-wide governor. Lazily initialized on first use.
+    pub fn global() -> &'static MemoryGovernor {
+        static GLOBAL: OnceLock<MemoryGovernor> = OnceLock::new();
+        GLOBAL.get_or_init(MemoryGovernor::new)
+    }
+
+    /// Latest snapshot, re-probing only if the cached one is older than the TTL.
+    pub fn snapshot(&self) -> MemorySnapshot {
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if st.sampled_at.elapsed() >= self.cfg.ttl {
+            st.cached = self.source.probe();
+            st.sampled_at = Instant::now();
+        }
+        st.cached
+    }
+
+    /// Force a fresh probe now (bypasses the TTL). Use after a large
+    /// alloc/free when the next decision needs ground truth.
+    pub fn refresh(&self) -> MemorySnapshot {
+        let mut st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        st.cached = self.source.probe();
+        st.sampled_at = Instant::now();
+        st.cached
+    }
+
+    /// Current pressure level from the live free fraction.
+    pub fn pressure(&self) -> MemoryPressure {
+        let s = self.snapshot();
+        if s.total_bytes == 0 {
+            // No device detected — can't reason about pressure; treat as
+            // comfortable so we never block on a detection gap.
+            return MemoryPressure::Comfortable;
+        }
+        let frac = s.free_bytes as f64 / s.total_bytes as f64;
+        if frac <= self.cfg.critical_frac {
+            MemoryPressure::Critical
+        } else if frac <= self.cfg.tight_frac {
+            MemoryPressure::Tight
+        } else if frac < self.cfg.comfortable_frac {
+            MemoryPressure::Moderate
+        } else {
+            MemoryPressure::Comfortable
+        }
+    }
+
+    /// Bytes a new allocation may safely claim right now: live free, minus the
+    /// safety floor, minus outstanding soft reservations. Saturates at 0.
+    pub fn available_bytes(&self) -> u64 {
+        let free = self.snapshot().free_bytes;
+        let reserved = self.soft_reserved.load(Ordering::Relaxed);
+        free.saturating_sub(self.cfg.floor_bytes)
+            .saturating_sub(reserved)
+    }
+
+    /// Whether `bytes` fits within [`Self::available_bytes`] right now.
+    pub fn can_fit(&self, bytes: u64) -> bool {
+        self.available_bytes() >= bytes
+    }
+
+    /// Announce an intent to allocate `bytes` soon (training activation peak, a
+    /// KV-pool grow, a graph capture). The reservation is subtracted from
+    /// `available_bytes` until the returned guard drops, so concurrent
+    /// consumers see an honest budget. This does NOT itself allocate.
+    pub fn reserve(&self, bytes: u64) -> Reservation<'_> {
+        self.soft_reserved.fetch_add(bytes, Ordering::Relaxed);
+        Reservation {
+            governor: self,
+            bytes,
+        }
+    }
+
+    /// Total outstanding soft reservations (for logging / introspection).
+    pub fn soft_reserved_bytes(&self) -> u64 {
+        self.soft_reserved.load(Ordering::Relaxed)
+    }
+
+    pub fn config(&self) -> &GovernorConfig {
+        &self.cfg
+    }
+}
+
+impl Default for MemoryGovernor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for MemoryGovernor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryGovernor")
+            .field("cfg", &self.cfg)
+            .field("soft_reserved", &self.soft_reserved_bytes())
+            .finish_non_exhaustive()
+    }
+}
+
+/// RAII guard for a soft reservation made via [`MemoryGovernor::reserve`].
+/// Releases the reservation (decrements the governor's outstanding total) on
+/// drop, so a consumer that plans an allocation and then either completes it
+/// (the memory now shows up in the live probe) or abandons it both end with a
+/// correct budget.
+pub struct Reservation<'a> {
+    governor: &'a MemoryGovernor,
+    bytes: u64,
+}
+
+impl Reservation<'_> {
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl Drop for Reservation<'_> {
+    fn drop(&mut self) {
+        self.governor
+            .soft_reserved
+            .fetch_sub(self.bytes, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vram::VramSource;
+
+    /// A fixed, injectable snapshot source for deterministic tests.
+    struct Fixed(std::sync::Mutex<MemorySnapshot>);
+    impl Fixed {
+        fn new(total: u64, free: u64) -> Self {
+            Fixed(std::sync::Mutex::new(snap(total, free)))
+        }
+        fn set_free(&self, free: u64) {
+            let mut s = self.0.lock().unwrap();
+            s.free_bytes = free;
+            s.used_bytes = s.total_bytes.saturating_sub(free);
+        }
+    }
+    impl MemorySource for Fixed {
+        fn probe(&self) -> MemorySnapshot {
+            *self.0.lock().unwrap()
+        }
+    }
+
+    fn snap(total: u64, free: u64) -> MemorySnapshot {
+        MemorySnapshot {
+            total_bytes: total,
+            used_bytes: total.saturating_sub(free),
+            free_bytes: free,
+            source: VramSource::NvidiaSmi,
+            unified: false,
+        }
+    }
+
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    fn gov(total: u64, free: u64) -> MemoryGovernor {
+        MemoryGovernor::with_source(Box::new(Fixed::new(total, free)), GovernorConfig::default())
+    }
+
+    #[test]
+    fn pressure_tracks_free_fraction() {
+        // 24 GiB total, default thresholds (crit 5%, tight 10%, comfy 25%).
+        assert_eq!(gov(24 * GB, 12 * GB).pressure(), MemoryPressure::Comfortable);
+        assert_eq!(gov(24 * GB, 4 * GB).pressure(), MemoryPressure::Moderate); // ~17%
+        assert_eq!(gov(24 * GB, 2 * GB).pressure(), MemoryPressure::Tight); // ~8%
+        assert_eq!(gov(24 * GB, GB).pressure(), MemoryPressure::Critical); // ~4%
+    }
+
+    #[test]
+    fn no_device_is_comfortable_not_a_panic() {
+        assert_eq!(gov(0, 0).pressure(), MemoryPressure::Comfortable);
+    }
+
+    #[test]
+    fn available_subtracts_floor() {
+        // 16 GiB free, 1 GiB floor -> 15 GiB available.
+        let g = gov(24 * GB, 16 * GB);
+        assert_eq!(g.available_bytes(), 15 * GB);
+        assert!(g.can_fit(15 * GB));
+        assert!(!g.can_fit(15 * GB + 1));
+    }
+
+    #[test]
+    fn soft_reservation_reduces_available_then_releases() {
+        let g = gov(24 * GB, 16 * GB);
+        assert_eq!(g.available_bytes(), 15 * GB);
+        {
+            let _r = g.reserve(10 * GB);
+            assert_eq!(g.soft_reserved_bytes(), 10 * GB);
+            assert_eq!(g.available_bytes(), 5 * GB);
+            assert!(!g.can_fit(6 * GB));
+        }
+        // Guard dropped -> reservation released.
+        assert_eq!(g.soft_reserved_bytes(), 0);
+        assert_eq!(g.available_bytes(), 15 * GB);
+    }
+
+    /// Manual on-hardware smoke (`cargo test -p kiln-memory --
+    /// --ignored --nocapture live_governor_smoke`): prints the REAL governor
+    /// state on this machine, including whatever other processes are using the
+    /// device. Ignored by default (hardware-dependent, no fixed assertion).
+    #[test]
+    #[ignore]
+    fn live_governor_smoke() {
+        let g = MemoryGovernor::new();
+        let s = g.snapshot();
+        eprintln!(
+            "LIVE: total={:.1}GB used={:.1}GB free={:.1}GB unified={} source={} \
+             | pressure={:?} available(after floor)={:.1}GB",
+            s.total_bytes as f64 / 1e9,
+            s.used_bytes as f64 / 1e9,
+            s.free_bytes as f64 / 1e9,
+            s.unified,
+            s.source,
+            g.pressure(),
+            g.available_bytes() as f64 / 1e9,
+        );
+    }
+
+    #[test]
+    fn coexisting_process_reduces_our_budget() {
+        // The probe is SYSTEM-WIDE (nvidia-smi memory.used / DRM mem_info_vram_used
+        // / unified MemAvailable all count every process), so a neighbour using
+        // the GPU shrinks what kiln may claim — we never assume we own the device.
+        // Start with 20 GiB free on a 24 GiB device.
+        let src = std::sync::Arc::new(Fixed::new(24 * GB, 20 * GB));
+        struct Shared(std::sync::Arc<Fixed>);
+        impl MemorySource for Shared {
+            fn probe(&self) -> MemorySnapshot {
+                self.0.probe()
+            }
+        }
+        let cfg = GovernorConfig {
+            ttl: Duration::from_millis(0),
+            ..GovernorConfig::default()
+        };
+        let g = MemoryGovernor::with_source(Box::new(Shared(src.clone())), cfg);
+        assert_eq!(g.available_bytes(), 19 * GB); // 20 free - 1 floor
+        assert_eq!(g.pressure(), MemoryPressure::Comfortable);
+
+        // A neighbouring process grabs 18 GiB of VRAM -> only 2 GiB free now.
+        src.set_free(2 * GB);
+        // Our available budget collapses accordingly (continuous awareness, not
+        // a startup snapshot), and pressure rises so the system reclaims.
+        assert_eq!(g.available_bytes(), GB); // 2 free - 1 floor
+        assert_eq!(g.pressure(), MemoryPressure::Tight); // 2/24 = 8.3% <= 10%
+        assert!(g.pressure().should_reclaim());
+        assert!(!g.can_fit(5 * GB));
+    }
+
+    #[test]
+    fn snapshot_refresh_picks_up_changes() {
+        let src = std::sync::Arc::new(Fixed::new(24 * GB, 16 * GB));
+        // ttl=0 so every read re-probes.
+        let cfg = GovernorConfig {
+            ttl: Duration::from_millis(0),
+            ..GovernorConfig::default()
+        };
+        struct Shared(std::sync::Arc<Fixed>);
+        impl MemorySource for Shared {
+            fn probe(&self) -> MemorySnapshot {
+                self.0.probe()
+            }
+        }
+        let g = MemoryGovernor::with_source(Box::new(Shared(src.clone())), cfg);
+        assert_eq!(g.snapshot().free_bytes, 16 * GB);
+        src.set_free(4 * GB);
+        assert_eq!(g.snapshot().free_bytes, 4 * GB);
+        assert_eq!(g.pressure(), MemoryPressure::Moderate);
+    }
+}

--- a/crates/kiln-memory/src/lib.rs
+++ b/crates/kiln-memory/src/lib.rs
@@ -21,7 +21,11 @@
 //! `vram` and land in this crate as they're implemented, so memory governance
 //! stays in one place rather than scattered across the server and model crates.
 
+pub mod governor;
 pub mod vram;
+
+pub use governor::{GovernorConfig, MemoryGovernor, MemoryPressure, MemorySource, OsProbe, Reservation};
+pub use vram::{current_free_bytes, current_memory_snapshot, MemorySnapshot};
 
 /// Process-wide lock serializing tests that mutate environment variables that
 /// the memory probes read (e.g. `KILN_GPU_MEMORY_GB`,

--- a/crates/kiln-memory/src/lib.rs
+++ b/crates/kiln-memory/src/lib.rs
@@ -1,0 +1,31 @@
+//! `kiln-memory` — Kiln's cross-engine memory awareness layer.
+//!
+//! This crate is the single home for everything about *how much memory there is
+//! and how it's being used* on whatever accelerator kiln is running on. It is
+//! **backend-agnostic by construction**: the probes read memory at the OS level
+//! (`nvidia-smi`, AMD/Intel DRM sysfs, Apple `sysctl`, host `/proc/meminfo`),
+//! not through any one GPU API, so a single set of figures is correct for CUDA,
+//! ROCm, Vulkan, Metal, and CPU alike — and it even sees memory used by other
+//! processes sharing the device.
+//!
+//! # Layers
+//!
+//! * [`vram`] — the low-level probes and [`vram::current_memory_snapshot`], the
+//!   keystone every other subsystem reads (KV-cache sizing, graph-capture
+//!   headroom, the budget arbiter, allocator pressure response). Unified-memory
+//!   aware: on an APU / Apple Silicon, "free" tracks host RAM, not a VRAM
+//!   carveout.
+//!
+//! Subsequent layers (the continuous `MemoryGovernor`, the pressure-aware
+//! allocator hooks, and the training/inference budget arbiter) build on top of
+//! `vram` and land in this crate as they're implemented, so memory governance
+//! stays in one place rather than scattered across the server and model crates.
+
+pub mod vram;
+
+/// Process-wide lock serializing tests that mutate environment variables that
+/// the memory probes read (e.g. `KILN_GPU_MEMORY_GB`,
+/// `KILN_TRAINING_MEMORY_RESERVE_GB`). `cargo nextest` runs each test in its own
+/// process so this is belt-and-suspenders for `cargo test`'s shared-process
+/// model. Moved here with `vram` from `kiln-core::env_flag`.
+pub static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/kiln-memory/src/vram.rs
+++ b/crates/kiln-memory/src/vram.rs
@@ -350,69 +350,87 @@ pub fn detect_used_vram_bytes() -> Option<u64> {
 /// the SAME probe, so the system is uniformly aware regardless of which backend
 /// is compiled in.
 ///
-/// The crucial nuance is `unified`: on a discrete GPU `free_bytes` is the GPU's
-/// own VRAM headroom, but on a unified-memory APU (AMD Strix Halo) or Apple
-/// Silicon, GPU allocations come out of **system RAM**, so the meaningful free
-/// figure is the host's `MemAvailable`, not a BIOS-reported VRAM carveout. Sizing
-/// against the carveout there would happily over-commit system RAM and OOM the
-/// box. This probe gets that right so "be mindful of VRAM on whatever the user
-/// is running" holds on every device class.
+/// Figures come from the GPU DRIVER's authoritative, ALL-PROCESS counters
+/// (nvidia-smi on NVIDIA; AMD/Intel `mem_info_{vram,gtt}_{total,used}` DRM sysfs,
+/// the same source `nvtop`/`rocm-smi` show). Because they are all-process, a
+/// coexisting GPU job — llama.cpp, vLLM, another kiln — is reflected by
+/// construction: `free` already has its footprint subtracted. On a unified APU
+/// (AMD Strix Halo) these are the real combined VRAM+GTT pool the GPU can use,
+/// NOT a BIOS carveout and NOT a sandbox-/cgroup-limited `/proc/meminfo`.
 #[derive(Debug, Clone, Copy)]
 pub struct MemorySnapshot {
-    /// Total memory addressable by the accelerator (unified-corrected on APUs).
+    /// Total accelerator memory (driver-reported; VRAM+GTT on an AMD APU).
     pub total_bytes: u64,
-    /// Currently-used bytes (`total - free`).
+    /// Currently-used bytes across ALL processes (`total - free`). Includes any
+    /// coexisting GPU workload — kiln never assumes it owns the device.
     pub used_bytes: u64,
-    /// Free bytes available to allocate RIGHT NOW.
+    /// Free bytes available to allocate RIGHT NOW (driver-reported).
     pub free_bytes: u64,
     /// Provenance of the figures.
     pub source: VramSource,
-    /// Whether the accelerator shares system RAM (APU / Apple Silicon). When
-    /// true, `free_bytes` tracks host `MemAvailable` and allocations contend
-    /// with the rest of the OS.
+    /// Whether the accelerator shares system RAM with the CPU (APU / Apple
+    /// Silicon). Informational — the figures are correct either way.
     pub unified: bool,
 }
 
-/// Take a live snapshot of accelerator memory: total, used, and free, with the
-/// unified-memory correction applied. This is the keystone of kiln's dynamic
+/// Take a live snapshot of accelerator memory: total, used, and free, from the
+/// GPU driver's all-process counters. This is the keystone of kiln's dynamic
 /// memory awareness — KV-cache sizing, graph-capture headroom checks, the
 /// training/inference budget arbiter, and allocator pressure response all read
-/// from here, so the whole system reacts to the SAME live figure on every
-/// backend (including coexisting GPU workloads, since the probe is OS-level).
+/// from here, so the whole system reacts to the SAME live figure (and the same
+/// view of any coexisting GPU workload) on every backend.
 pub fn current_memory_snapshot() -> MemorySnapshot {
+    // 1. NVIDIA: nvidia-smi reports authoritative, all-process total + used.
+    if let Some(total) = query_nvidia_smi() {
+        let used = query_nvidia_smi_field("memory.used").unwrap_or(0).min(total);
+        return MemorySnapshot {
+            total_bytes: total,
+            used_bytes: used,
+            free_bytes: total.saturating_sub(used),
+            source: VramSource::NvidiaSmi,
+            unified: false,
+        };
+    }
+
+    // 2. AMD / Intel via DRM sysfs: combined VRAM+GTT total/used — the driver's
+    //    authoritative, ALL-PROCESS view (what nvtop / rocm-smi report). On an
+    //    integrated APU this is the real unified pool, correctly sized.
+    #[cfg(target_os = "linux")]
+    if let Some((total, used)) = query_linux_drm_total_used() {
+        return MemorySnapshot {
+            total_bytes: total,
+            used_bytes: used.min(total),
+            free_bytes: total.saturating_sub(used),
+            source: VramSource::LinuxDrmSysfs,
+            unified: drm_is_integrated_unified(),
+        };
+    }
+
+    // 3. Apple Silicon / fallback: total from detect_vram (sysctl + the unified
+    //    correction + env override), free from host MemAvailable. No discrete
+    //    driver counter is available there.
     let total = detect_vram();
     let unified = matches!(
         total.source,
         VramSource::LinuxDrmSysfsUnified | VramSource::AppleSilicon
     );
-
-    // Unified memory: free is the host's available RAM (capped at our corrected
-    // budget), because GPU allocations are system-RAM allocations there.
-    if unified {
-        #[cfg(target_os = "linux")]
-        if let Some(avail) =
-            query_meminfo_available_bytes_at(std::path::Path::new("/proc/meminfo"))
-        {
-            let free = avail.min(total.total_bytes);
-            return MemorySnapshot {
-                total_bytes: total.total_bytes,
-                used_bytes: total.total_bytes.saturating_sub(free),
-                free_bytes: free,
-                source: total.source,
-                unified: true,
-            };
-        }
-        // macOS unified / meminfo unavailable: fall through to the used-probe.
+    #[cfg(target_os = "linux")]
+    if let Some(avail) = query_meminfo_available_bytes_at(std::path::Path::new("/proc/meminfo")) {
+        let free = avail.min(total.total_bytes);
+        return MemorySnapshot {
+            total_bytes: total.total_bytes,
+            used_bytes: total.total_bytes.saturating_sub(free),
+            free_bytes: free,
+            source: total.source,
+            unified,
+        };
     }
-
-    // Discrete GPU (or unified fallback): free = total − currently-used.
     let used = detect_used_vram();
-    let used_bytes = used.used_bytes;
-    let free = total.total_bytes.saturating_sub(used_bytes);
+    let used_bytes = used.used_bytes.min(total.total_bytes);
     MemorySnapshot {
         total_bytes: total.total_bytes,
         used_bytes,
-        free_bytes: free,
+        free_bytes: total.total_bytes.saturating_sub(used_bytes),
         source: if used.source != VramSource::None {
             used.source
         } else {
@@ -420,6 +438,42 @@ pub fn current_memory_snapshot() -> MemorySnapshot {
         },
         unified,
     }
+}
+
+/// Combined VRAM+GTT `(total, used)` from AMD/Intel DRM sysfs — the all-process
+/// driver counters `nvtop` sums. `used` defaults to 0 when idle; a `total` of 0
+/// (no GPU node) returns `None`.
+#[cfg(target_os = "linux")]
+fn query_linux_drm_total_used() -> Option<(u64, u64)> {
+    // Max-within-field-list avoids double-counting vram vs vis_vram (vis is a
+    // subset); max-across-nodes ignores 0-valued connector entries.
+    let vram_total =
+        query_linux_drm_memory_fields(&["mem_info_vram_total", "mem_info_vis_vram_total"])
+            .unwrap_or(0);
+    let gtt_total = query_linux_drm_memory_fields(&["mem_info_gtt_total"]).unwrap_or(0);
+    let total = vram_total.saturating_add(gtt_total);
+    if total == 0 {
+        return None;
+    }
+    let vram_used =
+        query_linux_drm_memory_fields(&["mem_info_vram_used", "mem_info_vis_vram_used"])
+            .unwrap_or(0);
+    let gtt_used = query_linux_drm_memory_fields(&["mem_info_gtt_used"]).unwrap_or(0);
+    Some((total, vram_used.saturating_add(gtt_used)))
+}
+
+/// Whether the primary DRM GPU is an integrated/unified-memory part (AMD/Intel
+/// display controller with a non-trivial GTT). Informational for the snapshot's
+/// `unified` flag; does not affect the byte figures.
+#[cfg(target_os = "linux")]
+fn drm_is_integrated_unified() -> bool {
+    let Some(dev) = collect_linux_drm_device_info_at(std::path::Path::new("/sys/class/drm")) else {
+        return false;
+    };
+    let integrated_vendor = matches!(dev.vendor, 0x1002 | 0x8086);
+    let display_controller = (dev.class >> 16) == 0x03;
+    let non_trivial_gtt = dev.gtt_total >= 1024 * 1024 * 1024;
+    integrated_vendor && display_controller && non_trivial_gtt
 }
 
 /// Free accelerator memory in bytes right now (0 if undetectable). Thin
@@ -484,7 +538,17 @@ fn query_nvidia_smi_field(field: &str) -> Option<u64> {
 /// entries do not add the same GPU multiple times.
 #[cfg(target_os = "linux")]
 fn query_linux_drm_used_vram() -> Option<u64> {
-    query_linux_drm_memory_fields(&["mem_info_vram_used", "mem_info_vis_vram_used"])
+    // VRAM + GTT: on an integrated/APU part a coexisting job's footprint spills
+    // into GTT (system-RAM-backed GPU memory) past the VRAM carveout, so
+    // counting VRAM alone undercounts it badly (e.g. a 40 GB llama.cpp model
+    // shows ~0 in `mem_info_vram_used` if it lives in GTT). Summing both matches
+    // what nvtop/rocm-smi report. `max` within each field-list avoids
+    // double-counting vram vs vis_vram.
+    let vram = query_linux_drm_memory_fields(&["mem_info_vram_used", "mem_info_vis_vram_used"])
+        .unwrap_or(0);
+    let gtt = query_linux_drm_memory_fields(&["mem_info_gtt_used"]).unwrap_or(0);
+    let total = vram.saturating_add(gtt);
+    (total > 0).then_some(total)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/kiln-memory/src/vram.rs
+++ b/crates/kiln-memory/src/vram.rs
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn recommended_checkpoint_plan_respects_user_override() {
-        let _g = crate::env_flag::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = crate::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::set_var("KILN_GRAD_CHECKPOINT_SEGMENTS", "12");
         }
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[test]
     fn recommended_checkpoint_plan_respects_disable_env() {
-        let _g = crate::env_flag::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = crate::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
         }
@@ -1046,7 +1046,7 @@ mod tests {
         // parallel test that's mid-`set_var` can't make us return
         // UserOverride via env before we reach the VRAM check. macOS CI
         // reproducibly hit this on the parallel test interleave.
-        let _g = crate::env_flag::TEST_ENV_LOCK
+        let _g = crate::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         unsafe {
@@ -1071,7 +1071,7 @@ mod tests {
         // Same env isolation as the test above — scrub the overrides so
         // a parallel test can't make us return UserOverride via env
         // before we reach the headroom check.
-        let _g = crate::env_flag::TEST_ENV_LOCK
+        let _g = crate::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         unsafe {
@@ -1103,7 +1103,7 @@ mod tests {
         // recommended_checkpoint_plan reads KILN_GRAD_CHECKPOINT_SEGMENTS
         // and KILN_NO_GRAD_CHECKPOINT — take the env lock + scrub so a
         // parallel env-mutating test can't flip our cells to UserOverride.
-        let _g = crate::env_flag::TEST_ENV_LOCK
+        let _g = crate::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         unsafe {
@@ -1188,7 +1188,7 @@ mod tests {
     /// linearly with hidden, so the Disable→Enable boundary shifts.
     #[test]
     fn perf_regression_llama_8b_plan_matrix() {
-        let _g = crate::env_flag::TEST_ENV_LOCK
+        let _g = crate::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         unsafe {
@@ -1254,7 +1254,7 @@ mod tests {
     /// constant-factor change in the reported `max_act_gib`.
     #[test]
     fn perf_regression_disabled_plan_reports_sane_act_tape() {
-        let _g = crate::env_flag::TEST_ENV_LOCK
+        let _g = crate::TEST_ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         unsafe {
@@ -1311,7 +1311,7 @@ mod tests {
         // `test_unified_memory_reserve_env_override` doesn't race
         // with this test's reads of the same env var via
         // `unified_memory_reserve_bytes`.
-        let _env_guard = crate::env_flag::TEST_ENV_LOCK.lock().unwrap();
+        let _env_guard = crate::TEST_ENV_LOCK.lock().unwrap();
         // Synthesize the user's hardware: AMD Strix Halo APU. DRM
         // reports a 103 GB VRAM carveout on a 30 GB host. The corrected
         // budget must be MemTotal − reserve, not the carveout.
@@ -1473,7 +1473,7 @@ mod tests {
     fn test_unified_memory_reserve_env_override() {
         // Hold the shared env-mutation lock — see
         // test_unified_memory_apu_corrects_oversized_carveout.
-        let _env_guard = crate::env_flag::TEST_ENV_LOCK.lock().unwrap();
+        let _env_guard = crate::TEST_ENV_LOCK.lock().unwrap();
         // SAFETY: env mutation is safe under nextest's per-test process
         // isolation; this test must run via `cargo nextest run`.
         unsafe { std::env::set_var("KILN_TRAINING_MEMORY_RESERVE_GB", "10.0") };

--- a/crates/kiln-memory/src/vram.rs
+++ b/crates/kiln-memory/src/vram.rs
@@ -160,23 +160,28 @@ fn detect_linux_drm_vram_at(
 ) -> Option<GpuVramInfo> {
     let device = collect_linux_drm_device_info_at(drm_base)?;
     let mem_total = query_meminfo_total_bytes_at(meminfo_path);
+    let unified = mem_total
+        .map(|mt| is_unified_memory_drm(&device, mt))
+        .unwrap_or(false);
 
-    if let Some(mem_total_bytes) = mem_total
-        && is_unified_memory_drm(&device, mem_total_bytes)
-    {
-        let reserve = unified_memory_reserve_bytes(mem_total_bytes);
-        let corrected = device
-            .vram_total
-            .min(mem_total_bytes.saturating_sub(reserve));
-        return Some(GpuVramInfo {
-            total_bytes: corrected,
-            source: VramSource::LinuxDrmSysfsUnified,
-        });
-    }
-
+    // The honest GPU-addressable total is the driver's VRAM + GTT — exactly what
+    // nvtop / rocm-smi report. On an integrated APU the GTT is the system-RAM-
+    // backed budget the GPU can actually use (often far larger than the BIOS
+    // VRAM carveout); on a discrete card the GTT is a small staging area, so
+    // vram+gtt ≈ vram. We deliberately DON'T cap this against /proc/meminfo
+    // anymore: inside a cgroup/sandbox `MemTotal` reads a fake-small limit (e.g.
+    // 32 GB on a 128 GB box), which wrongly slashed the budget. Safety headroom
+    // is the consumer's job (KV `inference_fraction`, the training reserve) and
+    // they should size against live FREE (`current_memory_snapshot`) so a
+    // coexisting GPU job is accounted for — total here is just the ceiling.
+    let total = device.vram_total.saturating_add(device.gtt_total);
     Some(GpuVramInfo {
-        total_bytes: device.vram_total,
-        source: VramSource::LinuxDrmSysfs,
+        total_bytes: total,
+        source: if unified {
+            VramSource::LinuxDrmSysfsUnified
+        } else {
+            VramSource::LinuxDrmSysfs
+        },
     })
 }
 
@@ -277,6 +282,7 @@ fn is_unified_memory_drm(device: &LinuxDrmDeviceInfo, mem_total_bytes: u64) -> b
 ///
 /// Matches the Apple Silicon path: `max(6 GB, MemTotal / 4)`. Override
 /// with `KILN_TRAINING_MEMORY_RESERVE_GB` (parsed as f64).
+#[cfg_attr(not(test), allow(dead_code))]
 fn unified_memory_reserve_bytes(mem_total_bytes: u64) -> u64 {
     if let Ok(val) = std::env::var("KILN_TRAINING_MEMORY_RESERVE_GB") {
         if let Ok(gb) = val.parse::<f64>() {
@@ -1415,24 +1421,16 @@ mod tests {
         )
         .unwrap();
 
+        // The device is still RECOGNIZED as unified (so the source flag is set),
+        // but we no longer CAP the total against /proc/meminfo — that cap was the
+        // bug: on a big-RAM APU (and inside a memory-limited cgroup/sandbox) it
+        // slashed the real budget. The honest total is the driver's VRAM+GTT,
+        // which the GPU can genuinely address.
         assert!(is_unified_memory_drm(&device, mem_total));
-
-        // KILN_TRAINING_MEMORY_RESERVE_GB may leak from a parent test
-        // process; clear it so the assertion is deterministic. SAFETY:
-        // env mutation is safe under nextest's per-test process isolation.
-        unsafe { std::env::remove_var("KILN_TRAINING_MEMORY_RESERVE_GB") };
-        let reserve = unified_memory_reserve_bytes(mem_total);
-        // Default reserve = max(6 GB, MemTotal/4) = max(6, 7.5) = 7.5 GB.
-        assert_eq!(reserve, mem_total / 4);
-
         let info = detect_linux_drm_vram_at(&root, &meminfo_path).unwrap();
         assert_eq!(info.source, VramSource::LinuxDrmSysfsUnified);
-        // Corrected = min(carveout, MemTotal − reserve) = MemTotal − reserve.
-        assert_eq!(info.total_bytes, mem_total - reserve);
-        // Sanity-check the order of magnitude — corrected budget must
-        // sit between 14 and 24 GB on a 30 GB box.
-        let gb = info.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
-        assert!((14.0..=24.0).contains(&gb), "corrected budget = {gb} GB");
+        // total = vram_total + gtt_total (NOT capped to MemTotal − reserve).
+        assert_eq!(info.total_bytes, 103_079_215_104 + 16_629_477_376);
 
         std::fs::remove_dir_all(root).unwrap();
     }
@@ -1474,7 +1472,8 @@ mod tests {
 
         let info = detect_linux_drm_vram_at(&root, &meminfo_path).unwrap();
         assert_eq!(info.source, VramSource::LinuxDrmSysfs);
-        assert_eq!(info.total_bytes, 17_179_869_184);
+        // total = vram (16 GiB) + gtt (256 MiB staging) on a discrete card.
+        assert_eq!(info.total_bytes, 17_179_869_184 + 268_435_456);
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 kiln-core = { workspace = true }
+kiln-memory = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -18583,11 +18583,11 @@ fn try_flash_attn_paged_decode(
         Some(p) => p,
         None => return Ok(None),
     };
-    // #1082: `PagedKvCacheKt::pool_tensors` already returns kt pool references
-    // (`&KtTensor`), and every downstream consumer (kt `.narrow`, the kt backend
-    // decode methods, the kt flash-attn FFI) is kt now. The legacy candle→kt
-    // borrow/`candle_to_kt_activation` bridges are gone — use the kt pools
-    // directly.
+    // #26: `pool_tensors` now returns OWNED clones (cheap Arc bumps; the pools
+    // live behind an RwLock for live resize). Re-borrow as `&KtTensor` so every
+    // downstream consumer below is unchanged — the owned tensors stay alive in
+    // this scope and keep the pool storage pinned for the whole decode step.
+    let (k_pool, v_pool) = (&k_pool, &v_pool);
 
     // Common macOS/desktop case: a single sequence receives freshly-allocated
     // blocks, so its whole live KV window is already one contiguous run in the
@@ -19798,6 +19798,9 @@ pub fn gqa_attention_paged_decode_contiguous_batch(
     let (k_pool, v_pool) = paged_cache
         .pool_tensors(full_attn_layer_idx)
         .context("batched contiguous paged attention layer index out of range")?;
+    // #26: pool_tensors returns owned clones now — re-borrow so downstream is
+    // unchanged (owned tensors stay alive for this scope, pinning the storage).
+    let (k_pool, v_pool) = (&k_pool, &v_pool);
     // Prefer the once-per-step cached tensors when the caller built them;
     // otherwise use the per-layer ones we built above.
     let block_table_tensor: &Tensor = match (cached_meta, own_block_table_tensor.as_ref()) {
@@ -20826,8 +20829,8 @@ fn gqa_attention_paged_with_rope_tables(
                     // #1082: `PagedKvCacheKt::pool_tensors` already yields kt pool
                     // references; pass them straight to the kt backend read.
                     backend.paged_kv_head_major_read_append_token_major(
-                        k_pool,
-                        v_pool,
+                        &k_pool,
+                        &v_pool,
                         start_slot,
                         start_pos,
                         &k_cache_token_major,
@@ -20875,8 +20878,8 @@ fn gqa_attention_paged_with_rope_tables(
                     // #1082: `PagedKvCacheKt::pool_tensors` already yields kt pool
                     // references; pass them straight to the kt backend read.
                     backend.paged_kv_head_major_read(
-                        k_pool,
-                        v_pool,
+                        &k_pool,
+                        &v_pool,
                         start_slot,
                         fast_read_len,
                     )

--- a/crates/kiln-model/src/paged_kv_cache_kt.rs
+++ b/crates/kiln-model/src/paged_kv_cache_kt.rs
@@ -109,6 +109,113 @@ fn fp8_dequantize_direct_dev(t: &KtTensor, target: KtDType) -> Result<KtTensor> 
     }
 }
 
+/// Allocate one zero-filled `(k_pool, v_pool)` pair of shape `shape`
+/// (`= [total_slots, num_kv_heads, head_dim]`, `n_elements` elements total) on
+/// `device`, using the exact per-backend routing the cache constructor uses.
+/// Shared by [`PagedKvCacheKt::new_with_fp8`] and
+/// [`PagedKvCacheKt::physical_resize_to`] so the device matrix lives in ONE
+/// place — a divergence between construct-time and resize-time allocation would
+/// silently put the resized pool on the wrong device and trip the per-layer
+/// `slice_set` device-mismatch guard.
+fn alloc_pool_pair(
+    device: kiln_tensor::Device,
+    shape: &[usize],
+    n_elements: usize,
+    storage_dtype: KtDType,
+    layer_idx: usize,
+) -> Result<(KtTensor, KtTensor)> {
+    let _i = layer_idx;
+    let shape = shape.to_vec();
+    let (k, v) = match device {
+        kiln_tensor::Device::Cpu => {
+            let _ = n_elements;
+            let k = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
+            let v = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
+            (k, v)
+        }
+        #[cfg(feature = "cuda")]
+        kiln_tensor::Device::Cuda(i) => {
+            let k_storage = cuda_zeros_ctx(i, storage_dtype, n_elements)
+                .with_context(|| format!("kt paged-kv: alloc k_pool layer {_i}"))?;
+            let v_storage = cuda_zeros_ctx(i, storage_dtype, n_elements)
+                .with_context(|| format!("kt paged-kv: alloc v_pool layer {_i}"))?;
+            let k = KtTensor::from_parts(
+                k_storage,
+                Layout::contiguous(shape.clone()),
+                TensorId::next(),
+            )
+            .with_context(|| format!("kt paged-kv: wrap k_pool layer {_i}"))?;
+            let v = KtTensor::from_parts(
+                v_storage,
+                Layout::contiguous(shape.clone()),
+                TensorId::next(),
+            )
+            .with_context(|| format!("kt paged-kv: wrap v_pool layer {_i}"))?;
+            (k, v)
+        }
+        // #1082 ROCm: device-resident KV pools (mirror the CUDA arm),
+        // gated on KILN_ROCM_PAGED_DECODE so it pairs with the native
+        // sq=1 paged-decode routing in forward.rs (both default off until
+        // the KV-cache correctness fix lands). When off, ROCm falls to the
+        // `other` => CPU pool + the correct contiguous-decode path.
+        #[cfg(feature = "rocm")]
+        kiln_tensor::Device::Rocm(i) if crate::forward::rocm_paged_decode_enabled() => {
+            let k_storage = kiln_tensor::rocm_zeros_ctx(i, storage_dtype, n_elements)
+                .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc k_pool (rocm) layer {_i}: {e}"))?;
+            let v_storage = kiln_tensor::rocm_zeros_ctx(i, storage_dtype, n_elements)
+                .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc v_pool (rocm) layer {_i}: {e}"))?;
+            let k = KtTensor::from_parts(
+                k_storage,
+                Layout::contiguous(shape.clone()),
+                TensorId::next(),
+            )
+            .map_err(|e| anyhow::anyhow!("kt paged-kv: wrap k_pool (rocm) layer {_i}: {e}"))?;
+            let v = KtTensor::from_parts(
+                v_storage,
+                Layout::contiguous(shape.clone()),
+                TensorId::next(),
+            )
+            .map_err(|e| anyhow::anyhow!("kt paged-kv: wrap v_pool (rocm) layer {_i}: {e}"))?;
+            (k, v)
+        }
+        #[cfg(feature = "metal")]
+        kiln_tensor::Device::Metal(i) => {
+            let _ = n_elements;
+            let k = KtTensor::zeros_on(kiln_tensor::Device::Metal(i), shape.clone(), storage_dtype)
+                .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc k_pool (metal) layer {_i}: {e}"))?;
+            let v = KtTensor::zeros_on(kiln_tensor::Device::Metal(i), shape.clone(), storage_dtype)
+                .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc v_pool (metal) layer {_i}: {e}"))?;
+            (k, v)
+        }
+        // Vulkan and any backend whose feature isn't compiled in → host-resident
+        // CPU pools (matches the cache constructor's `other` arm exactly).
+        other => {
+            let _ = other;
+            let _ = n_elements;
+            let k = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
+            let v = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
+            (k, v)
+        }
+    };
+    Ok((k, v))
+}
+
+/// Block until all device work completes, so a subsequent pool drop can't free
+/// storage a still-running kernel reads. No-op on CPU (synchronous) and on
+/// backends whose feature isn't compiled in. Used by
+/// [`PagedKvCacheKt::physical_resize_to`] (#26) as the C2 use-after-free guard.
+fn sync_device_for_resize(device: kiln_tensor::Device) -> Result<()> {
+    match device {
+        #[cfg(feature = "cuda")]
+        kiln_tensor::Device::Cuda(i) => kiln_tensor::cuda_synchronize_default_stream(i)
+            .map_err(|e| anyhow::anyhow!("physical_resize_to: cuda sync: {e}")),
+        #[cfg(feature = "rocm")]
+        kiln_tensor::Device::Rocm(i) => kiln_tensor::rocm_synchronize_default_stream(i)
+            .map_err(|e| anyhow::anyhow!("physical_resize_to: rocm sync: {e}")),
+        _ => Ok(()),
+    }
+}
+
 /// Paged KV cache backed by `kiln_tensor::Tensor`. Twin of
 /// the deleted candle `PagedKvCache` (#1082 candle-drop).
 ///
@@ -199,98 +306,7 @@ impl PagedKvCacheKt {
             // host-resident `zeros_cpu` default — matching the prior
             // non-cuda/non-metal behavior, and exactly what the deleted candle
             // cache did for the Vulkan backend (it held CPU candle tensors).
-            let (k, v) = match device {
-                kiln_tensor::Device::Cpu => {
-                    let _ = n_elements;
-                    let k = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
-                    let v = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
-                    (k, v)
-                }
-                #[cfg(feature = "cuda")]
-                kiln_tensor::Device::Cuda(i) => {
-                    let k_storage = cuda_zeros_ctx(i, storage_dtype, n_elements)
-                        .with_context(|| format!("kt paged-kv: alloc k_pool layer {_i}"))?;
-                    let v_storage = cuda_zeros_ctx(i, storage_dtype, n_elements)
-                        .with_context(|| format!("kt paged-kv: alloc v_pool layer {_i}"))?;
-                    let k = KtTensor::from_parts(
-                        k_storage,
-                        Layout::contiguous(shape.clone()),
-                        TensorId::next(),
-                    )
-                    .with_context(|| format!("kt paged-kv: wrap k_pool layer {_i}"))?;
-                    let v = KtTensor::from_parts(
-                        v_storage,
-                        Layout::contiguous(shape.clone()),
-                        TensorId::next(),
-                    )
-                    .with_context(|| format!("kt paged-kv: wrap v_pool layer {_i}"))?;
-                    (k, v)
-                }
-                // #1082 ROCm: device-resident KV pools (mirror the CUDA arm),
-                // gated on KILN_ROCM_PAGED_DECODE so it pairs with the native
-                // sq=1 paged-decode routing in forward.rs (both default off until
-                // the KV-cache correctness fix lands). When off, ROCm falls to the
-                // `other` => CPU pool + the correct contiguous-decode path.
-                #[cfg(feature = "rocm")]
-                kiln_tensor::Device::Rocm(i) if crate::forward::rocm_paged_decode_enabled() => {
-                    let k_storage = kiln_tensor::rocm_zeros_ctx(i, storage_dtype, n_elements)
-                        .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc k_pool (rocm) layer {_i}: {e}"))?;
-                    let v_storage = kiln_tensor::rocm_zeros_ctx(i, storage_dtype, n_elements)
-                        .map_err(|e| anyhow::anyhow!("kt paged-kv: alloc v_pool (rocm) layer {_i}: {e}"))?;
-                    let k = KtTensor::from_parts(
-                        k_storage,
-                        Layout::contiguous(shape.clone()),
-                        TensorId::next(),
-                    )
-                    .map_err(|e| anyhow::anyhow!("kt paged-kv: wrap k_pool (rocm) layer {_i}: {e}"))?;
-                    let v = KtTensor::from_parts(
-                        v_storage,
-                        Layout::contiguous(shape.clone()),
-                        TensorId::next(),
-                    )
-                    .map_err(|e| anyhow::anyhow!("kt paged-kv: wrap v_pool (rocm) layer {_i}: {e}"))?;
-                    (k, v)
-                }
-                #[cfg(feature = "metal")]
-                kiln_tensor::Device::Metal(i) => {
-                    let _ = n_elements;
-                    let k = KtTensor::zeros_on(
-                        kiln_tensor::Device::Metal(i),
-                        shape.clone(),
-                        storage_dtype,
-                    )
-                    .map_err(|e| {
-                        anyhow::anyhow!("kt paged-kv: alloc k_pool (metal) layer {_i}: {e}")
-                    })?;
-                    let v = KtTensor::zeros_on(
-                        kiln_tensor::Device::Metal(i),
-                        shape.clone(),
-                        storage_dtype,
-                    )
-                    .map_err(|e| {
-                        anyhow::anyhow!("kt paged-kv: alloc v_pool (metal) layer {_i}: {e}")
-                    })?;
-                    (k, v)
-                }
-                // Vulkan: keep the kt KV pool HOST-resident (CPU). It is the
-                // seed cache that the resident decode path mirrors into the
-                // device-local VkPagedKvCache; allocating the kt pool ALSO on
-                // VRAM made the two ~24GB KV caches collide and OOM'd the
-                // VkPagedKvCache (resident decode then declined). The prefill
-                // write moves its small K/V rows to this CPU pool via the
-                // device-aligned slice_set in write_native. (Unifying prefill
-                // + decode on one VkPagedKvCache is the perf follow-up.)
-                other => {
-                    // Any GPU device whose backend feature isn't compiled in →
-                    // host-resident CPU pools (matches the prior
-                    // non-cuda/non-metal default).
-                    let _ = other;
-                    let _ = n_elements;
-                    let k = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
-                    let v = KtTensor::zeros_cpu(shape.clone(), storage_dtype);
-                    (k, v)
-                }
-            };
+            let (k, v) = alloc_pool_pair(device, &shape, n_elements, storage_dtype, _i)?;
             layers.push((k, v));
         }
         let fp8_scales = vec![(1.0_f32, 1.0_f32); num_full_attn_layers];
@@ -345,6 +361,129 @@ impl PagedKvCacheKt {
     /// Borrow the raw `(k_pool, v_pool)` kt-Tensors for `layer_idx`.
     pub fn pool_tensors(&self, layer_idx: usize) -> Option<(&KtTensor, &KtTensor)> {
         self.layers.get(layer_idx).map(|(k, v)| (k, v))
+    }
+
+    /// Physically reallocate every layer's `(k_pool, v_pool)` to back
+    /// `new_num_blocks` blocks, copying the surviving prefix and dropping the old
+    /// pools. This is the elastic actuator that lets inference physically
+    /// surrender KV VRAM and reclaim it — the physical half of the dynamic
+    /// resize whose logical half is [`kiln_core::block::BlockManager`].
+    ///
+    /// WHY THIS RECLAIMS (same-process arbitration): kiln runs inference AND
+    /// training in ONE process / ONE device memory pool. Dropping the old pool
+    /// returns its bytes to that pool, where the NEXT allocation (e.g. a training
+    /// run, or a regrown KV pool) REUSES them — verified on gfx1151: a 2 GB
+    /// alloc → drop → 2 GB realloc grows peak VRAM by 0 MB. It does NOT depend on
+    /// returning memory to the OS (`hipMemPoolTrimTo` is a measured no-op on
+    /// gfx1151/ROCm 7.2.4 — so is the sync `hipFree`); cross-process return is a
+    /// platform limitation we don't rely on. Reuse within the pool is what makes
+    /// "training and inference share VRAM, never OOM" work.
+    ///
+    /// SAFETY CONTRACT — the caller MUST guarantee that NO forward/decode pass is
+    /// in flight (the pool tensors are swapped; a kernel reading the old pool
+    /// would use freed storage). We additionally device-synchronize at entry to
+    /// flush any already-submitted kernel before the first drop (defends against
+    /// off-stream HIP-graph-replay kernels). On SHRINK the caller must have run
+    /// the paired `BlockManager::physical_truncate(new_num_blocks)` first, so no
+    /// live block sits in the truncated tail. Surviving KV (slots
+    /// `[0, copy_slots)`) is copied verbatim; the slot mapping
+    /// `slot = block_id*block_size + off` is preserved, so existing `BlockTable`s
+    /// stay valid with NO remapping.
+    ///
+    /// SHRINK vs GROW commit strategy:
+    /// - SHRINK swaps pools ONE LAYER AT A TIME, dropping each old pool the
+    ///   instant its data is copied so the next layer's (smaller) alloc reuses
+    ///   the freed bytes. Peak transient VRAM is bounded to `old + one_layer`,
+    ///   NOT `old + new` — a SHRINK runs when memory is tight, so a
+    ///   build-all-then-swap would spike VRAM exactly when we can least afford
+    ///   it. SHRINK is effectively atomic: only the layer-0 alloc can fail, and
+    ///   it fails before any mutation (every later, smaller alloc reuses freed
+    ///   bytes), so `self` is untouched on `Err`.
+    /// - GROW stages all new pools into a local vec and swaps them in only after
+    ///   every layer succeeds (ATOMIC: `Err` leaves `self` wholly on the old
+    ///   pools). A growing per-layer swap could fail mid-loop and leave the cache
+    ///   with mixed-size layers — corrupting the slot mapping. GROW peak is
+    ///   `old + new`, which is fine: GROW only runs when memory is NOT tight (the
+    ///   caller pre-checks `available_bytes`).
+    ///
+    /// No-op (returns `Ok`) when `new_num_blocks == num_blocks`.
+    pub fn physical_resize_to(
+        &mut self,
+        new_num_blocks: usize,
+        device: kiln_tensor::Device,
+    ) -> Result<()> {
+        if new_num_blocks == self.num_blocks {
+            return Ok(());
+        }
+        // C2: flush any in-flight kernel before we drop the old pools. The caller
+        // guarantees no NEW launches during the resize (actor barrier); this
+        // covers a kernel already submitted on another stream (graph replay).
+        sync_device_for_resize(device)?;
+
+        let storage_dtype = if self.fp8 {
+            KtDType::U8
+        } else {
+            self.compute_dtype
+        };
+        let new_total_slots = new_num_blocks * self.block_size;
+        let old_total_slots = self.num_blocks * self.block_size;
+        let copy_slots = new_total_slots.min(old_total_slots);
+        let growing = new_num_blocks > self.num_blocks;
+
+        // Allocate the new pool for layer `i` and copy its surviving prefix from
+        // the layer's current (old) pool. Pure: does not mutate `self.layers`.
+        let make_resized = |this: &Self, layer_idx: usize| -> Result<(KtTensor, KtTensor)> {
+            let dims = this.layers[layer_idx].0.dims().to_vec();
+            anyhow::ensure!(
+                dims.len() == 3,
+                "physical_resize_to: layer {layer_idx} pool has rank {} (want 3)",
+                dims.len()
+            );
+            let shape = vec![new_total_slots, dims[1], dims[2]];
+            let n_elements = new_total_slots * dims[1] * dims[2];
+            let (new_k, new_v) =
+                alloc_pool_pair(device, &shape, n_elements, storage_dtype, layer_idx)?;
+            // The new pool's async zero-fill must COMPLETE before we copy the
+            // surviving prefix over it — otherwise a large (grow) zero-fill can
+            // land AFTER the copy and wipe it. A plain same-stream ordering is
+            // not sufficient in practice here, so synchronize explicitly. Resize
+            // is rare, so this is cheap relative to the multi-layer realloc.
+            if copy_slots > 0 {
+                sync_device_for_resize(device)?;
+                let (old_k, old_v) = &this.layers[layer_idx];
+                let src_k = old_k.narrow(0, 0, copy_slots).map_err(|e| {
+                    anyhow::anyhow!("physical_resize_to: narrow k l{layer_idx}: {e}")
+                })?;
+                let src_v = old_v.narrow(0, 0, copy_slots).map_err(|e| {
+                    anyhow::anyhow!("physical_resize_to: narrow v l{layer_idx}: {e}")
+                })?;
+                new_k.slice_set(&src_k, 0, 0).map_err(|e| {
+                    anyhow::anyhow!("physical_resize_to: copy k l{layer_idx}: {e}")
+                })?;
+                new_v.slice_set(&src_v, 0, 0).map_err(|e| {
+                    anyhow::anyhow!("physical_resize_to: copy v l{layer_idx}: {e}")
+                })?;
+            }
+            Ok((new_k, new_v))
+        };
+
+        if growing {
+            // ATOMIC: stage all, then commit. `?` on any layer leaves self intact.
+            let mut staged: Vec<(KtTensor, KtTensor)> = Vec::with_capacity(self.layers.len());
+            for layer_idx in 0..self.layers.len() {
+                staged.push(make_resized(self, layer_idx)?);
+            }
+            self.layers = staged;
+        } else {
+            // SHRINK: in-place per layer so each old pool frees before the next
+            // alloc (bounded VRAM). Effectively atomic — see method doc.
+            for layer_idx in 0..self.layers.len() {
+                let resized = make_resized(self, layer_idx)?;
+                self.layers[layer_idx] = resized;
+            }
+        }
+        self.num_blocks = new_num_blocks;
+        Ok(())
     }
 
     /// Slot-based decode-token writer — the CUDA-graph contract entry
@@ -1489,5 +1628,72 @@ mod tests {
         assert!(cache.is_fp8());
         assert_eq!(cache.compute_dtype(), KtDType::BF16);
         assert!(cache.pool_tensors(0).is_none());
+    }
+
+    // Physical resize correctness on CPU pools (device-agnostic copy logic; the
+    // ROCm/CUDA paths reuse the SAME narrow+slice_set, validated on-box). Proves
+    // the elastic actuator (#26) preserves live KV byte-for-byte across a
+    // shrink and a grow, with the grown tail zero-filled.
+    #[test]
+    fn physical_resize_preserves_surviving_kv_and_zeros_grown_tail() {
+        let block_size = 2usize;
+        let kv_heads = 1usize;
+        let head_dim = 2usize;
+        let per_slot = kv_heads * head_dim; // 2 f32 per slot
+        let dev = kiln_tensor::Device::Cpu;
+
+        // 4 blocks * 2 = 8 slots; 1 full-attn layer; F32 so values round-trip exact.
+        let mut cache = PagedKvCacheKt::new(1, 4, block_size, kv_heads, head_dim, KtDType::F32, dev)
+            .expect("construct cpu cache");
+        assert_eq!(cache.num_blocks(), 4);
+
+        // Write a known pattern into the first 6 slots of layer 0's K and V pools
+        // (slots 6,7 stay zero). Pattern: k[slot,i] = slot*10 + i ; v = k + 100.
+        let n_known_slots = 6usize;
+        let mut k_vals = Vec::with_capacity(n_known_slots * per_slot);
+        let mut v_vals = Vec::with_capacity(n_known_slots * per_slot);
+        for slot in 0..n_known_slots {
+            for i in 0..per_slot {
+                let base = (slot * 10 + i) as f32;
+                k_vals.push(base);
+                v_vals.push(base + 100.0);
+            }
+        }
+        let k_src =
+            KtTensor::from_vec(k_vals.clone(), vec![n_known_slots, kv_heads, head_dim]).unwrap();
+        let v_src =
+            KtTensor::from_vec(v_vals.clone(), vec![n_known_slots, kv_heads, head_dim]).unwrap();
+        {
+            let (k_pool, v_pool) = cache.pool_tensors(0).unwrap();
+            k_pool.slice_set(&k_src, 0, 0).unwrap();
+            v_pool.slice_set(&v_src, 0, 0).unwrap();
+        }
+
+        // SHRINK 4 -> 3 blocks (8 -> 6 slots). copy_slots = 6, so all known KV
+        // survives verbatim and the (zero) tail is dropped.
+        cache.physical_resize_to(3, dev).expect("shrink");
+        assert_eq!(cache.num_blocks(), 3);
+        let (k_pool, v_pool) = cache.pool_tensors(0).unwrap();
+        assert_eq!(k_pool.dims(), &[6, kv_heads, head_dim]);
+        let k_after: Vec<f32> = k_pool.to_vec().unwrap();
+        let v_after: Vec<f32> = v_pool.to_vec().unwrap();
+        assert_eq!(k_after, k_vals, "shrink must preserve K slots 0..6");
+        assert_eq!(v_after, v_vals, "shrink must preserve V slots 0..6");
+
+        // GROW 3 -> 5 blocks (6 -> 10 slots). Prefix preserved, new tail zeroed.
+        cache.physical_resize_to(5, dev).expect("grow");
+        assert_eq!(cache.num_blocks(), 5);
+        let (k_pool, _) = cache.pool_tensors(0).unwrap();
+        assert_eq!(k_pool.dims(), &[10, kv_heads, head_dim]);
+        let k_grown: Vec<f32> = k_pool.to_vec().unwrap();
+        assert_eq!(&k_grown[..k_vals.len()], &k_vals[..], "grow preserves prefix");
+        assert!(
+            k_grown[k_vals.len()..].iter().all(|&x| x == 0.0),
+            "grown tail must be zero-filled"
+        );
+
+        // No-op resize returns Ok and changes nothing.
+        cache.physical_resize_to(5, dev).expect("noop");
+        assert_eq!(cache.num_blocks(), 5);
     }
 }

--- a/crates/kiln-model/src/paged_kv_cache_kt.rs
+++ b/crates/kiln-model/src/paged_kv_cache_kt.rs
@@ -227,9 +227,20 @@ fn sync_device_for_resize(device: kiln_tensor::Device) -> Result<()> {
 /// factors; the compute dtype is preserved separately for dequant.
 pub struct PagedKvCacheKt {
     /// Per full-attention layer: `(k_pool, v_pool)`.
-    layers: Vec<(KtTensor, KtTensor)>,
+    ///
+    /// Behind an `RwLock` so [`Self::physical_resize_to`] can swap the pools
+    /// through `&self` (#26) — the cache is held as a shared `Arc` cloned into
+    /// the decode paths, so a `&mut self` resizer would be unreachable during
+    /// serving. The decode read path takes the (uncontended) READ lock briefly
+    /// per access; the resizer takes the WRITE lock, and the caller guarantees
+    /// no forward is in flight while it does (the actor barrier), so the write
+    /// lock is never actually contended against a live kernel.
+    layers: std::sync::RwLock<Vec<(KtTensor, KtTensor)>>,
     block_size: usize,
-    num_blocks: usize,
+    /// Logical block count = `layers[i]` slot count / `block_size`. Atomic so
+    /// `physical_resize_to` can update it through `&self` in lockstep with the
+    /// `layers` swap. Read relaxed in the decode path.
+    num_blocks: std::sync::atomic::AtomicUsize,
     /// Whether FP8 quantization is enabled. When true, pool dtype is U8.
     fp8: bool,
     /// Per-layer FP8 scale factors `(k_scale, v_scale)`. Updated on
@@ -311,13 +322,20 @@ impl PagedKvCacheKt {
         }
         let fp8_scales = vec![(1.0_f32, 1.0_f32); num_full_attn_layers];
         Ok(Self {
-            layers,
+            layers: std::sync::RwLock::new(layers),
             block_size,
-            num_blocks,
+            num_blocks: std::sync::atomic::AtomicUsize::new(num_blocks),
             fp8,
             fp8_scales,
             compute_dtype: dtype,
         })
+    }
+
+    /// Read-borrow the per-layer pools. Recovers from lock poisoning (a panic
+    /// while reading leaves the data intact — reads don't mutate).
+    #[inline]
+    fn layers_read(&self) -> std::sync::RwLockReadGuard<'_, Vec<(KtTensor, KtTensor)>> {
+        self.layers.read().unwrap_or_else(|e| e.into_inner())
     }
 
     pub fn block_size(&self) -> usize {
@@ -340,11 +358,11 @@ impl PagedKvCacheKt {
     }
 
     pub fn num_blocks(&self) -> usize {
-        self.num_blocks
+        self.num_blocks.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn num_layers(&self) -> usize {
-        self.layers.len()
+        self.layers_read().len()
     }
 
     pub fn is_fp8(&self) -> bool {
@@ -358,9 +376,18 @@ impl PagedKvCacheKt {
         self.compute_dtype
     }
 
-    /// Borrow the raw `(k_pool, v_pool)` kt-Tensors for `layer_idx`.
-    pub fn pool_tensors(&self, layer_idx: usize) -> Option<(&KtTensor, &KtTensor)> {
-        self.layers.get(layer_idx).map(|(k, v)| (k, v))
+    /// Cheap owned clones of the `(k_pool, v_pool)` kt-Tensors for `layer_idx`
+    /// (an `Arc` bump each — the device buffers are shared, not copied).
+    ///
+    /// Returns OWNED tensors rather than borrows because the pools live behind a
+    /// `RwLock` (#26 resize): a borrow couldn't outlive the read guard. Holding
+    /// the clone keeps that pool's storage alive even across a concurrent
+    /// `physical_resize_to` swap — though the caller (decode) is barrier-ordered
+    /// against resize anyway.
+    pub fn pool_tensors(&self, layer_idx: usize) -> Option<(KtTensor, KtTensor)> {
+        self.layers_read()
+            .get(layer_idx)
+            .map(|(k, v)| (k.clone(), v.clone()))
     }
 
     /// Physically reallocate every layer's `(k_pool, v_pool)` to back
@@ -408,11 +435,12 @@ impl PagedKvCacheKt {
     ///
     /// No-op (returns `Ok`) when `new_num_blocks == num_blocks`.
     pub fn physical_resize_to(
-        &mut self,
+        &self,
         new_num_blocks: usize,
         device: kiln_tensor::Device,
     ) -> Result<()> {
-        if new_num_blocks == self.num_blocks {
+        let cur = self.num_blocks();
+        if new_num_blocks == cur {
             return Ok(());
         }
         // C2: flush any in-flight kernel before we drop the old pools. The caller
@@ -426,63 +454,71 @@ impl PagedKvCacheKt {
             self.compute_dtype
         };
         let new_total_slots = new_num_blocks * self.block_size;
-        let old_total_slots = self.num_blocks * self.block_size;
+        let old_total_slots = cur * self.block_size;
         let copy_slots = new_total_slots.min(old_total_slots);
-        let growing = new_num_blocks > self.num_blocks;
+        let growing = new_num_blocks > cur;
+
+        // Exclusive access for the structural swap. The caller's barrier (no
+        // forward in flight) guarantees this write lock is never contended
+        // against a live decode read, and that no kernel is mid-read of a pool we
+        // are about to drop.
+        let mut layers = self.layers.write().unwrap_or_else(|e| e.into_inner());
 
         // Allocate the new pool for layer `i` and copy its surviving prefix from
-        // the layer's current (old) pool. Pure: does not mutate `self.layers`.
-        let make_resized = |this: &Self, layer_idx: usize| -> Result<(KtTensor, KtTensor)> {
-            let dims = this.layers[layer_idx].0.dims().to_vec();
-            anyhow::ensure!(
-                dims.len() == 3,
-                "physical_resize_to: layer {layer_idx} pool has rank {} (want 3)",
-                dims.len()
-            );
-            let shape = vec![new_total_slots, dims[1], dims[2]];
-            let n_elements = new_total_slots * dims[1] * dims[2];
-            let (new_k, new_v) =
-                alloc_pool_pair(device, &shape, n_elements, storage_dtype, layer_idx)?;
-            // The new pool's async zero-fill must COMPLETE before we copy the
-            // surviving prefix over it — otherwise a large (grow) zero-fill can
-            // land AFTER the copy and wipe it. A plain same-stream ordering is
-            // not sufficient in practice here, so synchronize explicitly. Resize
-            // is rare, so this is cheap relative to the multi-layer realloc.
-            if copy_slots > 0 {
-                sync_device_for_resize(device)?;
-                let (old_k, old_v) = &this.layers[layer_idx];
-                let src_k = old_k.narrow(0, 0, copy_slots).map_err(|e| {
-                    anyhow::anyhow!("physical_resize_to: narrow k l{layer_idx}: {e}")
-                })?;
-                let src_v = old_v.narrow(0, 0, copy_slots).map_err(|e| {
-                    anyhow::anyhow!("physical_resize_to: narrow v l{layer_idx}: {e}")
-                })?;
-                new_k.slice_set(&src_k, 0, 0).map_err(|e| {
-                    anyhow::anyhow!("physical_resize_to: copy k l{layer_idx}: {e}")
-                })?;
-                new_v.slice_set(&src_v, 0, 0).map_err(|e| {
-                    anyhow::anyhow!("physical_resize_to: copy v l{layer_idx}: {e}")
-                })?;
-            }
-            Ok((new_k, new_v))
-        };
+        // the current (old) pool at `pools[i]`. Pure: does not mutate `pools`.
+        let make_resized =
+            |pools: &Vec<(KtTensor, KtTensor)>, layer_idx: usize| -> Result<(KtTensor, KtTensor)> {
+                let dims = pools[layer_idx].0.dims().to_vec();
+                anyhow::ensure!(
+                    dims.len() == 3,
+                    "physical_resize_to: layer {layer_idx} pool has rank {} (want 3)",
+                    dims.len()
+                );
+                let shape = vec![new_total_slots, dims[1], dims[2]];
+                let n_elements = new_total_slots * dims[1] * dims[2];
+                let (new_k, new_v) =
+                    alloc_pool_pair(device, &shape, n_elements, storage_dtype, layer_idx)?;
+                // The new pool's async zero-fill must COMPLETE before we copy the
+                // surviving prefix over it — otherwise a large (grow) zero-fill
+                // can land AFTER the copy and wipe it. Same-stream ordering is not
+                // sufficient in practice here, so synchronize explicitly. Resize
+                // is rare, so this is cheap relative to the multi-layer realloc.
+                if copy_slots > 0 {
+                    sync_device_for_resize(device)?;
+                    let (old_k, old_v) = &pools[layer_idx];
+                    let src_k = old_k.narrow(0, 0, copy_slots).map_err(|e| {
+                        anyhow::anyhow!("physical_resize_to: narrow k l{layer_idx}: {e}")
+                    })?;
+                    let src_v = old_v.narrow(0, 0, copy_slots).map_err(|e| {
+                        anyhow::anyhow!("physical_resize_to: narrow v l{layer_idx}: {e}")
+                    })?;
+                    new_k.slice_set(&src_k, 0, 0).map_err(|e| {
+                        anyhow::anyhow!("physical_resize_to: copy k l{layer_idx}: {e}")
+                    })?;
+                    new_v.slice_set(&src_v, 0, 0).map_err(|e| {
+                        anyhow::anyhow!("physical_resize_to: copy v l{layer_idx}: {e}")
+                    })?;
+                }
+                Ok((new_k, new_v))
+            };
 
         if growing {
             // ATOMIC: stage all, then commit. `?` on any layer leaves self intact.
-            let mut staged: Vec<(KtTensor, KtTensor)> = Vec::with_capacity(self.layers.len());
-            for layer_idx in 0..self.layers.len() {
-                staged.push(make_resized(self, layer_idx)?);
+            let mut staged: Vec<(KtTensor, KtTensor)> = Vec::with_capacity(layers.len());
+            for layer_idx in 0..layers.len() {
+                staged.push(make_resized(&layers, layer_idx)?);
             }
-            self.layers = staged;
+            *layers = staged;
         } else {
             // SHRINK: in-place per layer so each old pool frees before the next
             // alloc (bounded VRAM). Effectively atomic — see method doc.
-            for layer_idx in 0..self.layers.len() {
-                let resized = make_resized(self, layer_idx)?;
-                self.layers[layer_idx] = resized;
+            for layer_idx in 0..layers.len() {
+                let resized = make_resized(&layers, layer_idx)?;
+                layers[layer_idx] = resized;
             }
         }
-        self.num_blocks = new_num_blocks;
+        self.num_blocks
+            .store(new_num_blocks, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
 
@@ -527,7 +563,8 @@ impl PagedKvCacheKt {
         if k_shape.len() < 2 || k_shape[1] != 1 {
             return Ok(false);
         }
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
 
         if self.fp8 {
             // CUDA: read the device slot index host-side (one 4-byte D2H), then
@@ -658,7 +695,8 @@ impl PagedKvCacheKt {
                 "kt PagedKvCacheKt::write_contiguous_slot_run requires BF16 inputs"
             );
         }
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
         let pool_shape = k_pool.shape();
         anyhow::ensure!(
             pool_shape.len() == 3,
@@ -836,7 +874,8 @@ impl PagedKvCacheKt {
         block_table: &BlockTable,
         seq_len: usize,
     ) -> Result<(KtTensor, KtTensor)> {
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
 
         let (k_slice, v_slice) = if let Some(start_slot) =
             contiguous_slot_run_start(block_table, self.block_size, 0, seq_len)
@@ -954,7 +993,8 @@ impl PagedKvCacheKt {
         if self.fp8 || k.dtype() != KtDType::BF16 || v.dtype() != KtDType::BF16 {
             return Ok(false);
         }
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
         kiln_flash_attn::paged_kv_write_token_major_bf16_kt(k_pool, v_pool, k, v, slot)
             .map_err(|e| anyhow::anyhow!("kt paged_kv_write_token_major_bf16: {e}"))?;
         Ok(true)
@@ -992,7 +1032,8 @@ impl PagedKvCacheKt {
         let new_len = k
             .dim(1)
             .map_err(|e| anyhow::anyhow!("kt pkv token_major: k.dim(1): {e}"))?;
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
 
         if new_len == 1 {
             let slot = block_table
@@ -1119,7 +1160,8 @@ impl PagedKvCacheKt {
 
         #[cfg(feature = "metal")]
         if matches!(k.device(), kiln_tensor::Device::Metal(_)) {
-            let (k_pool, v_pool) = &self.layers[layer_idx];
+            let pools = self.layers_read();
+            let (k_pool, v_pool) = &pools[layer_idx];
             let slots_tensor = KtTensor::from_vec_on(k.device(), slots, vec![batch])
                 .map_err(|e| anyhow::anyhow!("kt pkv metal batch: build slots: {e}"))?;
             let k_c = k
@@ -1295,7 +1337,8 @@ impl PagedKvCacheKt {
         if slots.dtype() != KtDType::U32 || slots_shape.len() != 1 || slots_shape[0] != batch {
             return Ok(false);
         }
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
         // Collapse the seq_len=1 dim before dispatching so the fused
         // kernel sees a contiguous [batch, num_kv_heads, head_dim] block.
         let k_sq = k
@@ -1366,7 +1409,8 @@ impl PagedKvCacheKt {
         let new_len = k
             .dim(2)
             .map_err(|e| anyhow::anyhow!("kt pkv write_native: k.dim(2): {e}"))?;
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
 
         // (#1082 Vulkan/non-CUDA) The pool is allocated in the cache's storage
         // dtype (BF16 for Qwen3.5-4B — matches the CUDA cache + the memory
@@ -1516,7 +1560,8 @@ impl PagedKvCacheKt {
                 .map_err(|e| anyhow::anyhow!("kt pkv write_fp8: quantize k: {e}"))?;
             let v_q = fp8_quantize_direct_dev(&v_sq)
                 .map_err(|e| anyhow::anyhow!("kt pkv write_fp8: quantize v: {e}"))?;
-            let (k_pool, v_pool) = &self.layers[layer_idx];
+            let pools = self.layers_read();
+            let (k_pool, v_pool) = &pools[layer_idx];
             k_pool
                 .slice_set(&k_q, 0, slot)
                 .map_err(|e| anyhow::anyhow!("kt pkv write_fp8: slice_set k: {e}"))?;
@@ -1536,7 +1581,8 @@ impl PagedKvCacheKt {
         let v_q = fp8_quantize_direct_dev(&v_flat)
             .map_err(|e| anyhow::anyhow!("kt pkv write_fp8: quantize v block: {e}"))?;
 
-        let (k_pool, v_pool) = &self.layers[layer_idx];
+        let pools = self.layers_read();
+        let (k_pool, v_pool) = &pools[layer_idx];
 
         if let Some(start_slot) =
             contiguous_slot_run_start(block_table, self.block_size, start_pos, new_len)
@@ -1615,9 +1661,9 @@ mod tests {
         // cache via the field-fill pattern and confirm the accessors
         // surface the expected values.
         let cache = PagedKvCacheKt {
-            layers: Vec::new(),
+            layers: std::sync::RwLock::new(Vec::new()),
             block_size: 16,
-            num_blocks: 1024,
+            num_blocks: std::sync::atomic::AtomicUsize::new(1024),
             fp8: true,
             fp8_scales: Vec::new(),
             compute_dtype: KtDType::BF16,

--- a/crates/kiln-model/src/paged_kv_cache_kt.rs
+++ b/crates/kiln-model/src/paged_kv_cache_kt.rs
@@ -361,6 +361,31 @@ impl PagedKvCacheKt {
         self.num_blocks.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// The device the pools live on (layer 0's k pool), or `None` if the cache
+    /// has no layers. Needed by [`Self::physical_resize_to`] callers that don't
+    /// otherwise carry the device.
+    pub fn device(&self) -> Option<kiln_tensor::Device> {
+        self.layers_read().first().map(|(k, _)| k.device())
+    }
+
+    /// Storage bytes one block occupies across ALL layers and both K and V pools:
+    /// `num_layers * 2 * block_size * num_kv_heads * head_dim * storage_dtype_size`.
+    /// The memory governor's resize policy uses this to translate a VRAM target
+    /// into a block-count target. `0` if the cache has no layers.
+    pub fn bytes_per_block(&self) -> usize {
+        let layers = self.layers_read();
+        let Some((k, _)) = layers.first() else {
+            return 0;
+        };
+        let dims = k.dims();
+        if dims.len() != 3 {
+            return 0;
+        }
+        let per_slot = dims[1] * dims[2]; // num_kv_heads * head_dim
+        let dtype_size = k.dtype().size_in_bytes().max(1);
+        layers.len() * 2 * self.block_size * per_slot * dtype_size
+    }
+
     pub fn num_layers(&self) -> usize {
         self.layers_read().len()
     }

--- a/crates/kiln-model/src/rocm_graph.rs
+++ b/crates/kiln-model/src/rocm_graph.rs
@@ -390,6 +390,21 @@ impl RocmGraphRunner {
                 );
             }
 
+            // Memory-pressure guard: capturing a new graph mints freeze-pointer
+            // arena + per-layer output buffers (a few MB). Under Critical memory
+            // pressure (a coexisting job / training run has the VRAM), skip the
+            // capture and run eager rather than risk the allocation tipping the
+            // box into OOM — the governor sees all-process usage, so this respects
+            // whatever else is on the GPU. Decode stays correct either way.
+            if kiln_memory::MemoryGovernor::global().pressure()
+                == kiln_memory::MemoryPressure::Critical
+            {
+                return Self::eager_forward(
+                    backend, token_id, weights, config, paged_cache, block_table, seq_len,
+                    linear_state, lora,
+                );
+            }
+
             // Capture.
             match self.try_capture(
                 backend, token_id, weights, config, paged_cache, block_table, seq_len,

--- a/crates/kiln-model/tests/cuda_kv_physical_resize.rs
+++ b/crates/kiln-model/tests/cuda_kv_physical_resize.rs
@@ -1,0 +1,73 @@
+//! #26 — CUDA twin of `rocm_kv_physical_resize`: proves
+//! `PagedKvCacheKt::physical_resize_to` preserves live KV byte-for-byte across a
+//! shrink AND a grow on a real `Device::Cuda` device, exercising the CUDA arm of
+//! `alloc_pool_pair` (`cuda_zeros_ctx`) + the device-agnostic narrow/slice_set
+//! copy + the entry/zero-fill device syncs. Skips unless a CUDA device exists.
+//!
+//! Run: `cargo test -p kiln-model --no-default-features --features cuda \
+//!        --test cuda_kv_physical_resize -- --nocapture --test-threads=1`
+#![cfg(feature = "cuda")]
+
+use kiln_model::PagedKvCacheKt;
+use kiln_tensor::{DType, Device, Tensor};
+
+const LAYERS: usize = 4;
+const KV_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+const BLOCK_SIZE: usize = 16;
+const NUM_BLOCKS: usize = 4000;
+const SHRUNK_BLOCKS: usize = 500;
+
+#[test]
+fn cuda_physical_resize_preserves_kv() {
+    if !kiln_tensor::cuda_is_available() {
+        eprintln!("skip cuda_physical_resize: no CUDA device");
+        return;
+    }
+    let dev = Device::Cuda(0);
+
+    let cache = PagedKvCacheKt::new(
+        LAYERS, NUM_BLOCKS, BLOCK_SIZE, KV_HEADS, HEAD_DIM, DType::BF16, dev,
+    )
+    .expect("alloc cuda kv cache");
+    {
+        let (k0, _) = cache.pool_tensors(0).expect("layer 0");
+        assert!(
+            matches!(k0.device(), Device::Cuda(_)),
+            "pools must be device-resident (got {:?})",
+            k0.device()
+        );
+    }
+
+    // Marker into slot 7 of layer 0's K pool; reference = bytes as stored.
+    let marker: Vec<f32> = (0..(KV_HEADS * HEAD_DIM)).map(|i| (i % 17) as f32 + 1.0).collect();
+    let marker_t = Tensor::from_vec(marker.clone(), vec![1, KV_HEADS, HEAD_DIM])
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(dev)
+        .unwrap();
+    cache.pool_tensors(0).unwrap().0.slice_set(&marker_t, 0, 7).expect("write marker");
+
+    let read_marker = |c: &PagedKvCacheKt| -> Vec<f32> {
+        c.pool_tensors(0).unwrap().0
+            .narrow(0, 7, 1).unwrap()
+            .to_dtype(DType::F32).unwrap()
+            .flatten_all().unwrap()
+            .to_vec().unwrap()
+    };
+    let reference = read_marker(&cache);
+    let assert_marker = |got: &[f32], when: &str| {
+        assert_eq!(got, &reference[..], "marker slot 7 not preserved byte-for-byte {when}");
+    };
+
+    // SHRINK (data preserved) then GROW (prefix preserved).
+    cache.physical_resize_to(SHRUNK_BLOCKS, dev).expect("shrink");
+    assert_eq!(cache.num_blocks(), SHRUNK_BLOCKS);
+    assert_marker(&read_marker(&cache), "across cuda shrink");
+
+    cache.physical_resize_to(NUM_BLOCKS, dev).expect("grow");
+    assert_eq!(cache.num_blocks(), NUM_BLOCKS);
+    assert_marker(&read_marker(&cache), "across cuda grow");
+    eprintln!("[cuda-resize] OK: marker preserved across shrink {NUM_BLOCKS}->{SHRUNK_BLOCKS}->{NUM_BLOCKS}");
+}

--- a/crates/kiln-model/tests/rocm_kv_physical_resize.rs
+++ b/crates/kiln-model/tests/rocm_kv_physical_resize.rs
@@ -1,0 +1,127 @@
+//! #26 — On-box proof that `PagedKvCacheKt::physical_resize_to` is a REAL
+//! elastic VRAM actuator on `Device::Rocm`:
+//!   1. Surviving KV is preserved byte-for-byte across the realloc (shrink+grow).
+//!   2. A shrink RECLAIMS: it frees the KV bytes back to the device pool (pool
+//!      `used` drops), and a subsequent ("training") allocation REUSES them
+//!      WITHOUT growing the pool's reservation. That same-process, in-pool reuse
+//!      — not returning memory to the OS — is what makes training/inference VRAM
+//!      arbitration work and "never OOM".
+//!
+//! Memory is measured via `rocm_pool_stats` (the HIP pool's own reserved/used
+//! counters): PROCESS-ISOLATED, immune to the coexisting llama-server that makes
+//! the all-process DRM counters unusable for this measurement.
+//!
+//! Run: `cargo test -p kiln-model --no-default-features --features rocm \
+//!        --test rocm_kv_physical_resize -- --nocapture --test-threads=1`
+#![cfg(feature = "rocm")]
+
+use kiln_model::PagedKvCacheKt;
+use kiln_tensor::{DType, Device, Tensor};
+
+// ~2 GB cache: per-slot bytes = KV_HEADS*HEAD_DIM*2(bf16); 2 pools/layer.
+const LAYERS: usize = 4;
+const KV_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+const BLOCK_SIZE: usize = 16;
+const NUM_BLOCKS: usize = 8000;
+const SHRUNK_BLOCKS: usize = 500;
+
+fn pool_mb() -> (f64, f64) {
+    let (r, u) = kiln_tensor::rocm_pool_stats(0).unwrap();
+    (r as f64 / (1024.0 * 1024.0), u as f64 / (1024.0 * 1024.0))
+}
+
+#[test]
+fn rocm_physical_resize_preserves_kv_and_reclaims_for_reuse() {
+    if !kiln_tensor::rocm_is_available() {
+        eprintln!("skip rocm_physical_resize: no ROCm device");
+        return;
+    }
+    let dev = Device::Rocm(0);
+
+    let mut cache = PagedKvCacheKt::new(
+        LAYERS, NUM_BLOCKS, BLOCK_SIZE, KV_HEADS, HEAD_DIM, DType::BF16, dev,
+    )
+    .expect("alloc rocm kv cache");
+    {
+        let (k0, _) = cache.pool_tensors(0).expect("layer 0");
+        assert!(
+            matches!(k0.device(), Device::Rocm(_)),
+            "pools must be device-resident (got {:?}); is KILN_ROCM_PAGED_DECODE disabled?",
+            k0.device()
+        );
+    }
+
+    // Marker into slot 7 of layer 0's K pool; reference read = bytes as stored
+    // (BF16-rounded). A physical resize copies bytes verbatim, so later reads
+    // must equal this EXACTLY.
+    let marker: Vec<f32> = (0..(KV_HEADS * HEAD_DIM)).map(|i| (i as f32) * 0.5 + 1.0).collect();
+    let marker_t = Tensor::from_vec(marker.clone(), vec![1, KV_HEADS, HEAD_DIM])
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(dev)
+        .unwrap();
+    cache.pool_tensors(0).unwrap().0.slice_set(&marker_t, 0, 7).expect("write marker");
+    let read_marker = |c: &PagedKvCacheKt| -> Vec<f32> {
+        c.pool_tensors(0).unwrap().0
+            .narrow(0, 7, 1).unwrap()
+            .to_dtype(DType::F32).unwrap()
+            .flatten_all().unwrap()
+            .to_vec().unwrap()
+    };
+    let reference = read_marker(&cache);
+    let assert_marker = |got: &[f32], when: &str| {
+        assert_eq!(got, &reference[..], "marker slot 7 not preserved byte-for-byte {when}");
+    };
+
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let (res_full, used_full) = pool_mb();
+    eprintln!("[resize] full cache: reserved={res_full:.0} used={used_full:.0} MB");
+    assert!(used_full > 1500.0, "full cache should use ~2GB (got {used_full:.0})");
+
+    // SHRINK: realloc each layer's pool down to SHRUNK_BLOCKS → frees ~94% of KV.
+    cache.physical_resize_to(SHRUNK_BLOCKS, dev).expect("shrink");
+    assert_eq!(cache.num_blocks(), SHRUNK_BLOCKS);
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let (_res_shrunk, used_shrunk) = pool_mb();
+    eprintln!("[resize] after shrink: used={used_shrunk:.0} MB (was {used_full:.0})");
+    assert_marker(&read_marker(&cache), "across shrink");
+    assert!(
+        used_full - used_shrunk > 1500.0,
+        "shrink must free the KV bytes back to the pool: used {used_full:.0} -> {used_shrunk:.0} MB"
+    );
+
+    // RECLAIM PROOF: a ~1.8GB training-like workload (chunked) after the shrink
+    // must REUSE the freed KV bytes — pool RESERVED must not grow past the full
+    // cache's high-water. A leak would push reserved up by ~1.8GB.
+    let chunk_elems = (200usize * 1024 * 1024) / 2;
+    let mut training = Vec::new();
+    for _ in 0..9 {
+        training.push(kiln_tensor::rocm_zeros_ctx(0, DType::BF16, chunk_elems).expect("train chunk"));
+    }
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let (res_train, used_train) = pool_mb();
+    let reserved_growth = res_train - res_full;
+    eprintln!(
+        "[resize] after +1.8GB training: reserved={res_train:.0} used={used_train:.0} MB \
+         (reserved growth vs full-cache hwm: {reserved_growth:.0})"
+    );
+    assert!(
+        reserved_growth < 400.0,
+        "training after shrink must REUSE freed KV (reserved grew {reserved_growth:.0} MB; \
+         0=perfect reuse, ~1800=leak)"
+    );
+    // Localize any corruption: is the marker still intact in the LIVE shrunk
+    // pool after the training workload (before grow)?
+    assert_marker(&read_marker(&cache), "after training, before grow");
+    drop(training);
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    assert_marker(&read_marker(&cache), "after training drop, before grow");
+
+    // GROW back to full: prefix (marker) intact, num_blocks restored.
+    cache.physical_resize_to(NUM_BLOCKS, dev).expect("grow");
+    assert_eq!(cache.num_blocks(), NUM_BLOCKS);
+    assert_marker(&read_marker(&cache), "across grow");
+    eprintln!("[resize] grow OK; marker intact; num_blocks={}", cache.num_blocks());
+}

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -44,6 +44,7 @@ required-features = ["cuda"]
 
 [dependencies]
 kiln-core = { workspace = true }
+kiln-memory = { workspace = true }
 kiln-eval = { workspace = true }
 kiln-model = { workspace = true }
 kiln-scheduler = { workspace = true }

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -52,7 +52,7 @@ const QWEN_TOOL_CALL_OPEN_TAG: &str = "<tool_call>";
 const QWEN_TOOL_CALL_CLOSE_TAG: &str = "</tool_call>";
 
 fn observe_post_prefill_vram(memory_budget: &std::sync::Arc<crate::state::GpuMemoryBudget>) {
-    if let Some(bytes) = kiln_core::vram::detect_used_vram_bytes() {
+    if let Some(bytes) = kiln_memory::vram::detect_used_vram_bytes() {
         memory_budget.observe_prefill_used_vram_bytes(bytes);
     }
 }

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -71,6 +71,29 @@ struct GpuMemoryInfo {
     allocated_gb: f64,
     reserved_gb: f64,
     inference_memory_fraction: f64,
+    /// The memory governor's LIVE, all-process view right now (driver counters /
+    /// MemAvailable) — what kiln actually sees, including any coexisting GPU job.
+    /// Distinct from the static startup budget above. `None` on CPU / when
+    /// undetectable.
+    live: Option<LiveMemory>,
+}
+
+#[derive(Serialize)]
+struct LiveMemory {
+    total_gb: f64,
+    /// Used by ALL processes right now (includes coexisting GPU jobs).
+    used_gb: f64,
+    free_gb: f64,
+    /// Free − safety floor − soft reservations: what kiln may allocate now.
+    available_gb: f64,
+    /// Soft reservations announced by training/other planned allocations.
+    soft_reserved_gb: f64,
+    /// Comfortable | Moderate | Tight | Critical.
+    pressure: String,
+    /// Probe provenance (e.g. linux-drm-sysfs, nvidia-smi).
+    source: String,
+    /// True when GPU shares system RAM (APU / Apple Silicon).
+    unified: bool,
 }
 
 #[derive(Serialize)]
@@ -321,6 +344,22 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         let peak_prefill_used_bytes = b.peak_prefill_used_vram_bytes();
         let allocated_bytes = b.model_memory_bytes.saturating_add(b.kv_cache_bytes);
         let reserved_bytes = allocated_bytes.saturating_add(b.training_budget_bytes);
+        // The governor's LIVE view right now — what kiln actually sees, including
+        // a coexisting llama.cpp / vLLM / training job (the probe is all-process).
+        let live = {
+            let g = kiln_memory::MemoryGovernor::global();
+            let s = g.snapshot();
+            (s.total_bytes > 0).then(|| LiveMemory {
+                total_gb: s.total_bytes as f64 / 1e9,
+                used_gb: s.used_bytes as f64 / 1e9,
+                free_gb: s.free_bytes as f64 / 1e9,
+                available_gb: g.available_bytes() as f64 / 1e9,
+                soft_reserved_gb: g.soft_reserved_bytes() as f64 / 1e9,
+                pressure: format!("{:?}", g.pressure()),
+                source: s.source.to_string(),
+                unified: s.unified,
+            })
+        };
         Some(GpuMemoryInfo {
             total_vram_bytes: b.total_vram_bytes,
             model_bytes: b.model_memory_bytes,
@@ -341,6 +380,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
             allocated_gb: allocated_bytes as f64 / 1e9,
             reserved_gb: reserved_bytes as f64 / 1e9,
             inference_memory_fraction: b.inference_memory_fraction,
+            live,
         })
     } else {
         None

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -101,7 +101,7 @@ fn enforce_training_preflight(
     if max_seq_len == 0 {
         return Ok(());
     }
-    let vram = kiln_core::vram::detect_vram();
+    let vram = kiln_memory::vram::detect_vram();
     let available = available_for_training_bytes(&vram);
     if available == u64::MAX {
         // No memory signal at all — let the trainer be the line of
@@ -128,9 +128,9 @@ fn enforce_training_preflight(
     // process, so treat it as a post-load budget as well.
     let weights_already_resident = matches!(
         vram.source,
-        kiln_core::vram::VramSource::LinuxDrmSysfsUnified
-            | kiln_core::vram::VramSource::AppleSilicon
-            | kiln_core::vram::VramSource::EnvOverride
+        kiln_memory::vram::VramSource::LinuxDrmSysfsUnified
+            | kiln_memory::vram::VramSource::AppleSilicon
+            | kiln_memory::vram::VramSource::EnvOverride
     );
     let estimate = if vk_native_recompute {
         estimate_vk_native_recompute_working_set(

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -21,7 +21,10 @@ use kiln_model::{
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
-use crate::state::{GpuCoordinationLock, RealPrefixCache, gpu_coordination_read_guard};
+use crate::state::{
+    GpuCoordinationLock, RealPrefixCache, gpu_coordination_read_guard,
+    gpu_coordination_write_guard,
+};
 
 const DEFAULT_ENGINE_CHANNEL: usize = 1024;
 const DEFAULT_RESPONSE_CHANNEL: usize = 64;
@@ -251,6 +254,24 @@ pub trait DecodeForward: Send + Sync + 'static {
         finish_reason: FinishReason,
     ) -> Result<DecodeForwardOutput>;
     fn discard_request(&self, _slot: DecodeSlot) {}
+
+    /// Physically resize the KV cache to `target_blocks` usable blocks — the
+    /// memory-governor actuator (#26/#24). SHRINK hands KV VRAM back to the pool
+    /// for a coexisting training run to reuse; GROW reclaims it when pressure
+    /// eases. Called ONLY from the engine actor between decode steps (the
+    /// barrier), and takes exclusive GPU access internally so the other decode
+    /// actor / training are excluded while the pools swap. Returns the achieved
+    /// block count (a shrink may stop above `target_blocks` if live requests
+    /// still hold high blocks). Default: no-op (mock/non-paged backends).
+    fn resize_kv(&self, _target_blocks: usize) -> Result<usize> {
+        Ok(0)
+    }
+
+    /// Current usable KV block count, for the governor's resize policy. `None`
+    /// if this forward has no paged cache. Default: `None`.
+    fn kv_num_blocks(&self) -> Option<usize> {
+        None
+    }
 }
 
 pub struct RealDecodeForward {
@@ -663,6 +684,61 @@ impl DecodeForward for RealDecodeForward {
             }
         }
     }
+
+    fn kv_num_blocks(&self) -> Option<usize> {
+        Some(self.paged_cache.num_blocks())
+    }
+
+    fn resize_kv(&self, target_blocks: usize) -> Result<usize> {
+        let device = match self.paged_cache.device() {
+            Some(d) => d,
+            None => return Ok(0),
+        };
+        let cur = self.paged_cache.num_blocks();
+        if target_blocks == cur || target_blocks == 0 {
+            return Ok(cur);
+        }
+        // EXCLUSIVE GPU access for the pool swap: the write guard blocks BOTH
+        // decode actors (they hold the read guard) and any training step (also a
+        // write guard) until the resize completes — so no kernel is reading a
+        // pool we are about to drop. Combined with the device-sync inside
+        // `physical_resize_to`, the swap is race-free. Resize is rare
+        // (governor-driven under pressure), so the brief decode stall is fine.
+        let _gpu = gpu_coordination_write_guard(&self.gpu_lock);
+        if target_blocks < cur {
+            // SHRINK. Logical first: lower the ceiling + retire free high blocks.
+            // We can only physically drop to the live high-water mark right now;
+            // if requests still hold high blocks the shrink stops there, and a
+            // later resize finishes it once they drain.
+            let achievable = {
+                let mut bm = self.block_manager_guard()?;
+                bm.set_target_usable(target_blocks);
+                let achievable = target_blocks.max(bm.physical_floor());
+                bm.physical_truncate(achievable)
+                    .map_err(|e| anyhow::anyhow!("kv shrink truncate to {achievable}: {e}"))?;
+                achievable
+            };
+            self.paged_cache.physical_resize_to(achievable, device)?;
+            tracing::info!(
+                from = cur,
+                to = achievable,
+                target = target_blocks,
+                "KV cache physically shrunk (VRAM returned to pool for reuse)"
+            );
+            Ok(achievable)
+        } else {
+            // GROW. Physical first (alloc bigger, copy existing KV), then publish
+            // the new blocks to the manager and raise the ceiling.
+            self.paged_cache.physical_resize_to(target_blocks, device)?;
+            {
+                let mut bm = self.block_manager_guard()?;
+                bm.physical_grow(target_blocks);
+                bm.set_target_usable(target_blocks);
+            }
+            tracing::info!(from = cur, to = target_blocks, "KV cache physically grown");
+            Ok(target_blocks)
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -764,6 +840,37 @@ impl BatchingEngineHandle {
         rx.await
             .map_err(|_| anyhow::anyhow!("batching engine stopped before snapshot"))
     }
+
+    /// Physically resize the KV cache to `target_blocks` (#26). Returns the
+    /// achieved block count. Async variant for request-handler / API callers.
+    pub async fn resize_kv(&self, target_blocks: usize) -> Result<usize> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(EngineCommand::ResizeKv {
+                target_blocks,
+                reply,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("batching engine stopped"))?;
+        rx.await
+            .map_err(|_| anyhow::anyhow!("batching engine stopped before resize ack"))?
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    /// Blocking variant of [`Self::resize_kv`] for the memory governor's
+    /// (non-async) monitor thread.
+    pub fn resize_kv_blocking(&self, target_blocks: usize) -> Result<usize> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .blocking_send(EngineCommand::ResizeKv {
+                target_blocks,
+                reply,
+            })
+            .map_err(|_| anyhow::anyhow!("batching engine stopped"))?;
+        rx.blocking_recv()
+            .map_err(|_| anyhow::anyhow!("batching engine stopped before resize ack"))?
+            .map_err(|e| anyhow::anyhow!(e))
+    }
 }
 
 enum EngineCommand {
@@ -782,6 +889,12 @@ enum EngineCommand {
     },
     Snapshot {
         reply: oneshot::Sender<BatchingEngineSnapshot>,
+    },
+    /// Physically resize the KV cache to `target_blocks` usable blocks (#26).
+    /// Handled at the between-steps barrier so no forward is in flight.
+    ResizeKv {
+        target_blocks: usize,
+        reply: oneshot::Sender<std::result::Result<usize, String>>,
     },
 }
 
@@ -921,6 +1034,20 @@ impl BatchingEngineActor {
             EngineCommand::Snapshot { reply } => {
                 self.refresh_snapshot();
                 let _ = reply.send(self.snapshot.clone());
+            }
+            EngineCommand::ResizeKv {
+                target_blocks,
+                reply,
+            } => {
+                // Runs at the barrier (drain_commands, between decode steps): the
+                // previous step's `run_decode_batch` has returned, so no forward
+                // is in flight in THIS actor. `resize_kv` additionally takes the
+                // GPU write lock to exclude the other decode actor / training.
+                let result = self
+                    .forward
+                    .resize_kv(target_blocks)
+                    .map_err(|e| format!("{e:#}"));
+                let _ = reply.send(result);
             }
         }
     }

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -19,7 +19,7 @@ use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::token::TokenId;
 use kiln_core::tokenizer::{ChatMessage, KilnTokenizer};
-use kiln_core::vram::{detect_used_vram_bytes, detect_vram};
+use kiln_memory::vram::{detect_used_vram_bytes, detect_vram};
 use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{

--- a/crates/kiln-server/src/kv_autoscaler.rs
+++ b/crates/kiln-server/src/kv_autoscaler.rs
@@ -1,0 +1,243 @@
+//! KV cache autoscaler (#24/#26) — the training/inference VRAM arbiter.
+//!
+//! A background policy thread that watches the [`MemoryGovernor`]'s live,
+//! all-process memory view and physically resizes the paged-KV cache to match:
+//! SHRINK when VRAM gets tight (a coexisting training run / process needs it —
+//! the freed KV bytes return to the device pool for that workload to reuse), and
+//! GROW back toward the startup size when headroom returns. This is what makes
+//! "most workloads are 100% inference, but training dynamically takes VRAM and
+//! gives it back — never OOM" real.
+//!
+//! The actual resize runs on the batching-engine actor at its between-steps
+//! barrier (via `BatchingEngineHandle::resize_kv_blocking`), which takes
+//! exclusive GPU access so no decode/training kernel races the pool swap. This
+//! thread only decides the target and rate-limits.
+//!
+//! Conservative by design — a control loop that thrashes would stall decode
+//! (each resize briefly blocks the GPU). Hysteresis (distinct shrink/grow
+//! thresholds), a step cap, a minimum floor, and a cooldown prevent oscillation.
+//! Disable with `KILN_KV_AUTOSCALE=0`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use kiln_memory::{MemoryGovernor, MemoryPressure};
+use kiln_model::PagedKvCacheKt;
+
+use crate::batching_engine::BatchingEngineHandle;
+
+/// How often the policy re-evaluates.
+const TICK: Duration = Duration::from_secs(2);
+/// Minimum spacing between two resizes — a resize blocks the GPU briefly, so we
+/// never react faster than this even if pressure swings.
+const COOLDOWN: Duration = Duration::from_secs(8);
+/// Target free-VRAM headroom the policy steers toward, as a multiple of one
+/// block's bytes. Below `SHRINK` we free KV; above `GROW` (and below the
+/// startup size) we reclaim it. The gap is the anti-thrash dead-band.
+const HEADROOM_SHRINK_BLOCKS: u64 = 64;
+const HEADROOM_GROW_BLOCKS: u64 = 512;
+/// Never resize by more than this fraction of the current size in one step, so a
+/// transient spike can't collapse the cache.
+const MAX_STEP_FRACTION: f64 = 0.35;
+
+#[derive(Clone, Copy)]
+struct Bounds {
+    /// Startup block count — the grow ceiling.
+    max_blocks: usize,
+    /// Never shrink below this (keeps inference viable even under pressure).
+    min_blocks: usize,
+}
+
+fn is_disabled() -> bool {
+    matches!(
+        std::env::var("KILN_KV_AUTOSCALE").as_deref(),
+        Ok("0") | Ok("false") | Ok("FALSE") | Ok("off") | Ok("OFF") | Ok("no")
+    )
+}
+
+/// Spawn the autoscaler thread. No-op (returns without spawning) if disabled, or
+/// if the cache can't report its geometry. Idempotent is the CALLER's concern.
+pub fn spawn(engine: BatchingEngineHandle, paged_cache: Arc<PagedKvCacheKt>) {
+    if is_disabled() {
+        tracing::info!("KV autoscaler disabled (KILN_KV_AUTOSCALE=0)");
+        return;
+    }
+    let bytes_per_block = paged_cache.bytes_per_block();
+    let start_blocks = paged_cache.num_blocks();
+    if bytes_per_block == 0 || start_blocks == 0 {
+        tracing::info!("KV autoscaler not started: cache reports no geometry");
+        return;
+    }
+    // Keep at least a quarter of the startup cache (and >= 1) under any pressure.
+    let bounds = Bounds {
+        max_blocks: start_blocks,
+        min_blocks: (start_blocks / 4).max(1),
+    };
+    tracing::info!(
+        start_blocks,
+        min_blocks = bounds.min_blocks,
+        bytes_per_block,
+        "KV autoscaler started (set KILN_KV_AUTOSCALE=0 to disable)"
+    );
+
+    std::thread::Builder::new()
+        .name("kiln-kv-autoscaler".to_string())
+        .spawn(move || run(engine, paged_cache, bytes_per_block as u64, bounds))
+        .expect("spawn kv autoscaler");
+}
+
+fn run(
+    engine: BatchingEngineHandle,
+    paged_cache: Arc<PagedKvCacheKt>,
+    bytes_per_block: u64,
+    bounds: Bounds,
+) {
+    let gov = MemoryGovernor::global();
+    let mut last_resize = Instant::now() - COOLDOWN;
+
+    // Verification/debug knob: KILN_KV_FORCE_BLOCKS=N performs ONE resize to N
+    // blocks at startup (then normal policy resumes). Lets an operator confirm
+    // the full resize path end-to-end on a box that isn't under real pressure.
+    if let Some(target) = std::env::var("KILN_KV_FORCE_BLOCKS")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+    {
+        match engine.resize_kv_blocking(target) {
+            Ok(achieved) => {
+                last_resize = Instant::now();
+                tracing::info!(requested = target, achieved, "KV autoscaler FORCED resize (KILN_KV_FORCE_BLOCKS)");
+            }
+            Err(err) => tracing::warn!(error = %err, "KV autoscaler forced resize failed"),
+        }
+    }
+
+    loop {
+        std::thread::sleep(TICK);
+        if last_resize.elapsed() < COOLDOWN {
+            continue;
+        }
+        let cur = paged_cache.num_blocks();
+        // available_bytes is the governor's all-process free-VRAM estimate minus
+        // soft reservations — the honest "how much can we hand out" figure.
+        let avail = gov.available_bytes();
+        let pressure = gov.pressure();
+
+        let target = decide_target(cur, avail, bytes_per_block, pressure, bounds);
+        let Some(target) = target else { continue };
+
+        match engine.resize_kv_blocking(target) {
+            Ok(achieved) => {
+                last_resize = Instant::now();
+                if achieved != cur {
+                    tracing::info!(
+                        from = cur,
+                        to = achieved,
+                        requested = target,
+                        pressure = ?pressure,
+                        avail_mb = avail / (1024 * 1024),
+                        "KV autoscaler resized cache"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "KV autoscaler resize failed");
+                last_resize = Instant::now(); // back off on error too
+            }
+        }
+    }
+}
+
+/// Pure policy: given the current block count, available VRAM, per-block bytes,
+/// pressure, and bounds, return the new target block count — or `None` to hold.
+/// Hysteresis: shrink only when clearly tight, grow only when clearly roomy.
+fn decide_target(
+    cur: usize,
+    avail: u64,
+    bytes_per_block: u64,
+    pressure: MemoryPressure,
+    bounds: Bounds,
+) -> Option<usize> {
+    let avail_blocks = avail / bytes_per_block;
+    let max_step = ((cur as f64) * MAX_STEP_FRACTION).ceil() as usize;
+
+    // SHRINK: pressure is high OR free headroom has fallen below the low mark.
+    let tight = matches!(pressure, MemoryPressure::Tight | MemoryPressure::Critical)
+        || avail_blocks < HEADROOM_SHRINK_BLOCKS;
+    if tight && cur > bounds.min_blocks {
+        // Free enough blocks to restore the low headroom, capped by the step.
+        let deficit = HEADROOM_SHRINK_BLOCKS.saturating_sub(avail_blocks) as usize;
+        let step = deficit.clamp(1, max_step);
+        let target = cur.saturating_sub(step).max(bounds.min_blocks);
+        return (target < cur).then_some(target);
+    }
+
+    // GROW: pressure is comfortable AND there's room well above the high mark,
+    // and we're below the startup size.
+    let roomy =
+        matches!(pressure, MemoryPressure::Comfortable) && avail_blocks > HEADROOM_GROW_BLOCKS;
+    if roomy && cur < bounds.max_blocks {
+        // Use the surplus above the high mark, capped by step and the ceiling.
+        let surplus = (avail_blocks - HEADROOM_GROW_BLOCKS) as usize;
+        let step = surplus.clamp(1, max_step);
+        let target = (cur + step).min(bounds.max_blocks);
+        return (target > cur).then_some(target);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BPB: u64 = 10 * 1024 * 1024; // 10 MB/block
+    fn bounds() -> Bounds {
+        Bounds {
+            max_blocks: 1000,
+            min_blocks: 250,
+        }
+    }
+
+    #[test]
+    fn shrinks_under_critical_pressure() {
+        // Tiny headroom → shrink, but never below the floor, never beyond step.
+        let t = decide_target(1000, 0, BPB, MemoryPressure::Critical, bounds());
+        let t = t.expect("should shrink");
+        assert!(t < 1000 && t >= 250, "target {t}");
+        assert!(1000 - t <= 350, "step cap (35% of 1000)");
+    }
+
+    #[test]
+    fn does_not_shrink_below_floor() {
+        let t = decide_target(250, 0, BPB, MemoryPressure::Critical, bounds());
+        assert_eq!(t, None, "already at floor");
+    }
+
+    #[test]
+    fn grows_when_comfortable_with_headroom() {
+        // 5000 blocks of headroom, comfortable, cur below ceiling → grow.
+        let avail = 5000 * BPB;
+        let t = decide_target(300, avail, BPB, MemoryPressure::Comfortable, bounds());
+        let t = t.expect("should grow");
+        assert!(t > 300 && t <= 1000, "target {t}");
+    }
+
+    #[test]
+    fn holds_in_the_deadband() {
+        // Moderate pressure, headroom between the marks → no change (no thrash).
+        let avail = 200 * BPB; // between SHRINK(64) and GROW(512)
+        assert_eq!(
+            decide_target(500, avail, BPB, MemoryPressure::Moderate, bounds()),
+            None
+        );
+    }
+
+    #[test]
+    fn does_not_grow_past_ceiling() {
+        let avail = 99999 * BPB;
+        assert_eq!(
+            decide_target(1000, avail, BPB, MemoryPressure::Comfortable, bounds()),
+            None
+        );
+    }
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod eval;
 pub mod eval_adapter_cli;
 pub mod eval_history;
+pub mod kv_autoscaler;
 pub mod logging;
 pub mod metrics;
 pub mod recent_requests;

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -959,6 +959,45 @@ impl Metrics {
             push_line(&mut out, "kiln_active_adapter{name=\"base\"} 1");
         }
 
+        // --- Live GPU memory (the governor's all-process view) ---
+        // Scrapeable counterpart to /health's `live` block: total / used (ALL
+        // processes, incl. a coexisting llama.cpp / vLLM job) / free / available
+        // / soft-reserved bytes, plus a pressure level (0=Comfortable, 1=Moderate,
+        // 2=Tight, 3=Critical). Lets Prometheus/Grafana alert on memory pressure
+        // and watch coexistence without shelling into nvtop.
+        {
+            let g = kiln_memory::MemoryGovernor::global();
+            let s = g.snapshot();
+            if s.total_bytes > 0 {
+                out.push_str(
+                    "# HELP kiln_gpu_memory_bytes Live GPU memory by kind (all-process driver view).\n",
+                );
+                out.push_str("# TYPE kiln_gpu_memory_bytes gauge\n");
+                push_line(&mut out, &format!("kiln_gpu_memory_bytes{{kind=\"total\"}} {}", s.total_bytes));
+                push_line(&mut out, &format!("kiln_gpu_memory_bytes{{kind=\"used\"}} {}", s.used_bytes));
+                push_line(&mut out, &format!("kiln_gpu_memory_bytes{{kind=\"free\"}} {}", s.free_bytes));
+                push_line(
+                    &mut out,
+                    &format!("kiln_gpu_memory_bytes{{kind=\"available\"}} {}", g.available_bytes()),
+                );
+                push_line(
+                    &mut out,
+                    &format!("kiln_gpu_memory_bytes{{kind=\"soft_reserved\"}} {}", g.soft_reserved_bytes()),
+                );
+                out.push_str(
+                    "# HELP kiln_gpu_memory_pressure GPU memory pressure (0=Comfortable 1=Moderate 2=Tight 3=Critical).\n",
+                );
+                out.push_str("# TYPE kiln_gpu_memory_pressure gauge\n");
+                let level = match g.pressure() {
+                    kiln_memory::MemoryPressure::Comfortable => 0,
+                    kiln_memory::MemoryPressure::Moderate => 1,
+                    kiln_memory::MemoryPressure::Tight => 2,
+                    kiln_memory::MemoryPressure::Critical => 3,
+                };
+                push_line(&mut out, &format!("kiln_gpu_memory_pressure {level}"));
+            }
+        }
+
         out
     }
 }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1305,7 +1305,7 @@ pub struct AppState {
     /// `teacher: alias` request field.
     pub teacher_registry: crate::api::teachers::SharedTeacherRegistry,
     /// Detected VRAM info for config/debug reporting.
-    pub vram_info: kiln_core::vram::GpuVramInfo,
+    pub vram_info: kiln_memory::vram::GpuVramInfo,
     /// Shutdown flag — set to true when the server is shutting down.
     pub shutdown: ShutdownFlag,
     /// Per-request timeout duration. Configurable via KILN_REQUEST_TIMEOUT_SECS (default 600).
@@ -1512,9 +1512,9 @@ impl AppState {
             gpu_lock: Arc::new(std::sync::RwLock::new(())),
             training_queue: crate::training_queue::new_shared_queue(),
             teacher_registry: Arc::new(crate::api::teachers::TeacherRegistry::new()),
-            vram_info: kiln_core::vram::GpuVramInfo {
+            vram_info: kiln_memory::vram::GpuVramInfo {
                 total_bytes: 0,
-                source: kiln_core::vram::VramSource::None,
+                source: kiln_memory::vram::VramSource::None,
             },
             shutdown: crate::training_queue::new_shutdown_flag(),
             request_timeout: std::time::Duration::from_secs(request_timeout_secs),
@@ -1641,7 +1641,7 @@ impl AppState {
 
         // Detect VRAM once and reuse it for both auto-sizing and reporting so
         // startup doesn't repeat the same probe/logging path.
-        let vram_info = kiln_core::vram::detect_vram();
+        let vram_info = kiln_memory::vram::detect_vram();
         // `device_kt` is the (already kt-typed) device param after #1082;
         // the previous candle->kt bridge that lived here is gone.
         let total_vram = detected_gpu_total_memory(&device_kt, &vram_info);
@@ -1864,8 +1864,8 @@ impl AppState {
         // at-a-glance instead of diff'ing env vars against the docs.
         // Only logged when there's an actual Vulkan device — on CPU
         // or non-Vulkan backends these flags are irrelevant.
-        if vram_info.source == kiln_core::vram::VramSource::LinuxDrmSysfs
-            || vram_info.source == kiln_core::vram::VramSource::LinuxDrmSysfsUnified
+        if vram_info.source == kiln_memory::vram::VramSource::LinuxDrmSysfs
+            || vram_info.source == kiln_memory::vram::VramSource::LinuxDrmSysfsUnified
         {
             // Same truthy/falsy semantics as kiln_core::env_flag::env_flag,
             // but we want to surface whether the value came from the env
@@ -2258,9 +2258,9 @@ fn device_needs_inference_prewarm(device: &kiln_tensor::Device) -> bool {
 
 fn runtime_used_vram_for_device(
     device: &kiln_tensor::Device,
-) -> Option<kiln_core::vram::GpuMemoryUsedInfo> {
+) -> Option<kiln_memory::vram::GpuMemoryUsedInfo> {
     // The live used-memory probe is OS-level (nvidia-smi / AMD+Intel DRM sysfs /
-    // unified-APU MemAvailable, see `kiln_core::vram::current_memory_snapshot`),
+    // unified-APU MemAvailable, see `kiln_memory::vram::current_memory_snapshot`),
     // so it is BACKEND-AGNOSTIC — it works for CUDA, ROCm, Vulkan, and Metal,
     // not just CUDA. Previously this was `#[cfg(feature = "cuda")]`-gated, so on
     // every other backend the KV-cache sizer fell back to a STATIC model-size
@@ -2270,8 +2270,8 @@ fn runtime_used_vram_for_device(
     if device.backend() == kiln_tensor::Backend::Cpu {
         return None;
     }
-    let snap = kiln_core::vram::current_memory_snapshot();
-    (snap.used_bytes > 0).then_some(kiln_core::vram::GpuMemoryUsedInfo {
+    let snap = kiln_memory::vram::current_memory_snapshot();
+    (snap.used_bytes > 0).then_some(kiln_memory::vram::GpuMemoryUsedInfo {
         used_bytes: snap.used_bytes,
         source: snap.source,
     })
@@ -2279,7 +2279,7 @@ fn runtime_used_vram_for_device(
 
 fn detected_gpu_total_memory(
     device: &kiln_tensor::Device,
-    vram: &kiln_core::vram::GpuVramInfo,
+    vram: &kiln_memory::vram::GpuVramInfo,
 ) -> u64 {
     // Migrated to take `&kt::Device` directly. The cuda and metal arms
     // remain feature-gated to preserve the previous cfg-gated behavior
@@ -2438,7 +2438,7 @@ fn format_oom_remediation_message(
     bytes_per_block: u64,
     suggested_blocks: usize,
     configured_fraction: f64,
-    vram_source: kiln_core::vram::VramSource,
+    vram_source: kiln_memory::vram::VramSource,
 ) -> String {
     let mut buf = String::new();
     buf.push_str(
@@ -3654,7 +3654,7 @@ mod tests {
             bytes_per_block,
             suggested,
             0.85,
-            kiln_core::vram::VramSource::NvidiaSmi,
+            kiln_memory::vram::VramSource::NvidiaSmi,
         );
         assert!(
             msg.contains("KILN_NUM_BLOCKS=8192"),
@@ -3706,7 +3706,7 @@ mod tests {
             1024,
             64,
             0.85,
-            kiln_core::vram::VramSource::None,
+            kiln_memory::vram::VramSource::None,
         );
         assert!(msg.contains("KILN_NUM_BLOCKS=64"), "message: {msg}");
         assert!(

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1789,16 +1789,37 @@ impl AppState {
         // uninitialized — a one-time startup memset, not a correctness change
         // (paged writes overwrite slots before they are read).
         let allocate_cache = |n: usize| -> anyhow::Result<PagedKvCacheKt> {
-            PagedKvCacheKt::new_with_fp8(
-                model_config.num_full_attention_layers,
-                n,
-                block_size,
-                model_config.num_kv_heads,
-                model_config.head_dim,
-                kv_dtype,
-                device_kt,
-                fp8_enabled,
-            )
+            let attempt = || {
+                PagedKvCacheKt::new_with_fp8(
+                    model_config.num_full_attention_layers,
+                    n,
+                    block_size,
+                    model_config.num_kv_heads,
+                    model_config.head_dim,
+                    kv_dtype,
+                    device_kt,
+                    fp8_enabled,
+                )
+            };
+            match attempt() {
+                Ok(c) => Ok(c),
+                // OOM recovery (the "never OOM" path): before falling back to a
+                // smaller fraction, ask the governor to return pooled-but-unused
+                // VRAM to the OS and retry once at the SAME size — the alloc may
+                // have failed only because freed blocks were still pooled (or a
+                // coexisting job briefly spiked). Cheaper than shrinking the KV
+                // cache if the memory is genuinely reclaimable.
+                Err(first) if governor_backend != kiln_tensor::Backend::Cpu => {
+                    let freed = kiln_memory::MemoryGovernor::global().reclaim(u64::MAX);
+                    tracing::warn!(
+                        num_blocks = n,
+                        reclaimed_mb = freed / (1024 * 1024),
+                        "KV cache allocation failed; reclaimed pooled VRAM and retrying at same size"
+                    );
+                    attempt().map_err(|_| first)
+                }
+                Err(e) => Err(e),
+            }
         };
 
         // Determine num_blocks + paged cache:

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -2057,6 +2057,22 @@ impl AppState {
                 Some(backend_name),
             )
         });
+        // #24/#26: drive dynamic KV resize from live memory pressure on GPU
+        // backends whose KV pools are device-resident (CUDA/ROCm) — that's where
+        // inference and a coexisting training run / process actually contend for
+        // VRAM. Host-resident pools (CPU/Vulkan) don't, so there's nothing to
+        // arbitrate. The autoscaler shrinks KV when VRAM gets tight and grows it
+        // back when headroom returns; the resize itself runs on the engine actor
+        // at its barrier under exclusive GPU access.
+        if let Some(engine) = batching_engine.clone() {
+            let device_resident = matches!(
+                paged_cache.device(),
+                Some(kiln_tensor::Device::Rocm(_)) | Some(kiln_tensor::Device::Cuda(_))
+            );
+            if device_resident {
+                crate::kv_autoscaler::spawn(engine, paged_cache.clone());
+            }
+        }
         let decode_batcher = if let Some(config) = decode_batcher_config {
             tracing::info!(
                 backend = backend_name,

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1667,12 +1667,12 @@ impl AppState {
                 post_load_used_vram_gb = post_load_used_vram as f64 / 1e9,
                 estimated_model_gb = estimated_model_bytes as f64 / 1e9,
                 source = %post_load_used_vram_info.unwrap().source,
-                "post-load CUDA residency snapshot for KV sizing"
+                "post-load device residency snapshot for KV sizing"
             );
         } else {
             tracing::warn!(
                 estimated_model_gb = estimated_model_bytes as f64 / 1e9,
-                "post-load CUDA residency unavailable; falling back to static model memory estimate for KV sizing"
+                "post-load device residency unavailable; falling back to static model memory estimate for KV sizing"
             );
         }
 
@@ -2259,21 +2259,22 @@ fn device_needs_inference_prewarm(device: &kiln_tensor::Device) -> bool {
 fn runtime_used_vram_for_device(
     device: &kiln_tensor::Device,
 ) -> Option<kiln_core::vram::GpuMemoryUsedInfo> {
-    // Migrated to take `&kt::Device` directly. The cuda-only used VRAM
-    // probe is still gated on `feature = "cuda"`, matching the previous
-    // cfg-gated behavior. (#1082)
-    #[cfg(feature = "cuda")]
-    {
-        if device.backend() == kiln_tensor::Backend::Cuda {
-            let info = kiln_core::vram::detect_used_vram();
-            return (info.used_bytes > 0).then_some(info);
-        }
+    // The live used-memory probe is OS-level (nvidia-smi / AMD+Intel DRM sysfs /
+    // unified-APU MemAvailable, see `kiln_core::vram::current_memory_snapshot`),
+    // so it is BACKEND-AGNOSTIC — it works for CUDA, ROCm, Vulkan, and Metal,
+    // not just CUDA. Previously this was `#[cfg(feature = "cuda")]`-gated, so on
+    // every other backend the KV-cache sizer fell back to a STATIC model-size
+    // estimate that is blind to live residency and to coexisting GPU workloads.
+    // Wiring it for all GPU backends makes the sizer mindful of the actual VRAM
+    // on whatever device the user is running. CPU has no device memory to probe.
+    if device.backend() == kiln_tensor::Backend::Cpu {
+        return None;
     }
-    #[cfg(not(feature = "cuda"))]
-    {
-        let _ = device;
-    }
-    None
+    let snap = kiln_core::vram::current_memory_snapshot();
+    (snap.used_bytes > 0).then_some(kiln_core::vram::GpuMemoryUsedInfo {
+        used_bytes: snap.used_bytes,
+        source: snap.source,
+    })
 }
 
 fn detected_gpu_total_memory(

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1642,14 +1642,29 @@ impl AppState {
         // Detect VRAM once and reuse it for both auto-sizing and reporting so
         // startup doesn't repeat the same probe/logging path.
         let vram_info = kiln_memory::vram::detect_vram();
-        // `device_kt` is the (already kt-typed) device param after #1082;
-        // the previous candle->kt bridge that lived here is gone.
-        let total_vram = detected_gpu_total_memory(&device_kt, &vram_info);
         let is_metal = is_metal_device(&device_kt);
 
+        // Total AND used come from the SAME live, all-process driver snapshot
+        // (VRAM+GTT on AMD, nvidia-smi on NVIDIA) so they're mutually consistent
+        // and both account for any coexisting GPU workload (e.g. a llama.cpp
+        // server). Falling back to the static `detected_gpu_total_memory` only
+        // when the driver snapshot is unavailable (e.g. Apple Metal). Without
+        // this, total came from the carveout heuristic while used came from the
+        // snapshot — and `used` could exceed `total`.
+        let snap = if device_kt.backend() != kiln_tensor::Backend::Cpu {
+            let s = kiln_memory::vram::current_memory_snapshot();
+            (s.total_bytes > 0).then_some(s)
+        } else {
+            None
+        };
+        let total_vram = snap
+            .map(|s| s.total_bytes)
+            .unwrap_or_else(|| detected_gpu_total_memory(&device_kt, &vram_info));
+
         let post_load_used_vram_info = runtime_used_vram_for_device(&device_kt);
-        let post_load_used_vram = post_load_used_vram_info
-            .map(|info| info.used_bytes)
+        let post_load_used_vram = snap
+            .map(|s| s.used_bytes)
+            .or_else(|| post_load_used_vram_info.map(|info| info.used_bytes))
             .unwrap_or(0);
         let mut sizing_residency_bytes = post_load_used_vram.max(estimated_model_bytes);
         // Vulkan keeps BOTH the paged KV pool AND the resident-decode weight
@@ -1663,10 +1678,15 @@ impl AppState {
                 sizing_residency_bytes.saturating_add(estimated_model_bytes.saturating_mul(2));
         }
         if post_load_used_vram > 0 {
+            let used_source = snap
+                .map(|s| s.source)
+                .or_else(|| post_load_used_vram_info.map(|i| i.source))
+                .unwrap_or(kiln_memory::vram::VramSource::None);
             tracing::info!(
                 post_load_used_vram_gb = post_load_used_vram as f64 / 1e9,
+                total_vram_gb = total_vram as f64 / 1e9,
                 estimated_model_gb = estimated_model_bytes as f64 / 1e9,
-                source = %post_load_used_vram_info.unwrap().source,
+                source = %used_source,
                 "post-load device residency snapshot for KV sizing"
             );
         } else {

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1661,6 +1661,28 @@ impl AppState {
             .map(|s| s.total_bytes)
             .unwrap_or_else(|| detected_gpu_total_memory(&device_kt, &vram_info));
 
+        // Wire the device's memory-reclaim hook into the governor and start its
+        // continuous pressure monitor (once per process). Under memory pressure
+        // — e.g. a coexisting llama.cpp / vLLM job, or a training run, grabbing
+        // VRAM — the governor returns kiln's pooled-but-unused VRAM to the OS
+        // instead of hoarding it. Idempotent via the OnceLock guard.
+        {
+            static GOVERNOR_WIRED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+            GOVERNOR_WIRED.get_or_init(|| {
+                #[cfg(feature = "rocm")]
+                if let kiln_tensor::Device::Rocm(idx) = device_kt {
+                    kiln_memory::MemoryGovernor::global().register_reclaimer(move |_target| {
+                        // Best-effort: return all pooled-but-unused VRAM (keep 0).
+                        // Device-synced inside, so it's race-free; HIP doesn't
+                        // surface bytes freed, so report 0.
+                        let _ = kiln_tensor::rocm_trim_pool(idx, 0);
+                        0
+                    });
+                }
+                kiln_memory::MemoryGovernor::global().start_monitor();
+            });
+        }
+
         let post_load_used_vram_info = runtime_used_vram_for_device(&device_kt);
         let post_load_used_vram = snap
             .map(|s| s.used_bytes)

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1720,8 +1720,9 @@ impl AppState {
 
         // Compute num_blocks for a given fraction. Used both for the explicit
         // `memory_cfg.num_blocks` path and the auto-sizer retry loop below.
+        let governor_backend = device_kt.backend();
         let compute_blocks_for_fraction = |fraction: f64| -> usize {
-            auto_num_blocks_for_fraction(
+            let n = auto_num_blocks_for_fraction(
                 total_vram,
                 sizing_residency_bytes,
                 bytes_per_block,
@@ -1729,7 +1730,20 @@ impl AppState {
                 model_config.max_position_embeddings,
                 block_size,
                 is_metal,
-            )
+            );
+            // Additionally clamp so the KV pool fits within the governor's LIVE
+            // available budget = free − floor − soft reservations. This is the
+            // inference side of the training/inference arbiter: when a training
+            // run reserves its working set with the governor, inference's KV pool
+            // automatically leaves room for it (and for any coexisting GPU job,
+            // since `free` is the all-process driver figure).
+            if governor_backend != kiln_tensor::Backend::Cpu && bytes_per_block > 0 {
+                let avail = kiln_memory::MemoryGovernor::global().available_bytes();
+                let max_blocks = (avail / bytes_per_block) as usize;
+                n.min(max_blocks)
+            } else {
+                n
+            }
         };
 
         // FP8 (E4M3FN) packing currently uses a CPU round-trip on every

--- a/crates/kiln-server/src/training_preflight.rs
+++ b/crates/kiln-server/src/training_preflight.rs
@@ -10,7 +10,7 @@
 
 use kiln_core::config::{DType, ModelConfig};
 use kiln_core::tokenizer::KilnTokenizer;
-use kiln_core::vram::{GpuVramInfo, VramSource};
+use kiln_memory::vram::{GpuVramInfo, VramSource};
 use kiln_train::{GrpoGroup, SftExample};
 
 /// What the trainer can rely on being deduplicated across CPU and GPU.
@@ -642,7 +642,7 @@ pub fn format_oom_message_with_source(
     available_bytes: u64,
     lora_rank: usize,
     num_segments: usize,
-    vram_source: Option<kiln_core::vram::VramSource>,
+    vram_source: Option<kiln_memory::vram::VramSource>,
 ) -> String {
     let est_gb = estimate.total_bytes as f64 / BYTES_PER_GB as f64;
     let avail_gb = available_bytes as f64 / BYTES_PER_GB as f64;
@@ -672,7 +672,7 @@ pub fn format_oom_message_with_source(
 mod tests {
     use super::*;
     use kiln_core::config::ModelConfig;
-    use kiln_core::vram::{GpuVramInfo, VramSource};
+    use kiln_memory::vram::{GpuVramInfo, VramSource};
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/crates/kiln-tensor/Cargo.toml
+++ b/crates/kiln-tensor/Cargo.toml
@@ -124,3 +124,6 @@ rocm = ["dep:kiln-hip", "dep:kiln-rocblas"]
 # kiln-autograd backwards through the substrate end-to-end. Mirrors
 # the dev-dep wiring already used by kiln-optim's training tests.
 kiln-autograd = { workspace = true }
+# #26: on-box VRAM-reclaim isolation test measures all-process used via the
+# driver-counter snapshot. kiln-memory is dep-light (tracing only) → no cycle.
+kiln-memory = { workspace = true }

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -190,7 +190,7 @@ pub use rocm_storage::{
     host_to_rocm_copy, host_to_rocm_copy_ctx, primary_rocm_context, rocm_contiguous,
     rocm_is_available, rocm_slice_set_dim0, rocm_softmax_last_axis,
     rocm_htod_count, rocm_synchronize_compute_stream, rocm_synchronize_default_stream,
-    rocm_to_host_copy, rocm_write_host_in_place, rocm_zeros_ctx, RocmStorage,
+    rocm_mem_get_info, rocm_to_host_copy, rocm_trim_pool, rocm_write_host_in_place, rocm_zeros_ctx, RocmStorage,
 };
 #[cfg(feature = "rocm")]
 pub use rocm_ops::*;

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -190,7 +190,8 @@ pub use rocm_storage::{
     host_to_rocm_copy, host_to_rocm_copy_ctx, primary_rocm_context, rocm_contiguous,
     rocm_is_available, rocm_slice_set_dim0, rocm_softmax_last_axis,
     rocm_htod_count, rocm_synchronize_compute_stream, rocm_synchronize_default_stream,
-    rocm_mem_get_info, rocm_to_host_copy, rocm_trim_pool, rocm_write_host_in_place, rocm_zeros_ctx, RocmStorage,
+    rocm_mem_get_info, rocm_pool_stats, rocm_to_host_copy, rocm_trim_pool, rocm_write_host_in_place,
+    rocm_zeros_ctx, RocmStorage,
 };
 #[cfg(feature = "rocm")]
 pub use rocm_ops::*;

--- a/crates/kiln-tensor/src/rocm_storage.rs
+++ b/crates/kiln-tensor/src/rocm_storage.rs
@@ -415,6 +415,16 @@ pub fn rocm_synchronize_default_stream(device_index: usize) -> Result<()> {
         .map_err(|e| Error::Msg(format!("rocm_synchronize_default_stream({device_index}): {e:?}")))
 }
 
+/// `(reserved, used)` bytes of device `device_index`'s stream-ordered memory
+/// pool — PROCESS-ISOLATED (only kiln's pool), unlike the all-process DRM
+/// counters. `reserved` is kiln's VRAM high-water mark; `used` is what's live.
+/// The right signal for "is freed KV being reused vs growing our footprint."
+pub fn rocm_pool_stats(device_index: usize) -> Result<(u64, u64)> {
+    let ctx = primary_rocm_context(device_index)?;
+    ctx.pool_stats()
+        .map_err(|e| Error::Msg(format!("rocm_pool_stats({device_index}): {e:?}")))
+}
+
 /// Device-reported `(free, total)` ROCm memory via `hipMemGetInfo`. This is the
 /// most accurate "free VRAM on the active GPU" signal — it reports the actual
 /// pool the GPU allocates from (a discrete card's VRAM, or an APU's GART/UMA

--- a/crates/kiln-tensor/src/rocm_storage.rs
+++ b/crates/kiln-tensor/src/rocm_storage.rs
@@ -415,6 +415,29 @@ pub fn rocm_synchronize_default_stream(device_index: usize) -> Result<()> {
         .map_err(|e| Error::Msg(format!("rocm_synchronize_default_stream({device_index}): {e:?}")))
 }
 
+/// Device-reported `(free, total)` ROCm memory via `hipMemGetInfo`. This is the
+/// most accurate "free VRAM on the active GPU" signal — it reports the actual
+/// pool the GPU allocates from (a discrete card's VRAM, or an APU's GART/UMA
+/// carveout), which on a unified APU like Strix Halo is DISTINCT from host
+/// `MemAvailable` (GPU buffers come from the carveout, not system RAM). Use this
+/// to back the memory governor with ground truth for the device in use.
+pub fn rocm_mem_get_info(device_index: usize) -> Result<(usize, usize)> {
+    let ctx = primary_rocm_context(device_index)?;
+    ctx.mem_get_info()
+        .map_err(|e| Error::Msg(format!("rocm_mem_get_info({device_index}): {e:?}")))
+}
+
+/// Return pooled-but-unused ROCm VRAM to the OS, keeping at least
+/// `min_keep_bytes` cached. The memory-pressure reclaim hook: when the governor
+/// sees a coexisting process needs VRAM, this hands kiln's freed pool blocks
+/// back. Device-synchronizes first so the release is race-free (see
+/// [`kiln_hip::RocmContext::trim_pool`]).
+pub fn rocm_trim_pool(device_index: usize, min_keep_bytes: usize) -> Result<()> {
+    let ctx = primary_rocm_context(device_index)?;
+    ctx.trim_pool(min_keep_bytes)
+        .map_err(|e| Error::Msg(format!("rocm_trim_pool({device_index}): {e:?}")))
+}
+
 /// Block until all work on the ACTIVE compute stream completes
 /// (`hipStreamSynchronize`, not the device-wide `hipDeviceSynchronize`). Cheaper
 /// than [`rocm_synchronize_default_stream`] when other (e.g. hipBLASLt-internal)

--- a/crates/kiln-tensor/tests/cuda_resize_copy_primitives.rs
+++ b/crates/kiln-tensor/tests/cuda_resize_copy_primitives.rs
@@ -1,0 +1,82 @@
+//! #26 — CUDA verification of the exact device primitives the paged-KV physical
+//! resize relies on: `cuda_zeros_ctx` (pool alloc), `slice_set` (prefix copy),
+//! `narrow` (prefix view), and the device sync — WITHOUT pulling in kiln-model /
+//! the heavy flash-attn CUTLASS build. The `physical_resize_to` ORCHESTRATION is
+//! device-agnostic and already proven on CPU + ROCm (and its CPU path passes on
+//! this same A6000); this confirms its CUDA building blocks are sound, so the
+//! whole CUDA resize path is covered by composition.
+//!
+//! Run: `cargo test -p kiln-tensor --no-default-features --features cuda \
+//!        --test cuda_resize_copy_primitives -- --nocapture --test-threads=1`
+#![cfg(feature = "cuda")]
+
+use kiln_tensor::{cuda_zeros_ctx, DType, Device, Layout, Tensor, TensorId};
+
+// A KV-pool-shaped buffer: [total_slots, num_kv_heads, head_dim].
+const KV_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+
+fn cuda_pool(total_slots: usize) -> Tensor {
+    let n = total_slots * KV_HEADS * HEAD_DIM;
+    let storage = cuda_zeros_ctx(0, DType::BF16, n).expect("cuda_zeros_ctx");
+    Tensor::from_parts(
+        storage,
+        Layout::contiguous(vec![total_slots, KV_HEADS, HEAD_DIM]),
+        TensorId::next(),
+    )
+    .expect("wrap cuda pool")
+}
+
+#[test]
+fn cuda_pool_prefix_copy_preserves_bytes() {
+    if !kiln_tensor::cuda_is_available() {
+        eprintln!("skip cuda_resize_copy: no CUDA device");
+        return;
+    }
+    let dev = Device::Cuda(0);
+
+    // OLD pool of 256 slots; write a marker into slot 7 (as the KV writer does).
+    let old = cuda_pool(256);
+    assert!(matches!(old.device(), Device::Cuda(_)));
+    let marker: Vec<f32> = (0..(KV_HEADS * HEAD_DIM)).map(|i| (i % 19) as f32 + 1.0).collect();
+    let marker_t = Tensor::from_vec(marker.clone(), vec![1, KV_HEADS, HEAD_DIM])
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(dev)
+        .unwrap();
+    old.slice_set(&marker_t, 0, 7).expect("write marker slot 7");
+
+    let read_slot7 = |t: &Tensor| -> Vec<f32> {
+        t.narrow(0, 7, 1)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec()
+            .unwrap()
+    };
+    let reference = read_slot7(&old);
+
+    // SHRINK-style copy: new smaller pool (128 slots), copy prefix [0,128) via the
+    // same narrow + slice_set physical_resize_to uses. Marker (slot 7 < 128) must
+    // survive byte-for-byte.
+    let new_small = cuda_pool(128);
+    kiln_tensor::cuda_synchronize_default_stream(0).ok();
+    let src = old.narrow(0, 0, 128).unwrap();
+    new_small.slice_set(&src, 0, 0).expect("copy prefix into smaller pool");
+    kiln_tensor::cuda_synchronize_default_stream(0).ok();
+    assert_eq!(read_slot7(&new_small), reference, "marker not preserved on CUDA shrink-copy");
+
+    // GROW-style copy: new larger pool (512 slots), copy all old slots into the
+    // prefix; tail stays zero.
+    let new_big = cuda_pool(512);
+    kiln_tensor::cuda_synchronize_default_stream(0).ok();
+    let src_all = old.narrow(0, 0, 256).unwrap();
+    new_big.slice_set(&src_all, 0, 0).expect("copy prefix into larger pool");
+    kiln_tensor::cuda_synchronize_default_stream(0).ok();
+    assert_eq!(read_slot7(&new_big), reference, "marker not preserved on CUDA grow-copy");
+
+    eprintln!("[cuda-primitives] OK: cuda_zeros_ctx + narrow + slice_set preserve KV bytes across shrink+grow copies");
+}

--- a/crates/kiln-tensor/tests/rocm_pool_reuse.rs
+++ b/crates/kiln-tensor/tests/rocm_pool_reuse.rs
@@ -1,0 +1,54 @@
+//! Decisive, PROCESS-ISOLATED measurement for the dynamic training/inference
+//! goal: kiln does BOTH in ONE process / ONE HIP pool, so "free KV → training
+//! reuses it" requires the pool to reuse freed blocks rather than reserve new
+//! VRAM from the OS. Measured via `rocm_pool_stats` (the pool's own
+//! reserved/used counters) — immune to the coexisting llama-server, unlike the
+//! all-process DRM `current_memory_snapshot`.
+#![cfg(feature = "rocm")]
+
+use kiln_tensor::{rocm_pool_stats as stats, rocm_synchronize_default_stream as sync,
+                  rocm_zeros_ctx as alloc, DType};
+
+fn mb(bytes: u64) -> f64 { bytes as f64 / (1024.0 * 1024.0) }
+fn mb_elems(m: usize) -> usize { (m * 1024 * 1024) / 2 } // bf16
+
+#[test]
+fn pool_reuses_freed_blocks_without_growing_reserved() {
+    if !kiln_tensor::rocm_is_available() { eprintln!("skip"); return; }
+
+    // Allocate 8x256MB (mimics KV pools), then free them.
+    let (r0, u0) = stats(0).unwrap();
+    let mut a = Vec::new();
+    for _ in 0..8 { a.push(alloc(0, DType::BF16, mb_elems(256)).unwrap()); }
+    sync(0).ok();
+    let (r1, u1) = stats(0).unwrap();
+    drop(a);
+    sync(0).ok();
+    let (r2, u2) = stats(0).unwrap();
+    eprintln!("[pool] reserved: start={:.0} afterAlloc={:.0} afterFree={:.0} MB", mb(r0), mb(r1), mb(r2));
+    eprintln!("[pool] used:     start={:.0} afterAlloc={:.0} afterFree={:.0} MB", mb(u0), mb(u1), mb(u2));
+
+    // Alloc rose used by ~2GB; free returned used to ~baseline (pool keeps
+    // reserved, by the release-threshold pin).
+    assert!(u1 - u0 > mb_elems(8 * 256) as u64 / 2 || mb(u1) - mb(u0) > 1500.0,
+        "used must rise ~2GB on alloc (start {:.0} -> {:.0})", mb(u0), mb(u1));
+    assert!(mb(u2) - mb(u0) < 300.0, "used must drop back ~baseline after free (got {:.0})", mb(u2) - mb(u0));
+
+    // Now allocate 2GB again in DIFFERENT-SIZED chunks (10x205MB ≈ 2GB), like a
+    // training workload. If the pool reuses the freed blocks, RESERVED does not
+    // grow beyond the earlier high-water (r1); a leak would push reserved up.
+    let mut b = Vec::new();
+    for _ in 0..10 { b.push(alloc(0, DType::BF16, mb_elems(205)).unwrap()); }
+    sync(0).ok();
+    let (r3, u3) = stats(0).unwrap();
+    eprintln!("[pool] after 10x205MB realloc: reserved={:.0} used={:.0} MB (reserved growth vs hwm {:.0})",
+        mb(r3), mb(u3), mb(r3) - mb(r1.max(r2)));
+    let reserved_growth = mb(r3) - mb(r1.max(r2));
+    assert!(
+        reserved_growth < 400.0,
+        "pool must REUSE freed blocks for a differently-sized workload: reserved grew {reserved_growth:.0} MB \
+         (0 = perfect reuse; ~2048 = pool reserves fresh, no reuse)"
+    );
+    drop(b);
+    sync(0).ok();
+}

--- a/crates/kiln-tensor/tests/rocm_trim_pool.rs
+++ b/crates/kiln-tensor/tests/rocm_trim_pool.rs
@@ -1,0 +1,74 @@
+//! On-hardware smoke for `rocm_trim_pool` — proves kiln can RETURN pooled VRAM
+//! to the OS (so a coexisting process can reclaim it), which the
+//! release-threshold pin otherwise prevents by design.
+//!
+//! Ignored by default (needs a real ROCm device + is sensitive to other memory
+//! churn on the box). Run explicitly:
+//!   cargo test -p kiln-tensor --features rocm --test rocm_trim_pool -- --ignored --nocapture
+#![cfg(feature = "rocm")]
+
+use kiln_tensor::{DType, Device, Tensor};
+
+fn mem_available_bytes() -> u64 {
+    let raw = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            if let Some(kib) = rest.split_whitespace().next().and_then(|s| s.parse::<u64>().ok()) {
+                return kib * 1024;
+            }
+        }
+    }
+    0
+}
+
+#[test]
+fn trim_pool_is_callable_and_clean() {
+    if !kiln_tensor::rocm_is_available() {
+        eprintln!("no ROCm device; skipping");
+        return;
+    }
+    // A trim with nothing to release must be a clean no-op.
+    kiln_tensor::rocm_trim_pool(0, 0).expect("rocm_trim_pool no-op");
+}
+
+#[test]
+#[ignore]
+fn trim_pool_returns_memory_to_os() {
+    if !kiln_tensor::rocm_is_available() {
+        eprintln!("no ROCm device; skipping");
+        return;
+    }
+    let gb = |b: u64| b as f64 / 1e9;
+    let dev_free = || kiln_tensor::rocm_mem_get_info(0).map(|(f, _)| f as u64).unwrap_or(0);
+    let before = dev_free();
+    let _ = mem_available_bytes; // keep the helper referenced
+
+    // Allocate ~2 GiB on device, then drop it. With the release-threshold pin
+    // the freed block stays POOLED (not auto-returned to the OS).
+    //
+    // Discrete GPU: `after-trim` device-free rises by ~2 GiB (the pool released
+    // it). Unified APU (Strix Halo): GPU memory is GTT-paged system RAM and the
+    // device counter is a large virtual budget that the trim doesn't move — there
+    // the coexistence signal is system-RAM pressure (the `kiln-memory` governor),
+    // not a discrete pool. So this smoke is INFORMATIONAL, not asserted.
+    let n = 512usize * 1024 * 1024; // 512M f32 = 2 GiB
+    {
+        let _t = Tensor::zeros_on(Device::Rocm(0), vec![n], DType::F32).expect("alloc 2GiB");
+        kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    }
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let pooled = dev_free();
+
+    // Trim the pool back to the OS.
+    kiln_tensor::rocm_trim_pool(0, 0).expect("trim");
+    let after_trim = dev_free();
+
+    eprintln!(
+        "device free (hipMemGetInfo): before={:.2}GB  after-free(pooled)={:.2}GB  after-trim={:.2}GB  \
+         | reclaimed-by-trim={:.2}GB",
+        gb(before),
+        gb(pooled),
+        gb(after_trim),
+        gb(after_trim.saturating_sub(pooled)),
+    );
+}

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -17,6 +17,7 @@ license.workspace = true
 # for the full CP-4 rationale. (#1082)
 kiln-autograd = { workspace = true }
 kiln-core = { workspace = true }
+kiln-memory = { workspace = true }
 kiln-eval = { workspace = true }
 kiln-flce-kernel = { workspace = true }
 # CP-4 (#1082): the `kiln_kt_bridge::tape_bridge` module owns the

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -2130,8 +2130,8 @@ pub fn opd_train(
     // single segment count up front like SFT/GRPO do. Detection is
     // cheap (env var or one nvidia-smi spawn) but no reason to
     // re-detect on every step.
-    let opd_vram_cache = kiln_core::vram::detect_vram();
-    let opd_base_model_bytes = kiln_core::vram::estimate_base_model_bytes(
+    let opd_vram_cache = kiln_memory::vram::detect_vram();
+    let opd_base_model_bytes = kiln_memory::vram::estimate_base_model_bytes(
         model_config.num_layers,
         model_config.hidden_size,
         model_config.intermediate_size,

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -6816,7 +6816,7 @@ impl CheckpointConfig {
     ///
     /// Priority for num_segments:
     /// 1. `KILN_GRAD_CHECKPOINT_SEGMENTS` env var (user override)
-    /// 2. Auto-detect from GPU VRAM via `kiln_core::vram`
+    /// 2. Auto-detect from GPU VRAM via `kiln_memory::vram`
     /// 3. Fallback to 4 segments
     ///
     /// This is the *VRAM-only* path. Callers that know the workload's
@@ -6842,13 +6842,13 @@ impl CheckpointConfig {
         }
 
         // VRAM-aware auto-configuration
-        let vram = kiln_core::vram::detect_vram();
-        let num_segments = kiln_core::vram::recommended_checkpoint_segments(&vram)
+        let vram = kiln_memory::vram::detect_vram();
+        let num_segments = kiln_memory::vram::recommended_checkpoint_segments(&vram)
             .unwrap_or(4) // fallback if env var was set (shouldn't happen here)
             .min(num_layers)
             .max(1);
 
-        let auto_configured = vram.source != kiln_core::vram::VramSource::None;
+        let auto_configured = vram.source != kiln_memory::vram::VramSource::None;
 
         if auto_configured {
             tracing::info!(
@@ -6873,7 +6873,7 @@ impl CheckpointConfig {
     /// Behavior:
     /// * `KILN_GRAD_CHECKPOINT_SEGMENTS` / `KILN_NO_GRAD_CHECKPOINT` env
     ///   overrides are honored unchanged (falls through to `from_env`).
-    /// * Otherwise calls [`kiln_core::vram::recommended_checkpoint_plan`]
+    /// * Otherwise calls [`kiln_memory::vram::recommended_checkpoint_plan`]
     ///   which can *disable* checkpointing entirely when the activation tape
     ///   comfortably fits in available VRAM. On A6000 + Qwen3.5-4B, this
     ///   skips checkpointing for sequences up to ~12K tokens and only
@@ -6903,8 +6903,8 @@ impl CheckpointConfig {
             return Self::from_env(num_layers);
         }
 
-        let vram = kiln_core::vram::detect_vram();
-        let base_bytes = kiln_core::vram::estimate_base_model_bytes(
+        let vram = kiln_memory::vram::detect_vram();
+        let base_bytes = kiln_memory::vram::estimate_base_model_bytes(
             num_layers,
             hidden_size,
             intermediate_size,
@@ -6912,19 +6912,19 @@ impl CheckpointConfig {
             bytes_per_base_param,
         );
 
-        match kiln_core::vram::recommended_checkpoint_plan(
+        match kiln_memory::vram::recommended_checkpoint_plan(
             &vram,
             num_layers,
             max_seq_len_tokens,
             hidden_size,
             base_bytes,
         ) {
-            None | Some(kiln_core::vram::CheckpointPlan::UserOverride) => {
+            None | Some(kiln_memory::vram::CheckpointPlan::UserOverride) => {
                 // VRAM detection failed or env override is set — fall back
                 // to the existing VRAM-only path.
                 Self::from_env(num_layers)
             }
-            Some(kiln_core::vram::CheckpointPlan::Disabled {
+            Some(kiln_memory::vram::CheckpointPlan::Disabled {
                 max_act_gib,
                 available_gib,
             }) => {
@@ -6942,7 +6942,7 @@ impl CheckpointConfig {
                     auto_configured: true,
                 }
             }
-            Some(kiln_core::vram::CheckpointPlan::Enabled {
+            Some(kiln_memory::vram::CheckpointPlan::Enabled {
                 num_segments,
                 max_act_gib,
                 per_segment_gib,
@@ -11519,7 +11519,7 @@ pub(crate) mod tests {
     /// known VRAM number via env, then assert `auto_for_workload` returns
     /// the expected `enabled / num_segments` for a representative
     /// (vram, seq_len) cell. The pure `recommended_checkpoint_plan` matrix
-    /// is already exhaustive (`kiln_core::vram::tests::perf_regression_*_plan_matrix`);
+    /// is already exhaustive (`kiln_memory::vram::tests::perf_regression_*_plan_matrix`);
     /// this just proves the wrapper is wired to it and propagates the
     /// decision through the `CheckpointConfig` shape correctly.
     #[test]


### PR DESCRIPTION
## What — make memory awareness fundamental to kiln, across every engine

A new `kiln-memory` crate makes kiln **continuously aware of real, all-process GPU/RAM usage** on whatever device it runs on (CUDA / ROCm / Vulkan / Metal / CPU), and act on it — never assuming it owns the device, never silently OOMing.

Motivated by a concrete miss: with a llama.cpp server holding ~40 GB of GPU memory, kiln reported `used=11.3 GB`. It now reports the truth.

## The layers (all on `kiln-memory`, bottom of the workspace graph)

- **Driver-counter probe** (`current_memory_snapshot`) — reads the GPU driver's authoritative, **all-process** counters: nvidia-smi on NVIDIA, AMD/Intel DRM sysfs `mem_info_{vram,gtt}_{total,used}` summed (what nvtop/rocm-smi show), Apple sysctl. Backend-agnostic by construction — it reads the *physical GPU*, so Vulkan-on-AMD, CUDA/Vulkan-on-NVIDIA, and Metal all get correct numbers with no per-engine code. Unified-memory-aware. Fixed the `/proc/meminfo` cgroup/sandbox trap and the VRAM-only undercount (model in GTT read as ~0).
- **`MemoryGovernor`** — continuous TTL-cached snapshot, `pressure()` (Comfortable→Critical), soft `reserve()` (RAII), and **reclaim hooks + a background auto-monitor** that returns pooled VRAM to the OS under pressure.
- **ROCm reclaim** — race-free `hipMemPoolTrimTo` (device-synced) + `hipMemGetInfo`, registered as the governor's reclaimer; the KV auto-sizer does reclaim-then-retry on alloc failure (OOM recovery).
- **Arbiter (inference side)** — the KV sizer respects `governor.available_bytes()` (live free − floor − reservations), and HIP graph capture skips under Critical pressure.
- **BlockManager dynamic resize** — `set_target_usable()` shrinks/grows the inference KV footprint safely (retires free blocks; in-use ones retire as requests drain — never disrupting in-flight requests).
- **Observability** — `/health.gpu_memory.live` + Prometheus `kiln_gpu_memory_bytes{kind=…}` / `kiln_gpu_memory_pressure`.

## Validated on gfx1151 (Strix Halo) with llama.cpp Qwen-35B running

- Probe matches nvtop exactly: `total=119.7 GB used=46.4 GB free=73.3 GB` (was `used=11.3 GB`).
- Server KV sizing: `total=119.7 GB, used=63.5 GB (incl. llama), kv_cache=39.3 GB`, request served.
- `/health` live: `used=102.8 GB, free=16.9 GB, pressure=Moderate`.
- 30 kiln-memory + 9 BlockManager tests pass; default + ROCm builds green throughout.

## Remaining (tracked follow-ons)

- Physical paged-KV pool realloc (actually free the pool tensor's bytes — the deep elastic actuator; BlockManager logical resize is the safe half, landed here).
- CUDA / Metal / Vulkan reclaimer mirrors (same registry; cudarc exposes `mem_get_info`/`trim_to`).
- Holding a governor reservation across a training job's async lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)