### PR TITLE
train: enable ROCm server-side training — SFT, GRPO, OPD (#30)

### DIFF
--- a/crates/kiln-opd-loss-kernel/src/kt_tape.rs
+++ b/crates/kiln-opd-loss-kernel/src/kt_tape.rs
@@ -308,7 +308,7 @@ pub fn opd_top_k_reverse_kl_phase_b_per_position_via_kt_tape(
     if !envelope_ok(hidden, head_t, top_k) {
         bail!(
             "opd_top_k_reverse_kl_phase_b_per_position_via_kt_tape: inputs \
-             outside kt envelope (CUDA + matching F32/BF16 + \
+             outside kt envelope (CUDA/Metal/Vulkan/ROCm + matching F32/BF16 + \
              top_k ∈ {{16, 32}} required). Callers must filter via the \
              same envelope check the kt-typed backward applies."
         );
@@ -375,7 +375,7 @@ pub fn opd_top_k_reverse_kl_phase_b_via_kt_tape(
     if !envelope_ok(hidden, head_t, top_k) {
         bail!(
             "opd_top_k_reverse_kl_phase_b_via_kt_tape: inputs outside kt envelope \
-             (CUDA + matching F32/BF16 + top_k ∈ {{16, 32}} required). \
+             (CUDA/Metal/Vulkan/ROCm + matching F32/BF16 + top_k ∈ {{16, 32}} required). \
              Callers must filter via the same envelope check the kt-typed \
              backward applies."
         );

--- a/crates/kiln-train/src/grpo_tape_shim.rs
+++ b/crates/kiln-train/src/grpo_tape_shim.rs
@@ -522,6 +522,7 @@ pub(crate) fn try_tape_grpo_pg_loss_from_logits_kt(
             kiln_tensor::Device::Cuda(_)
                 | kiln_tensor::Device::Metal(_)
                 | kiln_tensor::Device::Vulkan(_)
+                | kiln_tensor::Device::Rocm(_)
         )
     {
         return Ok(None);

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -2770,10 +2770,11 @@ pub fn opd_train(
                     #[cfg(not(any(feature = "cuda", feature = "metal", feature = "vulkan", feature = "rocm")))]
                     {
                         anyhow::bail!(
-                            "opd_train: OPD training requires a CUDA or Metal build — the \
-                             kt tape-authoritative grad path (the sole grad producer \
-                             after the #1082 candle-drop) records kt GPU ops and \
-                             is gated behind `feature = \"cuda\"` / `feature = \"metal\"`"
+                            "opd_train: OPD training requires a CUDA / Metal / Vulkan / ROCm \
+                             build — the kt tape-authoritative grad path (the sole grad \
+                             producer after the #1082 candle-drop) records kt GPU ops and is \
+                             gated behind `feature = \"cuda\"` / `\"metal\"` / `\"vulkan\"` / \
+                             `\"rocm\"`"
                         );
                     }
                 };

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -4916,6 +4916,7 @@ fn train_tokenized_grpo_group_with_grad_norms(
                 kiln_tensor::Device::Cuda(_)
                     | kiln_tensor::Device::Metal(_)
                     | kiln_tensor::Device::Vulkan(_)
+                    | kiln_tensor::Device::Rocm(_)
             )
             && base_dtype_supports_tape(weights, device)
             && !(config.loss.echo.is_some()
@@ -7646,9 +7647,10 @@ pub fn standard_forward_backward(
                 kiln_tensor::Device::Cuda(_)
                     | kiln_tensor::Device::Metal(_)
                     | kiln_tensor::Device::Vulkan(_)
+                    | kiln_tensor::Device::Rocm(_)
             ),
             "standard_forward_backward: kt tape-authoritative SFT requires a GPU \
-             device (CUDA/Metal/Vulkan) post candle-drop (the candle CPU \
+             device (CUDA/Metal/Vulkan/ROCm) post candle-drop (the candle CPU \
              `loss.backward()` path was removed in #1082)."
         );
         anyhow::ensure!(


### PR DESCRIPTION
Full server-side training (SFT/GRPO/OPD) failed on ROCm with `requires a GPU device (CUDA/Metal/Vulkan)`, even though the kt tape-authoritative substrate is validated on ROCm (`rocm_sft_step_proof`) and inference runs fully on ROCm. The runtime device gates listed `Cuda|Metal|Vulkan` but omitted `Rocm`. This adds `Rocm` to the entry gates — **no new kernel needed** (the paths behind the gates are device-agnostic kt-tape, and OPD's fused topk-KL backward is already hipcc-built).

## Gates fixed
- **SFT** — `trainer.rs` `standard_forward_backward` device gate.
- **GRPO** — `trainer.rs` `tape_auth_eligible` gate + `grpo_tape_shim.rs` the fused PG-loss adapter's silent-decline gate (**critical**: without it ROCm GRPO returned `Ok(None)` → dead post-#1082 candle path → empty grad store).
- **OPD** — only stale error strings: the runtime arm already includes `rocm` (`opd.rs` `#[cfg]`, `kt_tape.rs` `envelope_ok`), so OPD was never actually blocked — the messages just said "CUDA only".

## Verified on-box (gfx1151, Qwen3.5-4B server, all completed end-to-end)
- **SFT**: queued→running→completed; log `training step` → `SFT training complete`.
- **GRPO**: completed; log `GRPO step end (tape-authoritative kt)` ×4 → `saved PEFT adapter` → `GRPO training complete` (gate B confirmed: real grads, not empty).
- **OPD**: completed via **off-policy self-distillation** (`teacher: self@local`, `training_mode: off_policy`, `top_k: 16`); log `OPD step` → `OPD training complete` (fused `kiln_opd_topk_kl_bwd` kernel on ROCm). Notes for users: OPD needs a `local` teacher registered via `/v1/teachers`, off-policy mode (on-policy needs rollout logits the local-teacher pre-compute doesn't have), and `top_k ∈ {16,32}`.

`rocm_sft_step_proof` (3/3) passes; builds clean on rocm + default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)