### PR TITLE
memory/training follow-ups: ROCm regression locks, event-driven grow-back, non-increasing shrink, OPD reservation (#33/#35/#38/#36)

### DIFF
--- a/crates/kiln-memory/src/governor.rs
+++ b/crates/kiln-memory/src/governor.rs
@@ -19,7 +19,7 @@
 //! deep-in-the-stack callers can consult it without threading an `Arc` around.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 /// A reclaim hook: "release up to `target` bytes of pooled/cached device memory
@@ -140,6 +140,15 @@ pub struct MemoryGovernor {
     reclaimers: Mutex<Vec<Reclaimer>>,
     /// Guards [`Self::start_monitor`] against spawning more than one thread.
     monitor_started: AtomicBool,
+    /// Event wake-up for budget-change consumers (the KV autoscaler). The
+    /// `u64` is a monotonically-increasing generation bumped on every
+    /// [`notify_change`](Self::notify_change); waiters block on the `Condvar`
+    /// until the generation advances or their timeout fires. This makes
+    /// grow-back EVENT-DRIVEN: when a training reservation drops (job ends),
+    /// the autoscaler wakes immediately to reclaim KV instead of waiting out
+    /// its poll tick. The timeout still backstops EXTERNAL changes (a
+    /// coexisting process freeing VRAM) that only the periodic probe sees.
+    wake: (Mutex<u64>, Condvar),
 }
 
 impl MemoryGovernor {
@@ -157,7 +166,36 @@ impl MemoryGovernor {
             soft_reserved: AtomicU64::new(0),
             reclaimers: Mutex::new(Vec::new()),
             monitor_started: AtomicBool::new(false),
+            wake: (Mutex::new(0), Condvar::new()),
         }
+    }
+
+    /// Wake any consumers blocked in [`Self::wait_for_change`] — the budget or
+    /// pressure just changed (a reservation taken/released, or the monitor saw a
+    /// pressure transition). Cheap; safe to over-call (waiters re-evaluate).
+    pub fn notify_change(&self) {
+        {
+            let mut wake_gen = self.wake.0.lock().unwrap_or_else(|e| e.into_inner());
+            *wake_gen = wake_gen.wrapping_add(1);
+        }
+        self.wake.1.notify_all();
+    }
+
+    /// Block until the memory budget/pressure changes (via [`Self::notify_change`])
+    /// or `timeout` elapses, whichever comes first. The KV autoscaler uses this
+    /// in place of a fixed sleep so it reacts PROMPTLY to a training job ending
+    /// (reservation drop → grow KV back) while still polling every `timeout` for
+    /// external changes the event path can't see.
+    pub fn wait_for_change(&self, timeout: Duration) {
+        let wake_gen = self.wake.0.lock().unwrap_or_else(|e| e.into_inner());
+        let start = *wake_gen;
+        // wait_timeout_while re-checks the predicate across spurious wakeups.
+        // The returned guard drops at the end of this scope (we don't read it).
+        let (_guard, _timed_out) = self
+            .wake
+            .1
+            .wait_timeout_while(wake_gen, timeout, |g| *g == start)
+            .unwrap_or_else(|e| e.into_inner());
     }
 
     /// The default governor: OS probe + env-tuned config.
@@ -230,6 +268,8 @@ impl MemoryGovernor {
     /// consumers see an honest budget. This does NOT itself allocate.
     pub fn reserve(&self, bytes: u64) -> Reservation<'_> {
         self.soft_reserved.fetch_add(bytes, Ordering::Relaxed);
+        // Budget dropped — wake the autoscaler so it can shrink KV promptly.
+        self.notify_change();
         Reservation {
             governor: self,
             bytes,
@@ -356,6 +396,9 @@ impl Drop for Reservation<'_> {
         self.governor
             .soft_reserved
             .fetch_sub(self.bytes, Ordering::Relaxed);
+        // Budget freed (e.g. a training job ended) — wake the autoscaler so KV
+        // grows back immediately instead of on the next poll tick.
+        self.governor.notify_change();
     }
 }
 
@@ -434,6 +477,35 @@ mod tests {
         // Guard dropped -> reservation released.
         assert_eq!(g.soft_reserved_bytes(), 0);
         assert_eq!(g.available_bytes(), 15 * GB);
+    }
+
+    #[test]
+    fn reservation_change_wakes_waiter_for_growback() {
+        use std::sync::Arc;
+        let g = Arc::new(gov(24 * GB, 16 * GB));
+        let res = g.reserve(4 * GB);
+        let g2 = g.clone();
+        let start = Instant::now();
+        // A waiter that would block the full 10s timeout absent an event.
+        let waiter = std::thread::spawn(move || g2.wait_for_change(Duration::from_secs(10)));
+        std::thread::sleep(Duration::from_millis(50));
+        drop(res); // Reservation::drop -> notify_change -> waiter must wake.
+        waiter.join().unwrap();
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "autoscaler waiter did NOT wake on reservation drop — grow-back would be late"
+        );
+        assert_eq!(g.soft_reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn wait_for_change_times_out_without_event() {
+        let g = gov(24 * GB, 16 * GB);
+        let start = Instant::now();
+        g.wait_for_change(Duration::from_millis(120)); // no notify -> returns ~timeout
+        let waited = start.elapsed();
+        assert!(waited >= Duration::from_millis(100), "returned too early: {waited:?}");
+        assert!(waited < Duration::from_secs(2), "timeout overshot: {waited:?}");
     }
 
     /// Manual on-hardware smoke (`cargo test -p kiln-memory --

--- a/crates/kiln-model/src/paged_kv_cache_kt.rs
+++ b/crates/kiln-model/src/paged_kv_cache_kt.rs
@@ -534,12 +534,56 @@ impl PagedKvCacheKt {
                 staged.push(make_resized(&layers, layer_idx)?);
             }
             *layers = staged;
-        } else {
-            // SHRINK: in-place per layer so each old pool frees before the next
-            // alloc (bounded VRAM). Effectively atomic — see method doc.
+        } else if copy_slots == 0 {
+            // Degenerate shrink-to-zero (no surviving KV): just allocate the new
+            // (empty/tiny) pools per layer.
             for layer_idx in 0..layers.len() {
-                let resized = make_resized(&layers, layer_idx)?;
-                layers[layer_idx] = resized;
+                layers[layer_idx] = make_resized(&layers, layer_idx)?;
+            }
+        } else {
+            // SHRINK — HOST-STAGED so device VRAM is STRICTLY NON-INCREASING (#38).
+            // For a shrink the surviving prefix `[0, copy_slots)` IS the entire new
+            // pool (copy_slots == new_total_slots), so per layer we: (1) D2H the
+            // K/V prefix into host RAM, (2) DROP the old pool — freeing its VRAM
+            // NOW, (3) H2D the prefix back as the new, smaller device pool. Peak
+            // device VRAM per layer never exceeds the OLD layer size — no one-layer
+            // overshoot, unlike the D2D alloc-then-drop which transiently held
+            // `old + new`. Cost: one D2H + H2D per layer; resize is rare.
+            debug_assert_eq!(
+                copy_slots, new_total_slots,
+                "shrink: surviving prefix must be the whole new pool"
+            );
+            let cpu = kiln_tensor::Device::Cpu;
+            for layer_idx in 0..layers.len() {
+                sync_device_for_resize(device)?;
+                // 1. D2H the surviving K/V prefix (independent host copies).
+                let host_k = layers[layer_idx]
+                    .0
+                    .narrow(0, 0, copy_slots)
+                    .and_then(|p| p.contiguous())
+                    .and_then(|p| p.to_device(cpu))
+                    .map_err(|e| anyhow::anyhow!("physical_resize_to: D2H k l{layer_idx}: {e}"))?;
+                let host_v = layers[layer_idx]
+                    .1
+                    .narrow(0, 0, copy_slots)
+                    .and_then(|p| p.contiguous())
+                    .and_then(|p| p.to_device(cpu))
+                    .map_err(|e| anyhow::anyhow!("physical_resize_to: D2H v l{layer_idx}: {e}"))?;
+                // 2. Drop the old layer's VRAM by overwriting with the host copies.
+                layers[layer_idx] = (host_k, host_v);
+                sync_device_for_resize(device)?;
+                // 3. H2D the prefix back as the new (smaller) device pool.
+                let new_k = layers[layer_idx]
+                    .0
+                    .to_device(device)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| anyhow::anyhow!("physical_resize_to: H2D k l{layer_idx}: {e}"))?;
+                let new_v = layers[layer_idx]
+                    .1
+                    .to_device(device)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| anyhow::anyhow!("physical_resize_to: H2D v l{layer_idx}: {e}"))?;
+                layers[layer_idx] = (new_k, new_v);
             }
         }
         self.num_blocks

--- a/crates/kiln-model/tests/rocm_shrink_nonincreasing.rs
+++ b/crates/kiln-model/tests/rocm_shrink_nonincreasing.rs
@@ -1,0 +1,69 @@
+//! #38 — On-box proof that a physical KV SHRINK is VRAM STRICTLY NON-INCREASING.
+//! The old D2D path allocated each new (smaller) layer pool BEFORE freeing the
+//! old one, so the HIP pool's reserved high-water bumped by ~one layer mid-shrink
+//! (an overshoot — bad precisely when shrinking under pressure). The host-staged
+//! path (D2H prefix → drop old → H2D back) never exceeds the pre-shrink size, so
+//! the pool's `reserved` does not grow across the shrink.
+//!
+//! Runs in its OWN process so the HIP pool's reserved high-water starts clean
+//! (it's a process-global hoard). A SMALL shrink (3/4) makes a D2D overshoot
+//! ~one near-full layer — clearly above the noise — while host-staging stays flat.
+//!
+//! Run: `cargo test -p kiln-model --no-default-features --features rocm \
+//!        --test rocm_shrink_nonincreasing -- --nocapture --test-threads=1`
+#![cfg(feature = "rocm")]
+
+use kiln_model::PagedKvCacheKt;
+use kiln_tensor::{DType, Device};
+
+const LAYERS: usize = 4;
+const KV_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+const BLOCK_SIZE: usize = 16;
+const START_BLOCKS: usize = 4000; // ~1 GB
+const SHRUNK_BLOCKS: usize = 3000; // small shrink → big D2D overshoot if present
+
+fn reserved_mb() -> f64 {
+    kiln_tensor::rocm_pool_stats(0).unwrap().0 as f64 / (1024.0 * 1024.0)
+}
+
+#[test]
+fn rocm_shrink_is_vram_nonincreasing() {
+    if !kiln_tensor::rocm_is_available() {
+        eprintln!("skip rocm_shrink_nonincreasing: no ROCm device");
+        return;
+    }
+    let dev = Device::Rocm(0);
+    let cache = PagedKvCacheKt::new(
+        LAYERS, START_BLOCKS, BLOCK_SIZE, KV_HEADS, HEAD_DIM, DType::BF16, dev,
+    )
+    .expect("alloc cache");
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let reserved_before = reserved_mb();
+    // Per-layer pool bytes (k or v): blocks*block_size*kv_heads*head_dim*2(bf16).
+    let layer_pool_mb =
+        (START_BLOCKS * BLOCK_SIZE * KV_HEADS * HEAD_DIM * 2) as f64 / (1024.0 * 1024.0);
+    eprintln!(
+        "[shrink-noninc] reserved before shrink: {reserved_before:.0} MB (one k-pool ≈ {layer_pool_mb:.0} MB)"
+    );
+
+    cache.physical_resize_to(SHRUNK_BLOCKS, dev).expect("shrink");
+    kiln_tensor::rocm_synchronize_default_stream(0).ok();
+    let reserved_after = reserved_mb();
+    let growth = reserved_after - reserved_before;
+    eprintln!(
+        "[shrink-noninc] reserved after shrink:  {reserved_after:.0} MB (growth {growth:+.0} MB)"
+    );
+
+    // Host-staging must NOT grow the pool's reserved high-water. A D2D
+    // alloc-then-drop would bump it by ~one new layer pool (3/4 of {layer_pool_mb}).
+    // Allow a small slack for allocator rounding, well below a layer.
+    let slack = (layer_pool_mb * 0.25).max(64.0);
+    assert!(
+        growth <= slack,
+        "SHRINK overshoot: reserved grew {growth:.0} MB (> {slack:.0} MB slack) — \
+         host-staging should keep VRAM non-increasing"
+    );
+    assert_eq!(cache.num_blocks(), SHRUNK_BLOCKS);
+    eprintln!("[shrink-noninc] OK: shrink did not grow reserved VRAM (growth {growth:+.0} MB)");
+}

--- a/crates/kiln-opd-loss-kernel/src/kt_tape.rs
+++ b/crates/kiln-opd-loss-kernel/src/kt_tape.rs
@@ -459,6 +459,91 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // ROCm regression lock (#33) — the OPD tape envelope + scalar backward must
+    // stay open on ROCm. A future refactor that drops `Device::Rocm(_)` from
+    // `envelope_ok` (kt_tape.rs:106) would silently route ROCm OPD back to an
+    // Ok(None) decline → empty grads; this catches that.
+    // -----------------------------------------------------------------------
+    #[cfg(feature = "rocm")]
+    mod rocm {
+        use super::*;
+
+        fn rocm_f32(shape: Vec<usize>, seed: u64) -> KtTensor {
+            let n: usize = shape.iter().product();
+            let mut s = seed.wrapping_mul(0x9E3779B97F4A7C15);
+            let data: Vec<f32> = (0..n)
+                .map(|_| {
+                    s ^= s << 13;
+                    s ^= s >> 7;
+                    s ^= s << 17;
+                    ((s >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+                })
+                .collect();
+            KtTensor::from_vec_on(kiln_tensor::Device::Rocm(0), data, shape).expect("rocm tensor")
+        }
+
+        #[test]
+        fn rocm_opd_tape_envelope_open_and_backward_finite() {
+            if !kiln_tensor::rocm_is_available() {
+                eprintln!("skip rocm_opd_tape: no ROCm device");
+                return;
+            }
+            let (seq_len, hidden_size, vocab_size, top_k) = (4usize, 128usize, 256usize, 16usize);
+            let h = rocm_f32(vec![1, seq_len, hidden_size], 1);
+            let w = rocm_f32(vec![hidden_size, vocab_size], 2);
+            // Minimal teacher top-k metadata: alternating active rows; per active
+            // row, K distinct indices < vocab + K teacher logprobs.
+            let label_mask: Vec<bool> = (0..seq_len).map(|i| i % 2 == 0).collect();
+            let active = label_mask.iter().filter(|m| **m).count();
+            let mut indices: Vec<u32> = Vec::with_capacity(active * top_k);
+            let mut logprobs: Vec<f32> = Vec::with_capacity(active * top_k);
+            for r in 0..active {
+                for j in 0..top_k {
+                    indices.push((((r * 7 + j * 3) % vocab_size) as u32).min(vocab_size as u32 - 1));
+                    logprobs.push(-((j as f32) * 0.3 + 0.5));
+                }
+            }
+
+            // Locks the envelope's ROCm device arm + the top_k ∈ {16,32} gate.
+            assert!(
+                envelope_ok(&h, &w, top_k),
+                "OPD envelope_ok must accept ROCm F32 + K=16 (regression: #1454 gate)"
+            );
+
+            let mut tape = Tape::new();
+            let loss = opd_top_k_reverse_kl_phase_b_via_kt_tape(
+                &h,
+                &w,
+                &indices,
+                &logprobs,
+                &label_mask,
+                top_k,
+                &mut tape,
+            )
+            .expect("via_kt_tape must record on ROCm (envelope open)");
+            assert_eq!(tape.len(), 1, "OPD records exactly one tape node on ROCm");
+
+            // Scalar-loss backward → finite d_hidden through flash_attn-free path.
+            let seed = KtTensor::from_vec_on(kiln_tensor::Device::Rocm(0), vec![1.0f32], vec![])
+                .expect("scalar seed");
+            let grads = tape
+                .backward(loss.id(), seed, |a, b| kiln_tensor::ops::add(a, b))
+                .expect("OPD tape backward on ROCm");
+            let dh = grads.get(h.id()).expect("d_hidden present");
+            let dh_v: Vec<f32> = dh
+                .to_dtype(KtDType::F32)
+                .unwrap()
+                .flatten_all()
+                .unwrap()
+                .to_vec()
+                .unwrap();
+            assert!(dh_v.iter().all(|x| x.is_finite()), "non-finite OPD d_hidden on ROCm");
+            assert!(dh_v.iter().any(|&x| x != 0.0), "OPD d_hidden all-zero on ROCm (dead backward)");
+            eprintln!("[rocm-opd-tape] OK: envelope open, 1 node, finite non-zero d_hidden");
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // CUDA-gated E2E tests — record + backward.apply round-trip.
     // -----------------------------------------------------------------------
 

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -557,6 +557,28 @@ async fn submit_opd(
     // replay / hot-swap / receipt semantics as SFT and GRPO. Wiring
     // OPD into the SFT/GRPO working-set preflight (so the §8.5
     // capacity calc applies) is a follow-up.
+    // Working-set reservation (#36): OPD previously skipped the preflight
+    // entirely (no VRAM check, no governor reservation). Estimate its footprint
+    // — longest prompt + rollout budget — and reserve it like SFT/GRPO, so the
+    // KV autoscaler accounts for OPD and a too-large job is rejected instead of
+    // OOMing mid-run.
+    let opd_max_seq_len = training_preflight::approximate_max_seq_len_opd(
+        &req.prompts,
+        req.config.max_tokens,
+        Some(state.tokenizer.as_ref()),
+    );
+    let reserved_bytes = enforce_training_preflight(
+        &state,
+        opd_max_seq_len,
+        EstimateOptions {
+            max_supervised_tokens: None,
+            recompute_boundaries:
+                training_preflight::recompute_checkpoint_boundaries_for_seq_len(opd_max_seq_len),
+        },
+        req.config.lora_rank,
+        false,
+    )?;
+
     let info = TrainingJobInfo {
         job_id: job_id.clone(),
         adapter_name: adapter_name.clone(),
@@ -584,7 +606,7 @@ async fn submit_opd(
         let mut q = state.training_queue.lock().unwrap();
         q.push(QueueEntry {
             job_id: job_id.clone(),
-            reserved_bytes: 0, // no preflight estimate for OPD
+            reserved_bytes, // #36: OPD working-set reservation (preflight estimate)
             job: QueuedJob::Opd(req),
         });
         q.len()

--- a/crates/kiln-server/src/kv_autoscaler.rs
+++ b/crates/kiln-server/src/kv_autoscaler.rs
@@ -112,7 +112,12 @@ fn run(
     }
 
     loop {
-        std::thread::sleep(TICK);
+        // Event-driven (#35): wake immediately when the budget changes (a
+        // training reservation taken → shrink; a job ends/reservation drops →
+        // grow KV back) rather than always waiting out the poll tick. The TICK
+        // timeout still backstops EXTERNAL changes (a coexisting process) that
+        // only the periodic probe sees.
+        gov.wait_for_change(TICK);
         if last_resize.elapsed() < COOLDOWN {
             continue;
         }

--- a/crates/kiln-server/src/training_preflight.rs
+++ b/crates/kiln-server/src/training_preflight.rs
@@ -567,6 +567,24 @@ pub fn approximate_max_seq_len_grpo(
         .unwrap_or(0)
 }
 
+/// Approximate the longest training sequence an OPD job builds: the longest
+/// chat-templated prompt plus the rollout budget (`max_tokens`). Off-policy
+/// dataset jobs (empty `prompts`, fed by `dataset_path`) fall back to the
+/// rollout budget alone — an under-estimate the trainer's own guard backstops,
+/// but enough to give the governor a non-zero working-set reservation.
+pub fn approximate_max_seq_len_opd(
+    prompts: &[kiln_train::opd::OpdPrompt],
+    max_tokens: usize,
+    tokenizer: Option<&KilnTokenizer>,
+) -> usize {
+    let longest_prompt = prompts
+        .iter()
+        .map(|p| approximate_tokens_for_messages(&p.messages, tokenizer))
+        .max()
+        .unwrap_or(0);
+    longest_prompt + max_tokens
+}
+
 pub fn approximate_max_seq_len_grpo_group(
     group: &GrpoGroup,
     tokenizer: Option<&KilnTokenizer>,

--- a/crates/kiln-train/src/grpo_tape_shim.rs
+++ b/crates/kiln-train/src/grpo_tape_shim.rs
@@ -600,6 +600,94 @@ mod tests {
     #[cfg(feature = "cuda")]
     use rand::{RngExt, SeedableRng};
 
+    /// ROCm regression lock (#33): the GRPO tape-authoritative PG-loss recorder
+    /// must STAY OPEN on ROCm. A refactor that drops `Device::Rocm(_)` from the
+    /// device gate (grpo_tape_shim.rs:520) or `tape_auth_eligible`
+    /// (trainer.rs:4919) would make this return Ok(None) → fall to the dead
+    /// post-#1082 candle path → EMPTY grad store (silent broken GRPO). This
+    /// catches that: it must record a node and emit a finite, non-zero d_logits.
+    #[cfg(feature = "rocm")]
+    #[test]
+    fn rocm_grpo_pg_loss_records_and_backprops() {
+        use crate::trainer::{token_log_probs, GrpoLossParams};
+        use crate::{IsLevel, KlEstimator};
+        use kiln_tensor::{DType as KtDType, Tensor as KtTensor};
+
+        if !kiln_tensor::rocm_is_available() {
+            eprintln!("[GRPO-ROCm] no ROCm device — skipping");
+            return;
+        }
+        unsafe {
+            std::env::set_var("KILN_USE_TAPE_FORWARD", "1");
+        }
+        let device = kiln_tensor::Device::Rocm(0);
+        let (seq_len, vocab) = (6usize, 16usize);
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2];
+        let action_mask = vec![false, false, true, true, false, true];
+        let num_active = action_mask[1..].iter().filter(|m| **m).count();
+        // Deterministic BF16 logits [1, T, V] on ROCm (the server path is BF16).
+        let logits_host: Vec<f32> = (0..seq_len * vocab)
+            .map(|i| (((i * 31) % 19) as f32 - 9.0) * 0.07)
+            .collect();
+        let logits = KtTensor::from_vec_on(device, logits_host, vec![1, seq_len, vocab])
+            .unwrap()
+            .to_dtype(KtDType::BF16)
+            .unwrap();
+        // ref_log_probs = the fixture's own policy log-probs minus 0.1 (in-range ratio).
+        let plp: Vec<f32> = token_log_probs(&logits, &input_ids, &action_mask, &device)
+            .unwrap()
+            .to_dtype(KtDType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec()
+            .unwrap();
+        let ref_host: Vec<f32> = plp.iter().map(|&p| p - 0.1).collect();
+        let ref_kt = KtTensor::from_vec_on(device, ref_host, vec![num_active]).unwrap();
+        let params = GrpoLossParams {
+            advantage: -0.7,
+            clip_low: 0.2,
+            clip_high: 0.2,
+            kl_coeff: 0.1,
+            kl_estimator: KlEstimator::K1,
+            loss_normalizer: 1.0,
+            is_level: IsLevel::Token,
+            reinforce: false,
+            entropy_aware_kl_quantile: None,
+        };
+
+        let (res, tape) = kiln_autograd::with_thread_local_tape(|| {
+            super::try_tape_grpo_pg_loss_from_logits_kt(
+                &logits,
+                &input_ids,
+                &action_mask,
+                &ref_kt,
+                params,
+                &device,
+            )
+        });
+        let loss = res
+            .expect("try_tape_grpo_pg_loss_from_logits_kt errored")
+            .expect("returned None on ROCm — GRPO tape gate REJECTED Rocm (regression #1454)");
+        assert!(tape.len() >= 1, "GRPO must record a tape node on ROCm");
+
+        let seed = KtTensor::from_vec_on(device, vec![1.0f32], vec![]).unwrap();
+        let grads = tape
+            .backward(loss.id(), seed, |a, b| kiln_tensor::ops::add(a, b))
+            .expect("GRPO tape backward on ROCm");
+        let dl = grads.get(logits.id()).expect("d_logits present");
+        let dl_v: Vec<f32> = dl
+            .to_dtype(KtDType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec()
+            .unwrap();
+        assert!(dl_v.iter().all(|x| x.is_finite()), "non-finite GRPO d_logits on ROCm");
+        assert!(dl_v.iter().any(|&x| x != 0.0), "GRPO d_logits all-zero on ROCm (empty grads)");
+        eprintln!("[GRPO-ROCm] OK: recorded {} node(s), finite non-zero d_logits", tape.len());
+    }
+
     /// Validate the analytic kt-native GRPO logit-grad
     /// (`grpo_pg_loss_from_logits_grad_kt`, with `grad_scalar = 1.0`) against
     /// an INDEPENDENT central finite-difference of the FULL GRPO loss composite


### PR DESCRIPTION
Four file-disjoint, independently-verified follow-ups from the memory/training thread sweep (the deep threads — CUDA-graph BUG2, ROCm flash-attn, self-distill, CUDA reclaimer — are separate branches).

### #33 — ROCm regression locks for the GRPO + OPD tape gates (test-only)
PR #1454 opened the SFT/GRPO/OPD ROCm gates via runtime `matches!`; these in-crate tests stop a refactor from silently re-closing them:
- `grpo_tape_shim::rocm_grpo_pg_loss_records_and_backprops` — must record + emit finite **non-zero** d_logits on `Rocm(0)` (empty = the dead candle path = silent broken GRPO).
- `kt_tape::rocm::rocm_opd_tape_envelope_open_and_backward_finite` — `envelope_ok` accepts ROCm+K16; `via_kt_tape` records + backprops finite non-zero d_hidden.

### #35 — event-driven KV grow-back (kiln-memory)
Autoscaler grew/shrank only on its ~2s poll tick. Added a governor `Condvar` change-notify: `reserve()` and `Reservation::drop()` call `notify_change()`, and the autoscaler waits on `wait_for_change(TICK)` — so a job ending wakes grow-back **immediately**; TICK still backstops external changes. Unit tests for wake-on-drop + timeout.

### #38 — host-staged KV shrink, strictly non-increasing VRAM
`physical_resize_to` shrink allocated each new pool **before** freeing the old → peak `old + one_layer` overshoot, exactly when shrinking under pressure. Now D2H the surviving prefix → drop old (free now) → H2D back. Verified `rocm_shrink_nonincreasing`: a 4000→3000 shrink does **not** grow reserved high-water (observed −160 MB); data preservation + CPU unit test still pass.

### #36 — OPD working-set reservation
OPD skipped the preflight entirely (reserved 0, no OOM reject). `submit_opd` now estimates its footprint and reserves it like SFT/GRPO. Verified: an off-policy OPD job drives `/health live.soft_reserved_gb` 0 → **5.61 GB** while running, back to 0 on completion.

All four build clean on rocm + default and were verified on a gfx1151 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)