### PR TITLE
build: fix fresh-clone CUDA build of gdn + rmsnorm kernels (missing shared include)

### DIFF
--- a/crates/kiln-flash-attn/build.rs
+++ b/crates/kiln-flash-attn/build.rs
@@ -42,6 +42,15 @@ fn main() {
     // Use nvcc as the compiler
     build.cuda(true);
     build.cpp(true);
+    // Never emit device debug info (`-G`) for these kernels, even in a debug
+    // (`cargo build`) profile. cc-rs adds `-G` when the cargo profile is debug,
+    // but `-G` on the cutlass FlashAttention template instantiations balloons
+    // nvcc's peak memory to tens of GB per source file — enough to get a single
+    // compile OOM-SIGKILLed (exit 137) inside a typical container cgroup, so a
+    // plain `cargo build --features cuda` of kiln-model fails on flash-attn. The
+    // kernels are always `-O3` (set below) and are never gdb'd, so dropping the
+    // debug flags is free. (`debug(false)` also drops host `-g`.)
+    build.debug(false);
     configure_nvcc_from_cuda_root(&cuda_root);
 
     // Include paths

--- a/crates/kiln-gdn-kernel/build.rs
+++ b/crates/kiln-gdn-kernel/build.rs
@@ -40,6 +40,17 @@ fn build_cuda() {
     configure_nvcc_from_cuda_root(&cuda_root);
 
     build.include(&csrc_dir);
+    // The shared `kt_gpu_compat.cuh` lives in the sibling kiln-tensor crate's
+    // csrc; `recurrent_gdn_fwd.cu` #includes it unconditionally, so the CUDA
+    // (nvcc) build needs that dir on the include path too — the ROCm arm already
+    // adds it. Without this a fresh-clone `cargo build --features cuda` fails with
+    // "kt_gpu_compat.cuh: No such file or directory". Mirrors kiln-opd-loss-kernel.
+    let kt_csrc = manifest_dir
+        .parent()
+        .expect("CARGO_MANIFEST_DIR has a parent (crates/)")
+        .join("kiln-tensor")
+        .join("csrc");
+    build.include(&kt_csrc);
     build.include(cuda_root.join("include"));
 
     build.flag("-std=c++17");

--- a/crates/kiln-rmsnorm-kernel/build.rs
+++ b/crates/kiln-rmsnorm-kernel/build.rs
@@ -60,6 +60,16 @@ fn build_cuda() {
     configure_nvcc_from_cuda_root(&cuda_root);
 
     build.include(&csrc_dir);
+    // Shared `kt_gpu_compat.cuh` lives in the sibling kiln-tensor crate's csrc
+    // (the reduction kernels #include it); add it to the nvcc include path so a
+    // fresh-clone `cargo build --features cuda` finds it. The ROCm arm already
+    // adds it. Mirrors kiln-opd-loss-kernel / kiln-gdn-kernel.
+    let kt_csrc = manifest_dir
+        .parent()
+        .expect("CARGO_MANIFEST_DIR has a parent (crates/)")
+        .join("kiln-tensor")
+        .join("csrc");
+    build.include(&kt_csrc);
     build.include(cuda_root.join("include"));
 
     build.flag("-std=c++17");


### PR DESCRIPTION
A clean `cargo build --features cuda` of kiln-model fails at the kiln-gdn-kernel nvcc step:
```
recurrent_gdn_fwd.cu:35: fatal error: kt_gpu_compat.cuh: No such file or directory
```
That shared header lives in `kiln-tensor/csrc` and is `#include`d unconditionally by **gdn** (`recurrent_gdn_fwd.cu`) and **rmsnorm** (the reduction kernels). Their **ROCm/hipcc** build arms put `kiln-tensor/csrc` on the include path, and **kiln-opd-loss-kernel's CUDA arm** already does — but gdn's and rmsnorm's **CUDA/nvcc** arms only add their own `csrc` + the CUDA dir. So fresh-clone CUDA builds of those two crates are broken. CI never caught it because the CUDA job only checks the dep-tree, never runs a full nvcc build.

Fix: add `build.include(<crates>/kiln-tensor/csrc)` to both CUDA arms, mirroring opd.

**Discovered + the fix's effect confirmed on a fresh RunPod A6000 clone**: before, the CUDA build died on gdn's `kt_gpu_compat.cuh`; after, it sails past gdn + rmsnorm and proceeds into the flash-attn kernels (a full kiln-model CUDA build is verifying now). #32's `cuda_reclaim_smoke` + pool-hoard tests pass on the same box (kiln-tensor's own cuda kernels were always fine — only these two sibling-header consumers were broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)