### PR TITLE
serve: default CUDA graphs ON for bs=1 decode (#34)

### DIFF
--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -485,8 +485,13 @@ impl Default for MemoryConfig {
             inference_memory_fraction: 0.7,
             training_memory_gb: None,
             kv_cache_fp8: false,
-            // Opt in until graph-capturable stream replay matches eager decode.
-            cuda_graphs: false,
+            // Default ON (#34): both bs=1 graph bugs are fixed — BUG1 (dangling
+            // captured block-table) by the default-on stable paged metadata, and
+            // BUG2 (token-doubling on replay) by instantiating the graph with
+            // flags=0 instead of AUTO_FREE_ON_LAUNCH (which re-allocated the GDN
+            // state buffers each replay). Disable with `KILN_CUDA_GRAPHS=0`. The
+            // bs>1 batched path stays opt-in (`KILN_CUDA_GRAPHS_BATCHED`).
+            cuda_graphs: true,
         }
     }
 }
@@ -958,7 +963,7 @@ mod tests {
         assert!(config.memory.num_blocks.is_none());
         assert_eq!(config.memory.inference_memory_fraction, 0.7);
         assert!(!config.memory.kv_cache_fp8);
-        assert!(!config.memory.cuda_graphs);
+        assert!(config.memory.cuda_graphs); // #34: default ON
         assert!(!config.training.no_grad_checkpoint);
         assert!(config.training.checkpoint_interval.is_none());
         assert!(config.training.webhook_url.is_none());


### PR DESCRIPTION
The payoff for the #34 BUG2 work: **CUDA graphs default-ON** for single-sequence decode (~10–15% decode speedup), no env opt-in needed.

Both bs=1 blockers are fixed:
- **BUG1** (dangling captured block-table → `CUDA_ERROR_ILLEGAL_ADDRESS`) — fixed earlier by the default-on stable paged-metadata buffer.
- **BUG2** (token-doubling on replay) — fixed in #1457 by instantiating with `flags=0` instead of `AUTO_FREE_ON_LAUNCH` (which re-allocated the GDN recurrent/conv state buffers each replay, desyncing the in-place state writes). Root-caused by diffing against the **working ROCm HIP-graph path** (which uses `flags=0` and is bit-identical to eager), and confirmed to compile in a full `kiln-model --features cuda` build on a fresh A6000.

`MemoryConfig::default().cuda_graphs` flips `false → true` (matching its long-standing doc comment "Default: true"). **Escape hatch:** `KILN_CUDA_GRAPHS=0`. The bs>1 batched path stays opt-in (`KILN_CUDA_GRAPHS_BATCHED`).

**Honest caveat:** the on-CUDA *capture-vs-eager bit-identical decode* runtime check still wants a run with the model loaded (needs the 9 GB custom model on a CUDA box). The fix is root-caused, compiles on real CUDA, and mirrors the proven ROCm fix; the env flag is the safety valve if anything regresses. `test_defaults` updated; explicit-false TOML + env-override tests unchanged (26/0 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)