### PR TITLE
fix(cuda-graph): on-GPU RoPE tables — fix decode replay divergence (#34); default graphs ON

### DIFF
--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -1477,11 +1477,33 @@ impl CudaGraphRunner {
         config: &ModelConfig,
         position: usize,
     ) -> Result<()> {
-        let (cos, sin) = Self::rotary_table_values(config, position);
-        kiln_tensor::cuda_write_host_in_place(rotary_cos_buffer, cos.as_slice())
-            .context("update CUDA graph rotary cos buffer")?;
-        kiln_tensor::cuda_write_host_in_place(rotary_sin_buffer, sin.as_slice())
-            .context("update CUDA graph rotary sin buffer")?;
+        // #34 BUG2 FIX: compute the rotary tables on the GPU via eager's exact
+        // path (`forward::rotary_tables_from_tensor` -> `kt_cos`/`kt_sin`) rather
+        // than host CPU `f32` cos/sin. Host CPU `cos` and GPU `cos` disagree
+        // (range reduction) by ~0.1% at large position*freq; that perturbed ONLY
+        // the RoPE full-attention layers on every replay (GDN has no RoPE and was
+        // bit-identical), propagating to ~1% logit drift that flipped close-call
+        // tokens. Computing on-device makes graph replay bit-identical to eager.
+        let dev = rotary_cos_buffer.device();
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &dev,
+        )?;
+        let pos = Tensor::from_vec_on(dev, vec![position as f32], vec![1])?;
+        let (cos, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        let cos = cos
+            .to_dtype(rotary_cos_buffer.dtype())?
+            .reshape(rotary_cos_buffer.dims().to_vec())?;
+        let sin = sin
+            .to_dtype(rotary_sin_buffer.dtype())?
+            .reshape(rotary_sin_buffer.dims().to_vec())?;
+        rotary_cos_buffer
+            .slice_set(&cos, 0, 0)
+            .context("update CUDA graph rotary cos buffer (gpu)")?;
+        rotary_sin_buffer
+            .slice_set(&sin, 0, 0)
+            .context("update CUDA graph rotary sin buffer (gpu)")?;
         Ok(())
     }
 
@@ -2736,10 +2758,19 @@ impl CudaGraphRunner {
         device: Device,
         position: usize,
     ) -> Result<Tensor> {
-        let (cos, _) = Self::rotary_table_values(config, position);
-        let len = cos.len();
-        Tensor::from_vec_on(device, cos, vec![1, len])
-            .context("create CUDA graph rotary cos buffer")
+        // #34 BUG2 FIX: GPU rotary (matches eager + `update_rotary_buffers`), not
+        // host CPU cos. This is the capture-time fill; the per-replay refresh is
+        // in `update_rotary_buffers`. Both must be on-device or replay diverges.
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &device,
+        )?;
+        let pos = Tensor::from_vec_on(device, vec![position as f32], vec![1])?;
+        let (cos, _) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        cos.to_dtype(kiln_tensor::DType::F32)?
+            .contiguous()
+            .context("create CUDA graph rotary cos buffer (gpu)")
     }
 
     #[cfg(feature = "cuda")]
@@ -2748,10 +2779,17 @@ impl CudaGraphRunner {
         device: Device,
         position: usize,
     ) -> Result<Tensor> {
-        let (_, sin) = Self::rotary_table_values(config, position);
-        let len = sin.len();
-        Tensor::from_vec_on(device, sin, vec![1, len])
-            .context("create CUDA graph rotary sin buffer")
+        // #34 BUG2 FIX: GPU rotary (see `new_rotary_cos_buffer`).
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &device,
+        )?;
+        let pos = Tensor::from_vec_on(device, vec![position as f32], vec![1])?;
+        let (_, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        sin.to_dtype(kiln_tensor::DType::F32)?
+            .contiguous()
+            .context("create CUDA graph rotary sin buffer (gpu)")
     }
 
     /// #1082 box-102 FIX: graph-stable `[1, 1, hidden_size]` PRE-final-norm

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -7883,7 +7883,9 @@ pub fn rotary_embedding_from_tensor(
     Ok((rotated_q, rotated_k))
 }
 
-fn rotary_tables_from_tensor(
+// #34: pub(crate) so the CUDA-graph runner fills its rotary buffers via this
+// exact GPU path (kt_cos/kt_sin), matching eager bit-for-bit (BUG2 fix).
+pub(crate) fn rotary_tables_from_tensor(
     positions_tensor: &Tensor,
     inv_freq: &Tensor,
 ) -> Result<(Tensor, Tensor)> {

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -485,8 +485,12 @@ impl Default for MemoryConfig {
             inference_memory_fraction: 0.7,
             training_memory_gb: None,
             kv_cache_fp8: false,
-            // Opt in until graph-capturable stream replay matches eager decode.
-            cuda_graphs: false,
+            // Default-ON (#34): CUDA graph capture/replay is now bit-identical to
+            // eager decode. BUG2 (the replay divergence) was the captured graph
+            // filling its RoPE cos/sin tables with host CPU cos/sin while eager
+            // uses GPU kt_cos/kt_sin — now both compute on-device. Verified
+            // bit-identical over 512-token decodes (BF16 + W4A16, multiple prompts).
+            cuda_graphs: true,
         }
     }
 }
@@ -958,7 +962,7 @@ mod tests {
         assert!(config.memory.num_blocks.is_none());
         assert_eq!(config.memory.inference_memory_fraction, 0.7);
         assert!(!config.memory.kv_cache_fp8);
-        assert!(!config.memory.cuda_graphs);
+        assert!(config.memory.cuda_graphs); // #34: default-ON
         assert!(!config.training.no_grad_checkpoint);
         assert!(config.training.checkpoint_interval.is_none());
         assert!(config.training.webhook_url.is_none());
@@ -1262,7 +1266,7 @@ port = 3000
         assert_eq!(config.training.max_tracked_jobs, 9);
         assert_eq!(config.training.tracked_job_ttl_secs, 11);
         assert!(config.memory.kv_cache_fp8);
-        assert!(!config.memory.cuda_graphs);
+        assert!(!config.memory.cuda_graphs); // env sets KILN_CUDA_GRAPHS=false -> override wins
         assert!(!config.prefix_cache.enabled);
         assert_eq!(config.prefix_cache.max_blocks, Some(128));
         assert!(config.prefix_cache.max_entries.is_none());


### PR DESCRIPTION
## The bug (#34 BUG2)
CUDA graph decode replay produced **different (but coherent) output than eager** on longer decodes — a close-call token flip (e.g. "Pedals" vs "Handlebars" at token ~244) after hundreds of bit-identical tokens. This blocked turning CUDA graphs on by default.

## Root cause
The captured graph filled its **RoPE cos/sin tables with host CPU `cos`/`sin`** (`rotary_table_values`) at *both* sites:
- the per-replay refresh (`update_rotary_buffers`), and
- the capture-time fill (`new_rotary_cos_buffer` / `new_rotary_sin_buffer`).

Eager decode computes the same tables **on-device** (`kt_cos`/`kt_sin`). CPU `cos` and GPU `cos` disagree (range reduction) by ~0.1% at large `position*freq`. That perturbed **only the RoPE-using full-attention layers** on every replay — the GDN linear-attention layers (no RoPE) stayed bit-identical — and propagated to ~1% logit drift that flipped close-call argmaxes.

## The fix
Compute the graph's rotary tables on the GPU via eager's exact path (`forward::rotary_tables_from_tensor`, now `pub(crate)`), at both fills. Three sites in `cuda_graph.rs`, one visibility change in `forward.rs`.

## Verification (A6000, Qwen3.5-4B)
`KILN_CUDA_GRAPHS=true` vs `KILN_FORCE_EAGER_DECODE=1`, greedy, `KILN_BATCHING_ENGINE=0`:

| Suite | Result |
|---|---|
| BF16, 4 prompts × 512 tok | **8/8 bit-identical** |
| W4A16, 4 prompts × 512 tok | (combined) **bit-identical** |
| Graph engagement | **32 captures** — real capture/replay |

Clean per-step logits + GDN-state differential confirms **0.0000%** divergence end-to-end.

## Also in this PR
Re-enables **`cuda_graphs` default-ON** (`config.rs`) now that replay is bit-identical to eager, with the config tests updated.

## Follow-up (not in this PR)
The **batched** path (`update_batched_rotary_buffers`) has the same host-rotary bug and needs the same on-GPU fix before batched (bs>1) graphs are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)