### PR TITLE
fix(graph,memory): complete on-GPU RoPE across CUDA-batched/ROCm/Metal + VRAM-OOM guard (#34)

### DIFF
--- a/crates/kiln-memory/src/vram.rs
+++ b/crates/kiln-memory/src/vram.rs
@@ -488,6 +488,35 @@ pub fn current_free_bytes() -> u64 {
     current_memory_snapshot().free_bytes
 }
 
+/// Free *VRAM* (`mem_info_vram_total` − `mem_info_vram_used`) in bytes on a Linux
+/// AMD/DRM GPU, EXCLUDING GTT. `None` on non-DRM platforms (NVIDIA→nvidia-smi,
+/// macOS, Windows) and when the sysfs counters are absent.
+///
+/// Why this exists, separate from [`current_free_bytes`] (which is vram+gtt):
+/// ROCm's HIP allocator `abort()`s (rocclr `vmheap::MapPhysMemory` assertion) on
+/// a VRAM OOM instead of returning an error. A consumer that sizes against the
+/// governor's vram+gtt budget can therefore drive a hard, un-catchable crash
+/// when VRAM is full (e.g. a coexisting GPU job) even though "free" (incl. GTT)
+/// looks ample. Callers pre-check that a VRAM allocation fits in *free VRAM*
+/// before issuing it, turning the abort into a normal `Err` they shrink-retry on.
+pub fn current_free_vram_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let total =
+            query_linux_drm_memory_fields(&["mem_info_vram_total", "mem_info_vis_vram_total"])?;
+        if total == 0 {
+            return None;
+        }
+        let used = query_linux_drm_memory_fields(&["mem_info_vram_used", "mem_info_vis_vram_used"])
+            .unwrap_or(0);
+        Some(total.saturating_sub(used))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
 /// Read `MemAvailable` (the kernel's estimate of allocatable RAM without
 /// swapping) from a `/proc/meminfo`-format file. This is the right "free"
 /// figure for unified-memory accelerators, where GPU buffers are backed by

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -1454,23 +1454,6 @@ impl CudaGraphRunner {
     }
 
     #[cfg(feature = "cuda")]
-    fn rotary_table_values(config: &ModelConfig, position: usize) -> (Vec<f32>, Vec<f32>) {
-        let half_rotary = config.rotary_dim() / 2;
-        let mut cos = Vec::with_capacity(half_rotary);
-        let mut sin = Vec::with_capacity(half_rotary);
-        for i in 0..half_rotary {
-            let inv_freq = 1.0f32
-                / (config
-                    .rope_theta
-                    .powf(2.0 * i as f64 / config.rotary_dim() as f64) as f32);
-            let freq = position as f32 * inv_freq;
-            cos.push(freq.cos());
-            sin.push(freq.sin());
-        }
-        (cos, sin)
-    }
-
-    #[cfg(feature = "cuda")]
     fn update_rotary_buffers(
         rotary_cos_buffer: &Tensor,
         rotary_sin_buffer: &Tensor,

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -1639,18 +1639,32 @@ impl CudaGraphRunner {
             !start_positions.is_empty(),
             "update_batched_rotary_buffers requires a non-empty batch"
         );
-        let half = config.rotary_dim() / 2;
-        let mut cos_flat: Vec<f32> = Vec::with_capacity(start_positions.len() * half);
-        let mut sin_flat: Vec<f32> = Vec::with_capacity(start_positions.len() * half);
-        for &pos in start_positions {
-            let (cos, sin) = Self::rotary_table_values(config, pos);
-            cos_flat.extend_from_slice(&cos);
-            sin_flat.extend_from_slice(&sin);
-        }
-        kiln_tensor::cuda_write_host_in_place(rotary_cos_buffer, cos_flat.as_slice())
-            .context("update CUDA graph batched rotary cos buffer")?;
-        kiln_tensor::cuda_write_host_in_place(rotary_sin_buffer, sin_flat.as_slice())
-            .context("update CUDA graph batched rotary sin buffer")?;
+        // #34 BUG2 FIX: compute the batched rotary tables on the GPU via eager's
+        // exact path (one position per batch row), not host CPU cos/sin. Same root
+        // cause + fix as the bs=1 path (`update_rotary_buffers`): CPU cos != GPU
+        // cos perturbs only the RoPE full-attention layers on replay.
+        let dev = rotary_cos_buffer.device();
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &dev,
+        )?;
+        let pos_f32: Vec<f32> = start_positions.iter().map(|&p| p as f32).collect();
+        let n = pos_f32.len();
+        let pos = Tensor::from_vec_on(dev, pos_f32, vec![n])?;
+        let (cos, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        let cos = cos
+            .to_dtype(rotary_cos_buffer.dtype())?
+            .reshape(rotary_cos_buffer.dims().to_vec())?;
+        let sin = sin
+            .to_dtype(rotary_sin_buffer.dtype())?
+            .reshape(rotary_sin_buffer.dims().to_vec())?;
+        rotary_cos_buffer
+            .slice_set(&cos, 0, 0)
+            .context("update CUDA graph batched rotary cos buffer (gpu)")?;
+        rotary_sin_buffer
+            .slice_set(&sin, 0, 0)
+            .context("update CUDA graph batched rotary sin buffer (gpu)")?;
         Ok(())
     }
 

--- a/crates/kiln-model/src/metal_graph.rs
+++ b/crates/kiln-model/src/metal_graph.rs
@@ -1222,7 +1222,7 @@ impl MetalStableDecodeBuffers {
         )?;
         let pos_f32: Vec<f32> = seq_lens.iter().map(|&p| p as f32).collect();
         let n = pos_f32.len();
-        let pos = Tensor::from_vec_on(dev, pos_f32, vec![n])?;
+        let pos = kiln_tensor::Tensor::from_vec_on(dev, pos_f32, vec![n])?;
         let (cos, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
         let cos = cos
             .to_dtype(self.rotary_cos.dtype())?

--- a/crates/kiln-model/src/metal_graph.rs
+++ b/crates/kiln-model/src/metal_graph.rs
@@ -1210,37 +1210,34 @@ impl MetalStableDecodeBuffers {
         let slots = slots?;
         kiln_tensor::metal_write_host_in_place(&self.kv_slot, slots.as_slice())
             .context("update Metal graph KV slot buffer")?;
-        let (cos, sin) = rotary_table_values_batch(config, seq_lens);
-        kiln_tensor::metal_write_host_in_place(&self.rotary_cos, cos.as_slice())
-            .context("update Metal graph rotary cos buffer")?;
-        kiln_tensor::metal_write_host_in_place(&self.rotary_sin, sin.as_slice())
-            .context("update Metal graph rotary sin buffer")?;
+        // #34 BUG2 FIX: compute the rotary tables on the GPU via eager's exact
+        // path (`forward::rotary_tables_from_tensor`), one position per batch row,
+        // not host CPU cos/sin. CPU cos != GPU cos perturbs only the RoPE
+        // full-attention layers on replay. Same root cause + fix as CUDA/ROCm.
+        let dev = self.rotary_cos.device();
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &dev,
+        )?;
+        let pos_f32: Vec<f32> = seq_lens.iter().map(|&p| p as f32).collect();
+        let n = pos_f32.len();
+        let pos = Tensor::from_vec_on(dev, pos_f32, vec![n])?;
+        let (cos, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        let cos = cos
+            .to_dtype(self.rotary_cos.dtype())?
+            .reshape(self.rotary_cos.dims().to_vec())?;
+        let sin = sin
+            .to_dtype(self.rotary_sin.dtype())?
+            .reshape(self.rotary_sin.dims().to_vec())?;
+        self.rotary_cos
+            .slice_set(&cos, 0, 0)
+            .context("update Metal graph rotary cos buffer (gpu)")?;
+        self.rotary_sin
+            .slice_set(&sin, 0, 0)
+            .context("update Metal graph rotary sin buffer (gpu)")?;
         Ok(())
     }
-}
-
-#[cfg(feature = "metal")]
-fn rotary_table_values(config: &ModelConfig, position: usize) -> (Vec<f32>, Vec<f32>) {
-    rotary_table_values_batch(config, &[position])
-}
-
-#[cfg(feature = "metal")]
-fn rotary_table_values_batch(config: &ModelConfig, positions: &[usize]) -> (Vec<f32>, Vec<f32>) {
-    let half_rotary = config.rotary_dim() / 2;
-    let mut cos = Vec::with_capacity(positions.len() * half_rotary);
-    let mut sin = Vec::with_capacity(positions.len() * half_rotary);
-    for &position in positions {
-        for i in 0..half_rotary {
-            let inv_freq = 1.0f32
-                / (config
-                    .rope_theta
-                    .powf(2.0 * i as f64 / config.rotary_dim() as f64) as f32);
-            let freq = position as f32 * inv_freq;
-            cos.push(freq.cos());
-            sin.push(freq.sin());
-        }
-    }
-    (cos, sin)
 }
 
 #[cfg(feature = "metal")]

--- a/crates/kiln-model/src/rocm_graph.rs
+++ b/crates/kiln-model/src/rocm_graph.rs
@@ -566,33 +566,37 @@ impl RocmGraphRunner {
             .context("update ROCm graph position buffer")
     }
 
-    fn rotary_table_values(config: &ModelConfig, position: usize) -> (Vec<f32>, Vec<f32>) {
-        let half_rotary = config.rotary_dim() / 2;
-        let mut cos = Vec::with_capacity(half_rotary);
-        let mut sin = Vec::with_capacity(half_rotary);
-        for i in 0..half_rotary {
-            let inv_freq = 1.0f32
-                / (config
-                    .rope_theta
-                    .powf(2.0 * i as f64 / config.rotary_dim() as f64) as f32);
-            let freq = position as f32 * inv_freq;
-            cos.push(freq.cos());
-            sin.push(freq.sin());
-        }
-        (cos, sin)
-    }
-
     fn update_rotary_buffers(
         rotary_cos_buffer: &Tensor,
         rotary_sin_buffer: &Tensor,
         config: &ModelConfig,
         position: usize,
     ) -> Result<()> {
-        let (cos, sin) = Self::rotary_table_values(config, position);
-        kiln_tensor::rocm_write_host_in_place(rotary_cos_buffer, cos.as_slice())
-            .context("update ROCm graph rotary cos buffer")?;
-        kiln_tensor::rocm_write_host_in_place(rotary_sin_buffer, sin.as_slice())
-            .context("update ROCm graph rotary sin buffer")?;
+        // #34 BUG2 FIX: compute the rotary tables on the GPU via eager's exact
+        // path (`forward::rotary_tables_from_tensor` -> device `cos`/`sin`), not
+        // host CPU cos/sin. CPU cos != GPU cos (range reduction) perturbs only the
+        // RoPE full-attention layers on replay -> divergence from eager. Same root
+        // cause + fix as the CUDA path.
+        let dev = rotary_cos_buffer.device();
+        let inv_freq = crate::forward::compute_rotary_inv_freq(
+            config.rotary_dim(),
+            config.rope_theta,
+            &dev,
+        )?;
+        let pos = Tensor::from_vec_on(dev, vec![position as f32], vec![1])?;
+        let (cos, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        let cos = cos
+            .to_dtype(rotary_cos_buffer.dtype())?
+            .reshape(rotary_cos_buffer.dims().to_vec())?;
+        let sin = sin
+            .to_dtype(rotary_sin_buffer.dtype())?
+            .reshape(rotary_sin_buffer.dims().to_vec())?;
+        rotary_cos_buffer
+            .slice_set(&cos, 0, 0)
+            .context("update ROCm graph rotary cos buffer (gpu)")?;
+        rotary_sin_buffer
+            .slice_set(&sin, 0, 0)
+            .context("update ROCm graph rotary sin buffer (gpu)")?;
         Ok(())
     }
 
@@ -677,15 +681,25 @@ impl RocmGraphRunner {
     }
 
     fn new_rotary_cos_buffer(config: &ModelConfig, device: Device, position: usize) -> Result<Tensor> {
-        let (cos, _) = Self::rotary_table_values(config, position);
-        let len = cos.len();
-        Tensor::from_vec_on(device, cos, vec![1, len]).context("create ROCm graph rotary cos buffer")
+        // #34 BUG2 FIX: GPU rotary (matches eager + update_rotary_buffers), not host CPU cos.
+        let inv_freq =
+            crate::forward::compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, &device)?;
+        let pos = Tensor::from_vec_on(device, vec![position as f32], vec![1])?;
+        let (cos, _) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        cos.to_dtype(kiln_tensor::DType::F32)?
+            .contiguous()
+            .context("create ROCm graph rotary cos buffer (gpu)")
     }
 
     fn new_rotary_sin_buffer(config: &ModelConfig, device: Device, position: usize) -> Result<Tensor> {
-        let (_, sin) = Self::rotary_table_values(config, position);
-        let len = sin.len();
-        Tensor::from_vec_on(device, sin, vec![1, len]).context("create ROCm graph rotary sin buffer")
+        // #34 BUG2 FIX: GPU rotary (see new_rotary_cos_buffer).
+        let inv_freq =
+            crate::forward::compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, &device)?;
+        let pos = Tensor::from_vec_on(device, vec![position as f32], vec![1])?;
+        let (_, sin) = crate::forward::rotary_tables_from_tensor(&pos, &inv_freq)?;
+        sin.to_dtype(kiln_tensor::DType::F32)?
+            .contiguous()
+            .context("create ROCm graph rotary sin buffer (gpu)")
     }
 
     fn new_output_hidden(

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1842,6 +1842,30 @@ impl AppState {
         // uninitialized — a one-time startup memset, not a correctness change
         // (paged writes overwrite slots before they are read).
         let allocate_cache = |n: usize| -> anyhow::Result<PagedKvCacheKt> {
+            // Governance / "never OOM": ROCm's HIP allocator `abort()`s (rocclr
+            // `vmheap::MapPhysMemory` assertion) on a VRAM OOM instead of returning
+            // Err — that bypasses the reclaim/shrink retry below and HARD-CRASHES
+            // the process. Seen when a coexisting GPU job fills VRAM, because the
+            // governor's budget counts GTT that the HIP VRAM allocator can't use.
+            // Pre-check against FREE VRAM (not vram+gtt) and return a normal Err so
+            // the auto-sizer shrinks gracefully. No-op off AMD/Linux-DRM (returns
+            // None), where the native allocator surfaces OOM as a catchable Err.
+            if bytes_per_block > 0 {
+                if let Some(free_vram) = kiln_memory::vram::current_free_vram_bytes() {
+                    let need = (n as u64).saturating_mul(bytes_per_block);
+                    // 8% headroom for the allocator's own metadata + fragmentation.
+                    let safe = (free_vram / 100).saturating_mul(92);
+                    if need > safe {
+                        anyhow::bail!(
+                            "KV cache {n} blocks ({} MiB) exceeds free VRAM \
+                             ({} MiB; 92% safe = {} MiB) — shrinking to avoid a HIP vmheap abort",
+                            need / (1 << 20),
+                            free_vram / (1 << 20),
+                            safe / (1 << 20)
+                        );
+                    }
+                }
+            }
             let attempt = || {
                 PagedKvCacheKt::new_with_fp8(
                     model_config.num_full_attention_layers,


### PR DESCRIPTION
Follow-up to #1462 (which fixed + default-enabled CUDA bs=1 graphs). Two related fixes, both surfaced while finishing #34.

## 1. Cross-backend RoPE fix (the audit)
#1462 fixed only the CUDA **bs=1** rotary. An audit for the same pattern — *host CPU `cos`/`sin` written into a graph-replay buffer that eager computes on-GPU* — found it in **three more places**. RoPE is the **only** instance of this class (the audit swept for ALiBi / host softmax / norm / bias tables and found none; all other host writes are safe value-copies).

- **CUDA batched** (`update_batched_rotary_buffers`)
- **ROCm** (`update_rotary_buffers` + `new_rotary_cos/sin_buffer`)
- **Metal** (`refresh_batch`)

All now compute the rotary tables on-GPU via eager's exact `forward::rotary_tables_from_tensor` (made `pub(crate)`), and the now-dead host `rotary_table_values{,_batch}` helpers are deleted from all three runners.

**Verification:** CUDA bs=1 is runtime-verified bit-identical (#1462, A6000). The batched/ROCm/Metal changes are **identical in structure** to that verified fix and compile clean. Local gfx1151 ROCm runtime re-verify is blocked by an unrelated `hipBLASLt` prefill failure + a leaked-VRAM state on that box; Metal has no local hardware.

## 2. VRAM pre-flight check — never crash on OOM (`kiln-memory`)
Surfaced on the gfx1151: a coexisting vLLM process held 85/103 GB VRAM, and kiln's KV sizing — which counts **GTT** (system RAM) in the budget that the HIP VRAM allocator can't use — over-committed. ROCm's allocator then **`abort()`s** (rocclr `vmheap` assertion) instead of returning `Err`, **bypassing the auto-sizer's shrink/retry loop and hard-crashing on default settings** — a "never OOM" violation.

**Fix:** `vram::current_free_vram_bytes()` (VRAM-only, excludes GTT; `None` off AMD/Linux-DRM) + a pre-flight check in `allocate_cache` that returns a normal `Err` when a request exceeds free VRAM, so the existing auto-sizer shrinks gracefully. No-op on CUDA/Metal/Vulkan, where OOM is already catchable.

## Known, separate (not in this PR)
The CUDA **batched graph path** itself is still half-done — with `KILN_CUDA_GRAPHS_BATCHED=1` the decode batcher stayed at `max_batch=1` (didn't engage bs>1) and requests hung. That's an orthogonal issue from this rotary fix; batched graphs remain opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)