### PR TITLE
fix(memory): clamp KV pool to free VRAM — degrade-and-serve instead of panic

### DIFF
--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1792,7 +1792,19 @@ impl AppState {
             // since `free` is the all-process driver figure).
             if governor_backend != kiln_tensor::Backend::Cpu && bytes_per_block > 0 {
                 let avail = kiln_memory::MemoryGovernor::global().available_bytes();
-                let max_blocks = (avail / bytes_per_block) as usize;
+                let mut max_blocks = (avail / bytes_per_block) as usize;
+                // #34 (never-OOM / dynamic reallocation): the HIP VRAM allocator
+                // can't use GTT, so the governor's vram+gtt budget over-states what
+                // a KV allocation can actually take. Clamp to FREE VRAM (92% margin)
+                // so a coexisting GPU job that fills VRAM DEGRADES the KV pool to
+                // what fits and still serves, instead of either over-committing into
+                // an unrecoverable rocclr `vmheap` abort or panicking the auto-sizer.
+                // No-op off AMD/Linux-DRM (returns None).
+                if let Some(free_vram) = kiln_memory::vram::current_free_vram_bytes() {
+                    let vram_blocks =
+                        ((free_vram / 100).saturating_mul(92) / bytes_per_block) as usize;
+                    max_blocks = max_blocks.min(vram_blocks);
+                }
                 n.min(max_blocks)
             } else {
                 n


### PR DESCRIPTION
Follow-up to #1463. That PR's pre-flight check turned the ROCm `vmheap` **abort** into a graceful error, but the fraction-based auto-sizer floors at ~0.45, so when a coexisting GPU job leaves only a few hundred MiB of free VRAM it exhausts its fallbacks and **panics** rather than serving. Per the "never OOM / dynamic reallocation" principle it should size the KV pool to **what actually fits**.

**Fix:** clamp `num_blocks` to **free VRAM** (92% margin) in the sizer, in addition to the governor's vram+gtt budget.

**Verified** on the leaked-VRAM repro (a zombie vLLM holding 85/103 GB on a gfx1151): kiln now sizes a **390-block** pool and reaches `✓ Ready` + serves health, instead of panicking. No-op off AMD/Linux-DRM and a no-op on uncontended GPUs (free VRAM > governor budget).

**Caveat (honest):** with VRAM near-zero, the *decode's own working set* (activations / attention scratch / hipBLASLt workspace) can still OOM — that's a genuine out-of-memory the GPU can't satisfy, not a sizable buffer to pre-check. Free VRAM (`sudo rocm-smi --gpureset` / reboot) to fully recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)