### PR TITLE
Overhaul UI for the pi/opencode agent-backend flywheel

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::extract::{DefaultBodyLimit, State};
-use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
@@ -478,8 +478,20 @@ fn request_record_from_req(
         max_tokens: Some(chat_request_max_tokens(req).min(u32::MAX as usize) as u32),
         thinking_mode: Some(thinking_mode_for_request(req).to_string()),
         prefix_cache: Some("unknown".to_string()),
+        user_agent: req.user_agent.clone(),
         ..RequestRecord::default()
     }
+}
+
+/// Extract the calling client's `User-Agent` for per-agent attribution on the
+/// /ui dashboard. Bounded so a hostile header can't bloat the ring.
+fn extract_user_agent(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(200).collect())
 }
 
 const REASONING_OPEN_TAG: &str = "<think>\n";
@@ -2876,6 +2888,10 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub model: Option<String>,
     pub messages: Vec<Message>,
+    /// Calling client's `User-Agent`, injected by the handler (never from the
+    /// JSON body) so the /ui dashboard can attribute traffic per agent.
+    #[serde(skip)]
+    pub user_agent: Option<String>,
     /// Number of completions to generate for this prompt. Defaults to 1.
     /// Non-streaming `n>1` reuses the same single-output fast paths below.
     #[serde(default)]
@@ -3340,10 +3356,15 @@ fn resolve_speculative_mode(
 
 async fn chat_completions(
     State(state): State<AppState>,
-    Json(req): Json<ChatCompletionRequest>,
+    headers: HeaderMap,
+    Json(mut req): Json<ChatCompletionRequest>,
 ) -> Result<Response, ApiError> {
     let start = std::time::Instant::now();
     let streaming = req.stream;
+    // Attribute this request to the calling agent (pi / opencode / SDK / curl)
+    // so the dashboard can show per-client traffic. Header-only, never trusted
+    // from the body.
+    req.user_agent = extract_user_agent(&headers);
     state.metrics.inc_active();
 
     let result = chat_completions_inner(&state, req).await;
@@ -7605,6 +7626,7 @@ async fn batch_completions_inner(
                     let synth_req = ChatCompletionRequest {
                         model: model.clone(),
                         messages: messages.clone(),
+                        user_agent: None,
                         n: None,
                         temperature,
                         top_p,
@@ -7853,6 +7875,7 @@ async fn generate_multi_chat_response(
         let synth_req = ChatCompletionRequest {
             model: req.model.clone(),
             messages: req.messages.clone(),
+            user_agent: req.user_agent.clone(),
             n: None,
             temperature: req.temperature,
             top_p: req.top_p,

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1121,6 +1121,7 @@ fn record_failed_chat_completion(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             prompt_tokens: prompt_tokens.min(u32::MAX as usize) as u32,
             completion_tokens: 0,
             duration_ms: request_start.elapsed().as_millis() as u64,
@@ -2216,6 +2217,7 @@ fn response_from_cached_completion(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -2318,6 +2320,7 @@ fn response_from_cached_chat_choices(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: cached.prompt_tokens as u32,
@@ -2401,6 +2404,7 @@ fn streaming_response_from_cached_completion(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -4732,6 +4736,7 @@ async fn generate_real_batched(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -4825,6 +4830,7 @@ async fn generate_real_batched_streaming(
     let prompt_preview = truncate_chars(&prompt_text_full, PROMPT_PREVIEW_MAX_CHARS);
     let prompt_full = truncate_chars(&prompt_text_full, FULL_BODY_MAX_CHARS);
     let req_adapter = req.adapter.request_adapter_name();
+    let req_user_agent = req.user_agent.clone();
     let req_temperature = req.temperature;
     let req_top_p = req.top_p;
     let req_max_tokens = Some(chat_request_max_tokens(req).min(u32::MAX as usize) as u32);
@@ -4848,6 +4854,7 @@ async fn generate_real_batched_streaming(
             let mut decoded_prefix = String::new();
             let record = |finish_reason: String, completion: &str, completion_tokens: u32| {
                 let record = RequestRecord {
+                    user_agent: req_user_agent.clone(),
                     id: id.clone(),
                     timestamp_unix_ms: now_unix_ms(),
                     model: model.clone(),
@@ -5484,6 +5491,7 @@ async fn generate_real(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -5607,6 +5615,7 @@ async fn generate_real_streaming(
     let prompt_preview = truncate_chars(&prompt_text_full, PROMPT_PREVIEW_MAX_CHARS);
     let prompt_full = truncate_chars(&prompt_text_full, FULL_BODY_MAX_CHARS);
     let req_adapter = req.adapter.request_adapter_name();
+    let req_user_agent = req.user_agent.clone();
     let req_temperature = req.temperature;
     let req_top_p = req.top_p;
     let req_max_tokens = Some(chat_request_max_tokens(req).min(u32::MAX as usize) as u32);
@@ -5633,6 +5642,7 @@ async fn generate_real_streaming(
 
             let record = |finish_reason: String, completion: &str, completion_tokens: u32| {
                 let record = RequestRecord {
+                    user_agent: req_user_agent.clone(),
                     id: id.clone(),
                     timestamp_unix_ms: now_unix_ms(),
                     model: model.clone(),
@@ -6349,6 +6359,7 @@ async fn generate_mock(
     record_recent_request(
         state,
         RequestRecord {
+            user_agent: req.user_agent.clone(),
             completion_preview: truncate_chars(
                 assistant_output.preview_source(),
                 COMPLETION_PREVIEW_MAX_CHARS,
@@ -10076,6 +10087,7 @@ mod tests {
         let mut state = make_batch_test_state();
         state.slow_request_warn_threshold = Some(std::time::Duration::from_millis(50));
         let mut record = RequestRecord {
+            user_agent: None,
             id: "chatcmpl-test".to_string(),
             timestamp_unix_ms: 0,
             model: "kiln-test".to_string(),

--- a/crates/kiln-server/src/api/debug_model_state.rs
+++ b/crates/kiln-server/src/api/debug_model_state.rs
@@ -537,6 +537,7 @@ mod tests {
         {
             let mut recent = state.recent_requests.lock().unwrap();
             recent.record(crate::recent_requests::RequestRecord {
+                user_agent: None,
                 id: "secret-id".to_string(),
                 prompt_preview: "secret prompt".to_string(),
                 prompt_full: Some("full secret prompt".to_string()),

--- a/crates/kiln-server/src/api/stats.rs
+++ b/crates/kiln-server/src/api/stats.rs
@@ -123,6 +123,7 @@ mod tests {
             let mut ring = state.recent_requests.lock().unwrap();
             for (i, id) in ["first", "second", "third"].iter().enumerate() {
                 ring.record(RequestRecord {
+                    user_agent: None,
                     id: (*id).to_owned(),
                     timestamp_unix_ms: 1_000 + i as u64,
                     model: "kiln-test".to_owned(),

--- a/crates/kiln-server/src/recent_requests.rs
+++ b/crates/kiln-server/src/recent_requests.rs
@@ -152,6 +152,7 @@ mod tests {
 
     fn make_record(id: &str) -> RequestRecord {
         RequestRecord {
+            user_agent: None,
             id: id.to_owned(),
             timestamp_unix_ms: 0,
             model: "kiln-test".to_owned(),

--- a/crates/kiln-server/src/recent_requests.rs
+++ b/crates/kiln-server/src/recent_requests.rs
@@ -57,6 +57,11 @@ pub struct RequestRecord {
     pub prompt_full: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completion_full: Option<String>,
+    /// Raw `User-Agent` of the calling client, captured so the /ui dashboard
+    /// can attribute traffic to the agent that produced it (pi, opencode, the
+    /// OpenAI SDKs, curl, …). The dashboard maps it to a friendly label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
 }
 
 /// Cap on full prompt / completion body size kept in the ring (chars).

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Kiln Dashboard</title>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' x2='0' y1='0' y2='1'%3E%3Cstop offset='0' stop-color='%23fbbf24'/%3E%3Cstop offset='1' stop-color='%23c2410c'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='32' height='32' rx='7' fill='%2308090c'/%3E%3Cpath d='M9 22 L16 8 L23 22 Z' fill='url(%23g)'/%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Cdefs%3E%3ClinearGradient%20id='g'%20x1='0'%20x2='0'%20y1='0'%20y2='1'%3E%3Cstop%20offset='0'%20stop-color='%23fbbf24'/%3E%3Cstop%20offset='0.5'%20stop-color='%23f97316'/%3E%3Cstop%20offset='1'%20stop-color='%23c2410c'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20width='32'%20height='32'%20rx='7'%20fill='%230a0908'/%3E%3Crect%20x='4'%20y='4'%20width='24'%20height='24'%20rx='5'%20fill='url%28%23g%29'/%3E%3Cg%20fill='none'%20stroke='%230a0908'%20stroke-width='2.6'%20stroke-linecap='round'%20stroke-linejoin='round'%20opacity='0.85'%3E%3Cpath%20d='M8%2012.5l8%204%208-4'/%3E%3Cpath%20d='M10%2017.5l6%203%206-3'/%3E%3Cpath%20d='M12%2022.5l4%202%204-2'/%3E%3C/g%3E%3C/svg%3E">
 <style>
 /* =====================================================================
    Kiln design system
@@ -27,21 +27,25 @@
   --kiln-800: #9a3412;
   --kiln-900: #7c2d12;
 
-  /* Surface — warm-tinted charcoal */
-  --ink-950: #08090c;
-  --ink-900: #0d0e12;
-  --ink-850: #11131a;
-  --ink-800: #14161e;
-  --ink-750: #181b24;
-  --ink-700: #1c1f29;
-  --ink-650: #232732;
-  --ink-600: #2a2f3b;
-  --ink-500: #353a48;
-  --ink-400: #4b5163;
-  --ink-300: #6b7280;
-  --ink-200: #9ca3af;
-  --ink-100: #d1d5db;
-  --ink-50:  #f4f5f7;
+  /* Surface — warm-tinted charcoal (true warm neutral: R > G > B at every step,
+     so a Kiln screenshot reads warm even with the logo cropped — never blue-gray). */
+  --ink-950: #0a0908;
+  --ink-900: #0e0d0b;
+  --ink-850: #131210;
+  --ink-800: #181613;
+  --ink-750: #1d1b17;
+  --ink-700: #23201b;
+  --ink-650: #2b2720;
+  --ink-600: #342f26;
+  --ink-500: #443c31;
+  /* Text-bearing steps are tuned for WCAG AA on the --surface (ink-800):
+     ink-300 (text-muted) ≈ 4.6:1, ink-200 (text-3) ≈ 7:1, ink-400
+     (text-quiet) ≈ 3:1 → large/bold only. */
+  --ink-400: #756b5b;
+  --ink-300: #938b79;
+  --ink-200: #b0a895;
+  --ink-100: #d9d3c7;
+  --ink-50:  #f7f4ef;
 
   /* Semantic */
   --success-fg:  #4ade80;
@@ -64,6 +68,7 @@
   --surface-2:  var(--ink-750);
   --surface-3:  var(--ink-700);
   --border:     var(--ink-650);
+  --border-soft: var(--ink-700);
   --border-strong: var(--ink-500);
   --text:       var(--ink-50);
   --text-2:     var(--ink-100);
@@ -75,6 +80,7 @@
   --accent-press: var(--kiln-600);
   --accent-soft: rgba(249, 115, 22, 0.12);
   --accent-ring: rgba(249, 115, 22, 0.42);
+  --accent-border: rgba(249, 115, 22, 0.30);
 
   /* Typography */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Helvetica, Arial, sans-serif;
@@ -87,9 +93,16 @@
   --text-md:  14px;
   --text-lg:  16px;
   --text-xl:  18px;
-  --text-2xl: 22px;
-  --text-3xl: 28px;
-  --text-4xl: 36px;
+  --text-2xl: clamp(18px, 1.8vw, 22px);
+  --text-3xl: clamp(22px, 2.4vw, 28px);
+  --text-4xl: clamp(28px, 3vw, 36px);
+  /* Display tier — reserved for the single hero live number per view.
+     Activates the previously-dead top of the scale. */
+  --text-display: clamp(34px, 4vw, 46px);
+
+  /* Letter-spacing — exactly two tokens, no scattered values. */
+  --tracking-caps:  0.06em;  /* all uppercase eyebrows / section labels */
+  --tracking-tight: -0.02em; /* display numbers + large headings */
 
   /* Spacing — 4px grid */
   --space-1:  4px;
@@ -97,7 +110,7 @@
   --space-3:  12px;
   --space-4:  16px;
   --space-5:  20px;
-  --space-6:  24px;
+  --space-6:  clamp(16px, 2vw, 24px);
   --space-7:  32px;
   --space-8:  40px;
   --space-10: 48px;
@@ -154,9 +167,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   min-height: 100vh;
+  /* Two warm glows only — the forge "heat from above". The top glow's
+     intensity is driven by --heat (0–1, set from live request volume) so a
+     busy server literally looks hotter. No cool/blue light anywhere. */
   background-image:
-    radial-gradient(1200px 600px at 50% -120px, rgba(249, 115, 22, 0.08), transparent 60%),
-    radial-gradient(800px 400px at 100% 0%, rgba(96, 165, 250, 0.04), transparent 60%);
+    radial-gradient(1200px 600px at 50% -160px, rgba(249, 115, 22, calc(0.05 + 0.07 * var(--heat, 0))), transparent 62%),
+    radial-gradient(900px 500px at 100% -40px, rgba(194, 65, 12, 0.05), transparent 60%);
   background-attachment: fixed;
 }
 a {
@@ -236,14 +252,7 @@ button, input, select, textarea { font-family: inherit; }
   box-shadow: var(--shadow-1), inset 0 1px 0 rgba(255, 255, 255, 0.12);
   flex-shrink: 0;
 }
-.brand-mark::after {
-  content: '';
-  position: absolute;
-  inset: 6px;
-  background: var(--ink-950);
-  clip-path: polygon(50% 12%, 88% 88%, 12% 88%);
-  opacity: 0.78;
-}
+/* Legacy triangle punch-out replaced by the inlined .brand-flame SVG. */
 .brand-text { display: flex; align-items: baseline; gap: var(--space-2); }
 .brand-name {
   font-family: var(--font-display);
@@ -285,7 +294,7 @@ button, input, select, textarea { font-family: inherit; }
 .stat-label {
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-caps);
   font-size: var(--text-2xs);
   font-weight: 500;
 }
@@ -454,15 +463,15 @@ button, input, select, textarea { font-family: inherit; }
   border-bottom: 1px solid var(--border);
 }
 .card-head h2 {
-  font-size: var(--text-md);
+  font-size: var(--text-lg);
   font-weight: 600;
-  letter-spacing: -0.005em;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 .card-head .eyebrow {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 500;
 }
@@ -473,7 +482,7 @@ button, input, select, textarea { font-family: inherit; }
   display: block;
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
   margin-bottom: var(--space-3);
@@ -519,18 +528,18 @@ button, input, select, textarea { font-family: inherit; }
 .hero-eyebrow {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
 }
 .hero-num {
   font-family: var(--font-display);
-  font-size: var(--text-3xl);
+  font-size: var(--text-4xl);
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: var(--tracking-tight);
   color: var(--text);
   font-variant-numeric: tabular-nums;
-  line-height: 1.1;
+  line-height: 1.08;
 }
 .hero-num .unit {
   font-size: var(--text-md);
@@ -582,11 +591,11 @@ button, input, select, textarea { font-family: inherit; }
   white-space: nowrap;
   overflow: hidden;
   font-weight: 600;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.75), 0 0 2px rgba(0, 0, 0, 0.55);
   transition: width var(--t-base) var(--ease-out);
 }
 .vram-seg:nth-child(1) { background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400)); }
-.vram-seg:nth-child(2) { background: linear-gradient(90deg, #2563eb, var(--info-fg)); }
+.vram-seg:nth-child(2) { background: linear-gradient(90deg, #6e6048, #9c8a63); }
 .vram-seg:nth-child(3) { background: linear-gradient(90deg, #15803d, var(--success-fg)); }
 .vram-seg:nth-child(4) { background: var(--ink-700); color: var(--text-muted); text-shadow: none; }
 .vram-legend {
@@ -610,7 +619,7 @@ button, input, select, textarea { font-family: inherit; }
   flex-shrink: 0;
 }
 .vram-legend .model::before { background: var(--kiln-500); }
-.vram-legend .kv::before    { background: var(--info-fg); }
+.vram-legend .kv::before    { background: #9c8a63; }
 .vram-legend .train::before { background: var(--success-fg); }
 .vram-legend .free::before  { background: var(--ink-600); }
 
@@ -645,7 +654,7 @@ button, input, select, textarea { font-family: inherit; }
 .sched-stat .lbl {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 500;
 }
@@ -698,7 +707,7 @@ button, input, select, textarea { font-family: inherit; }
 .form-group label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
 }
@@ -852,7 +861,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600));
   border-color: var(--kiln-700);
   color: white;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.18) inset, 0 4px 12px rgba(249, 115, 22, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 2px 8px rgba(249, 115, 22, 0.18);
 }
 .btn-primary:hover:not(:disabled) {
   background: linear-gradient(180deg, var(--kiln-400), var(--kiln-500));
@@ -922,6 +931,20 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .recent-row:last-child { border-bottom: 0; }
 .recent-row:hover { background: rgba(255, 255, 255, 0.04); }
 .recent-row:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: -2px; }
+/* Rows pi got a degraded result from — scannable at a glance even in "All",
+   so the bad ones jump out without needing the filter on. */
+.recent-row.attn { box-shadow: inset 2px 0 0 var(--warning-bd); }
+.recent-row.attn:hover { background: var(--warning-bg); }
+/* One-click capture on attention rows — warning-tinted (it lives on a flagged
+   row), flips to a success "Added" pulse. Sweep the column into corrections. */
+.recent-correct { display: inline-flex; align-items: center; gap: 4px; margin-top: 2px; padding: 2px 9px;
+  font-size: 11px; font-weight: 600; border-radius: var(--radius-pill); cursor: pointer; white-space: nowrap;
+  background: transparent; border: 1px solid var(--warning-bd); color: var(--warning-fg);
+  transition: background var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out); }
+.recent-correct:hover { background: var(--warning-bg); border-color: var(--warning-fg); }
+.recent-correct:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 1px; }
+.recent-correct .icn { width: 12px; height: 12px; }
+.recent-correct.is-added { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
 .recent-time {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -971,17 +994,18 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-family: var(--font-mono);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-caps);
   padding: 2px 7px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--border);
   background: var(--ink-850);
   color: var(--text-2);
 }
-.recent-pill.streamed { color: var(--info-fg); border-color: var(--info-bd); background: var(--info-bg); }
+.recent-pill.streamed { color: var(--text-muted); border-color: var(--border); background: transparent; }
 .recent-pill.stop     { color: var(--success-fg); border-color: var(--success-bd); background: var(--success-bg); }
 .recent-pill.length   { color: var(--warning-fg); border-color: var(--warning-bd); background: var(--warning-bg); }
 .recent-pill.error    { color: var(--danger-fg);  border-color: var(--danger-bd);  background: var(--danger-bg); }
+.recent-pill.tool_calls { color: var(--text-3); border-color: var(--border-strong); background: var(--surface-3); }
 
 @media (max-width: 700px) {
   .recent-row { grid-template-columns: 1fr; gap: 4px; }
@@ -1048,7 +1072,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-family: var(--font-mono);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-caps);
   padding: 2px 7px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--border);
@@ -1096,6 +1120,18 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   padding: 0 var(--space-5);
   border-bottom: 1px solid var(--border);
 }
+/* Grouped, scrollable sub-nav (used by the Distill page's Methods/Setup/Assets
+   groups). Group labels + separators sit inline; the tab JS ignores non-.tab. */
+.tabs.distill-tabs { overflow-x: auto; scrollbar-width: none; align-items: stretch; }
+.tabs.distill-tabs::-webkit-scrollbar { display: none; }
+.tab-group-label {
+  align-self: center; flex: 0 0 auto; white-space: nowrap;
+  font-size: 10px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: var(--tracking-caps); color: var(--text-quiet);
+  padding: 0 var(--space-2) 0 0;
+}
+.tab-group-label:not(:first-child) { padding-left: var(--space-3); }
+.tab-group-sep { align-self: center; flex: 0 0 auto; width: 1px; height: 16px; background: var(--border); margin: 0 var(--space-1); }
 .tab {
   background: transparent;
   border: 0;
@@ -1147,7 +1183,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-2xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   padding: 3px 10px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--border);
@@ -1155,7 +1191,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   color: var(--text-2);
 }
 .job-state.Queued    { color: var(--text-muted); }
-.job-state.Running   { color: var(--info-fg); border-color: var(--info-bd); background: var(--info-bg); }
+.job-state.Running   { color: var(--kiln-300); border-color: var(--accent-ring); background: var(--accent-soft); }
 .job-state.Completed { color: var(--success-fg); border-color: var(--success-bd); background: var(--success-bg); }
 .job-state.Failed,
 .job-state.Cancelled { color: var(--danger-fg); border-color: var(--danger-bd); background: var(--danger-bg); }
@@ -1196,7 +1232,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .queue-section-label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
   margin: var(--space-4) 0 var(--space-2);
@@ -1222,7 +1258,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .chat-controls > label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
   margin: 0;
@@ -1235,7 +1271,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   gap: 6px;
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
   cursor: pointer;
@@ -1270,7 +1306,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .chat-advanced .chat-adv-label {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
 }
@@ -1325,7 +1361,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .chat-msg .role {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-muted);
   font-weight: 600;
 }
@@ -1384,11 +1420,9 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   line-height: 1.55;
-  background:
-    repeating-linear-gradient(135deg,
-      var(--surface) 0 12px,
-      var(--surface-2) 12px 24px);
-  border: 1px dashed var(--border);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--border-strong);
   border-radius: var(--radius-md);
   margin-bottom: 6px;
   overflow: hidden;
@@ -1399,7 +1433,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   padding: 6px 12px;
   font-size: var(--text-2xs);
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   color: var(--text-muted);
   display: flex;
@@ -1569,7 +1603,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: 10px;
   color: var(--text-quiet);
   text-transform: lowercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-caps);
 }
 .chat-msg .md-body blockquote {
   margin: 0;
@@ -1645,7 +1679,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .chat-output-actions .chat-turn-count {
   font-size: var(--text-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-quiet);
 }
 .chat-output-actions .chat-turn-count[hidden] { display: none; }
@@ -1662,7 +1696,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .chat-starter-prompts > span {
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-caps);
   font-weight: 600;
   font-size: var(--text-2xs);
   margin-right: var(--space-2);
@@ -1865,7 +1899,9 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .eval-row:hover { background: rgba(255, 255, 255, 0.025); }
 .eval-row.eval-row-clickable { cursor: pointer; }
 .eval-row .row-title { font-weight: 500; color: var(--text); }
-.eval-row .row-sub { color: var(--text-quiet); font-size: var(--text-xs); margin-top: 2px; }
+/* row-sub carries the description/stats/pattern — real content, so it uses the
+   AA-passing muted grey (text-quiet is 3.96:1 on the card surface, below AA). */
+.eval-row .row-sub { color: var(--text-muted); font-size: var(--text-xs); margin-top: 2px; }
 .eval-row .row-actions { display: flex; gap: var(--space-1); justify-content: flex-end; }
 
 .eval-row-datasets   { grid-template-columns: 1.7fr 1.1fr 1.1fr 1.4fr auto; }
@@ -1910,7 +1946,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-2xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-caps);
   border: 1px solid var(--border);
 }
 .job-state-pill::before {
@@ -1920,8 +1956,8 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .job-state-pill.queued    { color: var(--text-muted); background: var(--surface-2); }
 .job-state-pill.queued::before    { background: var(--text-muted); }
-.job-state-pill.running   { color: var(--info-fg); background: var(--info-bg); border-color: var(--info-bd); }
-.job-state-pill.running::before   { background: var(--info-fg); animation: pulseDot 1.4s ease-in-out infinite; }
+.job-state-pill.running   { color: var(--kiln-300); background: var(--accent-soft); border-color: var(--accent-ring); }
+.job-state-pill.running::before   { background: var(--accent); animation: pulseDot 1.4s ease-in-out infinite; }
 .job-state-pill.completed { color: var(--success-fg); background: var(--success-bg); border-color: var(--success-bd); }
 .job-state-pill.completed::before { background: var(--success-fg); }
 .job-state-pill.failed    { color: var(--danger-fg); background: var(--danger-bg); border-color: var(--danger-bd); }
@@ -1963,6 +1999,16 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .acc-ring.tiny .acc-ring-num { font-size: 11px; }
 .acc-ring.large { width: 96px; height: 96px; }
 .acc-ring.large::before { inset: 7px; }
+/* Stand-in for the score ring on jobs with no score yet (running/queued/failed)
+   — a state figure, so a not-yet-scored job never shows a misleading "0". */
+.job-statefig { display: inline-grid; place-items: center; width: 96px; height: 96px; border-radius: 50%;
+  background: var(--surface-3); border: 1px solid var(--border); flex-shrink: 0; }
+.job-statefig .icn { width: 30px; height: 30px; color: var(--text-muted); }
+.job-statefig.running { border-color: var(--accent); }            /* running = alive = amber */
+.job-statefig.running .icn { color: var(--accent-hover); }
+.job-statefig.failed { border-color: var(--danger-bd); }
+.job-statefig.failed .icn { color: var(--danger-fg); }
+.job-statefig.queued .icn { color: var(--text-quiet); }
 .acc-ring.large .acc-ring-num { font-size: var(--text-2xl); }
 
 /* Job card (rich Jobs tab) */
@@ -2093,7 +2139,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-md); font-weight: 600; font-variant-numeric: tabular-nums;
 }
 .drill-counts .count-cell .count-label {
-  text-transform: uppercase; font-size: 10px; letter-spacing: 0.06em; color: var(--text-quiet);
+  text-transform: uppercase; font-size: 10px; letter-spacing: var(--tracking-caps); color: var(--text-quiet);
 }
 
 /* Recent-request inspect modal */
@@ -2113,12 +2159,12 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   padding: var(--space-3);
 }
 .req-stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.req-stat-k { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-quiet); }
+.req-stat-k { font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-quiet); }
 .req-stat-v { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text); overflow-wrap: anywhere; }
 .req-section { display: flex; flex-direction: column; gap: var(--space-2); min-width: 0; }
 .req-section-head {
   display: flex; align-items: center; justify-content: space-between;
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps);
   color: var(--text-quiet);
 }
 .req-pre {
@@ -2208,7 +2254,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-2xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-quiet);
 }
 .outcome-detail .messages-list { display: flex; flex-direction: column; gap: var(--space-2); }
@@ -2222,7 +2268,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-caps);
   color: var(--text-quiet);
   margin-bottom: 4px;
 }
@@ -2248,7 +2294,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .detail-tg .tg-cell.tg-fail { border-color: var(--danger-bd); background: var(--danger-bg); }
 .detail-tg .tg-cell .tg-label {
   font-size: var(--text-2xs); font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-quiet); margin-bottom: 6px;
+  letter-spacing: var(--tracking-caps); color: var(--text-quiet); margin-bottom: 6px;
 }
 .detail-tg .tg-cell pre {
   margin: 0; font-family: var(--font-mono); font-size: 12px; line-height: 1.55;
@@ -2326,7 +2372,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .judgment-reply.judgment-reply-b:hover { border-color: var(--kiln-400); }
 .judgment-reply .judgment-tag {
   font-size: var(--text-2xs); font-weight: 700; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-quiet); margin-bottom: 6px;
+  letter-spacing: var(--tracking-caps); color: var(--text-quiet); margin-bottom: 6px;
   display: flex; gap: var(--space-2); align-items: center;
 }
 .judgment-reply.judgment-reply-a .judgment-tag::before {
@@ -2483,7 +2529,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   border-bottom: 1px solid var(--border);
   background: var(--surface-2);
   font-size: var(--text-xs); font-weight: 600;
-  text-transform: uppercase; letter-spacing: 0.06em;
+  text-transform: uppercase; letter-spacing: var(--tracking-caps);
   color: var(--text-quiet);
 }
 
@@ -2563,7 +2609,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .cmdk-section-label {
   padding: 8px 14px 4px;
-  font-size: 10px; font-weight: 700; letter-spacing: 0.08em;
+  font-size: 10px; font-weight: 700; letter-spacing: var(--tracking-caps);
   text-transform: uppercase; color: var(--text-quiet);
 }
 .cmdk-item {
@@ -2702,7 +2748,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   transition: border-color 80ms ease;
 }
 .training-card:hover { border-color: var(--border-strong); }
-.training-card.training-card-running { border-color: var(--info-bd); }
+.training-card.training-card-running { border-color: var(--accent-ring); box-shadow: 0 0 0 1px var(--accent-soft), 0 8px 24px rgba(249, 115, 22, 0.10); }
 .training-card-head {
   display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap;
 }
@@ -2710,13 +2756,16 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-weight: 600; color: var(--text);
 }
 .training-card-head .training-card-type {
-  font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;
+  font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: var(--tracking-caps);
   padding: 1px 6px; border-radius: 3px;
   background: var(--surface-2); color: var(--text-quiet); border: 1px solid var(--border);
   font-family: var(--font-mono);
 }
-.training-card-head .training-card-type.sft  { color: var(--info-fg); border-color: var(--info-bd); background: var(--info-bg); }
-.training-card-head .training-card-type.grpo { color: var(--warning-fg); border-color: var(--warning-bd); background: var(--warning-bg); }
+/* SFT / GRPO / OPD are peer job-type tags — neutral (amber is reserved for the
+   RUNNING state only). The label text carries the distinction. */
+.training-card-head .training-card-type.sft,
+.training-card-head .training-card-type.grpo,
+.training-card-head .training-card-type.opd  { color: var(--text-3); border-color: var(--border-strong); background: var(--surface-3); }
 .training-card-progress {
   display: grid;
   grid-template-columns: 1fr 100px 100px;
@@ -2727,9 +2776,22 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   height: 8px; background: var(--surface-3); border-radius: 4px; overflow: hidden;
 }
 .training-card-progress .progress-bar-fill {
-  height: 100%; background: linear-gradient(90deg, var(--accent), var(--kiln-300));
-  transition: width 250ms ease;
+  height: 100%; background: var(--ink-400); border-radius: inherit;
+  transition: width 250ms ease; position: relative; overflow: hidden;
 }
+/* Amber == live / hot: only the RUNNING job's bar glows. */
+.training-card-running .progress-bar-fill {
+  background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400));
+  box-shadow: 0 0 14px rgba(249, 115, 22, 0.38);
+}
+.training-card-running .progress-bar-fill::after {
+  content: ''; position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.22), transparent);
+  animation: progress-shimmer 1.6s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) { .training-card-running .progress-bar-fill::after { animation: none; } }
+.training-card-completed .progress-bar-fill { background: linear-gradient(90deg, var(--success-bd), var(--success-fg)); }
+.training-card-failed   .progress-bar-fill { background: linear-gradient(90deg, var(--danger-bd), var(--danger-fg)); }
 .training-card-progress .training-stat {
   display: flex; flex-direction: column; gap: 2px; align-items: flex-start;
 }
@@ -2737,7 +2799,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-variant-numeric: tabular-nums; font-size: var(--text-md); font-weight: 600; color: var(--text);
 }
 .training-card-progress .training-stat-label {
-  font-size: 10px; color: var(--text-quiet); text-transform: uppercase; letter-spacing: 0.06em;
+  font-size: 10px; color: var(--text-quiet); text-transform: uppercase; letter-spacing: var(--tracking-caps);
 }
 
 .training-card-curve {
@@ -2773,7 +2835,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   position: absolute; top: 8px; right: 8px;
   background: var(--accent); color: white;
   font-size: 9px; font-weight: 700; text-transform: uppercase;
-  padding: 2px 7px; border-radius: 999px; letter-spacing: 0.06em;
+  padding: 2px 7px; border-radius: 999px; letter-spacing: var(--tracking-caps);
 }
 .adapter-card .adapter-card-name {
   font-weight: 600; color: var(--text); font-size: var(--text-md);
@@ -2785,6 +2847,15 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .adapter-card .adapter-card-meta .tabular-nums {
   color: var(--text-2); font-weight: 500;
 }
+/* Latest-eval score chip — turns the adapter list into a glanceable leaderboard.
+   Neutral (no green) so a low score isn't mis-signalled as good. */
+.adapter-card .adapter-eval-chip {
+  display: inline-flex; align-items: center; gap: 5px; padding: 1px 8px;
+  border-radius: var(--radius-pill); background: var(--surface-3);
+  border: 1px solid var(--border); color: var(--text-muted); font-size: 11px;
+}
+.adapter-card .adapter-eval-chip strong { color: var(--text); font-variant-numeric: tabular-nums; }
+.adapter-card .adapter-eval-chip.none { background: transparent; border-style: dashed; color: var(--text-quiet); }
 .adapter-card .adapter-card-actions {
   display: flex; gap: 4px; margin-top: 4px; flex-wrap: wrap;
 }
@@ -2848,7 +2919,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .compare-side .compare-side-head {
   font-size: 11px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-quiet);
+  letter-spacing: var(--tracking-caps); color: var(--text-quiet);
   margin-bottom: 6px;
   display: flex; gap: 8px; align-items: center;
 }
@@ -2878,9 +2949,330 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 <body>
 <a class="skip-link" href="#content">Skip to content</a>
 
+<!-- =====================================================================
+     Icon system — monochrome inline SVG sprite (Lucide-style, 24px grid,
+     currentColor). Replaces every emoji so glyphs inherit the warm accent
+     and sit on the pixel grid. Use inline via <svg class="icn"><use href="#i-NAME"/></svg>
+     or from JS via the icon('name') helper. Styling lives on .icn so the
+     symbols carry only geometry.
+     ===================================================================== -->
+<svg width="0" height="0" style="position:absolute;overflow:hidden" aria-hidden="true" focusable="false"><defs>
+  <symbol id="i-chart" viewBox="0 0 24 24"><path d="M4 20V4"/><path d="M4 20h16"/><path d="M8 20v-6"/><path d="M13 20V9"/><path d="M18 20v-4"/></symbol>
+  <symbol id="i-flask" viewBox="0 0 24 24"><path d="M9 3h6"/><path d="M10 3v6.5L5.2 18A1.6 1.6 0 0 0 6.6 21h10.8a1.6 1.6 0 0 0 1.4-3L14 9.5V3"/><path d="M7.6 14.5h8.8"/></symbol>
+  <symbol id="i-scale" viewBox="0 0 24 24"><path d="M12 4v16"/><path d="M7 20.5h10"/><path d="M4 8h16"/><path d="M12 4 4 8M12 4l8 4"/><path d="M2 13.5h4l-2-5.5z"/><path d="M18 13.5h4l-2-5.5z"/></symbol>
+  <symbol id="i-chat" viewBox="0 0 24 24"><path d="M21 11.5a7.6 7.6 0 0 1-11 6.8L4 20l1.7-5A7.6 7.6 0 1 1 21 11.5Z"/></symbol>
+  <symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></symbol>
+  <symbol id="i-flame" viewBox="0 0 24 24"><path d="M12 3c.6 2.4 2 3.7 3.2 5C16.6 9.6 18 11.3 18 14a6 6 0 0 1-12 0c0-1.6.7-3 1.8-4 .3 1.2 1.2 2 2.2 2 1.3 0 1.7-1.4 1-3-.5-1.1-1-2.3-1-3.4C10 5.3 11 4 12 3Z"/></symbol>
+  <symbol id="i-close" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></symbol>
+  <symbol id="i-gear" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.2"/><path d="M19.5 14a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.1-2.7l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5 1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V10a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.4 1z"/></symbol>
+  <symbol id="i-trash" viewBox="0 0 24 24"><path d="M4 7h16"/><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13"/><path d="M10 11.5v6M14 11.5v6"/></symbol>
+  <symbol id="i-pencil" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.4 3.6a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></symbol>
+  <symbol id="i-stop" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2.2"/></symbol>
+  <symbol id="i-warning" viewBox="0 0 24 24"><path d="M10.3 3.9 1.9 18a2 2 0 0 0 1.7 3h16.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9.5v4.5"/><path d="M12 17.5h.01"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+  <symbol id="i-home" viewBox="0 0 24 24"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.4V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.4"/><path d="M9.5 21v-6h5v6"/></symbol>
+  <symbol id="i-layers" viewBox="0 0 24 24"><path d="m12 3 9 5-9 5-9-5 9-5Z"/><path d="m3 13 9 5 9-5"/></symbol>
+  <symbol id="i-target" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.2"/><circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/></symbol>
+  <symbol id="i-folder" viewBox="0 0 24 24"><path d="M4 7a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7Z"/></symbol>
+  <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+  <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+  <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+  <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+  <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M12 4v11"/><path d="m7.5 10.5 4.5 4.5 4.5-4.5"/><path d="M5 20h14"/></symbol>
+  <symbol id="i-upload" viewBox="0 0 24 24"><path d="M12 16V5"/><path d="m7.5 9.5 4.5-4.5 4.5 4.5"/><path d="M5 20h14"/></symbol>
+  <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></symbol>
+  <symbol id="i-merge" viewBox="0 0 24 24"><path d="M7 21V8"/><path d="M17 21v-6a4 4 0 0 0-4-4H7"/><path d="m4 11 3-3 3 3"/><path d="M14 18l3 3 3-3"/></symbol>
+  <symbol id="i-book" viewBox="0 0 24 24"><path d="M5 4.5A1.5 1.5 0 0 1 6.5 3H19v15H6.5A1.5 1.5 0 0 0 5 19.5Z"/><path d="M5 19.5A1.5 1.5 0 0 0 6.5 21H19"/></symbol>
+  <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+  <symbol id="i-sparkles" viewBox="0 0 24 24"><path d="M12 3l1.8 4.7L18.5 9.5 13.8 11.3 12 16l-1.8-4.7L5.5 9.5l4.7-1.8Z"/><path d="M19 14l.7 1.8 1.8.7-1.8.7L19 19l-.7-1.8-1.8-.7 1.8-.7Z"/></symbol>
+  <symbol id="i-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
+  <symbol id="i-play" viewBox="0 0 24 24"><path d="M8 5.2v13.6L19 12 8 5.2Z" fill="currentColor" stroke="none"/></symbol>
+  <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+</defs></svg>
+
+<style>
+  .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+         fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round;
+         stroke-linejoin: round; flex-shrink: 0; }
+  .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
+  /* Brand mark flame, inlined into the gradient kiln-cube — a solid dark
+     flame cut out of the glowing ember cube. */
+  .brand-flame { position: absolute; inset: 0; margin: auto; width: 19px; height: 19px;
+                 fill: none; stroke: var(--ink-950); stroke-width: 2; stroke-linecap: round;
+                 stroke-linejoin: round; opacity: 0.82; }
+  @media (prefers-reduced-motion: no-preference) {
+    .brand-mark .brand-flame { animation: brand-ember 4.2s var(--ease-in-out) infinite; }
+  }
+  @keyframes brand-ember { 0%,100% { opacity: 0.82; } 50% { opacity: 0.66; } }
+
+  /* =====================================================================
+     Connect-your-agent panel — the onboarding centerpiece. Point pi /
+     opencode / any OpenAI client at Kiln. Lives at the top of Overview.
+     ===================================================================== */
+  .connect-panel { position: relative; overflow: hidden; border-color: var(--accent-ring); }
+  .connect-panel::before {
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background: radial-gradient(720px 220px at 8% -60px, rgba(249, 115, 22, 0.12), transparent 64%);
+  }
+  .connect-panel > * { position: relative; }
+  .connect-grid { display: grid; grid-template-columns: minmax(230px, 0.78fr) 1.45fr; gap: var(--space-6); padding: var(--space-5); }
+  @media (max-width: 900px) { .connect-grid { grid-template-columns: 1fr; } }
+  .connect-facts { display: flex; flex-direction: column; gap: var(--space-4); min-width: 0; }
+  .connect-field label, .connect-clients-label {
+    display: block; font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; margin-bottom: 6px;
+  }
+  .copy-field { display: flex; align-items: center; gap: var(--space-2);
+    background: var(--ink-850); border: 1px solid var(--border-strong); border-radius: var(--radius-md); padding: 7px 7px 7px 12px; }
+  .copy-field code { flex: 1; min-width: 0; background: none; border: 0; padding: 0;
+    font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .copy-btn { display: inline-flex; align-items: center; gap: 5px; flex-shrink: 0; cursor: pointer;
+    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+    border-radius: var(--radius-sm); padding: 5px 9px; font-size: var(--text-xs); font-weight: 500;
+    transition: color var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out); }
+  .copy-btn:hover { color: var(--text); border-color: var(--border-strong); background: var(--surface-3); }
+  .copy-btn.copied { color: var(--success-fg); border-color: var(--success-bd); background: var(--success-bg); }
+  .connect-keychip { display: inline-flex; align-items: center; gap: 7px; font-size: var(--text-xs);
+    color: var(--text-2); background: var(--ink-900); border: 1px solid var(--border);
+    border-radius: var(--radius-md); padding: 8px 12px; }
+  .connect-keychip .icn { color: var(--text-muted); }
+  .connect-keychip code { font-size: 11px; }
+  #connect-test { align-self: flex-start; }
+  .connect-test-result { font-size: var(--text-xs); line-height: 1.5; min-height: 1.1em; color: var(--text-muted); }
+  .connect-test-result.ok { color: var(--success-fg); }
+  .connect-test-result.err { color: var(--danger-fg); }
+
+  .connect-clients { display: flex; flex-direction: column; min-width: 0; }
+  .connect-tabs { display: flex; gap: 2px; margin-bottom: var(--space-3); overflow-x: auto; scrollbar-width: none; }
+  .connect-tabs::-webkit-scrollbar { display: none; }
+  .connect-snippet { display: none; }
+  .connect-snippet.active { display: block; }
+  .connect-snippet-note { font-size: var(--text-xs); color: var(--text-muted); margin-bottom: var(--space-2); line-height: 1.5; }
+  .code-block { position: relative; background: var(--ink-950); border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; }
+  .code-block-path { font-family: var(--font-mono); font-size: 11px; color: var(--text-quiet);
+    padding: 6px var(--space-4); border-bottom: 1px solid var(--border); background: var(--ink-900); }
+  .code-block pre { margin: 0; padding: var(--space-3) 44px var(--space-3) var(--space-4); overflow-x: auto;
+    font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-2); white-space: pre; }
+  .code-block .copy-btn { position: absolute; top: 8px; right: 8px; }
+  .code-block .tok-key { color: var(--kiln-300); }
+  .code-block .tok-str { color: var(--success-fg); }
+  .code-block .tok-com { color: var(--text-quiet); font-style: italic; }
+
+  /* Collapsed "connected" bar (auto-shown once traffic is flowing) */
+  .connect-collapsed { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-5); cursor: pointer; }
+  .connect-collapsed:hover { background: rgba(255, 255, 255, 0.02); }
+  .connect-collapsed .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success-fg); box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.16); flex-shrink: 0; }
+  .connect-collapsed-text { font-size: var(--text-sm); color: var(--text-2); }
+  .connect-collapsed-text strong { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+  .connect-collapsed .expand-hint { margin-left: auto; font-size: var(--text-xs); color: var(--text-muted); display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+  .connect-collapsed .expand-hint .icn { color: var(--accent-hover); }
+
+  /* Topbar Connect trigger */
+  .connect-trigger { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; cursor: pointer;
+    background: var(--accent-soft); border: 1px solid var(--accent-ring); color: var(--kiln-200);
+    border-radius: var(--radius-pill); padding: 5px 13px; font-size: var(--text-xs); font-weight: 600;
+    transition: background var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out); }
+  .connect-trigger:hover { background: rgba(249, 115, 22, 0.18); color: var(--kiln-100); }
+  .connect-trigger .icn { color: var(--accent-hover); }
+
+  /* Per-agent attribution on recent requests (driven by captured User-Agent) */
+  .agent-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: var(--space-4); }
+  .agent-chip { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; font-size: var(--text-xs);
+    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+    border-radius: var(--radius-pill); padding: 3px 11px;
+    transition: color var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out); }
+  .agent-chip:hover { color: var(--text); border-color: var(--border-strong); }
+  .agent-chip.active { color: var(--text); background: var(--accent-soft); border-color: var(--accent-ring); }
+  .agent-chip .icn { width: 13px; height: 13px; color: var(--text-quiet); }
+  .agent-chip.active .icn { color: var(--accent-hover); }
+  .agent-chip .count { font-variant-numeric: tabular-nums; color: var(--text-quiet); font-family: var(--font-mono); font-size: 11px; }
+  .agent-chip.active .count { color: var(--kiln-200); }
+  /* "Needs attention" filter — warning-tinted, visually separated from the
+     agent (client) chips by an auto left margin so it reads as a status toggle.
+     Amber stays reserved for "alive"; this uses the warning ramp. */
+  .agent-chip.attn-chip { margin-left: auto; color: var(--warning-fg); border-color: var(--warning-bd); background: var(--warning-bg); }
+  .agent-chip.attn-chip .icn { color: var(--warning-fg); }
+  .agent-chip.attn-chip .count { color: var(--warning-fg); }
+  .agent-chip.attn-chip:hover { border-color: var(--warning-fg); }
+  .agent-chip.attn-chip.active { background: var(--warning-fg); color: var(--ink-950); border-color: var(--warning-fg); }
+  .agent-chip.attn-chip.active .icn, .agent-chip.attn-chip.active .count { color: var(--ink-950); }
+  @media (max-width: 620px) { .agent-chip.attn-chip { margin-left: 0; } }
+  .recent-agent { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; font-weight: 600;
+    padding: 1px 8px; border-radius: var(--radius-pill); margin-right: 7px; vertical-align: 1px;
+    background: var(--surface-2); border: 1px solid var(--border); color: var(--text-2); white-space: nowrap;
+    letter-spacing: 0.01em; }
+  .recent-agent .icn { width: 11px; height: 11px; color: var(--text-3); }
+  /* Flywheel HOT-SWAP shows an adapter name (a label, not a count) → smaller. */
+  .flywheel-node[data-fw="swap"] .fw-value { font-size: var(--text-lg); }
+
+  /* Live heartbeat in the Recent requests header — "is pi reaching Kiln now?" */
+  .heartbeat { display: inline-flex; align-items: center; gap: 7px; font-size: var(--text-xs); color: var(--text-muted); white-space: nowrap; }
+  .heartbeat .hb-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-quiet); flex-shrink: 0; }
+  .heartbeat.hb-live .hb-dot { background: var(--success-fg); box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.18); animation: pulseDot 1.6s ease-in-out infinite; }
+  .heartbeat.hb-live .hb-text { color: var(--text-2); }
+  .heartbeat.hb-warn { color: var(--warning-fg); } .heartbeat.hb-warn .hb-dot { background: var(--warning-fg); }
+  .heartbeat.hb-err { color: var(--danger-fg); } .heartbeat.hb-err .hb-dot { background: var(--danger-fg); box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18); }
+  /* Per-request served-by (adapter) chip — surfaces silent base-model fallback */
+  .recent-served { display: inline-flex; align-items: center; gap: 3px; font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+    padding: 1px 7px; border-radius: var(--radius-pill); margin-right: 7px; vertical-align: 1px;
+    background: var(--surface-3); border: 1px solid var(--border); color: var(--text-3); white-space: nowrap; }
+  .recent-served.is-base { color: var(--warning-fg); border-color: var(--warning-bd); background: var(--warning-bg); }
+  .recent-served .icn { width: 10px; height: 10px; }
+  .recent-ttft { margin-left: 8px; color: var(--text-quiet); }
+
+  /* Corrections basket — the flywheel hinge. "Use as correction" in the drill
+     modal drops a bad answer here; the operator edits the ideal reply and trains
+     a named adapter in one click. Persists in localStorage across reloads. */
+  /* Amber is reserved for ALIVE/active only. The basket card chrome + count are
+     neutral; amber appears solely on the editable textarea's focus ring (where
+     the operator is actually acting). The actionable "needs your answer" state
+     uses the warning ramp (gold), distinct from alive orange. */
+  .corr-count { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 20px;
+    padding: 0 7px; margin-left: 6px; border-radius: var(--radius-pill); vertical-align: 2px;
+    background: var(--surface-3); color: var(--text-2); border: 1px solid var(--border-strong);
+    font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 700; }
+  #corrections-list { display: flex; flex-direction: column; gap: var(--space-3); padding-top: var(--space-3); padding-bottom: var(--space-3); }
+  .corr-item { border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2); overflow: hidden; }
+  .corr-item-head { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-soft, var(--border)); background: var(--surface-3); }
+  .corr-item-head .recent-agent { flex-shrink: 0; }
+  .corr-prompt { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-2); }
+  .corr-remove { flex-shrink: 0; padding: 2px; line-height: 0; color: var(--text-quiet); }
+  .corr-remove:hover { color: var(--danger-fg); }
+  /* Per-correction status: "needs your answer" (muted) vs "ready to train"
+     (success green once the ideal differs from pi's answer). The card's left
+     edge echoes the state so a basket scans at a glance. */
+  .corr-state { flex-shrink: 0; display: inline-flex; align-items: center; gap: 4px;
+    font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps);
+    font-weight: 600; color: var(--warning-fg); }
+  .corr-state .icn { width: 12px; height: 12px; }
+  .corr-item { border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--surface-2);
+    overflow: hidden; border-left-width: 3px; }
+  .corr-item.is-todo { border-left-color: var(--warning-bd); }
+  .corr-item.is-ready { border-left-color: var(--success-fg); }
+  .corr-item.is-ready .corr-state { color: var(--success-fg); }
+  .corr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0; }
+  .corr-col { padding: var(--space-3); min-width: 0; display: flex; flex-direction: column; }
+  .corr-col + .corr-col { border-left: 1px solid var(--border-soft, var(--border)); }
+  .corr-label { display: block; margin-bottom: 5px; font-size: var(--text-2xs); text-transform: uppercase;
+    letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; }
+  .corr-orig { margin: 0; max-height: 160px; overflow: auto; padding: var(--space-2) var(--space-3);
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm);
+    font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.5; color: var(--text-2);
+    white-space: pre-wrap; word-break: break-word; }
+  .corr-seed { align-self: flex-start; margin-top: 8px; color: var(--text-muted); }
+  .corr-seed:hover { color: var(--text); }
+  .corr-seed .icn { width: 12px; height: 12px; }
+  .corr-ideal { width: 100%; min-height: 120px; flex: 1; resize: vertical; padding: var(--space-2) var(--space-3);
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm);
+    font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.5; color: var(--text); }
+  .corr-ideal::placeholder { color: var(--text-quiet); }
+  .corr-ideal:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft, rgba(249,115,22,0.18)); }
+  .corrections-foot { display: flex; align-items: flex-end; gap: var(--space-3); flex-wrap: wrap;
+    border-top: 1px solid var(--border); }
+  /* Full-width own line so the "only edited items train" reassurance is never
+     clipped by the input/button row. */
+  .corr-foot-note { flex-basis: 100%; order: -1; font-size: var(--text-xs); color: var(--text-muted); }
+  #corr-train:disabled { opacity: 0.5; cursor: not-allowed; }
+  /* Persistent "training started" receipt — the loop's handoff made visible,
+     so submitting doesn't silently teleport you to the Training queue. */
+  .corr-receipt { display: flex; align-items: center; gap: 10px; padding: var(--space-2) var(--space-3);
+    margin-bottom: var(--space-3); border-radius: var(--radius-md);
+    background: var(--success-bg); border: 1px solid var(--success-bd); }
+  .corr-receipt-icon { color: var(--success-fg); display: inline-flex; flex-shrink: 0; }
+  .corr-receipt-icon .icn { width: 15px; height: 15px; }
+  .corr-receipt-text { flex: 1; min-width: 0; font-size: var(--text-sm); color: var(--text-2); }
+  .corr-receipt-text strong { color: var(--text); }
+  .corr-receipt-dismiss { flex-shrink: 0; padding: 2px; line-height: 0; color: var(--text-quiet); }
+  .corr-receipt-dismiss:hover { color: var(--text); }
+  .input-invalid { border-color: var(--danger-fg) !important; box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18) !important; }
+  #request-drill-correct.is-added { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
+
+  /* Inspect-modal prev/next — step through the current Recent-requests filter
+     (e.g. walk only the "Needs attention" rows) without leaving the modal. */
+  .icn-flip { transform: scaleX(-1); }
+  .modal-nav { display: inline-flex; align-items: center; gap: 2px; }
+  .modal-nav-pos { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-muted); min-width: 40px; text-align: center; }
+  .modal-nav .btn { padding: 3px 6px; }
+  .modal-nav .btn:disabled { opacity: 0.3; cursor: default; }
+
+  /* Latency breakdown — "the latency pi felt": a thin lead-in for time-to-first-
+     token, then the streaming/decode portion. Neutral warm fills (this is a past
+     record, not a live state, so no amber); the legend below carries the numbers
+     at full contrast on the card surface. */
+  .lat-bar { display: flex; gap: 1px; height: 12px; border-radius: var(--radius-pill); overflow: hidden;
+    background: var(--surface); border: 1px solid var(--border); margin: 2px 0 8px; }
+  /* TTFT is usually a tiny fraction of total, so give it a visible minimum width
+     and the BRIGHT warm tone — it reads as a distinct "first token landed here"
+     lead-marker against the dim decode fill. No text on the fills (the legend
+     carries the numbers at full contrast), so nothing fails AA on a mid-grey. */
+  .lat-seg { min-width: 3px; }
+  .lat-seg.lat-ttft { background: var(--text-muted); min-width: 10px; }
+  .lat-seg.lat-decode { background: var(--ink-500); }
+  .lat-legend { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-4); font-size: var(--text-xs); color: var(--text-muted); }
+  .lat-legend strong { color: var(--text-2); font-variant-numeric: tabular-nums; }
+  .lat-legend .lat-total { margin-left: auto; }
+  .lat-key { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 5px; vertical-align: 0; }
+  .lat-key.lat-ttft { background: var(--text-muted); }
+  .lat-key.lat-decode { background: var(--ink-500); }
+
+  /* Keyboard cheatsheet (opened with '?') */
+  .shortcuts-shell { max-width: 560px; width: 100%; }
+  .shortcuts-body { padding: var(--space-4) var(--space-5) var(--space-5); display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4) var(--space-5); }
+  .shortcuts-group-title { font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps);
+    color: var(--accent-hover); font-weight: 600; margin-bottom: var(--space-2); }
+  .shortcut-row { display: flex; align-items: baseline; gap: var(--space-3); padding: 3px 0; }
+  .shortcut-keys { flex-shrink: 0; display: inline-flex; align-items: center; gap: 5px; min-width: 96px; }
+  .shortcut-desc { font-size: var(--text-sm); color: var(--text-2); }
+  .shortcuts-body kbd { font-family: var(--font-mono); font-size: 11px; line-height: 1; color: var(--text);
+    background: var(--surface-3); border: 1px solid var(--border-strong); border-bottom-width: 2px;
+    border-radius: var(--radius-sm); padding: 3px 6px; white-space: nowrap; }
+  .kbd-or { font-size: 10px; color: var(--text-quiet); margin: 0 2px; }
+  @media (max-width: 560px) { .shortcuts-body { grid-template-columns: 1fr; } }
+
+  /* The loop — flywheel ribbon */
+  .flywheel-wrap { display: flex; flex-direction: column; gap: var(--space-2); }
+  .flywheel-title { display: flex; align-items: center; gap: 7px; font-size: var(--text-2xs);
+    text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; padding-left: 2px; }
+  .flywheel-title .icn { color: var(--accent-hover); }
+  .flywheel-tagline { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--text-quiet); }
+  .flywheel { display: flex; align-items: stretch;
+    background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+    border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; }
+  .flywheel-node { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 5px;
+    padding: var(--space-4) var(--space-4); cursor: pointer; position: relative; text-align: left;
+    background: transparent; border: 0; color: var(--text); font-family: inherit;
+    transition: background var(--t-fast) var(--ease-out); }
+  .flywheel-node:hover { background: rgba(255, 255, 255, 0.03); }
+  .flywheel-node .fw-eyebrow { display: flex; align-items: center; gap: 6px; font-size: var(--text-2xs);
+    text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; }
+  .flywheel-node .fw-eyebrow .icn { width: 13px; height: 13px; color: var(--text-quiet); }
+  .flywheel-node .fw-value { font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 700;
+    letter-spacing: var(--tracking-tight); font-variant-numeric: tabular-nums; line-height: 1.1;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .flywheel-node .fw-sub { font-size: 11px; color: var(--text-quiet); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  /* The active adapter's win verdict on the Hot-swap node — green when the swap
+     is proven better than base, so the flywheel's payoff pops on the Overview. */
+  .flywheel-node .fw-sub.fw-win { color: var(--success-fg); font-weight: 600; }
+  .flywheel-node .fw-sub.fw-loss { color: var(--danger-fg); font-weight: 600; }
+  .flywheel-node.hot { background: var(--accent-soft); }
+  .flywheel-node.hot .fw-eyebrow, .flywheel-node.hot .fw-eyebrow .icn { color: var(--kiln-300); }
+  .flywheel-node.hot .fw-value { color: var(--kiln-200); }
+  .flywheel-node.hot::after { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--accent); }
+  .flywheel-arrow { display: flex; align-items: center; color: var(--text-quiet); padding: 0 2px; flex: 0 0 auto; }
+  @media (max-width: 760px) {
+    .flywheel { flex-wrap: wrap; }
+    .flywheel-node { flex-basis: 40%; }
+    .flywheel-arrow { display: none; }
+  }
+</style>
+
 <header class="topbar header" role="banner">
   <a class="brand" href="/" aria-label="Kiln dashboard home">
-    <span class="brand-mark" aria-hidden="true"></span>
+    <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
     <span class="brand-text">
       <h1 class="brand-name">kiln</h1>
       <span class="brand-version" id="brand-version">dashboard</span>
@@ -2890,6 +3282,10 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   <div class="topbar-stats" id="header-stats" aria-live="polite">
     <span class="stat"><span class="status-dot offline" id="status-dot"></span><span class="stat-val" id="status-text">connecting…</span></span>
   </div>
+
+  <button class="connect-trigger" id="connect-trigger" type="button" title="Connect an agent to this Kiln server">
+    <svg class="icn icn-sm" aria-hidden="true"><use href="#i-link"></use></svg><span>Connect</span>
+  </button>
 
   <button class="cmdk-trigger" id="cmdk-trigger" type="button" aria-label="Open command palette" title="Open command palette (⌘K / Ctrl+K)">
     <span>Search</span>
@@ -2942,31 +3338,138 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
        ================================================================= -->
   <section class="page active" id="page-overview" role="tabpanel" aria-labelledby="primary-tab-overview">
 
+    <!-- =================================================================
+         Connect your agent — the onboarding centerpiece. The #1 task is
+         pointing pi / opencode / any OpenAI client at this server. Live
+         base URL + model id + per-client snippets + test connection.
+         Auto-collapses to a slim "connected" bar once traffic flows.
+         ================================================================= -->
+    <section class="card connect-panel" id="connect-panel" aria-label="Connect your agent">
+      <div class="connect-collapsed" id="connect-collapsed" role="button" tabindex="0" hidden
+           aria-label="Connection details — click to expand">
+        <span class="dot" aria-hidden="true"></span>
+        <span class="connect-collapsed-text" id="connect-collapsed-text">Connected</span>
+        <span class="expand-hint">Connect another agent <svg class="icn icn-sm" aria-hidden="true"><use href="#i-arrow-right"></use></svg></span>
+      </div>
+
+      <div class="connect-expanded" id="connect-expanded">
+        <div class="card-head">
+          <h2>Connect your agent</h2>
+          <span class="eyebrow" style="text-transform:none; letter-spacing:0;">Point pi, opencode, or any OpenAI client at Kiln</span>
+        </div>
+        <div class="connect-grid">
+          <div class="connect-facts">
+            <div class="connect-field">
+              <label for="connect-base-url">Base URL</label>
+              <div class="copy-field">
+                <code id="connect-base-url" tabindex="0">—</code>
+                <button class="copy-btn" type="button" data-copy-target="connect-base-url" aria-label="Copy base URL">
+                  <svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy
+                </button>
+              </div>
+            </div>
+            <div class="connect-field">
+              <label for="connect-model">Model id <span style="text-transform:none;letter-spacing:0;font-weight:400;">(the <code style="font-size:10px;">model</code> field)</span></label>
+              <div class="copy-field">
+                <code id="connect-model" tabindex="0">—</code>
+                <button class="copy-btn" type="button" data-copy-target="connect-model" aria-label="Copy model id">
+                  <svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy
+                </button>
+              </div>
+            </div>
+            <div class="connect-field">
+              <label>API key</label>
+              <span class="connect-keychip">
+                <svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg>
+                Not required — any value works (we use <code>unused</code>)
+              </span>
+            </div>
+            <button class="btn btn-primary" id="connect-test" type="button">
+              <svg class="icn icn-sm" aria-hidden="true"><use href="#i-bolt"></use></svg> Test connection
+            </button>
+            <div class="connect-test-result" id="connect-test-result" aria-live="polite"></div>
+          </div>
+
+          <div class="connect-clients">
+            <span class="connect-clients-label">Set up your client</span>
+            <div class="tabs connect-tabs" role="tablist" aria-label="Client setup">
+              <button class="tab active" type="button" role="tab" data-connect-tab="pi" aria-selected="true">pi</button>
+              <button class="tab" type="button" role="tab" data-connect-tab="opencode" aria-selected="false">opencode</button>
+              <button class="tab" type="button" role="tab" data-connect-tab="python" aria-selected="false">OpenAI Python</button>
+              <button class="tab" type="button" role="tab" data-connect-tab="js" aria-selected="false">OpenAI JS</button>
+              <button class="tab" type="button" role="tab" data-connect-tab="curl" aria-selected="false">curl</button>
+            </div>
+            <div class="connect-snippets" id="connect-snippets"><!-- rendered by initConnect() --></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- =================================================================
+         The loop — Kiln's flywheel made visible. Agent traffic becomes
+         training data becomes a better adapter you hot-swap, then repeat.
+         Each node is live + deep-links to its stage.
+         ================================================================= -->
+    <div class="flywheel-wrap">
+      <div class="flywheel-title"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> The loop <span class="flywheel-tagline">— your model gets better every time you use it</span></div>
+      <div class="flywheel" id="flywheel" role="group" aria-label="The improvement loop">
+        <button type="button" class="flywheel-node" data-fw="connect" aria-label="Connected agents">
+          <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-link"></use></svg> Agents</span>
+          <span class="fw-value" id="fw-agents">—</span>
+          <span class="fw-sub" id="fw-agents-sub">connected</span>
+        </button>
+        <span class="flywheel-arrow" aria-hidden="true"><svg class="icn icn-sm"><use href="#i-arrow-right"></use></svg></span>
+        <button type="button" class="flywheel-node" data-fw="traffic" aria-label="Recent requests">
+          <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-activity"></use></svg> Traffic</span>
+          <span class="fw-value" id="fw-traffic">—</span>
+          <span class="fw-sub" id="fw-traffic-sub">recent requests</span>
+        </button>
+        <span class="flywheel-arrow" aria-hidden="true"><svg class="icn icn-sm"><use href="#i-arrow-right"></use></svg></span>
+        <button type="button" class="flywheel-node" data-fw="train" aria-label="Training jobs">
+          <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-flask"></use></svg> Train</span>
+          <span class="fw-value" id="fw-train">—</span>
+          <span class="fw-sub" id="fw-train-sub">idle</span>
+        </button>
+        <span class="flywheel-arrow" aria-hidden="true"><svg class="icn icn-sm"><use href="#i-arrow-right"></use></svg></span>
+        <button type="button" class="flywheel-node" data-fw="eval" aria-label="Evaluations">
+          <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-chart"></use></svg> Eval</span>
+          <span class="fw-value" id="fw-eval">—</span>
+          <span class="fw-sub" id="fw-eval-sub">suites &amp; jobs</span>
+        </button>
+        <span class="flywheel-arrow" aria-hidden="true"><svg class="icn icn-sm"><use href="#i-arrow-right"></use></svg></span>
+        <button type="button" class="flywheel-node" data-fw="swap" aria-label="Active adapter">
+          <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-layers"></use></svg> Hot-swap</span>
+          <span class="fw-value" id="fw-active">base</span>
+          <span class="fw-sub" id="fw-active-sub">active model</span>
+        </button>
+      </div>
+    </div>
+
     <!-- Quick actions row — four most common next-steps -->
     <div class="quick-actions">
       <button class="quick-action-btn" type="button" data-quick-action="new-eval">
-        <span class="quick-action-icon">📊</span>
+        <span class="quick-action-icon"><svg class="icn"><use href="#i-chart"></use></svg></span>
         <span>
           <span class="quick-action-title">Run an eval</span>
           <div class="quick-action-sub">Compare any adapter against a suite</div>
         </span>
       </button>
       <button class="quick-action-btn" type="button" data-quick-action="train-sft">
-        <span class="quick-action-icon">🧪</span>
+        <span class="quick-action-icon"><svg class="icn"><use href="#i-flask"></use></svg></span>
         <span>
           <span class="quick-action-title">Train an adapter</span>
           <div class="quick-action-sub">Submit SFT or GRPO from a dataset</div>
         </span>
       </button>
       <button class="quick-action-btn" type="button" data-quick-action="judge">
-        <span class="quick-action-icon">⚖️</span>
+        <span class="quick-action-icon"><svg class="icn"><use href="#i-scale"></use></svg></span>
         <span>
           <span class="quick-action-title">Judge A/B pairs</span>
           <div class="quick-action-sub">Build a local judge LoRA from your picks</div>
         </span>
       </button>
       <button class="quick-action-btn" type="button" data-quick-action="playground">
-        <span class="quick-action-icon">💬</span>
+        <span class="quick-action-icon"><svg class="icn"><use href="#i-chat"></use></svg></span>
         <span>
           <span class="quick-action-title">Open playground</span>
           <div class="quick-action-sub">Try a prompt against the active adapter</div>
@@ -2974,29 +3477,49 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </button>
     </div>
 
-    <!-- Hero stats -->
-    <div class="hero" id="hero-stats" aria-live="polite">
-      <div class="hero-cell">
-        <span class="hero-eyebrow">Decode tok/s</span>
-        <span class="hero-num tabular-nums" id="hero-tps">—</span>
-        <span class="hero-sub" id="hero-tps-sub">Awaiting completions</span>
+    <!-- Recent requests — the operator's #1 job: watch live agent traffic and
+         mine it for corrections. Promoted directly under the flywheel; the
+         live perf/health detail cards sit below. (The former hero strip was
+         removed — its metrics are already covered by the flywheel + the
+         Decode performance card.) -->
+    <div class="card">
+      <div class="card-head">
+        <h2>Recent requests</h2>
+        <span class="heartbeat" id="recent-heartbeat" aria-live="polite"><span class="hb-dot"></span><span class="hb-text">Connecting…</span></span>
+        <span style="flex:1;"></span>
+        <input class="search-input" id="recent-requests-filter" type="search" placeholder="Filter by prompt, completion, id…" aria-label="Filter recent requests" style="max-width:280px;">
       </div>
-      <div class="hero-cell">
-        <span class="hero-eyebrow">P50 / P99 ITL</span>
-        <span class="hero-num tabular-nums" id="hero-itl">—</span>
-        <span class="hero-sub" id="hero-itl-sub">Inter-token latency</span>
-      </div>
-      <div class="hero-cell">
-        <span class="hero-eyebrow">Active LoRA</span>
-        <span class="hero-num tabular-nums" id="hero-adapter">base</span>
-        <span class="hero-sub" id="hero-adapter-sub">No adapter loaded</span>
-      </div>
-      <div class="hero-cell">
-        <span class="hero-eyebrow">Training</span>
-        <span class="hero-num tabular-nums" id="hero-training">idle</span>
-        <span class="hero-sub" id="hero-training-sub">Submit SFT or GRPO to begin</span>
+      <div class="card-body" id="recent-requests-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
+        <div class="empty">Loading recent requests…</div>
       </div>
     </div>
+
+    <!-- =================================================================
+         Corrections basket — the flywheel's core loop made one-click.
+         A bad pi response → "Use as correction" appends it here; you fix the
+         ideal answer inline; "Train" turns the whole basket into one SFT job.
+         localStorage-backed so it survives reloads across a coding session.
+         Hidden until the first correction is captured.
+         ================================================================= -->
+    <section class="card corrections-card" id="corrections-card" aria-label="Corrections basket" hidden>
+      <div class="card-head">
+        <h2>Corrections <span class="corr-count" id="corr-count">0</span></h2>
+        <span class="eyebrow" style="text-transform:none;letter-spacing:0;">Fix what pi got wrong, then train it in — once</span>
+        <span style="flex:1;"></span>
+        <button type="button" class="btn btn-sm" id="corr-clear">Clear</button>
+      </div>
+      <div class="card-body" id="corrections-list"></div>
+      <div class="card-body corrections-foot" id="corrections-foot">
+        <div class="form-group" style="margin:0;flex:1;min-width:200px;">
+          <label for="corr-adapter-name" style="margin-bottom:4px;">New adapter name</label>
+          <input type="text" id="corr-adapter-name" value="codebase-corrections" placeholder="codebase-corrections" spellcheck="false" autocapitalize="off" autocomplete="off">
+        </div>
+        <span class="corr-foot-note" id="corr-foot-note"></span>
+        <button type="button" class="btn btn-primary" id="corr-train" disabled>
+          <svg class="icn icn-sm" aria-hidden="true"><use href="#i-flask"></use></svg> Train adapter from <span id="corr-train-n">0</span> corrections
+        </button>
+      </div>
+    </section>
 
     <div class="row-2">
       <!-- Server Status card with VRAM donut chart -->
@@ -3014,24 +3537,11 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="card">
         <div class="card-head">
           <h2>Decode performance</h2>
-          <span class="eyebrow">60s rolling window</span>
+          <span class="eyebrow">live · 60s rolling window</span>
         </div>
         <div class="card-body" id="decode-perf-panel" data-panel-id="decode-stats-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
           <div class="empty">Loading live metrics…</div>
         </div>
-      </div>
-    </div>
-
-    <!-- Recent requests -->
-    <div class="card">
-      <div class="card-head">
-        <h2>Recent requests</h2>
-        <span class="eyebrow">Latest chat completions</span>
-        <span style="flex:1;"></span>
-        <input class="search-input" id="recent-requests-filter" type="search" placeholder="Filter by prompt, completion, id…" aria-label="Filter recent requests" style="max-width:280px;">
-      </div>
-      <div class="card-body" id="recent-requests-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
-        <div class="empty">Loading recent requests…</div>
       </div>
     </div>
   </section>
@@ -3236,7 +3746,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
        ================================================================= -->
   <section class="page" id="page-evals" role="tabpanel" aria-labelledby="primary-tab-evals" hidden inert>
     <div id="evals-onboarding" hidden style="background: linear-gradient(135deg, var(--accent-soft), rgba(249,115,22,0.05)); border: 1px solid var(--accent); border-radius: var(--radius-md); padding: var(--space-4) var(--space-5); margin-bottom: var(--space-3); display: flex; gap: var(--space-3); align-items: center;">
-      <div style="font-size: 28px; opacity: 0.85;">🚀</div>
+      <div style="opacity:0.92;color:var(--kiln-400);"><svg class="icn" style="width:30px;height:30px"><use href="#i-flame"></use></svg></div>
       <div style="flex:1;">
         <div style="font-size: 14px; font-weight: 600; color: var(--text); margin-bottom: 4px;">Welcome to Evals</div>
         <div style="font-size: 12px; color: var(--text-2); line-height: 1.5;">
@@ -3292,7 +3802,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
         <div id="synthesize-panel" hidden style="margin-top:16px; padding:12px; border:1px solid var(--border); border-radius:8px;">
           <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
             <h3 style="margin:0;">Synthesize eval suite from <code id="synth-dataset-name"></code></h3>
-            <button class="btn" id="synth-close" type="button">✕</button>
+            <button class="btn" id="synth-close" type="button" aria-label="Close synthesize panel"><svg class="icn icn-sm"><use href="#i-close"></use></svg></button>
           </div>
           <div class="form-row" style="gap:8px; flex-wrap:wrap;">
             <div class="form-group" style="min-width:180px;">
@@ -3465,9 +3975,9 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="modal-head">
         <h2 id="drill-title">Eval results</h2>
         <span class="modal-meta" id="drill-meta"></span>
-        <button class="btn btn-sm" id="drill-cancel" type="button" hidden title="Cancel this eval job (queued only)">⏹ Cancel</button>
-        <button class="btn btn-sm" id="drill-rerun" type="button" title="Queue a new eval job that runs only the failing examples again">↻ Re-run failures</button>
-        <button class="modal-close" id="drill-close" aria-label="Close">×</button>
+        <button class="btn btn-sm" id="drill-cancel" type="button" hidden title="Cancel this eval job (queued only)"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Cancel</button>
+        <button class="btn btn-sm" id="drill-rerun" type="button" title="Queue a new eval job that runs only the failing examples again"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> Re-run failures</button>
+        <button class="modal-close" id="drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>
       <div class="modal-body">
         <aside class="modal-sidebar">
@@ -3510,7 +4020,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   <div id="cmdk-modal" class="cmdk-backdrop" hidden role="dialog" aria-modal="true" aria-label="Command palette">
     <div class="cmdk-shell">
       <div class="cmdk-input-row">
-        <span class="cmdk-icon">🔍</span>
+        <span class="cmdk-icon"><svg class="icn"><use href="#i-search"></use></svg></span>
         <input class="cmdk-input" id="cmdk-input" placeholder="Search adapters, suites, jobs, datasets, judgments… or run an action" autocomplete="off" spellcheck="false">
         <span class="cmdk-hint">esc</span>
       </div>
@@ -3532,9 +4042,9 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="modal-head">
         <h2 id="train-drill-title">Training job</h2>
         <span class="modal-meta" id="train-drill-meta"></span>
-        <button class="btn btn-sm" id="train-drill-stop" type="button" title="Cancel this training job (queued only)">⏹ Stop</button>
-        <button class="btn btn-sm" id="train-drill-delete" type="button" hidden title="Permanently delete this terminal job from memory and from the on-disk archive">🗑 Delete</button>
-        <button class="modal-close" id="train-drill-close" aria-label="Close">×</button>
+        <button class="btn btn-sm" id="train-drill-stop" type="button" title="Cancel this training job (queued only)"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Stop</button>
+        <button class="btn btn-sm" id="train-drill-delete" type="button" hidden title="Permanently delete this terminal job from memory and from the on-disk archive"><svg class="icn icn-sm"><use href="#i-trash"></use></svg> Delete</button>
+        <button class="modal-close" id="train-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>
       <div class="modal-body" style="grid-template-columns: 1fr;">
         <div class="modal-content" id="train-drill-content">
@@ -3552,10 +4062,18 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="modal-head">
         <h2 id="request-drill-title">Request</h2>
         <span class="modal-meta" id="request-drill-meta"></span>
-        <button class="btn btn-sm" id="request-drill-copy-id" type="button" title="Copy request id">⧉ id</button>
-        <button class="btn btn-sm" id="request-drill-raw" type="button" title="Toggle the raw JSON view of this request record">{} raw</button>
-        <button class="btn btn-sm" id="request-drill-replay" type="button" title="Open the prompt in the playground">▶ Replay in playground</button>
-        <button class="modal-close" id="request-drill-close" aria-label="Close">×</button>
+        <span class="modal-nav" id="request-drill-nav" role="group" aria-label="Navigate requests">
+          <button class="btn btn-sm btn-ghost" id="request-drill-prev" type="button" title="Previous request (←)" aria-label="Previous request"><svg class="icn icn-sm icn-flip" aria-hidden="true"><use href="#i-arrow-right"></use></svg></button>
+          <span class="modal-nav-pos tabular-nums" id="request-drill-pos"></span>
+          <button class="btn btn-sm btn-ghost" id="request-drill-next" type="button" title="Next request (→)" aria-label="Next request"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-arrow-right"></use></svg></button>
+        </span>
+        <span style="flex:1 1 auto;"></span>
+        <button class="btn btn-sm btn-ghost" id="request-drill-copy-id" type="button" title="Copy request id"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> id</button>
+        <button class="btn btn-sm btn-ghost" id="request-drill-raw" type="button" title="Toggle the raw JSON view of this request record"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-terminal"></use></svg> raw</button>
+        <button class="btn btn-sm btn-ghost" id="request-drill-replay" type="button" title="Open the prompt in the playground"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-chat"></use></svg> Replay</button>
+        <button class="btn btn-sm btn-ghost" id="request-drill-verify" type="button" title="Re-run this prompt in the Playground, A/B: what served it vs your active adapter — did the swap actually help?"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-scale"></use></svg> Verify A/B</button>
+        <button class="btn btn-sm btn-primary" id="request-drill-correct" type="button" title="Turn this request into an SFT correction — edit the reply, then train"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-flask"></use></svg> Use as correction</button>
+        <button class="modal-close" id="request-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>
       <div class="modal-body" style="grid-template-columns: 1fr;">
         <div class="modal-content" id="request-drill-content">
@@ -3575,7 +4093,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
         <span class="modal-meta" id="adapter-drill-meta"></span>
         <button class="btn btn-sm primary" id="adapter-drill-load" type="button">Load</button>
         <button class="btn btn-sm" id="adapter-drill-eval" type="button">Run eval…</button>
-        <button class="modal-close" id="adapter-drill-close" aria-label="Close">×</button>
+        <button class="modal-close" id="adapter-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>
       <div class="modal-body" style="grid-template-columns: 1fr;">
         <div class="modal-content" id="adapter-drill-content">
@@ -3590,7 +4108,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
        =================================================================
        Surfaces the OPD primitives the grand plan describes:
          • Submit OPD (POST /v1/train/opd) — the §3.1 trainer body
-         • Teachers (/v1/teachers) — the §3.2 LogitSource registry
+         • Teachers (/v1/teachers) — the Registered teacher models
          • Recipes (/v1/recipes + /v1/recipes/run) — §3.7 one-click cookbook
          • Refresh / Pump / Merge / Self — §3.6 / §3.5 / §3.4 / §3.12
          • Cache (/v1/cache/stats) — §3.3 logit cache
@@ -3602,20 +4120,29 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
     <div class="card">
       <div class="card-head">
         <h2>On-Policy Distillation</h2>
-        <span class="eyebrow">Grand plan §3 + §10.6 — frontier brilliance, distilled</span>
+        <span class="eyebrow">Teach your model a bigger model&rsquo;s behavior</span>
       </div>
-      <div class="tabs" role="tablist" aria-label="Distill views" data-distill-tabs>
-        <button class="tab active" id="distill-tab-opd" data-tab="opd" type="button" role="tab" aria-selected="true" aria-controls="distill-tab-opd-pane" tabindex="0">Submit OPD</button>
-        <button class="tab" id="distill-tab-teachers" data-tab="teachers" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-teachers-pane" tabindex="-1">Teachers</button>
-        <button class="tab" id="distill-tab-recipes" data-tab="recipes" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-recipes-pane" tabindex="-1">Recipes</button>
-        <button class="tab" id="distill-tab-refresh" data-tab="refresh" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-refresh-pane" tabindex="-1">Refresh</button>
-        <button class="tab" id="distill-tab-pump" data-tab="pump" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-pump-pane" tabindex="-1">Pump</button>
-        <button class="tab" id="distill-tab-merge" data-tab="merge" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-merge-pane" tabindex="-1">Merge</button>
-        <button class="tab" id="distill-tab-self" data-tab="self" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-self-pane" tabindex="-1">Self</button>
-        <button class="tab" id="distill-tab-cache" data-tab="cache" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-cache-pane" tabindex="-1">Cache</button>
-        <button class="tab" id="distill-tab-library" data-tab="library" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-library-pane" tabindex="-1">Library</button>
-        <button class="tab" id="distill-tab-traces" data-tab="traces" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-traces-pane" tabindex="-1">Agent traces</button>
-        <button class="tab" id="distill-tab-preflight" data-tab="preflight" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-preflight-pane" tabindex="-1">Preflight</button>
+      <!-- Grouped sub-nav: Methods (the distillation actions) · Setup
+           (teachers/recipes/preflight) · Assets (cache/library/agent traces).
+           Labels + separators are not .tab elements, so the tab JS ignores
+           them; every data-tab/aria-controls is preserved. -->
+      <div class="tabs distill-tabs" role="tablist" aria-label="Distill views" data-distill-tabs>
+        <span class="tab-group-label" aria-hidden="true">Methods</span>
+        <button class="tab active" id="distill-tab-opd" data-tab="opd" type="button" role="tab" aria-selected="true" aria-controls="distill-tab-opd-pane" tabindex="0" title="On-Policy Distillation — teach from a teacher model">Distill</button>
+        <button class="tab" id="distill-tab-refresh" data-tab="refresh" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-refresh-pane" tabindex="-1" title="Refresh an adapter on new data (continual learning)">Refresh</button>
+        <button class="tab" id="distill-tab-pump" data-tab="pump" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-pump-pane" tabindex="-1" title="Boost a domain — 27B → 4B knowledge pump">Boost</button>
+        <button class="tab" id="distill-tab-self" data-tab="self" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-self-pane" tabindex="-1" title="Self-improve via self-distillation">Self-improve</button>
+        <button class="tab" id="distill-tab-merge" data-tab="merge" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-merge-pane" tabindex="-1" title="Behaviour-space LoRA merge">Merge</button>
+        <span class="tab-group-sep" aria-hidden="true"></span>
+        <span class="tab-group-label" aria-hidden="true">Setup</span>
+        <button class="tab" id="distill-tab-teachers" data-tab="teachers" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-teachers-pane" tabindex="-1" title="Registered teacher models">Teachers</button>
+        <button class="tab" id="distill-tab-recipes" data-tab="recipes" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-recipes-pane" tabindex="-1" title="One-click recipes — Kiln picks the hyperparameters">Recipes</button>
+        <button class="tab" id="distill-tab-preflight" data-tab="preflight" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-preflight-pane" tabindex="-1" title="Capacity & compatibility checks before you run">Preflight</button>
+        <span class="tab-group-sep" aria-hidden="true"></span>
+        <span class="tab-group-label" aria-hidden="true">Assets</span>
+        <button class="tab" id="distill-tab-cache" data-tab="cache" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-cache-pane" tabindex="-1" title="On-disk logit cache">Cache</button>
+        <button class="tab" id="distill-tab-library" data-tab="library" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-library-pane" tabindex="-1" title="Browse, install & publish adapters">Library</button>
+        <button class="tab" id="distill-tab-traces" data-tab="traces" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-traces-pane" tabindex="-1" title="Import pi agent sessions for distillation">Agent traces</button>
       </div>
 
       <!-- =================================================================
@@ -3627,7 +4154,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-output-name">Adapter name</label>
               <input type="text" id="opd-output-name" name="output_name" value="opd-adapter" required>
-              <div class="form-help">Saved adapter name. Path-safe; the §8.11 receipt is keyed by this.</div>
+              <div class="form-help">Saved adapter name. Path-safe — the training receipt is keyed by this.</div>
             </div>
             <div class="form-group">
               <label for="opd-teacher">Teacher</label>
@@ -3641,7 +4168,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-loss">Loss granularity</label>
               <select id="opd-loss" name="loss">
-                <option value="teacher_top_k" selected>teacher_top_k (§6 default; Fu et al. 2026)</option>
+                <option value="teacher_top_k" selected>teacher_top_k (recommended)</option>
                 <option value="sampled_token">sampled_token (Lu 2025 baseline)</option>
                 <option value="full_vocab">full_vocab (corporate tier; DeepSeek-V4)</option>
               </select>
@@ -3649,7 +4176,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-top-k">Top-K</label>
               <input type="number" id="opd-top-k" name="top_k" value="32" min="1" max="1024">
-              <div class="form-help">§6 default 32 (Fu et al. ablation table 3).</div>
+              <div class="form-help">Default 32 — number of teacher logits to match per token.</div>
             </div>
             <div class="form-group">
               <label for="opd-samples">Samples / prompt</label>
@@ -3661,7 +4188,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-lr">Learning rate</label>
               <input type="text" id="opd-lr" name="learning_rate" value="1e-5">
-              <div class="form-help">§6: 10× the FullFT optimum.</div>
+              <div class="form-help">10× the full fine-tune optimum.</div>
             </div>
             <div class="form-group">
               <label for="opd-rank">LoRA rank</label>
@@ -3670,7 +4197,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-max-tokens">Max tokens</label>
               <input type="number" id="opd-max-tokens" name="max_tokens" value="7168" min="64" max="32768">
-              <div class="form-help">§6 default 7K (Li et al. 2026 reward-decay curve).</div>
+              <div class="form-help">Default 7K.</div>
             </div>
           </div>
           <div class="form-row">
@@ -3685,7 +4212,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="opd-max-cost">Cost cap (USD)</label>
               <input type="text" id="opd-max-cost" name="max_cost_usd" value="25" placeholder="25">
-              <div class="form-help">§8.6 hard cap. Default 25.</div>
+              <div class="form-help">Hard cap. Default 25.</div>
             </div>
           </div>
           <div class="form-group">
@@ -3711,7 +4238,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="tab-content" id="distill-tab-teachers-pane" role="tabpanel" aria-labelledby="distill-tab-teachers" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Registered teachers</h3>
-          <span class="eyebrow">§3.2 LogitSource registry</span>
+          <span class="eyebrow">Registered teacher models</span>
         </div>
         <div id="teachers-list">
           <div class="empty">Loading…</div>
@@ -3750,7 +4277,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="teacher-api-key-env">API-key env var <span class="hint">(Remote)</span></label>
               <input type="text" id="teacher-api-key-env" name="api_key_env" placeholder="OPENROUTER_API_KEY">
-              <div class="form-help">§8.6 cost-lock: kiln never stores the key, only the env-var name to read.</div>
+              <div class="form-help">Cost-lock — Kiln never stores the key, only the env-var name to read.</div>
             </div>
             <div class="form-group">
               <label for="teacher-max-top-k">Max top-K</label>
@@ -3773,7 +4300,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="tab-content" id="distill-tab-recipes-pane" role="tabpanel" aria-labelledby="distill-tab-recipes" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Bundled recipes</h3>
-          <span class="eyebrow">§3.7 one-click — kiln picks all hyperparameters</span>
+          <span class="eyebrow">One-click — Kiln picks the hyperparameters</span>
         </div>
         <div id="recipes-list">
           <div class="empty">Loading…</div>
@@ -3781,7 +4308,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </div>
 
       <!-- =================================================================
-           Refresh — §3.6 continual-learning recovery
+           Refresh — continual-learning recovery
            ================================================================= -->
       <div class="tab-content" id="distill-tab-refresh-pane" role="tabpanel" aria-labelledby="distill-tab-refresh" hidden inert>
         <form id="distill-refresh-form">
@@ -3834,7 +4361,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </div>
 
       <!-- =================================================================
-           Pump — §3.5 27B → 4B knowledge pump
+           Pump — 27B → 4B knowledge pump
            ================================================================= -->
       <div class="tab-content" id="distill-tab-pump-pane" role="tabpanel" aria-labelledby="distill-tab-pump" hidden inert>
         <form id="distill-pump-form">
@@ -3875,7 +4402,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             </div>
             <div class="form-group">
               <label style="font-size: var(--text-xs); display: flex; align-items: center; gap: var(--space-2); color: var(--text-muted); text-transform: none; letter-spacing: 0; font-weight: 400; margin-top: 26px;">
-                <input type="checkbox" id="pump-use-cache" name="use_cache" checked> Honor logit cache (§3.3)
+                <input type="checkbox" id="pump-use-cache" name="use_cache" checked> Honor logit cache
               </label>
             </div>
           </div>
@@ -3890,7 +4417,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </div>
 
       <!-- =================================================================
-           Merge — §3.4 behaviour-space LoRA merge
+           Merge — behaviour-space LoRA merge
            ================================================================= -->
       <div class="tab-content" id="distill-tab-merge-pane" role="tabpanel" aria-labelledby="distill-tab-merge" hidden inert>
         <form id="distill-merge-form">
@@ -3921,7 +4448,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </div>
 
       <!-- =================================================================
-           Self — §3.12 PI self-distillation
+           Self — self-distillation
            ================================================================= -->
       <div class="tab-content" id="distill-tab-self-pane" role="tabpanel" aria-labelledby="distill-tab-self" hidden inert>
         <form id="distill-self-form">
@@ -3943,7 +4470,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
           <div class="form-group">
             <label for="self-prompts">Prompts (JSON array, optional)</label>
             <textarea id="self-prompts" name="prompts" rows="5" placeholder='[{"messages":[{"role":"user","content":"..."}]}]'></textarea>
-            <div class="form-help">Optional — when blank, kiln uses the §3.5.2 wide canonical seeds.</div>
+            <div class="form-help">Optional — when blank, Kiln uses wide canonical seeds.</div>
           </div>
           <div class="form-group" data-self-mode-field="ground_truth_conditioning" hidden>
             <label for="self-ground-truth">Ground-truth answers (JSON array of strings)</label>
@@ -3965,7 +4492,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="tab-content" id="distill-tab-cache-pane" role="tabpanel" aria-labelledby="distill-tab-cache" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Logit cache</h3>
-          <span class="eyebrow">§3.3 — prefix-keyed, RocksDB-backed</span>
+          <span class="eyebrow">Prefix-keyed logit cache on disk</span>
         </div>
         <div id="cache-stats">
           <div class="empty">Loading…</div>
@@ -3983,7 +4510,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="tab-content" id="distill-tab-library-pane" role="tabpanel" aria-labelledby="distill-tab-library" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Adapter library</h3>
-          <span class="eyebrow">§3.10 — browse, install, publish with reproducibility receipt</span>
+          <span class="eyebrow">Browse, install &amp; publish adapters</span>
         </div>
         <div id="library-list">
           <div class="empty">Loading…</div>
@@ -3996,7 +4523,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
             <div class="form-group">
               <label for="library-publish-name">Adapter name</label>
               <input type="text" id="library-publish-name" name="adapter_name" required placeholder="my-domain-pump">
-              <div class="form-help">Local adapter must have a §8.11 reproducibility receipt; library refuses to publish without one.</div>
+              <div class="form-help">Local adapter must have a reproducibility receipt; the library refuses to publish without one.</div>
             </div>
             <div class="form-group">
               <label for="library-publish-description">Description <span class="hint">(optional)</span></label>
@@ -4014,12 +4541,12 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       </div>
 
       <!-- =================================================================
-           Agent traces — §10.3 pi session ingestion
+           Agent traces — pi session ingestion
            ================================================================= -->
       <div class="tab-content" id="distill-tab-traces-pane" role="tabpanel" aria-labelledby="distill-tab-traces" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">pi session traces</h3>
-          <span class="eyebrow">§10.3 — ~/.pi/agent/sessions/ JSONL ingestion</span>
+          <span class="eyebrow">Import pi agent sessions for distillation</span>
         </div>
         <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-3);">
           <button type="button" class="btn btn-sm" id="agent-traces-refresh">Rescan ~/.pi/agent/sessions/</button>
@@ -4035,7 +4562,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
       <div class="tab-content" id="distill-tab-preflight-pane" role="tabpanel" aria-labelledby="distill-tab-preflight" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Compatibility table</h3>
-          <span class="eyebrow">§8.4 — 30+ validated (teacher × student × domain) rows</span>
+          <span class="eyebrow">Validated teacher × student × domain combos</span>
         </div>
         <div id="preflight-compat-list">
           <div class="empty">Loading…</div>
@@ -4043,7 +4570,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 
         <div class="card-head" style="border:none; padding: var(--space-4) 0 var(--space-2); margin-top: var(--space-4); border-top: 1px solid var(--border);">
           <h3 style="font-size: var(--text-lg);">Tier-aware defaults</h3>
-          <span class="eyebrow">§8.13 — laptop / prosumer / corporate</span>
+          <span class="eyebrow">Sized for laptop / prosumer / corporate GPUs</span>
         </div>
         <div id="preflight-tier-defaults">
           <div class="empty">Loading…</div>
@@ -4082,7 +4609,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
           <option value="custom">Custom (don't touch fields)</option>
         </select>
         <span style="flex:1;"></span>
-        <button class="btn btn-sm btn-ghost" id="chat-toggle-advanced" type="button" aria-expanded="false" aria-controls="chat-advanced">⚙ Advanced</button>
+        <button class="btn btn-sm btn-ghost" id="chat-toggle-advanced" type="button" aria-expanded="false" aria-controls="chat-advanced"><svg class="icn icn-sm"><use href="#i-gear"></use></svg> Advanced</button>
       </div>
       <div class="chat-advanced" id="chat-advanced" hidden>
         <label class="chat-adv-field chat-adv-system" for="chat-system">
@@ -4169,12 +4696,138 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   if (params.get('demo') !== '1') return;
 
   const start = Date.now() - 4527 * 1000;
+  // The demo paints Kiln as what it actually is: a local inference server that
+  // coding agents (pi, opencode) point at, with a flywheel of trained adapters.
   const demoState = {
-    adapters: ['support-bot', 'format-fixer', 'docstring-cleaner', 'typefix-alpha', 'code-helper-v3'],
-    active: 'support-bot',
+    active: 'opencode-agent-v4',
   };
 
   function uptimeSeconds() { return Math.floor((Date.now() - start) / 1000); }
+
+  // Shared fixture helpers so every page (not just Overview) has agent-centric
+  // data in the demo. ISO timestamps are anchored to load time so "x ago" reads
+  // naturally; MODEL/ACTIVE mirror the live server's identifiers.
+  const NOW = Date.now();
+  const MB = 1024 * 1024;
+  const MODEL = 'Qwen3.5-4B';
+  const ACTIVE_ADAPTER = demoState.active;
+  const ISO = (ago) => new Date(NOW - ago).toISOString();
+
+  const evalDatasets = () => ({
+    datasets: [
+      { name: 'opencode-traces', format: 'sft_jsonl', description: 'Curated opencode agent trajectories with tool calls', num_rows: 12_480, size_bytes: 184 * MB, created_at: ISO(20 * 86400_000), updated_at: ISO(2 * 86400_000), stats: { num_assistant_turns: 38_210, num_tool_messages: 21_004, num_with_tool_calls: 18_902, max_messages_per_conv: 42, max_content_chars: 18_400, avg_messages_per_conv: 11.4, sample_role_patterns: ['system→user→assistant→tool→assistant'] } },
+      { name: 'rust-review-pairs', format: 'sft_jsonl', description: 'PR review comments paired with diffs', num_rows: 5_120, size_bytes: 72 * MB, created_at: ISO(14 * 86400_000), updated_at: ISO(5 * 86400_000), stats: { num_assistant_turns: 5_120, num_tool_messages: 0, num_with_tool_calls: 88, max_messages_per_conv: 4, max_content_chars: 9_200, avg_messages_per_conv: 3.0, sample_role_patterns: ['system→user→assistant'] } },
+      { name: 'sql-explain-gold', format: 'sft_jsonl', description: 'SQL queries with natural-language explanations', num_rows: 3_004, size_bytes: 28 * MB, created_at: ISO(9 * 86400_000), updated_at: ISO(9 * 86400_000), stats: { num_assistant_turns: 3_004, num_tool_messages: 0, num_with_tool_calls: 0, max_messages_per_conv: 2, max_content_chars: 4_100, avg_messages_per_conv: 2.0, sample_role_patterns: ['user→assistant'] } },
+    ],
+  });
+  const evalSuites = () => ({
+    suites: [
+      { name: 'opencode-toolcall-eval', description: 'Does the agent emit the correct tool call for the task?', num_examples: 240, default_scorer_kind: 'tool_call' },
+      { name: 'rust-review-quality', description: 'LLM-judge scored review usefulness vs gold comments', num_examples: 128, default_scorer_kind: 'judge' },
+      { name: 'sql-exact-match', description: 'Normalized SQL equivalence against the gold query', num_examples: 300, default_scorer_kind: 'exact_match' },
+      { name: 'commit-msg-contains', description: 'Conventional-commit prefix + scope presence', num_examples: 96, default_scorer_kind: 'contains' },
+    ],
+  });
+  const evalSuiteDetail = (name) => ({
+    name, description: 'Eval suite ' + name,
+    default_scorer: { kind: 'exact_match', case_sensitive: false, strip_whitespace: true },
+    generation: { temperature: 0.0, top_p: 1.0, top_k: 0, max_tokens: 256, n: 1, stop: [], seed: null },
+    examples: [
+      { id: 'ex1', messages: [{ role: 'user', content: 'List files importing legacy_client' }], target: 'grep_repo legacy_client', tags: ['tool_call'] },
+      { id: 'ex2', messages: [{ role: 'user', content: 'Write the commit message' }], target: 'fix(cache): ...', tags: ['commit'] },
+    ],
+    schema_version: 1,
+  });
+  const evalJobs = () => ({
+    jobs: [
+      { job_id: 'eval_77a1c0de-aa11-bb22-cc33-dd44ee55ff66', suite_name: 'opencode-toolcall-eval', adapters: [ACTIVE_ADAPTER], submission_kind: 'on_demand', state: 'running', progress: { examples_completed: 162, examples_total: 240, running_accuracy: 0.913, running_mean_score: 0.91 }, finished_runs: [], headline_accuracy: null, error: null, submitted_at_iso: ISO(180_000) },
+      { job_id: 'eval_31b4f0a9-1234-5678-9abc-def012345678', suite_name: 'rust-review-quality', adapters: [null, ACTIVE_ADAPTER], submission_kind: 'compare', state: 'completed', progress: { examples_completed: 128, examples_total: 128, running_accuracy: 0, running_mean_score: 0 }, headline_accuracy: 0.84, error: null, submitted_at_iso: ISO(3 * 3600_000), finished_runs: [
+        { suite_name: 'rust-review-quality', adapter: null, metrics: { num_examples: 128, num_pass: 79, accuracy: 0.617, mean_score: 0.62, pass_rate_by_tag: { correctness: 0.71, style: 0.55, security: 0.58 } }, outcomes: [] },
+        { suite_name: 'rust-review-quality', adapter: ACTIVE_ADAPTER, metrics: { num_examples: 128, num_pass: 108, accuracy: 0.844, mean_score: 0.85, pass_rate_by_tag: { correctness: 0.92, style: 0.80, security: 0.81 } }, outcomes: [] },
+      ] },
+      { job_id: 'eval_9c2d1e8f-aaaa-bbbb-cccc-dddddddddddd', suite_name: 'sql-exact-match', adapters: [ACTIVE_ADAPTER], submission_kind: 'on_demand', state: 'completed', progress: { examples_completed: 300, examples_total: 300, running_accuracy: 0, running_mean_score: 0 }, headline_accuracy: 0.91, error: null, submitted_at_iso: ISO(8 * 3600_000), finished_runs: [
+        { suite_name: 'sql-exact-match', adapter: ACTIVE_ADAPTER, metrics: { num_examples: 300, num_pass: 273, accuracy: 0.91, mean_score: 0.91, pass_rate_by_tag: { select: 0.96, join: 0.88, window: 0.79 } }, outcomes: [] },
+      ] },
+      { job_id: 'eval_44e5f607-0000-1111-2222-333344445555', suite_name: 'commit-msg-contains', adapters: ['commit-msg-writer'], submission_kind: 'on_demand', state: 'queued', progress: { examples_completed: 0, examples_total: 96, running_accuracy: 0, running_mean_score: 0 }, finished_runs: [], headline_accuracy: null, error: null, submitted_at_iso: ISO(30_000) },
+      { job_id: 'eval_55f6a708-9999-8888-7777-666655554444', suite_name: 'opencode-toolcall-eval', adapters: ['tool-call-tuned-v1'], submission_kind: 'on_demand', state: 'failed', progress: { examples_completed: 41, examples_total: 240, running_accuracy: 0, running_mean_score: 0 }, finished_runs: [], headline_accuracy: null, error: 'adapter tool-call-tuned-v1 failed to load: rank mismatch (expected 32, got 16)', submitted_at_iso: ISO(2 * 86400_000) },
+    ],
+  });
+  const evalJobDetail = (id) => ({
+    job_id: id, state: 'completed',
+    runs: [ { suite_name: 'sql-exact-match', adapter: ACTIVE_ADAPTER, metrics: { num_examples: 300, num_pass: 273, accuracy: 0.91, mean_score: 0.91, pass_rate_by_tag: { select: 0.96, join: 0.88, window: 0.79 } }, outcomes: [
+      { example_id: 'ex1', kind: 'pass', score: 1.0, output: 'SELECT * FROM users WHERE active = true', expected: 'SELECT * FROM users WHERE active = true', tags: ['select'] },
+      { example_id: 'ex2', kind: 'fail', score: 0.0, output: 'SELECT id FROM t', expected: 'SELECT id, name FROM t', tags: ['select'] },
+    ] } ],
+    progress: null,
+  });
+  const judgments = () => ({
+    judgments: [
+      { name: 'review-tone-ab', description: 'Which review comment is more actionable?', num_rows: 142, winner_histogram: { a: 64, b: 58, tie: 20 } },
+      { name: 'sql-explain-clarity', description: 'Clearer SQL explanation A vs B', num_rows: 88, winner_histogram: { a: 41, b: 39, tie: 8 } },
+      { name: 'commit-msg-quality', description: 'Better conventional-commit message', num_rows: 36, winner_histogram: { a: 19, b: 14, tie: 3 } },
+    ],
+  });
+  const teachers = () => ({
+    teachers: [
+      { spec: { alias: 'qwen3.6-27b-local', kind: 'local', model_id: 'Qwen/Qwen3.6-27B' }, capabilities: { teacher_id: 'qwen3.6-27b@local', vocab_size: 151_936, max_top_k: 128 } },
+      { spec: { alias: 'gpt-frontier', kind: 'http', model_id: 'gpt-4.1', url: 'https://api.openai.com/v1', api_key_env: 'OPENAI_API_KEY' }, capabilities: { teacher_id: 'gpt-4.1@openai', vocab_size: 200_000, max_top_k: 20 } },
+      { spec: { alias: 'claude-judge', kind: 'http', model_id: 'claude-opus-4', url: 'https://api.anthropic.com', api_key_env: 'ANTHROPIC_API_KEY' }, capabilities: { teacher_id: 'claude-opus-4@anthropic', vocab_size: 0, max_top_k: 0 } },
+    ],
+  });
+  const recipes = () => ({
+    recipes: [
+      { name: 'cold-start-distill', description: 'OPD warm-up then GRPO refinement for a new domain', num_steps: 3 },
+      { name: 'review-quality-loop', description: 'SFT on review pairs, judge LoRA, then GRPO against the judge', num_steps: 4 },
+      { name: 'tool-call-bootstrap', description: 'Synthesize tool-call eval, OPD distill, gate on eval recovery', num_steps: 3 },
+    ],
+  });
+  const library = () => ({
+    adapters: [
+      { id: 'kiln/opencode-agent-v4', name: 'opencode-agent-v4', source_kind: 'local', description: 'Tool-calling coding agent, GRPO-tuned', uploader: 'floguy', size_bytes: 86 * MB, post_eval: { 'opencode-toolcall-eval': 0.93 } },
+      { id: 'kiln/rust-reviewer-v2', name: 'rust-reviewer-v2', source_kind: 'local', description: 'Rust PR review assistant', uploader: 'floguy', size_bytes: 64 * MB, post_eval: { 'rust-review-quality': 0.84 } },
+      { id: 'hub/math-tutor-distilled', name: 'math-tutor-distilled', source_kind: 'huggingface', description: 'Distilled from qwen3.6-27b for grade-school math', uploader: 'community', size_bytes: 41 * MB, post_eval: {} },
+    ],
+    note: 'Showing 3 local + 1 remote entry. Configure a registry URL to see more.',
+  });
+  const cacheStats = () => ({
+    root: '/home/floguy/.kiln/logit-cache',
+    stats: { total_entries: 482_104, total_bytes: 14 * 1024 * MB, per_teacher: { 'qwen3.6-27b@local': 391_002, 'gpt-4.1@openai': 84_220, 'claude-opus-4@anthropic': 6_882 } },
+  });
+  const preflightCompat = () => ({
+    matches: [
+      { teacher: 'qwen3.6-27b-local', student: MODEL, domain: 'coding-agent', predicted_initial_overlap: 0.72, recommended_rank: 32, expected_gpu_hours: 4.5, expected_cost_usd: 6.30, validation_eval: 'opencode-toolcall-eval', expected_eval_delta_points: 11.2, cold_start_epochs: 1 },
+      { teacher: 'qwen3.6-27b-local', student: MODEL, domain: 'sql', predicted_initial_overlap: 0.81, recommended_rank: 16, expected_gpu_hours: 2.1, expected_cost_usd: 2.94, validation_eval: 'sql-exact-match', expected_eval_delta_points: 6.8, cold_start_epochs: 1 },
+      { teacher: 'gpt-frontier', student: MODEL, domain: 'review', predicted_initial_overlap: 0.41, recommended_rank: 64, expected_gpu_hours: 9.0, expected_cost_usd: 38.0, validation_eval: 'rust-review-quality', expected_eval_delta_points: 14.5, cold_start_epochs: 2 },
+    ],
+    note: '3 compatibility rows from the teacher registry.',
+  });
+  const preflightTiers = () => ({
+    tiers: [
+      { tier: 'fast', default_logit_source: 'local', default_loss: 'kl_topk', default_top_k: 64, lora_rank: 16, batch_size: 8, samples_per_prompt_default: 2, samples_per_prompt_data_multiplier: 1, max_rollout_tokens: 512, auto_checkpoint_cadence_steps: 100, cost_cap_default_usd: 10, cold_start_overlap_threshold: 0.5, mixture_distillation_golden_fraction: 0.1, eval_gate_required: false, notifications_channels: [] },
+      { tier: 'balanced', default_logit_source: 'local', default_loss: 'kl_topk', default_top_k: 128, lora_rank: 32, batch_size: 8, samples_per_prompt_default: 4, samples_per_prompt_data_multiplier: 2, max_rollout_tokens: 1024, auto_checkpoint_cadence_steps: 250, cost_cap_default_usd: 50, cold_start_overlap_threshold: 0.6, mixture_distillation_golden_fraction: 0.15, eval_gate_required: true, notifications_channels: ['slack'] },
+      { tier: 'quality', default_logit_source: 'http', default_loss: 'full_kl', default_top_k: 256, lora_rank: 64, batch_size: 4, samples_per_prompt_default: 8, samples_per_prompt_data_multiplier: 3, max_rollout_tokens: 2048, auto_checkpoint_cadence_steps: 500, cost_cap_default_usd: null, cold_start_overlap_threshold: 0.7, mixture_distillation_golden_fraction: 0.2, eval_gate_required: true, notifications_channels: ['slack', 'email'] },
+    ],
+  });
+  const agentTraces = () => ({
+    traces: [
+      { id: 'pi-2026-06-08-a1b2c3', working_dir: '/home/floguy/dev/kiln', num_turns: 24, num_tool_calls: 41, forked: false, parent_id: null, first_event_at: ISO(3 * 3600_000), last_event_at: ISO(2 * 3600_000), outcome: { ended_with_exit_0: true, user_edited_agent_files: ['src/cache.rs'], has_followup_attempt: false } },
+      { id: 'pi-2026-06-07-d4e5f6', working_dir: '/home/floguy/dev/webapp', num_turns: 12, num_tool_calls: 18, forked: true, parent_id: 'pi-2026-06-07-aaaa', first_event_at: ISO(28 * 3600_000), last_event_at: ISO(27 * 3600_000), outcome: { ended_with_exit_0: false, user_edited_agent_files: [], has_followup_attempt: true } },
+      { id: 'pi-2026-06-06-998877', working_dir: '/home/floguy/dev/kiln', num_turns: 31, num_tool_calls: 52, forked: false, parent_id: null, first_event_at: ISO(52 * 3600_000), last_event_at: ISO(51 * 3600_000), outcome: { ended_with_exit_0: true, user_edited_agent_files: ['src/api/eval.rs', 'src/ui.html'], has_followup_attempt: false } },
+    ],
+  });
+  const agentDiscover = () => ({ indexed: 3, path: '/home/floguy/.pi/agent/sessions/' });
+  const trainJobDetail = (id) => ({
+    job_id: id, state: 'Running', job_type: 'GRPO', adapter_name: 'rust-reviewer-v3', progress: 0.58, current_loss: 0.286, elapsed_secs: 1_842, submitted_unix_ms: NOW - 1_842_000,
+    loss_history: Array.from({ length: 40 }, (_, i) => ({ step: i + 1, loss: 0.9 * Math.exp(-i / 14) + 0.22 + (Math.sin(i) * 0.01) })),
+    config: { lora_rank: 32, learning_rate: 1e-4, batch_size: 8, samples_per_prompt: 4 },
+  });
+  const adapterDetail = (name) => ({
+    name, active: name === ACTIVE_ADAPTER, size_bytes: 86 * MB,
+    base_model: 'Qwen/Qwen3.5-4B', lora_rank: 32, lora_alpha: 64, target_modules: ['q_proj', 'k_proj', 'v_proj', 'o_proj'],
+    created_at: ISO(6 * 3600_000),
+    files: [ { name: 'adapter_config.json', size_bytes: 612 }, { name: 'adapter_model.safetensors', size_bytes: 85 * MB } ],
+    post_eval: { 'opencode-toolcall-eval': 0.93 },
+  });
 
   const responses = {
     '/health': () => ({
@@ -4197,57 +4850,160 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
         { pass: true, name: 'lora_engine' },
       ],
     }),
-    '/v1/stats/decode': () => ({
-      window_secs: 60,
-      sample_count: 8,
-      tok_per_sec: 142.8,
-      p50_itl_ms: 7.0,
-      p99_itl_ms: 11.4,
-      mean_itl_ms: 7.6,
-    }),
+    // Jittered so the live tok/s sparkline reads as a trend, not a flat line.
+    '/v1/stats/decode': () => {
+      const t = Date.now() / 1000;
+      const tps = 138 + Math.sin(t / 7) * 11 + Math.sin(t / 2.3) * 4;
+      const p50 = 6.6 + Math.sin(t / 5) * 0.7;
+      return {
+        window_secs: 60,
+        sample_count: 9,
+        tok_per_sec: Math.round(tps * 10) / 10,
+        p50_itl_ms: Math.round(p50 * 10) / 10,
+        p99_itl_ms: Math.round((p50 + 4.2) * 10) / 10,
+        mean_itl_ms: Math.round((p50 + 0.6) * 10) / 10,
+      };
+    },
     '/v1/stats/recent-requests': () => {
       const now = Date.now();
       return [
-        { timestamp_unix_ms: now - 4_000,   prompt_preview: 'Refund the customer on order #4821 and reply', completion_preview: 'I\u2019ve issued a full refund of $148.20 to the original card. You should see it within 3-5 business days.', prompt_tokens: 28, completion_tokens: 36, finish_reason: 'stop',   streamed: true,  duration_ms: 254 },
-        { timestamp_unix_ms: now - 18_000,  prompt_preview: 'Format this JSON response as a single line', completion_preview: '{"id":"msg_92","status":"complete","payload":{"score":0.91,"label":"approved"}}', prompt_tokens: 41, completion_tokens: 22, finish_reason: 'stop', streamed: true, duration_ms: 158 },
-        { timestamp_unix_ms: now - 41_000,  prompt_preview: 'Why is my package still showing in transit?', completion_preview: 'I see your package shipped on May 6 and is currently with the local carrier. The latest tracking…', prompt_tokens: 19, completion_tokens: 64, finish_reason: 'stop', streamed: true, duration_ms: 462 },
-        { timestamp_unix_ms: now - 92_000,  prompt_preview: 'Apologize and offer a 10% credit on the next order', completion_preview: 'I\u2019m really sorry for the trouble with this order. As a thank-you for your patience, I\u2019ve added a 10% credit to your account.', prompt_tokens: 25, completion_tokens: 38, finish_reason: 'stop', streamed: true, duration_ms: 271 },
-        { timestamp_unix_ms: now - 145_000, prompt_preview: 'Generate a one-line product summary for SKU-2271', completion_preview: 'Compact wireless earbuds with active noise cancellation, 8h battery, and a USB-C charging case.', prompt_tokens: 22, completion_tokens: 24, finish_reason: 'stop', streamed: true, duration_ms: 167 },
-        { timestamp_unix_ms: now - 198_000, prompt_preview: 'Extract the order number from this email', completion_preview: 'Order number: #4821', prompt_tokens: 87, completion_tokens: 6, finish_reason: 'stop', streamed: true, duration_ms: 84 },
+        {
+          id: 'chatcmpl-9f2a7c41-0e3b-4a18-b9d2-1c8e7a4f02d1',
+          model: 'Qwen3.5-4B', adapter: 'opencode-agent-v4', streamed: true,
+          timestamp_unix_ms: now - 2_400, duration_ms: 1_812, ttft_ms: 38,
+          prompt_tokens: 4_182, completion_tokens: 268, finish_reason: 'stop',
+          temperature: 0.2, top_p: 0.95, max_tokens: 2048,
+          user_agent: 'opencode/0.4.2 (@ai-sdk/openai-compatible)',
+          prompt_preview: 'Refactor src/auth/session.rs to use the new TokenStore trait and update call sites',
+          completion_preview: "I'll update `Session::new` to take a `TokenStore` and migrate the three call sites in `handlers/`. Running cargo check…",
+          prompt_full: 'You are opencode, an autonomous coding agent.\n\nRefactor src/auth/session.rs to use the new TokenStore trait and update call sites.',
+          completion_full: "I'll update `Session::new` to take a `TokenStore` and migrate the three call sites in `handlers/`. Running cargo check now to confirm the trait bounds line up.",
+        },
+        {
+          id: 'chatcmpl-7b1d5e92-aa14-4c0f-9e71-2f6b3d9c8a55',
+          model: 'Qwen3.5-4B', adapter: 'opencode-agent-v4', streamed: true,
+          timestamp_unix_ms: now - 9_100, duration_ms: 642, ttft_ms: 29,
+          prompt_tokens: 2_011, completion_tokens: 96, finish_reason: 'tool_calls',
+          temperature: 0.0, top_p: 1.0, max_tokens: 1024,
+          user_agent: 'pi/1.2.0',
+          prompt_preview: 'What files import the deprecated `legacy_client` module?',
+          completion_preview: 'grep_repo({"pattern":"legacy_client","glob":"**/*.rs"})',
+          prompt_full: 'What files import the deprecated `legacy_client` module?',
+          completion_full: 'grep_repo({"pattern":"legacy_client","glob":"**/*.rs"})',
+        },
+        {
+          id: 'chatcmpl-3c8f0a17-7d22-49b6-8c41-0a5e6f2b1d34',
+          model: 'Qwen3.5-4B', adapter: 'opencode-agent-v4', streamed: true,
+          timestamp_unix_ms: now - 21_500, duration_ms: 3_204, ttft_ms: 41,
+          prompt_tokens: 6_540, completion_tokens: 512, finish_reason: 'stop',
+          temperature: 0.2, top_p: 0.95, max_tokens: 4096,
+          user_agent: 'opencode/0.4.2 (@ai-sdk/openai-compatible)',
+          prompt_preview: 'Write a unit test for the new rate limiter covering burst + steady-state',
+          completion_preview: '```rust\n#[tokio::test]\nasync fn limiter_allows_burst_then_throttles() {\n    let lim = RateLimiter::new(5, Duration::from_secs(1));',
+          prompt_full: 'Write a unit test for the new rate limiter covering burst + steady-state behaviour.',
+          completion_full: '```rust\n#[tokio::test]\nasync fn limiter_allows_burst_then_throttles() {\n    let lim = RateLimiter::new(5, Duration::from_secs(1));\n    for _ in 0..5 { assert!(lim.try_acquire().await); }\n    assert!(!lim.try_acquire().await);\n}\n```',
+        },
+        {
+          id: 'chatcmpl-5e9a2b48-3f61-4d7a-a2b8-9c0d1e4f7a26',
+          model: 'Qwen3.5-4B', adapter: null, streamed: true,
+          timestamp_unix_ms: now - 47_800, duration_ms: 988, ttft_ms: 33,
+          prompt_tokens: 1_204, completion_tokens: 142, finish_reason: 'stop',
+          temperature: 0.3, top_p: 0.95, max_tokens: 1024,
+          user_agent: 'pi/1.2.0',
+          prompt_preview: 'Summarize the diff in this PR and flag anything risky',
+          completion_preview: 'The PR swaps the blocking Mutex for an async RwLock in `cache.rs`. Risk: the `.read()` guard is now held across an await on line 88…',
+          prompt_full: 'Summarize the diff in this PR and flag anything risky.',
+          completion_full: 'The PR swaps the blocking Mutex for an async RwLock in `cache.rs`. Risk: the `.read()` guard is now held across an await on line 88, which can deadlock under contention.',
+        },
+        {
+          id: 'chatcmpl-8a3c1f76-6b94-4e2c-bf03-7d5a9e8c2b41',
+          model: 'Qwen3.5-4B', adapter: 'opencode-agent-v4', streamed: false,
+          timestamp_unix_ms: now - 92_300, duration_ms: 421, ttft_ms: null,
+          prompt_tokens: 812, completion_tokens: 54, finish_reason: 'stop',
+          temperature: 0.0, top_p: 1.0, max_tokens: 256,
+          user_agent: 'curl/8.7.1',
+          prompt_preview: 'Generate a conventional-commit message for the staged changes',
+          completion_preview: 'fix(cache): hold read guard only for the lookup, not across the network fetch',
+          prompt_full: 'Generate a conventional-commit message for the staged changes.',
+          completion_full: 'fix(cache): hold read guard only for the lookup, not across the network fetch',
+        },
+        {
+          id: 'chatcmpl-2d6b9e03-1a48-4f57-9b21-3e8c0a7d5f62',
+          model: 'Qwen3.5-4B', adapter: 'opencode-agent-v4', streamed: true,
+          timestamp_unix_ms: now - 158_400, duration_ms: 2_140, ttft_ms: 36,
+          prompt_tokens: 3_902, completion_tokens: 318, finish_reason: 'length',
+          temperature: 0.2, top_p: 0.95, max_tokens: 320,
+          user_agent: 'OpenAI/Python 1.40.0',
+          prompt_preview: 'Explain why the integration test `flaky_reconnect` is failing intermittently',
+          completion_preview: 'The test asserts reconnection within 100ms but the backoff jitter can push the first retry to 150ms under load. Either widen…',
+          prompt_full: 'Explain why the integration test `flaky_reconnect` is failing intermittently.',
+          completion_full: 'The test asserts reconnection within 100ms but the backoff jitter can push the first retry to 150ms under load. Either widen the assertion window or seed the jitter RNG in the test harness.',
+        },
       ];
     },
     '/v1/adapters': () => ({
       active: demoState.active,
       available: [
-        { name: 'support-bot',       size_bytes: 17 * 1024 * 1024 },
-        { name: 'format-fixer',      size_bytes: 14 * 1024 * 1024 },
-        { name: 'code-helper-v3',    size_bytes: 22 * 1024 * 1024 },
-        { name: 'docstring-cleaner', size_bytes: 12 * 1024 * 1024 + 600 * 1024 },
-        { name: 'typefix-alpha',     size_bytes: 9 * 1024 * 1024 + 400 * 1024 },
+        { name: 'opencode-agent-v4',  size_bytes: 86 * 1024 * 1024 },
+        { name: 'rust-reviewer-v3',   size_bytes: 64 * 1024 * 1024 },
+        { name: 'sql-explainer-v2',   size_bytes: 28 * 1024 * 1024 },
+        { name: 'commit-msg-writer',  size_bytes: 12 * 1024 * 1024 + 600 * 1024 },
+        { name: 'tool-call-tuned-v1', size_bytes: 41 * 1024 * 1024 },
       ],
     }),
     '/v1/train/queue': () => ({
-      running: { job_id: 'job_7_support_grpo', state: 'Running', progress: 0.42, current_loss: 1.18, adapter_name: 'support-bot-v2', elapsed_secs: 87, job_type: 'GRPO' },
+      running: { job_id: 'job_43_rust_reviewer_grpo', state: 'Running', progress: 0.58, current_loss: 0.286, adapter_name: 'rust-reviewer-v3', elapsed_secs: 1_842, job_type: 'GRPO' },
       queued:  [
-        { job_id: 'job_8_format_sft', state: 'Queued', adapter_name: 'format-fixer-v3', position: 1, job_type: 'SFT' },
+        { job_id: 'job_44_sql_explainer_sft', state: 'Queued', adapter_name: 'sql-explainer-v2', position: 1, job_type: 'SFT' },
       ],
       completed: [
-        { job_id: 'job_6_format_sft',   state: 'Completed', progress: 1.0, current_loss: 0.41, adapter_name: 'format-fixer',      elapsed_secs: 124, job_type: 'SFT' },
-        { job_id: 'job_5_typefix_sft',  state: 'Completed', progress: 1.0, current_loss: 0.37, adapter_name: 'typefix-alpha',     elapsed_secs: 98,  job_type: 'SFT' },
-        { job_id: 'job_4_docstring_sft', state: 'Completed', progress: 1.0, current_loss: 0.52, adapter_name: 'docstring-cleaner', elapsed_secs: 142, job_type: 'SFT' },
+        { job_id: 'job_42_opencode_grpo',  state: 'Completed', progress: 1.0, current_loss: 0.214, adapter_name: 'opencode-agent-v4', elapsed_secs: 5_280, job_type: 'GRPO' },
+        { job_id: 'job_41_commit_sft',     state: 'Completed', progress: 1.0, current_loss: 0.331, adapter_name: 'commit-msg-writer', elapsed_secs: 1_212, job_type: 'SFT' },
+        { job_id: 'job_40_corrections_sft', state: 'Completed', progress: 1.0, current_loss: 0.402, adapter_name: 'codebase-corrections', elapsed_secs: 318, job_type: 'SFT' },
       ],
     }),
-    '/v1/models': () => ({ data: [{ id: 'Qwen/Qwen3.5-4B', object: 'model' }] }),
+    '/v1/models': () => ({ data: [{ id: 'Qwen3.5-4B', object: 'model' }] }),
+    // Train / Eval / Distill pages so the whole demo is a complete agent-backend
+    // showcase, not just the Overview.
+    '/v1/eval/datasets': evalDatasets,
+    '/v1/eval/suites': evalSuites,
+    '/v1/eval/jobs': evalJobs,
+    '/v1/judgments': judgments,
+    '/v1/teachers': teachers,
+    '/v1/recipes': recipes,
+    '/v1/library': library,
+    '/v1/cache/stats': cacheStats,
+    '/v1/preflight/compatibility': preflightCompat,
+    '/v1/preflight/tiers': preflightTiers,
+    '/v1/agent/traces': agentTraces,
   };
+
+  // Parameterized GETs (detail drills) — matched by pattern, not exact path.
+  function paramResponse(method, path) {
+    let m;
+    if (method === 'GET' && (m = path.match(/^\/v1\/adapters\/(.+)\/detail$/))) return adapterDetail(decodeURIComponent(m[1]));
+    if (method === 'GET' && (m = path.match(/^\/v1\/eval\/suites\/(.+)$/))) return evalSuiteDetail(decodeURIComponent(m[1]));
+    if (method === 'GET' && (m = path.match(/^\/v1\/eval\/jobs\/(.+)$/))) return evalJobDetail(decodeURIComponent(m[1]));
+    if (method === 'GET' && (m = path.match(/^\/v1\/train\/jobs\/(.+)$/))) return trainJobDetail(decodeURIComponent(m[1]));
+    if (method === 'POST' && path === '/v1/agent/traces/discover') return agentDiscover();
+    return undefined;
+  }
 
   const realFetch = window.fetch.bind(window);
   window.fetch = function (input, init) {
     const url = typeof input === 'string' ? input : (input && input.url) || '';
     const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
-    if (responses[path]) {
-      const body = JSON.stringify(responses[path]());
-      return Promise.resolve(new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const method = ((init && init.method) || (typeof input !== 'string' && input && input.method) || 'GET').toUpperCase();
+    const ok = (body) => Promise.resolve(new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    if (responses[path]) return ok(responses[path]());
+    const param = paramResponse(method, path);
+    if (param !== undefined) return ok(param);
+    // Any other mutation under /v1 → generic success ack so buttons don't error.
+    if (path.startsWith('/v1/') && (method === 'POST' || method === 'DELETE' || method === 'PUT')) {
+      return ok({ ok: true, status: 'ok', message: 'Demo mode: ' + method + ' ' + path + ' acknowledged', job_id: 'job_demo_' + path.replace(/\W+/g, '_') });
     }
+    // Any other /v1 GET → empty-but-valid envelope (keeps panels from erroring).
+    if (path.startsWith('/v1/') && method === 'GET') return ok({});
     return realFetch(input, init);
   };
 })();
@@ -4353,14 +5109,551 @@ function toast(msg, type) {
   el.dataset.toastTimer = String(setTimeout(() => el.remove(), 4000));
 }
 
+// --- Icon helper ---
+// Returns inline-SVG markup for a sprite symbol (see #i-* defs at top of body).
+// Use in template strings instead of emoji so glyphs inherit currentColor.
+function icon(name, extraCls) {
+  return `<svg class="icn${extraCls ? ' ' + extraCls : ''}" aria-hidden="true"><use href="#i-${name}"></use></svg>`;
+}
+
 // --- API Helpers ---
 async function api(path, opts) {
-  const res = await fetch(path, opts);
+  let res;
+  try {
+    res = await fetch(path, opts);
+  } catch (e) {
+    // A thrown fetch = the server didn't answer at all (down / wrong host /
+    // CORS) — say so plainly instead of the browser's opaque "Failed to fetch".
+    const err = new Error(`Can't reach Kiln at ${window.location.origin} — is \`kiln serve\` running on this host/port?`);
+    err.unreachable = true;
+    throw err;
+  }
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.detail || body.error || `HTTP ${res.status}`);
+    throw new Error(body.detail || body.error || `HTTP ${res.status} from ${path}`);
   }
   return res.json();
+}
+
+/* =====================================================================
+   Connect-your-agent panel — onboarding centerpiece. Live base URL + model
+   id + per-client setup snippets + test-connection. The #1 task for an
+   operator: point pi / opencode / any OpenAI client at this server.
+   ===================================================================== */
+const CONNECT_FALLBACK_MODEL = 'Qwen3.5-4B';
+let connectModelId = CONNECT_FALLBACK_MODEL;
+let connectManualState = null; // null = auto-collapse on traffic; true/false = user override
+
+function connectBaseUrl() { return window.location.origin + '/v1'; }
+
+// Token highlighter operating on RAW code (so quotes/comments survive escaping).
+function renderHighlighted(code, lang) {
+  const esc = s => escapeHtml(s);
+  return code.split('\n').map(line => {
+    const cm = (lang === 'py' || lang === 'sh') ? line.match(/^(\s*)(#.*)$/)
+             : (lang === 'js') ? line.match(/^(\s*)(\/\/.*)$/) : null;
+    if (cm) return esc(cm[1]) + '<span class="tok-com">' + esc(cm[2]) + '</span>';
+    let res = '', last = 0, m; const re = /"(?:[^"\\]|\\.)*"/g;
+    while ((m = re.exec(line))) { res += esc(line.slice(last, m.index)) + '<span class="tok-str">' + esc(m[0]) + '</span>'; last = m.index + m[0].length; }
+    return res + esc(line.slice(last));
+  }).join('\n');
+}
+
+function connectSnippets() {
+  const base = connectBaseUrl(), origin = window.location.origin, model = connectModelId;
+  return {
+    pi: { lang: 'sh',
+      note: 'One command — backs up &amp; merges <code>~/.pi/agent/{models,settings}.json</code>, then makes Kiln pi&rsquo;s default model.',
+      code: `# Point pi at this Kiln server\nkiln pi-setup\n\n# Remote server? pass its URL — /v1 is appended for you\nkiln pi-setup --kiln-url ${origin}` },
+    opencode: { lang: 'js', path: '~/.config/opencode/opencode.json',
+      note: 'Add this provider, then run <code>opencode</code> and pick the model with <code>/models</code>. No API key needed.',
+      code: `{\n  "$schema": "https://opencode.ai/config.json",\n  "provider": {\n    "kiln": {\n      "npm": "@ai-sdk/openai-compatible",\n      "name": "Kiln (local)",\n      "options": { "baseURL": "${base}", "apiKey": "unused" },\n      "models": { "${model}": { "name": "Kiln · ${model}" } }\n    }\n  }\n}` },
+    python: { lang: 'py',
+      note: 'Drop-in OpenAI SDK — only <code>base_url</code> changes.',
+      code: `from openai import OpenAI\n\nclient = OpenAI(base_url="${base}", api_key="unused")\n\nresp = client.chat.completions.create(\n    model="${model}",\n    messages=[{"role": "user", "content": "Hello from my agent"}],\n)\nprint(resp.choices[0].message.content)` },
+    js: { lang: 'js',
+      note: 'Drop-in OpenAI SDK for Node / Bun / Deno.',
+      code: `import OpenAI from "openai";\n\nconst client = new OpenAI({ baseURL: "${base}", apiKey: "unused" });\n\nconst resp = await client.chat.completions.create({\n  model: "${model}",\n  messages: [{ role: "user", content: "Hello from my agent" }],\n});\nconsole.log(resp.choices[0].message.content);` },
+    curl: { lang: 'sh',
+      note: 'Raw HTTP — drop into any shell, CI job, or script.',
+      code: `curl -s ${base}/chat/completions \\\n  -H "Content-Type: application/json" \\\n  -d '{\n    "model": "${model}",\n    "messages": [{"role": "user", "content": "Hello from my agent"}]\n  }'` },
+  };
+}
+
+function renderConnectSnippets(active) {
+  const host = document.getElementById('connect-snippets');
+  if (!host) return;
+  const snips = connectSnippets();
+  host.innerHTML = Object.entries(snips).map(([key, s]) => {
+    const pathLine = s.path ? `<div class="code-block-path">${escapeHtml(s.path)}</div>` : '';
+    return `<div class="connect-snippet${key === active ? ' active' : ''}" data-connect-pane="${key}">
+      <div class="connect-snippet-note">${s.note}</div>
+      <div class="code-block">${pathLine}<button class="copy-btn" type="button" data-copy-code aria-label="Copy code"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button><pre>${renderHighlighted(s.code, s.lang)}</pre></div>
+    </div>`;
+  }).join('');
+}
+
+function selectConnectTab(key) {
+  document.querySelectorAll('.connect-tabs .tab').forEach(t => {
+    const on = t.dataset.connectTab === key;
+    t.classList.toggle('active', on);
+    t.setAttribute('aria-selected', String(on));
+  });
+  document.querySelectorAll('.connect-snippet').forEach(p => p.classList.toggle('active', p.dataset.connectPane === key));
+}
+
+async function copyText(text, btn) {
+  try { await navigator.clipboard.writeText(text); }
+  catch { const ta = document.createElement('textarea'); ta.value = text; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch {} ta.remove(); }
+  if (btn) {
+    const orig = btn.innerHTML;
+    btn.classList.add('copied');
+    btn.innerHTML = `${icon('check', 'icn-sm')}Copied`;
+    setTimeout(() => { btn.classList.remove('copied'); btn.innerHTML = orig; }, 1400);
+  }
+}
+
+function setConnectCollapsed(collapsed) {
+  const exp = document.getElementById('connect-expanded');
+  const col = document.getElementById('connect-collapsed');
+  if (!exp || !col) return;
+  exp.hidden = collapsed; col.hidden = !collapsed;
+}
+
+function openConnect() {
+  connectManualState = true;
+  setConnectCollapsed(false);
+  selectPage('overview');
+  const panel = document.getElementById('connect-panel');
+  if (panel) panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// Auto-collapse to the slim "connected" bar once traffic flows (unless the
+// operator has manually picked a state this session).
+function updateConnectSummary(rows) {
+  const n = Array.isArray(rows) ? rows.length : 0;
+  const txt = document.getElementById('connect-collapsed-text');
+  if (txt && n > 0) {
+    const last = rows[0]?.timestamp_unix_ms;
+    txt.innerHTML = `<strong>Connected</strong> · <strong>${n}</strong> recent request${n === 1 ? '' : 's'}${last ? ' · last ' + fmtRelTime(last) : ''}`;
+  }
+  if (connectManualState === null && n > 0) setConnectCollapsed(true);
+}
+
+// Exposed for inline onclick handlers in dynamically-rendered empty states.
+window.openConnect = openConnect;
+window.selectPage = selectPage;
+
+/* === Request health & ambient awareness (the in-flow pi coder) ===========
+   The dashboard usually lives in a background tab while the dev codes with pi.
+   These derive what pi ACTUALLY experiences from the recent-requests ring —
+   errors, truncations, end-to-end TTFT, which adapter actually served, and
+   freshness — and surface it as a live heartbeat, a silent-base-fallback
+   warning, and ambient document.title + favicon so real problems break
+   through without alt-tabbing back to the dashboard. */
+let lastRequestHealth = null;
+function nonBaseAdapterCount() {
+  const av = (lastAdapters && lastAdapters.available) || [];
+  return av.filter(a => a && a.name && a.name !== 'base').length;
+}
+function computeRequestHealth(rows) {
+  rows = rows || [];
+  const now = Date.now();
+  const sample = rows.slice(0, 30);
+  let errors = 0, truncated = 0; const ttfts = [];
+  for (const r of sample) {
+    const f = (r.finish_reason || '').toLowerCase();
+    if (r.error || f === 'error' || f === 'client_disconnect') errors++;
+    else if (f === 'length') truncated++;
+    if (typeof r.ttft_ms === 'number') ttfts.push(r.ttft_ms);
+  }
+  ttfts.sort((a, b) => a - b);
+  const q = p => ttfts.length ? ttfts[Math.min(ttfts.length - 1, Math.floor(p * (ttfts.length - 1)))] : null;
+  const lastTs = rows.length ? rows[0].timestamp_unix_ms : null;
+  return {
+    total: rows.length, errors, truncated, ttftP50: q(0.5), ttftP99: q(0.95),
+    lastTs, sinceMs: lastTs ? now - lastTs : null,
+    servedBy: rows.length ? (rows[0].adapter || 'base') : null,
+  };
+}
+function fmtMsShort(ms) { return ms == null ? '—' : (ms < 1000 ? Math.round(ms) + ' ms' : (ms / 1000).toFixed(1) + ' s'); }
+
+function updateHeartbeat(h) {
+  const el = document.getElementById('recent-heartbeat');
+  if (!el) return;
+  const txt = el.querySelector('.hb-text');
+  const baseFallback = h.servedBy === 'base' && nonBaseAdapterCount() > 0;
+  let cls, label;
+  if (h.errors > 0) {
+    cls = 'err';
+    label = `${h.errors} error${h.errors === 1 ? '' : 's'}${h.truncated ? ` · ${h.truncated} truncated` : ''} recently`;
+  } else if (h.lastTs == null) {
+    cls = 'idle'; label = 'No requests yet';
+  } else if (h.sinceMs != null && h.sinceMs < 15000) {
+    if (baseFallback) { cls = 'warn'; label = `Live · serving base model · last ${fmtRelTime(h.lastTs)}`; }
+    else { cls = 'live'; label = `Live · last ${fmtRelTime(h.lastTs)}${h.ttftP50 != null ? ` · TTFT ${fmtMsShort(h.ttftP50)}` : ''}`; }
+  } else if (h.truncated > 0) {
+    cls = 'warn'; label = `${h.truncated} truncated · last ${fmtRelTime(h.lastTs)}`;
+  } else if (h.sinceMs != null && h.sinceMs < 120000) {
+    cls = 'idle'; label = `Last request ${fmtRelTime(h.lastTs)}`;
+  } else {
+    cls = 'quiet'; label = `Quiet · ${fmtRelTime(h.lastTs)}`;
+  }
+  el.className = 'heartbeat hb-' + cls;
+  if (txt) txt.textContent = label;
+  el.title = baseFallback
+    ? 'pi is hitting the BASE model even though you have trained adapters. Hot-swap one on the Adapters page so your usage actually improves the model.'
+    : (h.ttftP99 != null ? `End-to-end TTFT p50 ${fmtMsShort(h.ttftP50)} · p99 ${fmtMsShort(h.ttftP99)} (the latency pi feels)` : '');
+}
+
+// Ambient document.title + favicon so the in-flow coder catches problems from
+// a background tab. Green = actively serving, amber = truncations/base
+// fallback, red = errors, none = idle.
+function updateAmbient(h) {
+  let title = 'Kiln Dashboard', dot = null;
+  const live = h.sinceMs != null && h.sinceMs < 15000;
+  if (h.errors > 0) { title = `⚠ ${h.errors} error${h.errors === 1 ? '' : 's'} · Kiln`; dot = '#f87171'; }
+  else if (live && h.servedBy === 'base' && nonBaseAdapterCount() > 0) { title = '● base model · Kiln'; dot = '#fbbf24'; }
+  else if (live) {
+    const tps = lastDecode && lastDecode.tok_per_sec ? Math.round(lastDecode.tok_per_sec) : null;
+    title = tps ? `● ${tps} tok/s · Kiln` : '● serving · Kiln'; dot = '#4ade80';
+  } else if (h.truncated > 0) { title = `${h.truncated} truncated · Kiln`; dot = '#fbbf24'; }
+  else if (h.lastTs != null) { title = 'Kiln — idle'; }
+  if (document.title !== title) document.title = title;
+  setFaviconDot(dot);
+}
+let _faviconDot = 'init';
+function setFaviconDot(color) {
+  if (color === _faviconDot) return; _faviconDot = color;
+  const dot = color ? `<circle cx="24" cy="8" r="6.5" fill="${color}" stroke="#0a0908" stroke-width="2"/>` : '';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><linearGradient id="g" x1="0" x2="0" y1="0" y2="1"><stop offset="0" stop-color="#fbbf24"/><stop offset="0.5" stop-color="#f97316"/><stop offset="1" stop-color="#c2410c"/></linearGradient></defs><rect width="32" height="32" rx="7" fill="#0a0908"/><rect x="4" y="4" width="24" height="24" rx="5" fill="url(#g)"/><g fill="none" stroke="#0a0908" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"><path d="M8 12.5l8 4 8-4"/><path d="M10 17.5l6 3 6-3"/><path d="M12 22.5l4 2 4-2"/></g>${dot}</svg>`;
+  const link = document.querySelector('link[rel="icon"]');
+  if (link) link.setAttribute('href', 'data:image/svg+xml,' + encodeURIComponent(svg));
+}
+
+// Recompute + repaint all request-health surfaces. Called every recent-requests
+// poll (2s).
+function refreshRequestHealth() {
+  lastRequestHealth = computeRequestHealth(recentRequestsCache);
+  updateHeartbeat(lastRequestHealth);
+  updateAmbient(lastRequestHealth);
+}
+
+/* === Corrections basket — the flywheel's core loop, one-click =============
+   pi gives a bad answer → "Use as correction" APPENDS it here (not overwrite)
+   → you fix the ideal answer inline → "Train" turns the whole basket into ONE
+   SFT job and hot-swaps the result. localStorage-backed so corrections
+   accumulate across a coding session and survive reloads. This is the literal
+   mechanism of "your model gets better every time you use it". */
+const CORR_KEY = 'kiln.corrections.v1';
+let correctionsBasket = [];
+// A persistent "training started" receipt shown in the Corrections card after a
+// train submit, so the handoff isn't a silent page-jump. {name, count}.
+let corrReceipt = null;
+function loadCorrections() {
+  try { const v = JSON.parse(localStorage.getItem(CORR_KEY) || '[]'); correctionsBasket = Array.isArray(v) ? v : []; }
+  catch { correctionsBasket = []; }
+}
+function saveCorrections() { try { localStorage.setItem(CORR_KEY, JSON.stringify(correctionsBasket)); } catch {} }
+function addCorrectionFromRequest(r) {
+  if (!r) return false;
+  const rid = r.id || ('req-' + Date.now());
+  if (correctionsBasket.some(c => c.request_id === rid)) { toast('Already in your corrections', 'info'); return false; }
+  correctionsBasket.unshift({
+    request_id: rid,
+    agent: (clientFromUA(r.user_agent) || {}).label || 'client',
+    ts: r.timestamp_unix_ms || Date.now(),
+    model: r.model || '', adapter: r.adapter || 'base',
+    user: r.prompt_full || r.prompt_preview || '',
+    original: r.completion_full || r.completion_preview || '',
+    // Start EMPTY — never pre-seed with the bad answer. A correction left
+    // untouched must never silently train the model on its own mistake.
+    ideal: '',
+  });
+  saveCorrections();
+  renderCorrections();
+  toast(`Added to corrections (${correctionsBasket.length}) — write the ideal answer, then Train`, 'ok');
+  return true;
+}
+function removeCorrection(rid) { correctionsBasket = correctionsBasket.filter(c => c.request_id !== rid); saveCorrections(); renderCorrections(); }
+function clearCorrections() {
+  if (correctionsBasket.length && !confirm(`Discard ${correctionsBasket.length} correction${correctionsBasket.length === 1 ? '' : 's'}?`)) return;
+  correctionsBasket = []; saveCorrections(); renderCorrections();
+}
+// A correction trains ONLY if you supplied a genuinely different answer. Empty
+// (untouched) or identical-to-original (reverted) is excluded — the whole point
+// is that the model never learns from the very output you flagged as wrong.
+function corrTrainable(c) {
+  const ideal = (c.ideal || '').trim();
+  return ideal.length > 0 && ideal !== (c.original || '').trim();
+}
+function corrStateHtml(ready) {
+  return ready ? icon('check', 'icn-sm') + 'ready to train' : 'needs your answer';
+}
+function renderCorrections() {
+  const card = document.getElementById('corrections-card');
+  const list = document.getElementById('corrections-list');
+  const n = correctionsBasket.length;
+  setText('corr-count', String(n));
+  // Keep the card visible while a training receipt is showing, even if the
+  // basket emptied out (all corrections were just trained in).
+  if (card) card.hidden = n === 0 && !corrReceipt;
+  if (!list) { updateCorrFoot(); return; }
+  const receiptHtml = corrReceipt ? `
+    <div class="corr-receipt" role="status">
+      <span class="corr-receipt-icon">${icon('check', 'icn-sm')}</span>
+      <span class="corr-receipt-text">Training <strong>${escapeHtml(corrReceipt.name)}</strong> from ${corrReceipt.count} correction${corrReceipt.count === 1 ? '' : 's'} — it'll hot-swap in when done.</span>
+      <button type="button" class="btn btn-sm" id="corr-receipt-view">View in queue ${icon('arrow-right', 'icn-sm')}</button>
+      <button type="button" class="btn btn-sm btn-ghost corr-receipt-dismiss" id="corr-receipt-dismiss" aria-label="Dismiss receipt">${icon('close', 'icn-sm')}</button>
+    </div>` : '';
+  list.innerHTML = receiptHtml + correctionsBasket.map(c => {
+    const prev = (c.user || '').slice(0, 180);
+    const rid = escapeHtml(c.request_id);
+    const ready = corrTrainable(c);
+    return `<div class="corr-item ${ready ? 'is-ready' : 'is-todo'}" data-corr="${rid}">
+      <div class="corr-item-head">
+        <span class="recent-agent">${escapeHtml(c.agent)}</span>
+        <span class="corr-prompt" title="${escapeHtml(c.user)}">${escapeHtml(prev)}${c.user.length > 180 ? '…' : ''}</span>
+        <span class="corr-state" data-corr-state="${rid}">${corrStateHtml(ready)}</span>
+        <button type="button" class="btn btn-sm btn-ghost corr-remove" data-corr-remove="${rid}" aria-label="Remove correction">${icon('close', 'icn-sm')}</button>
+      </div>
+      <div class="corr-grid">
+        <div class="corr-col">
+          <div class="corr-label">pi answered${c.adapter && c.adapter !== 'base' ? ' (' + escapeHtml(c.adapter) + ')' : ''}</div>
+          <pre class="corr-orig">${escapeHtml(c.original) || '—'}</pre>
+          <button type="button" class="btn btn-sm btn-ghost corr-seed" data-corr-seed="${rid}" title="Copy pi's answer into the editor so you can fix it in place">${icon('copy', 'icn-sm')} Start from this &amp; edit</button>
+        </div>
+        <div class="corr-col">
+          <label class="corr-label" for="corr-ideal-${rid}">should have answered</label>
+          <textarea class="corr-ideal" id="corr-ideal-${rid}" data-corr-ideal="${rid}" rows="6" spellcheck="false" placeholder="Write the answer pi should have given…">${escapeHtml(c.ideal)}</textarea>
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+  list.querySelectorAll('[data-corr-ideal]').forEach(ta => ta.addEventListener('input', () => {
+    const c = correctionsBasket.find(x => x.request_id === ta.dataset.corrIdeal);
+    if (c) { c.ideal = ta.value; saveCorrections(); markCorrState(c); updateCorrFoot(); }
+  }));
+  list.querySelectorAll('[data-corr-seed]').forEach(b => b.addEventListener('click', () => {
+    const c = correctionsBasket.find(x => x.request_id === b.dataset.corrSeed);
+    if (!c) return;
+    const ta = document.getElementById('corr-ideal-' + c.request_id);
+    if (ta) { ta.value = c.original; c.ideal = c.original; saveCorrections(); markCorrState(c); updateCorrFoot();
+      ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+  }));
+  list.querySelectorAll('[data-corr-remove]').forEach(b => b.addEventListener('click', () => removeCorrection(b.dataset.corrRemove)));
+  document.getElementById('corr-receipt-view')?.addEventListener('click', () => {
+    selectPage('training');
+    setTimeout(() => document.querySelector('#page-training [data-tab="queue"]')?.click(), 40);
+  });
+  document.getElementById('corr-receipt-dismiss')?.addEventListener('click', () => { corrReceipt = null; renderCorrections(); });
+  updateCorrFoot();
+}
+// Repaint one item's ready/todo affordance in place — no full re-render, so the
+// textarea keeps focus and caret position while the operator types.
+function markCorrState(c) {
+  const ready = corrTrainable(c);
+  document.querySelectorAll('.corr-item[data-corr]').forEach(item => {
+    if (item.getAttribute('data-corr') !== c.request_id) return;
+    item.classList.toggle('is-ready', ready); item.classList.toggle('is-todo', !ready);
+  });
+  document.querySelectorAll('[data-corr-state]').forEach(st => {
+    if (st.getAttribute('data-corr-state') === c.request_id) st.innerHTML = corrStateHtml(ready);
+  });
+}
+function updateCorrFoot() {
+  const ready = correctionsBasket.filter(corrTrainable).length;
+  const todo = correctionsBasket.length - ready;
+  setText('corr-train-n', String(ready));
+  const note = document.getElementById('corr-foot-note');
+  if (note) note.textContent = todo > 0
+    ? `${todo} still need${todo === 1 ? 's' : ''} an answer · only edited items train`
+    : (ready > 0 ? 'These become one SFT job — the new adapter hot-swaps in when done' : '');
+  const btn = document.getElementById('corr-train');
+  if (btn) btn.disabled = ready === 0;
+}
+async function trainFromCorrections() {
+  const trainable = correctionsBasket.filter(corrTrainable);
+  if (!trainable.length) { toast('Write at least one ideal answer (different from pi’s) before training', 'err'); return; }
+  const nameInput = document.getElementById('corr-adapter-name');
+  const name = ((nameInput && nameInput.value) || '').trim() || 'codebase-corrections';
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) { toast('Adapter name: letters, digits, . _ - only', 'err'); nameInput && nameInput.focus(); return; }
+  const examples = trainable.map(c => ({ messages: [{ role: 'user', content: c.user }, { role: 'assistant', content: c.ideal }] }));
+  const btn = document.getElementById('corr-train');
+  if (btn) btn.disabled = true;
+  try {
+    const body = { examples, config: { output_name: name, auto_load: true, learning_rate: 0.0002, epochs: 3, lora_rank: 8 } };
+    const res = await api('/v1/train/sft', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    toast(res.message || `Training ${name} from ${examples.length} correction${examples.length === 1 ? '' : 's'} — it will hot-swap in when done`, 'ok');
+    // Remove ONLY the corrections we actually trained on. Anything still
+    // awaiting an answer stays in the basket so no hand-written work is lost
+    // if a later job is submitted.
+    const trained = new Set(trainable.map(c => c.request_id));
+    correctionsBasket = correctionsBasket.filter(c => !trained.has(c.request_id));
+    // Leave a persistent in-card receipt instead of a disorienting auto-jump —
+    // the user stays in context and chooses when to view the job.
+    corrReceipt = { name, count: examples.length };
+    saveCorrections(); renderCorrections();
+    if (typeof pollTraining === 'function') pollTraining();
+  } catch (e) { toast(e.message || 'Could not submit training', 'err'); }
+  finally { if (btn) btn.disabled = correctionsBasket.filter(corrTrainable).length === 0; }
+}
+function initCorrections() {
+  loadCorrections();
+  renderCorrections();
+  document.getElementById('corr-clear')?.addEventListener('click', clearCorrections);
+  document.getElementById('corr-train')?.addEventListener('click', trainFromCorrections);
+  // Inline adapter-name validation so a bad name isn't a submit-time surprise.
+  const nameInput = document.getElementById('corr-adapter-name');
+  if (nameInput) nameInput.addEventListener('input', () => {
+    const ok = !nameInput.value.trim() || /^[A-Za-z0-9._-]+$/.test(nameInput.value.trim());
+    nameInput.classList.toggle('input-invalid', !ok);
+  });
+}
+window.addCorrectionFromRequest = addCorrectionFromRequest;
+
+// Update the flywheel ribbon from whatever live caches are populated. Called
+// from the various polls; tolerant of missing data (cold start).
+function updateFlywheel() {
+  const set = (id, v) => { const e = document.getElementById(id); if (e) e.textContent = v; };
+  const rows = recentRequestsCache || [];
+  const agents = new Set(rows.map(r => clientFromUA(r.user_agent).key));
+  set('fw-agents', agents.size || 0);
+  set('fw-agents-sub', agents.size ? (agents.size === 1 ? '1 client' : agents.size + ' clients') : 'none yet');
+  set('fw-traffic', rows.length || 0);
+  set('fw-traffic-sub', rows.length ? 'recent requests' : 'no traffic yet');
+
+  const tj = (typeof trainingJobsCache !== 'undefined') ? trainingJobsCache : null;
+  const running = tj && tj.running ? 1 : 0;
+  const queued = tj && Array.isArray(tj.queued) ? tj.queued.length : 0;
+  const done = tj && Array.isArray(tj.completed) ? tj.completed.length : 0;
+  const activeJobs = running + queued;
+  // Corrections in the basket are pending training — surface them on the Train
+  // node so the ribbon reflects the live to-do, not just submitted jobs.
+  const corrReady = (typeof correctionsBasket !== 'undefined' && typeof corrTrainable === 'function')
+    ? correctionsBasket.filter(corrTrainable).length : 0;
+  const corrTotal = (typeof correctionsBasket !== 'undefined') ? correctionsBasket.length : 0;
+  set('fw-train', activeJobs > 0 ? activeJobs : (corrTotal || done));
+  set('fw-train-sub',
+    corrReady ? corrReady + ' correction' + (corrReady === 1 ? '' : 's') + ' ready'
+    : running ? 'running now'
+    : corrTotal ? corrTotal + ' correction' + (corrTotal === 1 ? '' : 's') + ' to answer'
+    : queued ? queued + ' queued'
+    : done ? done + ' completed' : 'idle');
+
+  const evalCountStr = document.getElementById('evals-count')?.textContent || '0';
+  const noEvals = evalCountStr === '0' || evalCountStr === '';
+  set('fw-eval', evalCountStr);
+
+  const active = lastHealth && lastHealth.active_adapter;
+  set('fw-active', active || 'base');
+  // Lead with the win verdict when the active adapter has a compare eval — the
+  // flywheel's payoff ("is what's serving pi better than base?") right on the ribbon.
+  const activeVerdict = active && typeof adapterCompareVerdict === 'function' ? adapterCompareVerdict(active) : null;
+  const subEl = document.getElementById('fw-active-sub');
+  if (subEl) {
+    subEl.classList.remove('fw-win', 'fw-loss');
+    if (activeVerdict) {
+      subEl.textContent = Math.abs(activeVerdict.delta) <= 0.5 ? 'matches base' : `${activeVerdict.delta > 0 ? '+' : ''}${activeVerdict.delta.toFixed(1)} pts vs base`;
+      if (activeVerdict.delta > 0.5) subEl.classList.add('fw-win');       // green: the swap is proven better
+      else if (activeVerdict.delta < -0.5) subEl.classList.add('fw-loss'); // red: it regressed vs base
+    } else {
+      subEl.textContent = active ? 'hot-swapped LoRA' : 'base model';
+    }
+  }
+  // Caution the eval node when an adapter is live but never evaluated.
+  set('fw-eval-sub', (active && noEvals) ? 'not evaluated yet' : (noEvals ? 'no evals yet' : 'suites & jobs'));
+
+  // Highlight the single most valuable next stage (the "hot" node). A genuine
+  // downstream GAP (active adapter that was never evaluated) wins over an
+  // already-running stage — that's the move the operator should make next.
+  let hot = 'connect';
+  if (corrReady > 0) hot = 'train';            // you authored fixes — train them in
+  else if (active && noEvals) hot = 'eval';    // adapter live but unproven — verify it
+  else if (running) hot = 'train';
+  else if (rows.length > 0 && !active) hot = 'train';
+  else if (active) hot = 'swap';
+  else if (rows.length > 0) hot = 'train';
+  document.querySelectorAll('.flywheel-node').forEach(n => n.classList.toggle('hot', n.dataset.fw === hot));
+
+  // Explanatory + clickable-cue tooltips, keyed to the live value so they read
+  // as state ("3 clients seen") not generic help. Every node is a button → say
+  // where clicking goes.
+  const tip = (fw, t) => { const n = document.querySelector(`.flywheel-node[data-fw="${fw}"]`); if (n) n.title = t; };
+  tip('connect', `${agents.size || 0} distinct client${agents.size === 1 ? '' : 's'} seen in recent traffic — click for connection setup`);
+  tip('traffic', `${rows.length} request${rows.length === 1 ? '' : 's'} in the live ring — click to jump to Recent requests`);
+  tip('train', running ? 'A training job is running — click to view the queue'
+    : corrReady ? `${corrReady} correction${corrReady === 1 ? '' : 's'} ready to train — click to the Corrections basket`
+    : 'Train an adapter from your corrections — click for the Training queue');
+  tip('eval', (active && noEvals) ? 'Your active adapter has no eval yet — click to prove it beats base'
+    : noEvals ? 'No evals run yet — click to score an adapter' : 'Eval suites & results — click to view');
+  tip('swap', active ? `Serving adapter "${active}" — click to manage / hot-swap adapters` : 'Serving the base model — click to load a trained adapter');
+}
+
+function bindFlywheel() {
+  const go = {
+    connect: () => openConnect(),
+    traffic: () => { selectPage('overview'); document.getElementById('recent-requests-panel')?.scrollIntoView({ behavior: 'smooth', block: 'center' }); },
+    // When corrections are pending, the actionable place is the Corrections card
+    // on Overview (answer + train), not the Training queue.
+    train: () => {
+      const hasCorr = (typeof correctionsBasket !== 'undefined') && correctionsBasket.length > 0;
+      if (hasCorr) { selectPage('overview'); setTimeout(() => document.getElementById('corrections-card')?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 40); }
+      else selectPage('training');
+    },
+    eval: () => selectPage('evals'),
+    swap: () => selectPage('adapters'),
+  };
+  document.querySelectorAll('.flywheel-node').forEach(n => n.addEventListener('click', () => go[n.dataset.fw]?.()));
+}
+
+async function initConnect() {
+  const baseEl = document.getElementById('connect-base-url');
+  if (baseEl) { baseEl.textContent = connectBaseUrl(); baseEl.title = connectBaseUrl(); }
+  try { const m = await api('/v1/models'); const id = m?.data?.[0]?.id; if (id) connectModelId = id; } catch {}
+  const modelEl = document.getElementById('connect-model');
+  if (modelEl) { modelEl.textContent = connectModelId; modelEl.title = connectModelId; }
+  renderConnectSnippets('pi');
+  const tr = document.getElementById('connect-test-result');
+  if (tr && !tr.textContent.trim()) tr.innerHTML = 'Once connected, your agent&rsquo;s calls stream into <strong>Recent requests</strong> below.';
+  document.querySelectorAll('.connect-tabs .tab').forEach(t => t.addEventListener('click', () => selectConnectTab(t.dataset.connectTab)));
+  document.getElementById('connect-panel')?.addEventListener('click', (e) => {
+    const f = e.target.closest('[data-copy-target]');
+    if (f) { copyText(document.getElementById(f.dataset.copyTarget)?.textContent || '', f); return; }
+    const c = e.target.closest('[data-copy-code]');
+    if (c) { copyText(c.parentElement.querySelector('pre')?.innerText || '', c); return; }
+  });
+  const col = document.getElementById('connect-collapsed');
+  col?.addEventListener('click', openConnect);
+  col?.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openConnect(); } });
+  document.getElementById('connect-trigger')?.addEventListener('click', openConnect);
+  document.getElementById('connect-test')?.addEventListener('click', testConnection);
+  bindFlywheel();
+  updateFlywheel();
+}
+
+async function testConnection() {
+  const btn = document.getElementById('connect-test');
+  const out = document.getElementById('connect-test-result');
+  if (!out) return;
+  out.className = 'connect-test-result'; out.textContent = 'Testing…';
+  if (btn) btn.disabled = true;
+  const t0 = performance.now();
+  try {
+    const res = await fetch(connectBaseUrl() + '/chat/completions', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: connectModelId, messages: [{ role: 'user', content: 'Reply with the single word: connected' }], max_tokens: 8, temperature: 0 }),
+    });
+    const ms = Math.round(performance.now() - t0);
+    if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.error?.message || b.detail || `HTTP ${res.status}`); }
+    const data = await res.json();
+    const reply = (data.choices?.[0]?.message?.content || '').trim().slice(0, 40);
+    out.className = 'connect-test-result ok';
+    out.innerHTML = `${icon('check', 'icn-sm')} Connected — <strong>${escapeHtml(connectModelId)}</strong> replied in ${ms} ms${reply ? ' · &ldquo;' + escapeHtml(reply) + '&rdquo;' : ''}`;
+  } catch (e) {
+    out.className = 'connect-test-result err';
+    out.innerHTML = `${icon('warning', 'icn-sm')} ${escapeHtml(e.message || 'Request failed')} — the model may still be loading. See <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener">Troubleshooting</a>.`;
+  } finally { if (btn) btn.disabled = false; }
 }
 
 function setPanelBusy(id, busy) {
@@ -4442,6 +5735,10 @@ function setText(id, value) {
   const el = document.getElementById(id);
   if (el) el.textContent = value;
 }
+function setHtml(id, html) {
+  const el = document.getElementById(id);
+  if (el) el.innerHTML = html;
+}
 
 // --- Health Polling ---
 let lastHealth = null;
@@ -4454,6 +5751,7 @@ async function pollHealth() {
     renderHeader(h);
     renderServerStatus(h);
     renderHeroFromHealth(h);
+    updateFlywheel();
     if (typeof refreshVramDonut === 'function') refreshVramDonut();
   } catch (e) {
     document.getElementById('status-dot').className = 'status-dot offline';
@@ -4496,7 +5794,7 @@ function renderServerStatus(h) {
     vramHtml = `
       <div class="vram-bar-wrap">
         <div class="vram-meta">
-          <span style="font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); font-weight: 600;">GPU VRAM</span>
+          <span style="font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600;">GPU VRAM</span>
           <span class="vram-meta-total"><strong>${fmtGb(total)}</strong> total</span>
         </div>
         <div class="vram-bar">
@@ -4581,9 +5879,9 @@ async function pollDecodePerf() {
       <div style="margin-top: var(--space-3); font-size: var(--text-xs); color: var(--text-muted);">Mean inter-token latency: <span class="tabular-nums" style="color: var(--text-2);">${mean} ms</span></div>`;
     // Hero
     setText('hero-tps', tps);
-    document.getElementById('hero-tps').innerHTML = `${tps}<span class="unit">tok/s</span>`;
+    setHtml('hero-tps', `${tps}<span class="unit">tok/s</span>`);
     setText('hero-tps-sub', `${data.sample_count} samples · ${window}s window`);
-    document.getElementById('hero-itl').innerHTML = `${p50}<span class="unit">/ ${p99} ms</span>`;
+    setHtml('hero-itl', `${p50}<span class="unit">/ ${p99} ms</span>`);
     setText('hero-itl-sub', `mean ${mean} ms`);
     if (typeof refreshDecodeSparkline === 'function') refreshDecodeSparkline();
   } catch (e) {
@@ -4595,6 +5893,10 @@ async function pollDecodePerf() {
 
 // --- Recent Requests ---
 let recentRequestsCache = [];
+// The ids currently shown in Recent requests, in display order, AFTER the active
+// agent/status/text filters. The inspect modal's prev/next steps through THIS —
+// so under "Needs attention" you walk only the problem requests.
+let lastRenderedRequestIds = [];
 
 function fmtRelTime(unixMs) {
   if (!unixMs) return '-';
@@ -4646,28 +5948,98 @@ function apiFailureHtml(action, e, retryFn) {
 }
 
 let recentRequestsFilter = '';
+let recentAgentFilter = 'all';
+// 'all' | 'attention' — the "show me what went wrong" toggle. A pi user lands
+// on the dashboard precisely when something looked off; this isolates the rows
+// worth correcting (errored, truncated, or silently base-served) so they can be
+// opened and dropped into the Corrections basket without scrolling.
+let recentStatusFilter = 'all';
+
+// A request "needs attention" if pi got a degraded result from it: an error, a
+// truncated (max_tokens-clipped) completion, or a silent fallback to the base
+// model while trained adapters exist. These are the rows worth turning into
+// corrections — the same predicate drives the heartbeat's warning states.
+function requestNeedsAttention(r) {
+  if (!r) return false;
+  const f = (r.finish_reason || '').toLowerCase();
+  if (r.error || f === 'error' || f === 'client_disconnect') return true;
+  if (f === 'length') return true;
+  const adapterName = r.adapter || 'base';
+  if (adapterName === 'base' && nonBaseAdapterCount() > 0) return true;
+  return false;
+}
+
+// Map a raw User-Agent to a friendly client identity for per-agent attribution.
+// Best-effort: known agents/SDKs get a clean label; anything else shows its
+// leading token. The raw UA is always available on hover.
+function clientFromUA(ua) {
+  if (!ua) return { key: 'unknown', label: 'unknown' };
+  const s = ua.toLowerCase();
+  if (s.includes('opencode')) return { key: 'opencode', label: 'opencode' };
+  if (/(^|[\/ _-])pi([\/ _-]|$)|pi-agent|earendil/.test(s)) return { key: 'pi', label: 'pi' };
+  if (s.includes('ai-sdk')) return { key: 'opencode', label: 'opencode' };
+  if (s.includes('openai-python') || s.includes('python-openai')) return { key: 'openai-python', label: 'OpenAI Python' };
+  if (s.includes('openai') && (s.includes('node') || s.includes('js') || s.includes('deno') || s.includes('bun'))) return { key: 'openai-js', label: 'OpenAI JS' };
+  if (s.includes('openai')) return { key: 'openai', label: 'OpenAI SDK' };
+  if (s.includes('curl')) return { key: 'curl', label: 'curl' };
+  if (s.includes('httpx') || s.includes('python-requests') || s.includes('aiohttp') || s.startsWith('python')) return { key: 'python', label: 'Python' };
+  if (s.includes('undici') || s.includes('node') || s.includes('bun') || s.includes('deno')) return { key: 'node', label: 'Node' };
+  return { key: 'other', label: (ua.split(/[\/ ]/)[0] || 'client').slice(0, 16) };
+}
+
 function renderRecentRequests(rows) {
   const el = document.getElementById('recent-requests-panel');
   if (!el) return;
   if (!rows || rows.length === 0) {
     el.innerHTML = `<div class="empty">
-      <div style="font-weight:600;color:var(--text);margin-bottom:6px;">No recent requests yet.</div>
-      <div>Recent chat completions will appear here with prompt and completion previews, token counts, finish status, and streaming/error badges.</div>
-      <div style="margin-top:var(--space-2);">Use <strong>Playground</strong> above to create the first entry, or walk through the <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>.</div>
+      <div style="font-weight:600;color:var(--text);margin-bottom:6px;">Waiting for your first agent request.</div>
+      <div style="color:var(--text-3);">Point <strong>pi</strong>, <strong>opencode</strong>, or any OpenAI client at <code>${escapeHtml(connectBaseUrl())}</code> (model <code>${escapeHtml(connectModelId)}</code>) and every chat completion shows up here — prompt &amp; completion previews, tokens, latency, and finish status. That live traffic is the raw material your model learns from.</div>
+      <div style="margin-top:var(--space-3);"><button type="button" class="btn btn-primary btn-sm" onclick="openConnect()">${icon('link','icn-sm')} Connect your agent</button> <button type="button" class="btn btn-sm" onclick="selectPage('playground')">${icon('chat','icn-sm')} Or try the Playground</button></div>
     </div>`;
     return;
   }
-  // Apply the live filter (substring match on prompt preview, completion
-  // preview, and id). Empty filter is a no-op pass-through.
+  // Tag every row with its calling agent so we can both badge it and offer
+  // per-client filter chips — the operator confirms "is opencode getting
+  // through?" in one click.
+  rows.forEach(r => { r._client = clientFromUA(r.user_agent); });
+
+  // Build the agent-filter chips from the clients actually present.
+  const counts = new Map();
+  rows.forEach(r => counts.set(r._client.key, (counts.get(r._client.key) || 0) + 1));
+  const ordered = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const labelFor = k => (rows.find(r => r._client.key === k)?._client.label) || k;
+  if (!counts.has(recentAgentFilter) && recentAgentFilter !== 'all') recentAgentFilter = 'all';
+  const chip = (key, label, n) =>
+    `<button type="button" class="agent-chip${recentAgentFilter === key ? ' active' : ''}" data-agent-chip="${escapeHtml(key)}">${key === 'all' ? '' : icon('terminal')}${escapeHtml(label)}<span class="count">${n}</span></button>`;
+
+  // "Needs attention" toggle — only shown when there's actually something wrong.
+  // It sits with the agent chips but reads as a distinct, warning-tinted pill.
+  const attentionCount = rows.filter(requestNeedsAttention).length;
+  if (recentStatusFilter === 'attention' && attentionCount === 0) recentStatusFilter = 'all';
+  const attentionChip = attentionCount > 0
+    ? `<button type="button" class="agent-chip attn-chip${recentStatusFilter === 'attention' ? ' active' : ''}" data-status-chip="attention" title="Errored, truncated, or served by the base model — the requests worth correcting">${icon('warning')}Needs attention<span class="count">${attentionCount}</span></button>`
+    : '';
+  const chipsInner = (ordered.length > 1 || attentionChip)
+    ? chip('all', 'All agents', rows.length) + ordered.map(([k, n]) => chip(k, labelFor(k), n)).join('') + attentionChip
+    : '';
+  const chipsHtml = chipsInner
+    ? `<div class="agent-chips" role="group" aria-label="Filter requests">${chipsInner}</div>`
+    : '';
+
+  // Apply text filter (prompt/completion/id) + agent filter + status filter together.
   const q = (recentRequestsFilter || '').trim().toLowerCase();
-  const filtered = q
-    ? rows.filter(r =>
-        (r.prompt_preview || '').toLowerCase().includes(q) ||
-        (r.completion_preview || '').toLowerCase().includes(q) ||
-        (r.id || '').toLowerCase().includes(q))
-    : rows;
+  const filtered = rows.filter(r =>
+    (recentAgentFilter === 'all' || r._client.key === recentAgentFilter) &&
+    (recentStatusFilter !== 'attention' || requestNeedsAttention(r)) &&
+    (!q || (r.prompt_preview || '').toLowerCase().includes(q)
+        || (r.completion_preview || '').toLowerCase().includes(q)
+        || (r.id || '').toLowerCase().includes(q)));
+  // Record display order so the inspect modal can step prev/next within the
+  // current filter (e.g. walk only the "Needs attention" rows).
+  lastRenderedRequestIds = filtered.map(r => r.id).filter(Boolean);
   if (filtered.length === 0) {
-    el.innerHTML = `<div class="empty">No requests match <code>${escapeHtml(q)}</code>.</div>`;
+    el.innerHTML = chipsHtml + `<div class="empty">No requests match this filter.</div>`;
+    bindAgentChips(el);
     return;
   }
   const items = filtered.map(r => {
@@ -4675,36 +6047,79 @@ function renderRecentRequests(rows) {
     const finishClass = finish.replace(/[^a-z_]/gi, '_');
     const streamPill = r.streamed ? '<span class="recent-pill streamed">stream</span>' : '';
     const finishPill = `<span class="recent-pill ${finishClass}">${escapeHtml(finish)}</span>`;
+    const agentPill = `<span class="recent-agent" title="${escapeHtml(r.user_agent || 'unknown client')}">${escapeHtml(r._client.label)}</span>`;
+    // Which adapter actually served this request — so a silent fallback to the
+    // base model (your trained LoRA quietly off) is visible per request, not
+    // buried in the inspect modal. Base-while-adapters-exist gets a warning tint.
+    const adapterName = r.adapter || 'base';
+    const baseFallback = adapterName === 'base' && nonBaseAdapterCount() > 0;
+    const adapterPill = `<span class="recent-served${baseFallback ? ' is-base' : ''}" title="${baseFallback ? 'Served by the BASE model — your trained adapters are not being used for this request' : 'Served by ' + escapeHtml(adapterName)}">${baseFallback ? icon('warning', 'icn-sm') : ''}${escapeHtml(adapterName)}</span>`;
     const tokens = `${r.prompt_tokens || 0} → ${r.completion_tokens || 0} tok`;
     const dur = (r.duration_ms != null) ? `${r.duration_ms} ms` : '';
+    const ttft = (r.ttft_ms != null) ? `<span class="recent-ttft tabular-nums" title="Time to first token — the latency pi feels before output starts">${fmtMsShort(r.ttft_ms)} ttft</span>` : '';
     const promptText = r.prompt_preview || '—';
     const completionText = r.completion_preview || '—';
+    const attn = requestNeedsAttention(r);
     return `
-      <li class="recent-row" data-ts="${r.timestamp_unix_ms || 0}" data-id="${escapeHtml(r.id || '')}" tabindex="0" role="button" aria-label="Inspect request ${escapeHtml(shortId(r.id || ''))}">
+      <li class="recent-row${attn ? ' attn' : ''}" data-ts="${r.timestamp_unix_ms || 0}" data-id="${escapeHtml(r.id || '')}" tabindex="0" role="button" aria-label="Inspect request ${escapeHtml(shortId(r.id || ''))} from ${escapeHtml(r._client.label)}${attn ? ' — needs attention' : ''}">
         <div class="recent-time">${fmtRelTime(r.timestamp_unix_ms)}</div>
         <div class="recent-previews">
-          <div class="recent-prompt" title="${escapeHtml(promptText)}">${streamPill}${escapeHtml(promptText)}</div>
+          <div class="recent-prompt" title="${escapeHtml(promptText)}">${agentPill}${adapterPill}${streamPill}${escapeHtml(promptText)}</div>
           <div class="recent-completion" title="${escapeHtml(completionText)}">${escapeHtml(completionText)}</div>
         </div>
         <div class="recent-meta">
-          <span class="recent-tokens">${tokens}</span>
+          <span class="recent-tokens">${tokens}${ttft}</span>
           <span>${finishPill}${dur ? `<span class="tabular-nums">${escapeHtml(dur)}</span>` : ''}</span>
+          ${attn ? `<button type="button" class="recent-correct" data-correct-id="${escapeHtml(r.id || '')}" title="Add this to your Corrections basket — write the fix on the Overview, then train">${icon('flask', 'icn-sm')} Correct</button>` : ''}
         </div>
       </li>
     `;
   }).join('');
-  el.innerHTML = `<ul class="recent-list">${items}</ul>`;
+  el.innerHTML = chipsHtml + `<ul class="recent-list">${items}</ul>`;
+  bindAgentChips(el);
   el.querySelectorAll('.recent-row').forEach(row => {
     const id = row.dataset.id;
     if (!id) return;
     row.addEventListener('click', () => openRequestDrillModal(id));
     row.addEventListener('keydown', (ev) => {
-      if (ev.key === 'Enter' || ev.key === ' ') {
+      // Only the row itself opens the modal — let the inline Correct button
+      // (a focusable child) handle its own Enter/Space.
+      if ((ev.key === 'Enter' || ev.key === ' ') && ev.target === row) {
         ev.preventDefault();
         openRequestDrillModal(id);
       }
     });
   });
+  // Inline one-click capture for the rows worth correcting — sweep the whole
+  // "Needs attention" column into the basket without opening each modal.
+  el.querySelectorAll('[data-correct-id]').forEach(btn => {
+    btn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const r = findRecentRequest(btn.dataset.correctId);
+      if (!r) return;
+      const added = window.addCorrectionFromRequest(r);
+      if (added) {
+        const orig = btn.innerHTML;
+        btn.classList.add('is-added'); btn.disabled = true;
+        btn.innerHTML = `${icon('check', 'icn-sm')} Added`;
+        setTimeout(() => { btn.innerHTML = orig; btn.classList.remove('is-added'); btn.disabled = false; }, 1100);
+      }
+    });
+  });
+}
+
+function bindAgentChips(el) {
+  el.querySelectorAll('[data-agent-chip]').forEach(c => c.addEventListener('click', () => {
+    recentAgentFilter = c.dataset.agentChip;
+    lastRecentRequestsKey = null; // force re-render
+    renderRecentRequests(recentRequestsCache);
+  }));
+  el.querySelectorAll('[data-status-chip]').forEach(c => c.addEventListener('click', () => {
+    // Toggle the attention filter off when re-clicking the active chip.
+    recentStatusFilter = (recentStatusFilter === 'attention') ? 'all' : 'attention';
+    lastRecentRequestsKey = null; // force re-render
+    renderRecentRequests(recentRequestsCache);
+  }));
 }
 
 /* ---------------------------------------------------------------------
@@ -4741,6 +6156,7 @@ function openRequestDrillModal(id) {
     modal.hidden = false;
     modal.dataset.requestId = id;
     document.body.style.overflow = 'hidden';
+    updateRequestDrillNav(id);
     return;
   }
   // Strip the API-style `chatcmpl-` prefix so the shortened id is the
@@ -4750,6 +6166,7 @@ function openRequestDrillModal(id) {
   titleEl.textContent = `Request ${trimmedId.slice(0, 8) || 'unknown'}`;
   const pieces = [];
   pieces.push(escapeHtml(r.model || '—'));
+  if (r.user_agent) pieces.push(`via <strong>${escapeHtml(clientFromUA(r.user_agent).label)}</strong>`);
   if (r.adapter) pieces.push(`adapter <code>${escapeHtml(r.adapter)}</code>`);
   pieces.push(r.streamed ? 'streamed' : 'unary');
   metaEl.innerHTML = pieces.join(' · ');
@@ -4775,9 +6192,32 @@ function openRequestDrillModal(id) {
   const errBlock = r.error
     ? `<div class="req-section req-error"><div class="req-section-head">Error</div><pre class="req-pre">${escapeHtml(r.error)}</pre></div>`
     : '';
+  // Latency breakdown — the experience pi actually felt: the wait for the first
+  // token (TTFT), then how fast the rest streamed. Only meaningful when we have
+  // both a TTFT and a total duration (i.e. a streamed completion).
+  let latencyHtml = '';
+  if (r.ttft_ms != null && r.duration_ms != null && r.duration_ms >= r.ttft_ms) {
+    const total = r.duration_ms, ttft = r.ttft_ms, decode = Math.max(0, total - ttft);
+    const ttftPct = total > 0 ? (ttft / total * 100) : 0;
+    const tps = (r.completion_tokens && decode > 0) ? (r.completion_tokens / (decode / 1000)).toFixed(0) : null;
+    latencyHtml = `
+      <div class="req-section">
+        <div class="req-section-head">Latency pi felt</div>
+        <div class="lat-bar" role="img" aria-label="Time to first token ${fmtMsShort(ttft)}, then ${fmtMsShort(decode)} streaming ${r.completion_tokens || 0} tokens, ${fmtMsShort(total)} total">
+          <div class="lat-seg lat-ttft" style="width:${ttftPct.toFixed(1)}%" title="Time to first token (${fmtMsShort(ttft)}) — the wait pi feels before any output"></div>
+          <div class="lat-seg lat-decode" style="width:${(100 - ttftPct).toFixed(1)}%" title="Streaming the response (${fmtMsShort(decode)}${tps ? ', ' + tps + ' tok/s' : ''})"></div>
+        </div>
+        <div class="lat-legend">
+          <span><span class="lat-key lat-ttft"></span>first token in <strong>${fmtMsShort(ttft)}</strong></span>
+          <span><span class="lat-key lat-decode"></span>${r.completion_tokens || 0} tokens in <strong>${fmtMsShort(decode)}</strong>${tps ? ' · ' + tps + ' tok/s' : ''}</span>
+          <span class="lat-total">total <strong>${fmtMsShort(total)}</strong></span>
+        </div>
+      </div>`;
+  }
   content.innerHTML = `
     <div class="req-detail">
       <div class="req-stats">${statRow}</div>
+      ${latencyHtml}
       ${errBlock}
       <div class="req-section">
         <div class="req-section-head">Prompt
@@ -4794,6 +6234,7 @@ function openRequestDrillModal(id) {
       <div class="req-section req-meta">
         <div class="req-section-head">Identity</div>
         <div class="req-stat"><span class="req-stat-k">Request id</span><span class="req-stat-v"><code>${escapeHtml(r.id || '')}</code></span></div>
+        ${r.user_agent ? `<div class="req-stat"><span class="req-stat-k">Client</span><span class="req-stat-v"><code>${escapeHtml(r.user_agent)}</code></span></div>` : ''}
       </div>
     </div>`;
   content.querySelectorAll('button[data-copy]').forEach(btn => {
@@ -4807,6 +6248,34 @@ function openRequestDrillModal(id) {
   modal.hidden = false;
   modal.dataset.requestId = id;
   document.body.style.overflow = 'hidden';
+  updateRequestDrillNav(id);
+}
+
+// Prev/next walk the CURRENT filtered Recent-requests order, so triaging under
+// "Needs attention" steps through only the problem requests. Hidden when there's
+// nothing to step through (single result or the row isn't in the current view).
+function updateRequestDrillNav(id) {
+  const nav = document.getElementById('request-drill-nav');
+  const pos = document.getElementById('request-drill-pos');
+  const prev = document.getElementById('request-drill-prev');
+  const next = document.getElementById('request-drill-next');
+  const ids = lastRenderedRequestIds || [];
+  const idx = ids.indexOf(id);
+  const has = idx >= 0 && ids.length > 1;
+  if (nav) nav.style.display = has ? '' : 'none';
+  if (!has) return;
+  if (pos) pos.textContent = `${idx + 1} / ${ids.length}`;
+  if (prev) prev.disabled = idx <= 0;
+  if (next) next.disabled = idx >= ids.length - 1;
+}
+function navigateRequestDrill(dir) {
+  const modal = document.getElementById('request-drill-modal');
+  if (!modal || modal.hidden) return;
+  const ids = lastRenderedRequestIds || [];
+  const idx = ids.indexOf(modal.dataset.requestId || '');
+  const ni = idx + dir;
+  if (idx < 0 || ni < 0 || ni >= ids.length) return;
+  openRequestDrillModal(ids[ni]);
 }
 
 function closeRequestDrillModal() {
@@ -4817,11 +6286,43 @@ function closeRequestDrillModal() {
   document.body.style.overflow = '';
 }
 
+// Load the Playground in compare mode with a prompt and a before/after adapter
+// pair, ready to Send. Used by the drill modal's "Verify A/B" to prove a fix.
+// Tolerant of adapters not present in the selectors (falls back to base).
+function setupCompareReplay(prompt, adapterA, adapterB) {
+  const input = document.getElementById('chat-input');
+  if (input) {
+    input.value = prompt || '';
+    if (typeof autoresizeChatInput === 'function') autoresizeChatInput();
+    if (typeof updateChatSendState === 'function') updateChatSendState();
+  }
+  // Turn compare mode on via the toggle so its change-handler wires up the B
+  // selector + the side-by-side panel exactly as a manual toggle would.
+  const toggle = document.getElementById('chat-compare-toggle');
+  if (toggle && !toggle.checked) { toggle.checked = true; toggle.dispatchEvent(new Event('change', { bubbles: true })); }
+  const setSel = (id, val) => {
+    const sel = document.getElementById(id);
+    if (!sel) return;
+    sel.value = Array.from(sel.options).some(o => o.value === val) ? val : '';
+  };
+  setSel('chat-adapter', adapterA || '');
+  setSel('chat-adapter-b', adapterB || '');
+  const aName = adapterA || 'base', bName = adapterB || 'base';
+  if (aName === bName) {
+    toast(`Loaded for A/B — pick a second adapter to compare against ${aName}, then Send`, 'info');
+  } else {
+    toast(`Loaded A/B: ${aName} vs ${bName} — press Send to see if the swap helped`, 'ok');
+  }
+  if (input) setTimeout(() => input.focus(), 60);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('request-drill-close')?.addEventListener('click', closeRequestDrillModal);
   document.getElementById('request-drill-modal')?.addEventListener('click', (ev) => {
     if (ev.target.id === 'request-drill-modal') closeRequestDrillModal();
   });
+  document.getElementById('request-drill-prev')?.addEventListener('click', () => navigateRequestDrill(-1));
+  document.getElementById('request-drill-next')?.addEventListener('click', () => navigateRequestDrill(1));
   document.getElementById('request-drill-copy-id')?.addEventListener('click', () => {
     const modal = document.getElementById('request-drill-modal');
     const id = modal?.dataset.requestId || '';
@@ -4865,11 +6366,51 @@ document.addEventListener('DOMContentLoaded', () => {
     if (playgroundTab) playgroundTab.click();
     if (input) setTimeout(() => input.focus(), 50);
   });
-  document.addEventListener('keydown', (ev) => {
-    if (ev.key === 'Escape') {
-      const m = document.getElementById('request-drill-modal');
-      if (m && !m.hidden) closeRequestDrillModal();
+  // Verify A/B — close the flywheel loop. Re-run this exact prompt in the
+  // Playground's compare mode, side A = whatever served it (the "before"),
+  // side B = the currently active adapter (the "after" you hot-swapped in).
+  // This is the "did the swap actually help?" proof the loop was missing.
+  document.getElementById('request-drill-verify')?.addEventListener('click', () => {
+    const modal = document.getElementById('request-drill-modal');
+    const r = findRecentRequest(modal?.dataset.requestId || '');
+    if (!r) return;
+    const prompt = r.prompt_full || r.prompt_preview || '';
+    const before = r.adapter || '';                              // '' = base
+    const after = (lastHealth && lastHealth.active_adapter) || ''; // current hot-swapped adapter
+    closeRequestDrillModal();
+    selectPage('playground');
+    setTimeout(() => setupCompareReplay(prompt, before, after), 60);
+  });
+  // Use-as-correction — the literal flywheel hinge. Append this captured
+  // request to the Corrections basket on the Overview (it persists across
+  // reloads and accumulates over a coding session). The modal stays open so
+  // the operator can flick through Recent requests and grab several bad
+  // answers in a row; a brief "Added ✓" pulse confirms each capture.
+  document.getElementById('request-drill-correct')?.addEventListener('click', () => {
+    const modal = document.getElementById('request-drill-modal');
+    const id = modal?.dataset.requestId || '';
+    const r = findRecentRequest(id);
+    if (!r) return;
+    const btn = document.getElementById('request-drill-correct');
+    const added = addCorrectionFromRequest(r);
+    if (btn && added) {
+      const orig = btn.innerHTML;
+      btn.classList.add('is-added');
+      btn.innerHTML = `${icon('check', 'icn-sm')} Added`;
+      btn.disabled = true;
+      setTimeout(() => { btn.innerHTML = orig; btn.classList.remove('is-added'); btn.disabled = false; }, 1100);
     }
+  });
+  document.addEventListener('keydown', (ev) => {
+    const m = document.getElementById('request-drill-modal');
+    if (!m || m.hidden) return;
+    if (ev.key === 'Escape') { closeRequestDrillModal(); return; }
+    // Arrow-key triage through the filtered list — but not while typing in the
+    // "Use as correction" editor or any field.
+    const typing = /^(INPUT|TEXTAREA|SELECT)$/.test((ev.target.tagName || '')) || ev.target.isContentEditable;
+    if (typing) return;
+    if (ev.key === 'ArrowLeft') { ev.preventDefault(); navigateRequestDrill(-1); }
+    else if (ev.key === 'ArrowRight') { ev.preventDefault(); navigateRequestDrill(1); }
   });
 });
 
@@ -4938,6 +6479,9 @@ async function pollRecentRequests() {
   try {
     const data = await api('/v1/stats/recent-requests');
     recentRequestsCache = Array.isArray(data) ? data : [];
+    updateConnectSummary(recentRequestsCache);
+    updateFlywheel();
+    refreshRequestHealth();
     const key = recentRequestsCache
       .map(r => `${r.timestamp_unix_ms || r.id || ''}:${r.completion_tokens || 0}`)
       .join('|');
@@ -5409,18 +6953,19 @@ async function pollTraining() {
     }
     const liveCount = (data.running ? 1 : 0) + (data.queued ? data.queued.length : 0);
     setText('training-count', String(liveCount));
+    updateFlywheel();
     if (data.running) {
       const j = data.running;
       const pct = ((j.progress || 0) * 100).toFixed(0);
       const lossLabel = j.current_loss != null ? ` · loss ${j.current_loss.toFixed(3)}` : '';
       const adapterLabel = j.adapter_name ? ` ${j.adapter_name}` : '';
       setText('hero-training', `${pct}%`);
-      document.getElementById('hero-training').innerHTML = `${pct}<span class="unit">%</span>`;
+      setHtml('hero-training', `${pct}<span class="unit">%</span>`);
       setText('hero-training-sub', `${j.job_type || 'job'}${adapterLabel}${lossLabel}`);
     } else if ((data.queued || []).length > 0) {
       const q = data.queued[0];
       setText('hero-training', String(data.queued.length));
-      document.getElementById('hero-training').innerHTML = `${data.queued.length}<span class="unit">queued</span>`;
+      setHtml('hero-training', `${data.queued.length}<span class="unit">queued</span>`);
       setText('hero-training-sub', `Next: ${q.adapter_name || q.job_id}`);
     } else if (data.completed && data.completed.length > 0) {
       // When the queue is empty but archived jobs exist, surface the most
@@ -5432,11 +6977,11 @@ async function pollTraining() {
       const lastState = (last.state || 'completed').toString().toLowerCase();
       const when = last.finished_unix_ms || last.submitted_unix_ms;
       setText('hero-training', 'idle');
-      document.getElementById('hero-training').innerHTML = `${data.completed.length}<span class="unit">recent</span>`;
+      setHtml('hero-training', `${data.completed.length}<span class="unit">recent</span>`);
       setText('hero-training-sub', `Last ${lastState}: ${last.adapter_name || last.job_id} · loss ${lastLoss}${when ? ' · ' + fmtSmartTime(when) : ''}`);
     } else {
       setText('hero-training', 'idle');
-      document.getElementById('hero-training').textContent = 'idle';
+      setText('hero-training', 'idle');
       setText('hero-training-sub', 'Submit SFT or GRPO to begin');
     }
   } catch (e) {
@@ -5517,7 +7062,7 @@ function renderTrainingQueue(data) {
 
   if (!data.running && (!data.queued || !data.queued.length) && (!data.completed || !data.completed.length)) {
     html = `<div class="eval-empty empty">
-      <div class="eval-empty-icon">🧪</div>
+      <div class="eval-empty-icon"><svg class="icn"><use href="#i-flask"></use></svg></div>
       <div class="eval-empty-title">No training jobs yet.</div>
       <div class="eval-empty-body">Submit SFT examples to teach a correction, or use GRPO for scored completions. Datasets uploaded under Evals can be picked directly in the SFT/GRPO submit forms. New here? Read the <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener">Quickstart</a> or the <a href="https://ericflo.github.io/kiln/grpo.html" target="_blank" rel="noopener">GRPO Guide</a>.</div>
       <button class="eval-empty-cta" type="button" onclick="document.getElementById('training-tab-sft').click();">Submit SFT</button>
@@ -5559,7 +7104,10 @@ function renderTrainingCard(j, state) {
   // for this job — populated by openTrainDrillModal). We just leave a
   // placeholder for now.
   const isRunning = state === 'running';
-  const cardClass = isRunning ? 'training-card training-card-running' : 'training-card';
+  // State class drives the amber rule: only a RUNNING job's bar is hot (amber);
+  // completed → green, failed → red, queued → neutral.
+  const stateClass = isRunning ? 'training-card-running' : 'training-card-' + (j.state || state || 'done').toString().toLowerCase();
+  const cardClass = 'training-card ' + stateClass;
   let stateBadge;
   if (state === 'queued') {
     stateBadge = `<span class="job-state-pill queued">queued${j.position ? ' · #'+j.position : ''}</span>`;
@@ -6477,14 +8025,14 @@ function renderAssistantBubble(m) {
       const title = m.finishReason === 'length'
         ? 'Response was cut off — increase Max tokens to let the model finish.'
         : `Generation ended with finish_reason=${m.finishReason}.`;
-      stats.push(`<span class="${cls}" title="${escapeHtml(title)}"><strong>⚠</strong> ${escapeHtml(kind)}</span>`);
+      stats.push(`<span class="${cls}" title="${escapeHtml(title)}">${icon('warning','icn-sm')} ${escapeHtml(kind)}</span>`);
     }
     stats.push(`<span class="spacer"></span>`);
     if (!m.pending && m.error) {
-      stats.push(`<button class="turn-btn" type="button" data-chat-action="regenerate" data-chat-id="${escapeHtml(m._id)}" title="Retry this request">↻ retry</button>`);
+      stats.push(`<button class="turn-btn" type="button" data-chat-action="regenerate" data-chat-id="${escapeHtml(m._id)}" title="Retry this request"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> retry</button>`);
     } else if (!m.pending && hasContent) {
-      stats.push(`<button class="turn-btn" type="button" data-chat-action="copy" data-chat-id="${escapeHtml(m._id)}" title="Copy assistant answer">⧉ copy</button>`);
-      stats.push(`<button class="turn-btn" type="button" data-chat-action="regenerate" data-chat-id="${escapeHtml(m._id)}" title="Regenerate this response">↻ regenerate</button>`);
+      stats.push(`<button class="turn-btn" type="button" data-chat-action="copy" data-chat-id="${escapeHtml(m._id)}" title="Copy assistant answer"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> copy</button>`);
+      stats.push(`<button class="turn-btn" type="button" data-chat-action="regenerate" data-chat-id="${escapeHtml(m._id)}" title="Regenerate this response"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> regenerate</button>`);
     } else if (m.pending) {
       stats.push(`<button class="turn-btn" type="button" data-chat-action="stop" title="Stop generation">■ stop</button>`);
     }
@@ -6591,7 +8139,7 @@ function renderChat() {
       return `<div class="chat-msg user${m._editing ? ' editing' : ''}">
         <div class="role">user</div>
         <pre>${escapeHtml(m.content)}</pre>
-        <button class="user-edit-btn" type="button" data-chat-action="edit" data-chat-id="${escapeHtml(m._id)}" title="Edit and resend">✎</button>
+        <button class="user-edit-btn" type="button" data-chat-action="edit" data-chat-id="${escapeHtml(m._id)}" title="Edit and resend"><svg class="icn icn-sm"><use href="#i-pencil"></use></svg></button>
         <div class="user-edit-area">
           <textarea class="user-edit-input">${escapeHtml(m.content)}</textarea>
           <div class="user-edit-actions">
@@ -7385,7 +8933,7 @@ async function refreshDatasets() {
     if (!datasets.length) {
       el.className = 'eval-empty';
       el.innerHTML = `
-        <div class="eval-empty-icon">📂</div>
+        <div class="eval-empty-icon"><svg class="icn"><use href="#i-folder"></use></svg></div>
         <div class="eval-empty-title">No datasets yet</div>
         <div class="eval-empty-body">Upload an SFT JSONL above and Kiln will let you preview, sample, and synthesize an eval suite from it in seconds.</div>
         <button class="eval-empty-cta" type="button" onclick="document.getElementById('dataset-name').focus()">Upload your first dataset</button>`;
@@ -7616,7 +9164,7 @@ async function refreshSuites() {
     if (!suites.length) {
       el.className = 'eval-empty';
       el.innerHTML = `
-        <div class="eval-empty-icon">🎯</div>
+        <div class="eval-empty-icon"><svg class="icn"><use href="#i-target"></use></svg></div>
         <div class="eval-empty-title">No eval suites yet</div>
         <div class="eval-empty-body">A suite is a named collection of (prompt, target, scorer) triplets. Synthesize one from a dataset, or POST an EvalSuite document to <code>/v1/eval/suites</code>.</div>
         <button class="eval-empty-cta" type="button" onclick="document.getElementById('evals-tab-datasets').click()">Browse datasets</button>`;
@@ -7705,7 +9253,7 @@ async function openSuitePreview(name) {
       <div class="modal-head">
         <h2 id="suite-preview-title">Suite preview</h2>
         <span class="modal-meta" id="suite-preview-meta"></span>
-        <button class="modal-close" id="suite-preview-close" aria-label="Close">×</button>
+        <button class="modal-close" id="suite-preview-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>
       <div class="modal-body" style="grid-template-columns: 1fr;">
         <div class="modal-content" id="suite-preview-content"><div class="detail-empty">Loading…</div></div>
@@ -7743,7 +9291,7 @@ async function openSuitePreview(name) {
     }
     const rows = preview.map((ex, i) => {
       const msgs = (ex.messages || [])
-        .map(m => `<div style="margin-bottom:4px;"><span class="role ${escapeHtml(m.role)}" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em; color:var(--text-muted); margin-right:6px;">${escapeHtml(m.role)}</span><span style="white-space:pre-wrap; font-family:var(--font-mono); font-size:12px;">${escapeHtml(truncate(m.content || '', 600))}</span></div>`)
+        .map(m => `<div style="margin-bottom:4px;"><span class="role ${escapeHtml(m.role)}" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps); color:var(--text-muted); margin-right:6px;">${escapeHtml(m.role)}</span><span style="white-space:pre-wrap; font-family:var(--font-mono); font-size:12px;">${escapeHtml(truncate(m.content || '', 600))}</span></div>`)
         .join('');
       const target = ex.target != null
         ? `<div style="margin-top:6px;"><span class="hint" style="font-size:11px;">target:</span> <code style="font-family:var(--font-mono); font-size:12px;">${escapeHtml(truncate(String(ex.target), 200))}</code></div>`
@@ -7789,6 +9337,9 @@ async function refreshEvalJobs() {
     const d = await api('/v1/eval/jobs');
     const jobs = d.jobs || [];
     evalJobsCache = jobs;
+    // Adapter cards show each adapter's latest eval score — refresh them now that
+    // eval results changed (the dedup key includes the completed-eval signature).
+    if (typeof refreshAdapterCards === 'function') refreshAdapterCards();
     // Header badge counts active jobs (queued + running), mirroring the
     // training badge — total job history is shown inside the tab so the
     // badge should signal "needs attention now", not "lifetime count".
@@ -7817,7 +9368,7 @@ async function refreshEvalJobs() {
     if (!jobs.length) {
       el.className = 'eval-empty';
       el.innerHTML = `
-        <div class="eval-empty-icon">📊</div>
+        <div class="eval-empty-icon"><svg class="icn"><use href="#i-chart"></use></svg></div>
         <div class="eval-empty-title">No eval jobs yet</div>
         <div class="eval-empty-body">Run a suite from the Suites tab. Jobs land here as they complete; click any job to drill into the per-example outcomes.</div>
         <button class="eval-empty-cta" type="button" onclick="document.getElementById('evals-tab-suites').click()">Browse suites</button>`;
@@ -7837,10 +9388,34 @@ async function refreshEvalJobs() {
   }
 }
 
+// The flywheel's headline answer: did the adapter beat base, and by how much?
+// Reads the per-run accuracies (base run keyed by adapter==null) and renders the
+// existing-but-unused .delta-badge so the verdict isn't left as mental math.
+function compareVerdictBadge(runs) {
+  if (!Array.isArray(runs) || runs.length < 2) return '';
+  const base = runs.find(r => r.adapter == null || r.adapter === 'base');
+  const cand = runs.filter(r => r.adapter != null && r.adapter !== 'base' && typeof r.metrics?.accuracy === 'number');
+  if (!base || typeof base.metrics?.accuracy !== 'number' || !cand.length) return '';
+  const adapter = cand.reduce((a, b) => (b.metrics.accuracy > a.metrics.accuracy ? b : a));
+  const delta = Math.round((adapter.metrics.accuracy - base.metrics.accuracy) * 1000) / 10; // pts
+  const cls = delta > 0.5 ? 'delta-up' : (delta < -0.5 ? 'delta-down' : 'delta-flat');
+  const label = cls === 'delta-flat' ? 'matches base' : `${delta > 0 ? '+' : ''}${delta.toFixed(1)} pts vs base`;
+  const title = `${escapeHtml(adapter.adapter)} ${(adapter.metrics.accuracy * 100).toFixed(0)}% vs base ${(base.metrics.accuracy * 100).toFixed(0)}%`;
+  return `<span class="delta-badge ${cls}" title="${title}">${label}</span>`;
+}
+
+// Non-completed jobs have no score — show a state figure, never a giant "0"
+// (which reads as "lost to base" and obscures the actual win answer).
+function jobStateFigure(stateClass) {
+  const g = stateClass === 'running' ? 'activity' : stateClass === 'queued' ? 'play' : stateClass === 'failed' ? 'warning' : 'activity';
+  return `<span class="job-statefig ${stateClass}" aria-hidden="true">${icon(g)}</span>`;
+}
+
 function renderJobCard(j) {
   const acc = j.headline_accuracy;
   const adapters = (j.adapters || []).map(a => a == null ? '<span class="hint">base</span>' : escapeHtml(a)).join(' vs ');
   const stateClass = (j.state || 'queued').toLowerCase();
+  const showRing = stateClass === 'completed' && typeof acc === 'number' && isFinite(acc);
   const progress = j.progress || {};
   const progFrac = progress.examples_total > 0 ? progress.examples_completed / progress.examples_total : 0;
   const isRunning = stateClass === 'running' || stateClass === 'queued';
@@ -7875,13 +9450,14 @@ function renderJobCard(j) {
         <span class="hint" style="font-size:10px;">(${r.metrics.num_pass}/${r.metrics.num_examples})</span>
       </span>`;
     }).join('');
-    progressOrCounts = `<div style="margin-top:6px;">${runsHtml}</div>`;
+    const verdict = compareVerdictBadge(j.finished_runs);
+    progressOrCounts = `<div style="margin-top:6px; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">${runsHtml}${verdict}</div>`;
   } else if (j.error) {
     progressOrCounts = `<div class="hint" style="color:var(--danger-fg); margin-top:4px;">${escapeHtml(j.error)}</div>`;
   }
 
   return `<div class="job-card" data-job-id="${escapeHtml(j.job_id)}">
-    ${ringHtml(acc, 'large')}
+    ${showRing ? ringHtml(acc, 'large') : jobStateFigure(stateClass)}
     <div class="job-card-meta">
       <div class="job-card-suite">${escapeHtml(j.suite_name)}</div>
       <div class="job-card-sub">
@@ -8022,7 +9598,7 @@ function renderDrillModal(preserveSelection) {
   const cancelBtn = document.getElementById('drill-cancel');
   if (cancelBtn) {
     cancelBtn.hidden = false;
-    cancelBtn.textContent = isActive ? '⏹ Cancel' : '🗑 Delete';
+    cancelBtn.innerHTML = isActive ? icon('stop','icn-sm') + ' Cancel' : icon('trash','icn-sm') + ' Delete';
     cancelBtn.title = isActive
       ? 'Cancel this eval job (queued or running)'
       : 'Permanently delete this terminal job from memory and the on-disk archive';
@@ -8075,7 +9651,8 @@ function renderDrillModal(preserveSelection) {
   if (isCompare && runs.length >= 2) {
     compareEl.hidden = false;
     const total = (run.metrics?.num_examples || 1);
-    compareEl.innerHTML = '<div class="eval-section-head" style="background:transparent; border:none; padding:0 0 4px 0;">Adapter comparison</div>' +
+    const verdictBadge = compareVerdictBadge(runs);
+    compareEl.innerHTML = `<div class="eval-section-head" style="background:transparent; border:none; padding:0 0 4px 0; display:flex; align-items:center; gap:10px;">Adapter comparison${verdictBadge}</div>` +
       runs.map((r, i) => {
         const rm = r.metrics || {};
         const tot = Math.max(1, rm.num_examples || total);
@@ -8267,9 +9844,9 @@ function renderOutcomeDetail(o) {
     ? (example.messages.filter(m => m.role === 'user').pop()?.content || '')
     : '';
   const actionsHtml = `<div class="outcome-actions" style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:6px;">
-    <button type="button" class="btn btn-sm" data-outcome-copy="completion" title="Copy the model's output">⧉ Copy output</button>
-    ${promptForReplay ? `<button type="button" class="btn btn-sm" data-outcome-copy="prompt" title="Copy the full prompt as role-prefixed text">⧉ Copy prompt</button>` : ''}
-    ${userMsg ? `<button type="button" class="btn btn-sm" data-outcome-replay="1" title="Drop the last user message into the playground so you can iterate">▶ Replay in playground</button>` : ''}
+    <button type="button" class="btn btn-sm" data-outcome-copy="completion" title="Copy the model's output"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> Copy output</button>
+    ${promptForReplay ? `<button type="button" class="btn btn-sm" data-outcome-copy="prompt" title="Copy the full prompt as role-prefixed text"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> Copy prompt</button>` : ''}
+    ${userMsg ? `<button type="button" class="btn btn-sm" data-outcome-replay="1" title="Drop the last user message into the playground so you can iterate"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-chat"></use></svg> Replay in playground</button>` : ''}
   </div>`;
   detail.innerHTML = `
     <div class="detail-section">
@@ -8410,7 +9987,7 @@ async function refreshJudgments() {
     if (!items.length) {
       el.className = 'eval-empty';
       el.innerHTML = `
-        <div class="eval-empty-icon">⚖️</div>
+        <div class="eval-empty-icon"><svg class="icn"><use href="#i-scale"></use></svg></div>
         <div class="eval-empty-title">No judgment datasets yet</div>
         <div class="eval-empty-body">Create a dataset, then judge model outputs A/B/Tie. After ~20 picks you can compile them into SFT data and train a local judge LoRA — no frontier LLM in the loop.</div>
         <button class="eval-empty-cta" type="button" onclick="document.getElementById('judgment-create-name').focus()">Create your first dataset</button>`;
@@ -8620,9 +10197,9 @@ async function generateJudgmentPair() {
     streamCompletion('b', bBody),
   ]);
   if (a.status === 'fulfilled') pendingJudgmentPair.response_a = a.value;
-  else document.getElementById('judgment-a-text').textContent = '⚠ ' + (a.reason?.message || 'failed');
+  else document.getElementById('judgment-a-text').innerHTML = icon('warning','icn-sm') + ' ' + escapeHtml(a.reason?.message || 'failed');
   if (b.status === 'fulfilled') pendingJudgmentPair.response_b = b.value;
-  else document.getElementById('judgment-b-text').textContent = '⚠ ' + (b.reason?.message || 'failed');
+  else document.getElementById('judgment-b-text').innerHTML = icon('warning','icn-sm') + ' ' + escapeHtml(b.reason?.message || 'failed');
 }
 
 document.getElementById('judgment-generate-btn')?.addEventListener('click', () => generateJudgmentPair());
@@ -8727,7 +10304,7 @@ document.getElementById('compile-btn')?.addEventListener('click', async () => {
     });
     document.getElementById('compile-output').innerHTML =
       `<div style="padding:10px; background:var(--success-bg); border:1px solid var(--success-bd); border-radius:6px; color:var(--success-fg); font-size:12px;">
-        ✓ Compiled <strong>${res.rows}</strong> judgments into SFT dataset <code>${escapeHtml(res.dataset.name)}</code> (${res.dataset.num_rows} rows). Train a judge LoRA via the Training tab using this dataset.
+        ${icon('check','icn-sm')} Compiled <strong>${res.rows}</strong> judgments into SFT dataset <code>${escapeHtml(res.dataset.name)}</code> (${res.dataset.num_rows} rows). Train a judge LoRA via the Training tab using this dataset.
       </div>`;
     toast('Compiled to SFT', 'ok');
     refreshDatasets();
@@ -8819,21 +10396,22 @@ function closeCmdk() {
 function buildCmdkIndex() {
   const items = [];
   // Navigation
-  items.push({ kind: 'nav', icon: '🏠', title: 'Overview',   sub: 'Live stats, recent requests, quick actions', action: () => selectPage('overview') });
-  items.push({ kind: 'nav', icon: '🧬', title: 'Adapters',   sub: 'Saved LoRAs, upload, merge', action: () => selectPage('adapters') });
-  items.push({ kind: 'nav', icon: '🧪', title: 'Training',   sub: 'SFT/GRPO queue + submit', action: () => selectPage('training') });
-  items.push({ kind: 'nav', icon: '📊', title: 'Evals',      sub: 'Datasets, suites, jobs, judgments', action: () => selectPage('evals') });
-  items.push({ kind: 'nav', icon: '💬', title: 'Playground', sub: 'Quick inference + A/B compare', action: () => selectPage('playground') });
+  items.push({ kind: 'nav', icon: icon('home'), title: 'Overview',   sub: 'Live stats, recent requests, quick actions', action: () => selectPage('overview') });
+  items.push({ kind: 'nav', icon: icon('layers'), title: 'Adapters',   sub: 'Saved LoRAs, upload, merge', action: () => selectPage('adapters') });
+  items.push({ kind: 'nav', icon: icon('flask'), title: 'Training',   sub: 'SFT/GRPO queue + submit', action: () => selectPage('training') });
+  items.push({ kind: 'nav', icon: icon('chart'), title: 'Evals',      sub: 'Datasets, suites, jobs, judgments', action: () => selectPage('evals') });
+  items.push({ kind: 'nav', icon: icon('chat'), title: 'Playground', sub: 'Quick inference + A/B compare', action: () => selectPage('playground') });
   // Actions
-  items.push({ kind: 'action', icon: '＋', title: 'Run a new eval',   sub: 'Submit a suite against an adapter', action: () => { selectPage('evals'); document.getElementById('evals-tab-suites')?.click(); } });
-  items.push({ kind: 'action', icon: '＋', title: 'Train a new SFT adapter', sub: 'Open the SFT submit form', action: () => { selectPage('training'); document.getElementById('training-tab-sft')?.click(); } });
-  items.push({ kind: 'action', icon: '＋', title: 'Train a new GRPO adapter', sub: 'Open the GRPO submit form', action: () => { selectPage('training'); document.getElementById('training-tab-grpo')?.click(); } });
-  items.push({ kind: 'action', icon: '＋', title: 'Upload a dataset', sub: 'Drop an SFT JSONL', action: () => { selectPage('evals'); document.getElementById('evals-tab-datasets')?.click(); document.getElementById('dataset-name')?.focus(); } });
-  items.push({ kind: 'action', icon: '＋', title: 'Create judgment dataset', sub: 'Start the A/B flywheel', action: () => { selectPage('evals'); document.getElementById('evals-tab-judgments')?.click(); document.getElementById('judgment-create-name')?.focus(); } });
+  items.push({ kind: 'action', icon: icon('link'), title: 'Connect your agent', sub: 'Base URL, model id, pi / opencode setup, test connection', action: () => openConnect() });
+  items.push({ kind: 'action', icon: icon('plus'), title: 'Run a new eval',   sub: 'Submit a suite against an adapter', action: () => { selectPage('evals'); document.getElementById('evals-tab-suites')?.click(); } });
+  items.push({ kind: 'action', icon: icon('plus'), title: 'Train a new SFT adapter', sub: 'Open the SFT submit form', action: () => { selectPage('training'); document.getElementById('training-tab-sft')?.click(); } });
+  items.push({ kind: 'action', icon: icon('plus'), title: 'Train a new GRPO adapter', sub: 'Open the GRPO submit form', action: () => { selectPage('training'); document.getElementById('training-tab-grpo')?.click(); } });
+  items.push({ kind: 'action', icon: icon('plus'), title: 'Upload a dataset', sub: 'Drop an SFT JSONL', action: () => { selectPage('evals'); document.getElementById('evals-tab-datasets')?.click(); document.getElementById('dataset-name')?.focus(); } });
+  items.push({ kind: 'action', icon: icon('plus'), title: 'Create judgment dataset', sub: 'Start the A/B flywheel', action: () => { selectPage('evals'); document.getElementById('evals-tab-judgments')?.click(); document.getElementById('judgment-create-name')?.focus(); } });
   // Adapters
   for (const name of evalAdaptersCache) {
     items.push({
-      kind: 'adapter', icon: '🧬',
+      kind: 'adapter', icon: icon('layers'),
       title: name,
       sub: name === evalActiveAdapter ? 'Adapter · ACTIVE' : 'Adapter',
       action: async () => {
@@ -8842,7 +10420,7 @@ function buildCmdkIndex() {
       },
     });
     items.push({
-      kind: 'adapter-load', icon: '↺',
+      kind: 'adapter-load', icon: icon('refresh'),
       title: 'Load adapter ' + name,
       sub: 'Switch active LoRA',
       action: async () => {
@@ -8860,7 +10438,7 @@ function buildCmdkIndex() {
   for (const j of evalJobsCache) suiteNames.add(j.suite_name);
   for (const name of suiteNames) {
     items.push({
-      kind: 'suite', icon: '🎯',
+      kind: 'suite', icon: icon('target'),
       title: name,
       sub: 'Eval suite',
       action: async () => {
@@ -8869,7 +10447,7 @@ function buildCmdkIndex() {
       },
     });
     items.push({
-      kind: 'suite-run', icon: '▶',
+      kind: 'suite-run', icon: icon('play'),
       title: `Run "${name}" vs active adapter`,
       sub: 'Queue an eval immediately',
       action: async () => {
@@ -8886,7 +10464,7 @@ function buildCmdkIndex() {
   // Jobs (recent — clickable to drill in)
   for (const j of evalJobsCache.slice(0, 20)) {
     items.push({
-      kind: 'job', icon: '📊',
+      kind: 'job', icon: icon('chart'),
       title: `${j.suite_name}`,
       sub: `Eval · ${j.state} · ${j.headline_accuracy != null ? (j.headline_accuracy*100).toFixed(0)+'%' : '—'} · ${j.job_id.slice(0, 8)}`,
       action: () => { selectPage('evals'); document.getElementById('evals-tab-jobs')?.click(); openDrillModal(j.job_id); },
@@ -8904,7 +10482,7 @@ function buildCmdkIndex() {
     const stateNorm = (j.state || '').toString().toLowerCase() || 'queued';
     const lossLbl = j.current_loss != null ? `loss ${j.current_loss.toFixed(3)}` : 'no loss yet';
     items.push({
-      kind: 'train-job', icon: '🧪',
+      kind: 'train-job', icon: icon('flask'),
       title: j.adapter_name || j.job_id,
       sub: `${(j.job_type || 'train').toString().toUpperCase()} · ${stateNorm} · ${lossLbl} · ${j.job_id.slice(0, 8)}`,
       action: () => {
@@ -8920,7 +10498,7 @@ function buildCmdkIndex() {
   for (const r of (recentRequestsCache || []).slice(0, 20)) {
     const preview = (r.prompt_preview || '').replace(/\s+/g, ' ').slice(0, 60) || '(no prompt)';
     items.push({
-      kind: 'recent-req', icon: '↩',
+      kind: 'recent-req', icon: icon('arrow-right'),
       title: preview,
       sub: `Request · ${r.streamed ? 'stream' : 'unary'} · ${r.completion_tokens || 0} tok · ${(r.id || '').replace(/^chatcmpl-/, '').slice(0, 8)}`,
       action: () => {
@@ -8999,6 +10577,47 @@ document.getElementById('cmdk-modal')?.addEventListener('click', ev => {
   if (ev.target.id === 'cmdk-modal') closeCmdk();
 });
 
+// Keyboard cheatsheet — opened with '?'. Lists the shortcuts that already exist
+// so power users can discover triage/judging/playground keys without hunting.
+function toggleShortcutsSheet() {
+  const existing = document.getElementById('shortcuts-modal');
+  if (existing) { existing.remove(); document.body.style.overflow = ''; return; }
+  const isMac = /Mac|iPhone|iPad/.test(navigator.platform || '');
+  const mod = isMac ? '⌘' : 'Ctrl';
+  const groups = [
+    ['Global', [[[mod + 'K', '/'], 'Command palette'], [['?'], 'This shortcuts list'], [['Esc'], 'Close any modal or palette']]],
+    ['Recent requests', [[['Enter', 'Space'], 'Inspect the focused request'], [['←', '→'], 'Previous / next request in the inspector']]],
+    ['Eval results drill', [[['/'], 'Search outcomes'], [['r'], 'Re-run the suite'], [['j', 'k'], 'Next / previous outcome']]],
+    ['A/B judging', [[['a', 'b'], 'Prefer A / B'], [['t'], 'Tie'], [['s'], 'Skip']]],
+    ['Playground', [[['Enter'], 'Send'], [['⇧Enter'], 'Newline'], [['Esc'], 'Stop generating']]],
+  ];
+  const kbd = keys => keys.map(k => `<kbd>${escapeHtml(k)}</kbd>`).join('<span class="kbd-or">or</span>');
+  const body = groups.map(([title, rows]) => `
+    <div class="shortcuts-group">
+      <div class="shortcuts-group-title">${escapeHtml(title)}</div>
+      ${rows.map(([keys, desc]) => `<div class="shortcut-row"><span class="shortcut-keys">${kbd(keys)}</span><span class="shortcut-desc">${escapeHtml(desc)}</span></div>`).join('')}
+    </div>`).join('');
+  const m = document.createElement('div');
+  m.id = 'shortcuts-modal';
+  m.className = 'modal-backdrop';
+  m.setAttribute('role', 'dialog');
+  m.setAttribute('aria-modal', 'true');
+  m.setAttribute('aria-label', 'Keyboard shortcuts');
+  m.innerHTML = `<div class="modal-shell shortcuts-shell">
+    <div class="modal-head"><h2>Keyboard shortcuts</h2><span style="flex:1 1 auto;"></span>
+      <button class="modal-close" id="shortcuts-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button></div>
+    <div class="shortcuts-body">${body}</div>
+  </div>`;
+  document.body.appendChild(m);
+  document.body.style.overflow = 'hidden';
+  const close = () => toggleShortcutsSheet();
+  m.querySelector('#shortcuts-close')?.addEventListener('click', close);
+  m.addEventListener('click', ev => { if (ev.target === m) close(); });
+  document.addEventListener('keydown', function esc(ev) {
+    if (ev.key === 'Escape' && document.getElementById('shortcuts-modal')) { close(); document.removeEventListener('keydown', esc); }
+  });
+}
+
 document.addEventListener('keydown', ev => {
   // Open: ⌘K / Ctrl+K (anywhere except inside an input that already has its own handler)
   if ((ev.key === 'k' || ev.key === 'K') && (ev.metaKey || ev.ctrlKey)) {
@@ -9010,6 +10629,12 @@ document.addEventListener('keydown', ev => {
   if (!cmdkOpen && ev.key === '/' && !['INPUT','TEXTAREA','SELECT'].includes((ev.target.tagName||'').toUpperCase())) {
     ev.preventDefault();
     openCmdk();
+    return;
+  }
+  // '?' (Shift+/) opens the keyboard cheatsheet when not typing.
+  if (!cmdkOpen && ev.key === '?' && !['INPUT','TEXTAREA','SELECT'].includes((ev.target.tagName||'').toUpperCase()) && !ev.target.isContentEditable) {
+    ev.preventDefault();
+    toggleShortcutsSheet();
     return;
   }
   if (!cmdkOpen) return;
@@ -9036,6 +10661,7 @@ document.addEventListener('keydown', ev => {
 /// `series` is an array of {points: [[x, y], ...], color, label}. Auto-scales
 /// X linearly between min/max; Y linearly between 0 and max(y) with a small
 /// headroom. Suitable for loss curves and tok/s timelines.
+let lineChartSeq = 0;
 function renderLineChart(container, series, opts = {}) {
   const w = opts.width || 600;
   const h = opts.height || 280;
@@ -9046,13 +10672,13 @@ function renderLineChart(container, series, opts = {}) {
   // every sample as a function arg. With training-loss curves capped at
   // 1024 samples we're still within engine limits today, but the spread
   // pattern crashes around ~125k args on Chrome — better to never use it.
-  let xMin = Infinity, xMax = -Infinity, yMaxRaw = 0, count = 0;
+  let xMin = Infinity, xMax = -Infinity, yMaxRaw = 0, yMinRaw = Infinity, count = 0;
   for (const s of series) {
     for (const p of (s.points || [])) {
       const x = p[0], y = p[1];
       if (x < xMin) xMin = x;
       if (x > xMax) xMax = x;
-      if (isFinite(y) && y > yMaxRaw) yMaxRaw = y;
+      if (isFinite(y)) { if (y > yMaxRaw) yMaxRaw = y; if (y < yMinRaw) yMinRaw = y; }
       count++;
     }
   }
@@ -9060,8 +10686,16 @@ function renderLineChart(container, series, opts = {}) {
     container.innerHTML = `<div class="hint" style="padding:12px; text-align:center;">Awaiting first samples…</div>`;
     return;
   }
-  const yMin = 0;
-  const yMax = yMaxRaw <= 0 ? 1 : yMaxRaw * 1.1;
+  // Default: baseline at 0. opts.yZoom auto-scales to the data range (+padding)
+  // so a steady-but-live series (e.g. tok/s hovering ~145) reads as a living
+  // trend instead of a dead-flat line pinned to the top of a 0-based axis.
+  let yMin = 0;
+  let yMax = yMaxRaw <= 0 ? 1 : yMaxRaw * 1.1;
+  if (opts.yZoom && isFinite(yMinRaw) && yMaxRaw > yMinRaw) {
+    const pad = (yMaxRaw - yMinRaw) * 0.35 || 1;
+    yMin = Math.max(0, yMinRaw - pad);
+    yMax = yMaxRaw + pad;
+  }
   const xRange = (xMax - xMin) || 1;
   const yRange = (yMax - yMin) || 1;
   const xx = x => padL + ((x - xMin) / xRange) * innerW;
@@ -9079,17 +10713,24 @@ function renderLineChart(container, series, opts = {}) {
     `<text class="axis-label" x="${padL}" y="${(h - 6).toFixed(1)}" text-anchor="start">${xMin.toFixed(0)}s</text>`,
     `<text class="axis-label" x="${(padL + innerW).toFixed(1)}" y="${(h - 6).toFixed(1)}" text-anchor="end">${xMax.toFixed(0)}s</text>`,
   ];
-  // Series paths
+  // Series paths — the area uses a vertical gradient that fades to
+  // transparent at the baseline, so even a flat/constant series reads as a
+  // soft glow under the line rather than a solid block.
+  const cid = 'lc' + (++lineChartSeq);
+  const defs = [];
   const seriesHtml = series.map((s, idx) => {
     const color = s.color || ['var(--accent)', 'var(--info-fg)', 'var(--success-fg)', 'var(--warning-fg)'][idx % 4];
     const pts = s.points || [];
     if (pts.length < 2) return '';
+    const gid = `${cid}-a${idx}`;
+    defs.push(`<linearGradient id="${gid}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" style="stop-color:${color};stop-opacity:0.26"/><stop offset="0.85" style="stop-color:${color};stop-opacity:0.02"/><stop offset="1" style="stop-color:${color};stop-opacity:0"/></linearGradient>`);
     const linePath = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${xx(p[0]).toFixed(1)} ${yy(p[1]).toFixed(1)}`).join(' ');
     const areaPath = `${linePath} L${xx(pts[pts.length-1][0]).toFixed(1)} ${(padT+innerH).toFixed(1)} L${xx(pts[0][0]).toFixed(1)} ${(padT+innerH).toFixed(1)} Z`;
-    return `<path class="data-area" d="${areaPath}" style="fill: ${color}; fill-opacity: 0.12;"/>
+    return `<path class="data-area" d="${areaPath}" style="fill: url(#${gid});"/>
             <path class="data-line" d="${linePath}" style="stroke: ${color};"/>`;
   }).join('');
   container.innerHTML = `<svg class="line-chart ${opts.large ? 'line-chart-large' : ''}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>${defs.join('')}</defs>
     ${grid.join('')}
     <line class="axis" x1="${padL}" y1="${padT}" x2="${padL}" y2="${(padT+innerH).toFixed(1)}" />
     <line class="axis" x1="${padL}" y1="${(padT+innerH).toFixed(1)}" x2="${(padL+innerW).toFixed(1)}" y2="${(padT+innerH).toFixed(1)}" />
@@ -9123,7 +10764,7 @@ function donutChartSvg(slices, opts = {}) {
   }).join('');
   const center = opts.centerLabel
     ? `<text x="${c}" y="${c - 2}" text-anchor="middle" style="fill:var(--text); font-weight:700; font-size:14px; font-variant-numeric:tabular-nums;">${escapeHtml(opts.centerLabel)}</text>
-       <text x="${c}" y="${c + 12}" text-anchor="middle" style="fill:var(--text-quiet); font-size:9px; text-transform:uppercase; letter-spacing:0.06em;">${escapeHtml(opts.centerSub || '')}</text>`
+       <text x="${c}" y="${c + 12}" text-anchor="middle" style="fill:var(--text-quiet); font-size:9px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">${escapeHtml(opts.centerSub || '')}</text>`
     : '';
   return `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
     <circle cx="${c}" cy="${c}" r="${r}" fill="none" stroke="var(--surface-3)" stroke-width="${stroke}"/>
@@ -9178,7 +10819,7 @@ function refreshDecodeSparkline() {
   for (const s of tpsHistory) if (s.tps > peakTps) peakTps = s.tps;
   spark.firstChild.innerHTML = `tok/s over the last ${tpsHistory.length}s · peak <span class="tabular-nums" style="color:var(--text-2);">${peakTps.toFixed(0)}</span> · now <span class="tabular-nums" style="color:var(--text-2);">${tps.toFixed(1)}</span>`;
   const series = [{ points: tpsHistory.map((s, i) => [i, s.tps]), color: 'var(--accent)' }];
-  renderLineChart(spark.querySelector('.decode-spark-body'), series, { width: 520, height: 100 });
+  renderLineChart(spark.querySelector('.decode-spark-body'), series, { width: 520, height: 100, yZoom: true });
 }
 
 // VRAM donut. Same approach: read `lastHealth` cache, dedupe on a key
@@ -9240,6 +10881,49 @@ document.querySelectorAll('[data-quick-action]').forEach(btn => {
    ===================================================================== */
 
 let adaptersFilter = '';
+// The Saved-adapters list is where you pick what to load — so surface each
+// adapter's latest eval score (from the already-polled evalJobsCache) as a chip,
+// turning a file browser into a glanceable leaderboard. No new endpoint.
+function adapterEvalChip(name) {
+  const jobs = (typeof evalJobsCache !== 'undefined' ? evalJobsCache : []) || [];
+  const done = jobs.filter(j => (j.state || '').toLowerCase() === 'completed'
+    && Array.isArray(j.adapters) && j.adapters.includes(name));
+  if (!done.length) return `<span class="adapter-eval-chip none" title="No completed eval for this adapter yet — Run eval… below">not evaluated</span>`;
+  done.sort((a, b) => String(b.submitted_at_iso || '').localeCompare(String(a.submitted_at_iso || '')));
+  const j = done[0];
+  let acc = null;
+  const run = (j.finished_runs || []).find(r => r.adapter === name);
+  if (run && typeof run.metrics?.accuracy === 'number') acc = run.metrics.accuracy;
+  else if (typeof j.headline_accuracy === 'number' && (j.adapters || []).filter(a => a != null).length === 1) acc = j.headline_accuracy;
+  if (acc == null) return `<span class="adapter-eval-chip none" title="Eval completed but no per-adapter accuracy recorded">not evaluated</span>`;
+  const pct = (acc * 100).toFixed(0);
+  return `<span class="adapter-eval-chip" title="${escapeHtml(j.suite_name || 'eval')}: ${pct}% accuracy (latest completed eval)">${escapeHtml(j.suite_name || 'eval')} <strong>${pct}%</strong></span>`;
+}
+
+// The strongest signal for "is the loaded adapter actually better than base?":
+// the newest completed COMPARE eval (base run + this adapter's run). Returns
+// { delta, suite } in accuracy points, or null. Powers the hero/active-card verdict.
+function adapterCompareVerdict(name) {
+  const jobs = ((typeof evalJobsCache !== 'undefined' ? evalJobsCache : []) || [])
+    .filter(j => (j.state || '').toLowerCase() === 'completed' && Array.isArray(j.finished_runs)
+      && j.finished_runs.length >= 2 && Array.isArray(j.adapters) && j.adapters.includes(name));
+  jobs.sort((a, b) => String(b.submitted_at_iso || '').localeCompare(String(a.submitted_at_iso || '')));
+  for (const j of jobs) {
+    const base = j.finished_runs.find(r => r.adapter == null || r.adapter === 'base');
+    const run = j.finished_runs.find(r => r.adapter === name);
+    if (base && run && typeof base.metrics?.accuracy === 'number' && typeof run.metrics?.accuracy === 'number') {
+      return { delta: Math.round((run.metrics.accuracy - base.metrics.accuracy) * 1000) / 10, suite: j.suite_name };
+    }
+  }
+  return null;
+}
+function verdictDeltaHtml(v) {
+  if (!v) return '';
+  const cls = v.delta > 0.5 ? 'delta-up' : (v.delta < -0.5 ? 'delta-down' : 'delta-flat');
+  const label = cls === 'delta-flat' ? 'matches base' : `${v.delta > 0 ? '+' : ''}${v.delta.toFixed(1)} pts vs base`;
+  return `<span class="delta-badge ${cls}" title="vs base on ${escapeHtml(v.suite || 'eval')}">${label}</span>`;
+}
+
 function renderAdaptersAsCards(data) {
   const panel = document.getElementById('adapters-panel');
   if (!panel) return;
@@ -9249,7 +10933,7 @@ function renderAdaptersAsCards(data) {
   const filtered = q ? adapters.filter(a => (a.name || '').toLowerCase().includes(q)) : adapters;
   if (!adapters.length) {
     panel.innerHTML = `<div class="eval-empty empty">
-      <div class="eval-empty-icon">🧬</div>
+      <div class="eval-empty-icon"><svg class="icn"><use href="#i-layers"></use></svg></div>
       <div class="eval-empty-title">No adapters found yet.</div>
       <div class="eval-empty-body">Train one via the Training tab, or upload a PEFT-compatible <code>.tar.gz</code> archive below. New here? Read the <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener">Quickstart</a> or the <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener">Troubleshooting</a> guide.</div>
       <button class="eval-empty-cta" type="button" data-focus-id="upload-name">Upload an adapter</button>
@@ -9273,6 +10957,8 @@ function renderAdaptersAsCards(data) {
         <span><span class="tabular-nums">${fmtBytes(a.size_bytes)}</span> on disk</span>
         ${a.modified_at ? `<span title="modified ${escapeHtml(a.modified_at)}">${escapeHtml(fmtSmartTime(Date.parse(a.modified_at)))}</span>` : ''}
         ${a.files ? `<span class="tabular-nums">${a.files.length} file${a.files.length === 1 ? '' : 's'}</span>` : ''}
+        ${adapterEvalChip(a.name)}
+        ${isActive ? verdictDeltaHtml(adapterCompareVerdict(a.name)) : ''}
       </div>
       <div class="adapter-card-actions">
         ${isActive
@@ -9334,9 +11020,14 @@ let lastAdaptersKey = null;
 function refreshAdapterCards() {
   const d = lastAdapters;
   if (!d) return;
+  // Include a signature of completed evals so the per-card eval-score chips
+  // refresh when a job finishes (the dedup must not pin the cold-start render).
+  const evalSig = ((typeof evalJobsCache !== 'undefined' ? evalJobsCache : []) || [])
+    .filter(j => (j.state || '').toLowerCase() === 'completed')
+    .map(j => j.job_id).join(',');
   const key = (d.active || '') + '|' + (d.available || [])
     .map(a => `${a.name}:${a.size_bytes}:${a.modified_at || ''}`)
-    .join(',');
+    .join(',') + '|' + evalSig;
   if (key === lastAdaptersKey) return;
   lastAdaptersKey = key;
   renderAdaptersAsCards(d);
@@ -9344,7 +11035,13 @@ function refreshAdapterCards() {
   const heroAdapter = document.getElementById('hero-adapter');
   const heroSub = document.getElementById('hero-adapter-sub');
   if (heroAdapter) heroAdapter.textContent = d.active || 'base';
-  if (heroSub) heroSub.textContent = d.active ? `${count} adapter${count === 1 ? '' : 's'} on disk` : `${count} adapter${count === 1 ? '' : 's'} available · base model active`;
+  if (heroSub) {
+    // Lead with the win verdict when the active adapter has a compare eval —
+    // "is what's serving pi actually better than base?" answered at the top.
+    const verdict = d.active ? adapterCompareVerdict(d.active) : null;
+    if (verdict) heroSub.innerHTML = verdictDeltaHtml(verdict);
+    else heroSub.textContent = d.active ? `${count} adapter${count === 1 ? '' : 's'} on disk` : `${count} adapter${count === 1 ? '' : 's'} available · base model active`;
+  }
 }
 // Driven from `pollAdapters` end-of-success directly — no standalone
 // interval, no first-render kick needed.
@@ -9441,19 +11138,19 @@ function renderAdapterDrillBody(d) {
   return `<div style="padding: var(--space-4) var(--space-5); border-bottom:1px solid var(--border);">
     <div style="display:flex; gap:24px; align-items:center; flex-wrap:wrap;">
       <div>
-        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Disk</div>
+        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Disk</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${fmtBytes(d.size_bytes)}</div>
       </div>
       <div>
-        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Files</div>
+        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Files</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${d.files.length}</div>
       </div>
       <div>
-        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Training</div>
+        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Training</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${d.training_jobs.length}</div>
       </div>
       <div>
-        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Evals</div>
+        <div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Evals</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${d.eval_jobs.length}</div>
       </div>
     </div>
@@ -9616,7 +11313,7 @@ async function fetchTrainDrill() {
 function renderTrainDrillBody(j) {
   const linkedIds = j.linked_eval_job_ids || [];
   const linkedHtml = linkedIds.length
-    ? linkedIds.map(id => `<button class="btn btn-sm" type="button" data-linked-eval="${escapeHtml(id)}">↗ Eval ${escapeHtml(id.slice(0, 8))}</button>`).join(' ')
+    ? linkedIds.map(id => `<button class="btn btn-sm" type="button" data-linked-eval="${escapeHtml(id)}"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-arrow-right"></use></svg> Eval ${escapeHtml(id.slice(0, 8))}</button>`).join(' ')
     : '<span class="hint">None</span>';
   const finalLoss = j.current_loss != null ? j.current_loss.toFixed(4) : '—';
   const epoch = j.epoch != null ? j.epoch.toString() : '—';
@@ -9638,15 +11335,15 @@ function renderTrainDrillBody(j) {
     : '';
   const html = `<div style="padding: var(--space-4) var(--space-5); border-bottom:1px solid var(--border);">
     <div style="display:flex; gap:24px; align-items:center; flex-wrap:wrap;">
-      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Progress</div>
+      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Progress</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${(j.progress*100).toFixed(0)}%</div></div>
-      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">${j.state === 'completed' || j.state === 'failed' ? 'Final loss' : 'Current loss'}</div>
+      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">${j.state === 'completed' || j.state === 'failed' ? 'Final loss' : 'Current loss'}</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${finalLoss}</div></div>
-      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Epoch</div>
+      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Epoch</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${epoch}</div></div>
-      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Duration</div>
+      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Duration</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${fmtDuration(durationSecs)}</div></div>
-      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing:0.06em;">Samples</div>
+      <div><div class="hint" style="font-size:10px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">Samples</div>
         <div style="font-size:18px; font-weight:600;" class="tabular-nums">${samples}</div></div>
     </div>
     ${timeRow}
@@ -9749,7 +11446,7 @@ if (playgroundCard) {
     saveBtn.id = 'chat-save-judgment';
     saveBtn.disabled = true;
     saveBtn.title = 'Send this A/B pair into a judgment dataset';
-    saveBtn.textContent = '↗ Save A/B preference';
+    saveBtn.innerHTML = icon('arrow-right','icn-sm') + ' Save A/B preference';
     const exportBtn = outputActions.querySelector('#chat-export');
     if (exportBtn) outputActions.insertBefore(saveBtn, exportBtn);
     else outputActions.appendChild(saveBtn);
@@ -10052,6 +11749,8 @@ document.getElementById('chat-save-judgment')?.addEventListener('click', () => {
 // --- Init ---
 renderChat();
 updateChatSendState();
+initConnect();
+initCorrections();
 pollHealth();
 pollAdapters();
 pollTraining();

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -5992,9 +5992,10 @@ function renderRecentRequests(rows) {
   if (!el) return;
   if (!rows || rows.length === 0) {
     el.innerHTML = `<div class="empty">
-      <div style="font-weight:600;color:var(--text);margin-bottom:6px;">Waiting for your first agent request.</div>
+      <div style="font-weight:600;color:var(--text);margin-bottom:6px;">No recent requests yet. Waiting for your first agent request.</div>
       <div style="color:var(--text-3);">Point <strong>pi</strong>, <strong>opencode</strong>, or any OpenAI client at <code>${escapeHtml(connectBaseUrl())}</code> (model <code>${escapeHtml(connectModelId)}</code>) and every chat completion shows up here — prompt &amp; completion previews, tokens, latency, and finish status. That live traffic is the raw material your model learns from.</div>
       <div style="margin-top:var(--space-3);"><button type="button" class="btn btn-primary btn-sm" onclick="openConnect()">${icon('link','icn-sm')} Connect your agent</button> <button type="button" class="btn btn-sm" onclick="selectPage('playground')">${icon('chat','icn-sm')} Or try the Playground</button></div>
+      <div style="margin-top:var(--space-2);color:var(--text-3);">New to Kiln? Follow the <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>.</div>
     </div>`;
     return;
   }

--- a/desktop/ui/_kiln-tokens.css
+++ b/desktop/ui/_kiln-tokens.css
@@ -1,13 +1,15 @@
 /* =====================================================================
-   Kiln Desktop — shared design tokens & component overrides
+   Kiln Desktop — shared design system
    ---------------------------------------------------------------------
-   Mirrors the tokens used by the embedded server `/ui` so the Tauri
-   shell (toolbar, settings, logs, about, install pane) reads as one
-   continuous product surface — warm amber accents on warm-tinted
-   charcoal, Inter typography, 4px spacing grid.
+   The Tauri shell (dashboard app bar, settings, logs, about, tray
+   placeholder, install pane) is built directly against these classes so
+   it reads as one continuous product with the embedded server `/ui`
+   dashboard — warm amber accents on warm-tinted charcoal, Inter
+   typography, a 4px spacing grid, and the same inline-SVG icon sprite.
 
-   This sheet is linked AFTER each window's inline <style>, so it wins
-   the cascade on selector ties without rewriting every existing rule.
+   This sheet is linked AFTER each window's (now-minimal) inline reset,
+   and the markup uses these classes directly, so there is no need for
+   the `!important` paint-over that the prior pass relied on.
    ===================================================================== */
 
 :root {
@@ -23,21 +25,23 @@
   --kiln-800: #9a3412;
   --kiln-900: #7c2d12;
 
-  /* Surface — warm-tinted charcoal */
-  --ink-950: #08090c;
-  --ink-900: #0d0e12;
-  --ink-850: #11131a;
-  --ink-800: #14161e;
-  --ink-750: #181b24;
-  --ink-700: #1c1f29;
-  --ink-650: #232732;
-  --ink-600: #2a2f3b;
-  --ink-500: #353a48;
-  --ink-400: #4b5163;
-  --ink-300: #6b7280;
-  --ink-200: #9ca3af;
-  --ink-100: #d1d5db;
-  --ink-50:  #f4f5f7;
+  /* Surface — warm-tinted charcoal (mirrors the server dashboard ramp).
+     WCAG AA preserved: text-muted=ink-300 ≈4.6:1, text-3=ink-200 ≈7:1 on
+     surface=ink-800; text-quiet=ink-400 is large/bold only. */
+  --ink-950: #0a0908;
+  --ink-900: #0e0d0b;
+  --ink-850: #131210;
+  --ink-800: #181613;
+  --ink-750: #1d1b17;
+  --ink-700: #23201b;
+  --ink-650: #2b2720;
+  --ink-600: #342f26;
+  --ink-500: #443c31;
+  --ink-400: #756b5b;
+  --ink-300: #938b79;
+  --ink-200: #b0a895;
+  --ink-100: #d9d3c7;
+  --ink-50:  #f7f4ef;
 
   /* Semantic */
   --success-fg: #4ade80;
@@ -49,9 +53,11 @@
   --danger-fg:  #f87171;
   --danger-bg:  #2a1414;
   --danger-bd:  #4a1f1f;
-  --info-fg:    #60a5fa;
-  --info-bg:    #0f1c2c;
-  --info-bd:    #1a3050;
+  /* "Info" warmed to ember so the restart/secondary affordance reads as part
+     of the kiln family rather than a generic cool-blue accent. */
+  --info-fg:    #fbbf24;
+  --info-bg:    #2c220a;
+  --info-bd:    #4a3a14;
 
   --bg:           var(--ink-950);
   --canvas:       var(--ink-900);
@@ -70,10 +76,22 @@
   --accent-press: var(--kiln-600);
   --accent-soft:  rgba(249, 115, 22, 0.12);
   --accent-ring:  rgba(249, 115, 22, 0.42);
+  --on-accent:    #1a0c00;
 
   --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Helvetica, Arial, sans-serif;
   --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Helvetica, Arial, sans-serif;
   --font-mono:    'SF Mono', 'JetBrains Mono', 'Berkeley Mono', 'Cascadia Code', 'Fira Code', Consolas, monospace;
+
+  /* Type ladder — one shared clamp() scale across every window. */
+  --text-2xs: 11px;
+  --text-xs:  12px;
+  --text-sm:  13px;
+  --text-md:  14px;
+  --text-lg:  16px;
+  --text-xl:  18px;
+  --text-2xl: clamp(18px, 1.8vw, 22px);
+  --text-3xl: clamp(22px, 2.4vw, 28px);
+  --text-display: clamp(26px, 3vw, 34px);
 
   --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
   --space-5: 20px; --space-6: 24px; --space-7: 32px; --space-8: 40px;
@@ -81,12 +99,16 @@
   --radius-xs: 3px;  --radius-sm: 5px;  --radius-md: 8px;
   --radius-lg: 12px; --radius-pill: 999px;
 
+  --tracking-caps:  0.06em;  /* all uppercase eyebrows / section labels */
+  --tracking-tight: -0.02em; /* display numbers + large headings */
+
   --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-2: 0 4px 16px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-3: 0 16px 40px rgba(0, 0, 0, 0.55), 0 4px 12px rgba(0, 0, 0, 0.4);
   --glow-brand: 0 0 0 1px rgba(249, 115, 22, 0.18), 0 12px 28px rgba(249, 115, 22, 0.18);
 
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --t-fast: 140ms;
   --t-base: 220ms;
 
@@ -94,16 +116,19 @@
 }
 
 /* ---------------------------------------------------------------------
-   Base — page chrome, typography, scrollbars
+   Base
    --------------------------------------------------------------------- */
 html, body {
-  background: var(--bg) !important;
-  color: var(--text) !important;
-  font-family: var(--font-sans) !important;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
+
+*, *::before, *::after { box-sizing: border-box; }
 
 *::-webkit-scrollbar { width: 10px; height: 10px; }
 *::-webkit-scrollbar-track { background: transparent; }
@@ -116,529 +141,585 @@ html, body {
 
 ::selection { background: var(--accent-soft); color: var(--text); }
 
-a, a.doc-link, .meta a, .help-row a, #status a.doc-link, #install a.doc-link {
-  color: var(--kiln-300) !important;
-  text-decoration: none;
-}
-a:hover, a.doc-link:hover, .meta a:hover, .help-row a:hover { text-decoration: underline; }
+.hidden { display: none !important; }
 
-code, kbd, pre, samp,
-.modal-card kbd,
-#install code, #status code,
-header input[type="search"],
-#log,
-#base-url, #model-path, #vram-value, #adapter-name, #training-value {
-  font-family: var(--font-mono) !important;
-  font-feature-settings: 'liga' 0, 'calt' 0, 'tnum' 1;
-}
+a { color: var(--kiln-300); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, kbd, pre, samp { font-family: var(--font-mono); }
 
 /* ---------------------------------------------------------------------
-   Buttons — default to secondary, opt-in to primary
-
-   Rationale: a desktop shell has many small action buttons (Copy, Save,
-   Clear, Close, Reload, Browse…). Making them all amber CTAs visually
-   shouts. Default to a quiet surface-2 chip; reserve amber for the
-   primary action of each window.
+   Icons — monochrome inline SVG (Lucide-style), inherit currentColor.
+   The sprite <symbol>s are inlined per-window near the top of <body>;
+   reference with <svg class="icn"><use href="#i-NAME"/></svg>.
    --------------------------------------------------------------------- */
-button {
-  background: var(--surface-2) !important;
-  color: var(--text-2) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-sm) !important;
-  font-family: var(--font-sans) !important;
-  font-weight: 500;
-  letter-spacing: 0;
-  transition: background var(--t-fast) var(--ease-out),
-              border-color var(--t-fast) var(--ease-out),
-              color var(--t-fast) var(--ease-out),
-              box-shadow var(--t-fast) var(--ease-out);
-  cursor: pointer;
+.icn {
+  width: 1.15em;
+  height: 1.15em;
+  display: inline-block;
+  vertical-align: -0.18em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
 }
-button:hover {
-  background: var(--surface-3) !important;
-  border-color: var(--border-strong) !important;
-  color: var(--text) !important;
-}
-button:active { background: var(--surface-3) !important; }
-button:focus-visible {
-  outline: 2px solid var(--accent-ring) !important;
-  outline-offset: 2px;
-}
-button:disabled {
-  background: var(--surface-2) !important;
-  color: var(--text-quiet) !important;
-  cursor: default;
-  border-color: var(--border) !important;
-  opacity: 0.55;
-}
-
-/* Primary action — amber CTA. Opt-in via .primary, type="submit",
-   or the well-known dashboard IDs below (one true CTA per window).
-   #save is intentionally NOT in this list because logs.html and
-   settings.html both use that ID; settings.html opts in via class.
-   `#toolbar #copy-url` chained selector is required to outweigh the
-   `#toolbar button` rule (specificity 1,1,0,0 > 1,0,0,1) further down. */
-button.primary,
-button[type="submit"],
-#toolbar #copy-url,
-#copy-url,
-#install-download-btn,
-#start-server,
-#hf-start {
-  background: var(--accent) !important;
-  color: #1a0c00 !important;
-  border: 1px solid transparent !important;
-  font-weight: 600;
-}
-button.primary:hover,
-button[type="submit"]:hover,
-#toolbar #copy-url:hover,
-#copy-url:hover,
-#install-download-btn:hover,
-#start-server:hover,
-#hf-start:hover {
-  background: var(--accent-hover) !important;
-  color: #1a0c00 !important;
-  border-color: transparent !important;
-}
-button.primary:active,
-button[type="submit"]:active,
-#toolbar #copy-url:active,
-#copy-url:active,
-#install-download-btn:active,
-#start-server:active,
-#hf-start:active {
-  background: var(--accent-press) !important;
-}
-button.primary:disabled,
-#hf-start:disabled,
-#install-download-btn:disabled {
-  background: var(--ink-700) !important;
-  color: var(--text-quiet) !important;
-  border-color: var(--border) !important;
-  opacity: 0.65;
-}
-
-/* Explicit secondary class kept as alias of the new default,
-   so existing markup with class="secondary" / class="browse" still works. */
-button.secondary,
-button.browse,
-#install-actions button.secondary,
-footer button.secondary {
-  background: var(--surface-2) !important;
-  color: var(--text-2) !important;
-  border: 1px solid var(--border) !important;
-  font-weight: 500;
-}
-button.secondary:hover,
-button.browse:hover,
-#install-actions button.secondary:hover,
-footer button.secondary:hover {
-  background: var(--surface-3) !important;
-  border-color: var(--border-strong) !important;
-  color: var(--text) !important;
-}
+.icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
+.icn-lg { width: 1.5em; height: 1.5em; vertical-align: -0.3em; }
 
 /* ---------------------------------------------------------------------
-   Status / install panes (dashboard.html landing states)
+   Brand mark — the stacked-fire cube, mirroring the server dashboard.
+   A solid dark flame/stack cut out of a glowing ember-gradient cube.
    --------------------------------------------------------------------- */
-#status, #install {
-  background: radial-gradient(
-      120% 80% at 50% -20%,
-      rgba(249, 115, 22, 0.08),
-      transparent 60%
-    ),
-    var(--bg) !important;
+.brand { display: flex; align-items: center; gap: var(--space-3); text-decoration: none; color: var(--text); flex-shrink: 0; }
+.brand:hover { text-decoration: none; }
+.brand-mark {
+  position: relative;
+  border-radius: var(--radius-md);
+  background:
+    radial-gradient(120% 120% at 30% 20%, rgba(255, 255, 255, 0.06), transparent 60%),
+    linear-gradient(160deg, var(--kiln-700) 0%, var(--kiln-500) 55%, var(--kiln-300) 100%);
+  box-shadow: var(--shadow-1), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+  width: 30px; height: 30px;
 }
-#status h1, #install h1 {
+.brand-mark .brand-flame {
+  position: absolute; inset: 0; margin: auto;
+  width: 64%; height: 64%;
+  fill: none; stroke: var(--ink-950); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+  opacity: 0.85;
+}
+.brand-mark.brand-mark-lg { width: 56px; height: 56px; border-radius: var(--radius-lg); }
+.brand-mark.brand-mark-xl { width: 76px; height: 76px; border-radius: var(--radius-lg); }
+@media (prefers-reduced-motion: no-preference) {
+  .brand-mark .brand-flame { animation: brand-ember 4.2s var(--ease-in-out) infinite; }
+}
+@keyframes brand-ember { 0%, 100% { opacity: 0.85; } 50% { opacity: 0.68; } }
+.brand-name {
   font-family: var(--font-display);
-  font-size: 22px;
-  font-weight: 600;
+  font-size: var(--text-xl);
+  font-weight: 700;
   letter-spacing: -0.01em;
-  color: var(--text) !important;
+  line-height: 1;
 }
-#status p, #install p {
-  color: var(--text-3) !important;
-  line-height: 1.55;
-}
-#status p.help-links { color: var(--text-muted) !important; }
-#status code, #install code {
-  background: var(--surface-2) !important;
-  color: var(--text-2) !important;
+
+/* ---------------------------------------------------------------------
+   Buttons — quiet surface chip by default; opt into amber / danger.
+   A desktop shell has many small actions, so amber is reserved for the
+   single primary CTA per window.
+   --------------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: var(--surface-2);
+  color: var(--text-2);
   border: 1px solid var(--border);
-  border-radius: var(--radius-xs);
-  padding: 2px 6px;
-  font-size: 12px;
-}
-
-#install-progress-wrap {
-  background: var(--surface) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-pill) !important;
-  height: 8px !important;
-  overflow: hidden;
-}
-#install-progress-bar {
-  background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400)) !important;
-  box-shadow: 0 0 18px rgba(249, 115, 22, 0.45);
-  height: 100% !important;
-  transition: width var(--t-base) var(--ease-out);
-}
-#install-progress-label {
-  color: var(--text-muted) !important;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
-/* ---------------------------------------------------------------------
-   Toolbar (dashboard top-right pill rail)
-   --------------------------------------------------------------------- */
-#toolbar {
-  background: rgba(13, 14, 18, 0.78) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-md) !important;
-  backdrop-filter: blur(10px) saturate(140%);
-  -webkit-backdrop-filter: blur(10px) saturate(140%);
-  box-shadow: var(--shadow-1);
-  padding: 6px 8px !important;
-  gap: 6px !important;
-}
-
-#toolbar button {
-  background: var(--surface-2) !important;
-  color: var(--text-2) !important;
-  border: 1px solid var(--border) !important;
-  font-weight: 500;
-  font-size: 12px;
-}
-#toolbar button:hover {
-  background: var(--surface-3) !important;
-  border-color: var(--border-strong) !important;
-  color: var(--text) !important;
-}
-
-#toolbar button#stop-server:hover {
-  background: var(--danger-bg) !important;
-  border-color: var(--danger-bd) !important;
-  color: var(--danger-fg) !important;
-}
-#toolbar button#restart-server:hover {
-  background: var(--info-bg) !important;
-  border-color: var(--info-bd) !important;
-  color: var(--info-fg) !important;
-}
-
-#toolbar .toolbar-divider {
-  background: var(--border) !important;
-  width: 1px !important;
-  margin: 4px 4px !important;
-}
-
-/* Pills (status, base-url, model-path, vram, adapter, training) */
-#status-badge,
-#base-url,
-#model-path-pill,
-#vram-pill,
-#adapter-pill,
-#training-pill {
-  background: var(--surface-2) !important;
-  color: var(--text-3) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-sm) !important;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-#status-badge .dot {
-  width: 8px !important;
-  height: 8px !important;
-  border-radius: var(--radius-pill);
-  box-shadow: 0 0 0 0 transparent;
-  transition: box-shadow var(--t-base) var(--ease-out);
-}
-#status-badge.state-stopped .dot { background: var(--ink-400) !important; }
-#status-badge.state-starting .dot {
-  background: var(--warning-fg) !important;
-  box-shadow: 0 0 8px rgba(251, 191, 36, 0.45);
-}
-#status-badge.state-running .dot {
-  background: var(--success-fg) !important;
-  box-shadow: 0 0 8px rgba(74, 222, 128, 0.45);
-}
-#status-badge.state-training .dot {
-  background: var(--accent) !important;
-  box-shadow: 0 0 10px rgba(249, 115, 22, 0.55);
-  animation: kiln-pulse 1.6s ease-in-out infinite;
-}
-#status-badge.state-error .dot {
-  background: var(--danger-fg) !important;
-  box-shadow: 0 0 8px rgba(248, 113, 113, 0.45);
-}
-#status-badge.state-unknown .dot { background: var(--ink-400) !important; }
-
-@keyframes kiln-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50%      { opacity: 0.55; transform: scale(0.85); }
-}
-
-#model-path-pill .model-label,
-#vram-pill .vram-label,
-#adapter-pill .adapter-label,
-#training-pill .training-label {
-  color: var(--text-quiet) !important;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-#base-url, #model-path, #vram-value, #adapter-name, #training-value {
-  color: var(--text-2) !important;
-}
-#base-url.empty, #model-path.empty, #vram-value.empty, #adapter-name.empty, #training-value.empty {
-  color: var(--text-quiet) !important;
-}
-
-/* Pill flash states */
-#copy-url.flash,
-#check-updates-btn.flash,
-#model-path-pill.flash,
-#adapter-pill.flash,
-#vram-pill.flash,
-#base-url.flash {
-  background: var(--success-bg) !important;
-  border-color: var(--success-bd) !important;
-  color: var(--success-fg) !important;
-}
-#copy-url.flash-warn,
-#check-updates-btn.flash-warn,
-#model-path-pill.flash-warn,
-#adapter-pill.flash-warn,
-#vram-pill.flash-warn,
-#base-url.flash-warn,
-#stop-server.flash-warn,
-#restart-server.flash-warn {
-  background: var(--danger-bg) !important;
-  border-color: var(--danger-bd) !important;
-  color: var(--danger-fg) !important;
-}
-
-/* ---------------------------------------------------------------------
-   Update banner (warm amber, not generic blue)
-   --------------------------------------------------------------------- */
-#update-banner {
-  background: linear-gradient(180deg, var(--warning-bg), var(--ink-800)) !important;
-  border: 1px solid var(--warning-bd) !important;
-  color: var(--warning-fg) !important;
-  border-radius: var(--radius-md) !important;
-  font-size: 13px;
-}
-#update-banner button {
-  background: var(--warning-bg) !important;
-  color: var(--warning-fg) !important;
-  border: 1px solid var(--warning-bd) !important;
-}
-#update-banner button:hover { background: var(--ink-700) !important; }
-#update-banner button.secondary {
-  background: transparent !important;
-  border-color: transparent !important;
-  color: var(--warning-fg) !important;
-}
-#update-banner button.secondary:hover {
-  background: rgba(251, 191, 36, 0.08) !important;
-}
-
-/* ---------------------------------------------------------------------
-   Settings window
-   --------------------------------------------------------------------- */
-.wrap { padding: 28px 32px !important; max-width: 560px !important; }
-.wrap > h1 {
-  font-family: var(--font-display);
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 0 0 4px 0;
-}
-fieldset {
-  background: var(--surface) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-md) !important;
-  padding: 14px 18px 18px 18px !important;
-  margin: 0 0 16px 0 !important;
-}
-fieldset legend {
-  color: var(--text-muted) !important;
-  font-size: 11px !important;
-  font-weight: 600;
-  letter-spacing: 0.08em !important;
-  text-transform: uppercase !important;
-  padding: 0 8px !important;
-}
-label.row { padding: 8px 0 !important; }
-label.row > span.name { color: var(--text-2) !important; font-weight: 500; }
-label.row > span.hint { color: var(--text-quiet) !important; }
-label.row > span.path-warning { color: var(--warning-fg) !important; }
-
-label.row > input[type="text"],
-label.row > input[type="number"],
-.hf-form input[type="text"],
-.hf-form input[type="password"],
-header input[type="search"] {
-  background: var(--canvas) !important;
-  color: var(--text) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-sm) !important;
-  font-family: var(--font-mono);
-  font-size: 12px !important;
-  padding: 6px 10px !important;
-  transition: border-color var(--t-fast) var(--ease-out), box-shadow var(--t-fast) var(--ease-out);
-}
-label.row > input[type="text"]:focus,
-label.row > input[type="number"]:focus,
-.hf-form input[type="text"]:focus,
-.hf-form input[type="password"]:focus,
-header input[type="search"]:focus {
-  outline: 0;
-  border-color: var(--accent) !important;
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
-
-header input[type="checkbox"] { accent-color: var(--accent) !important; }
-
-.update-status.up-to-date { color: var(--success-fg) !important; }
-.update-status.available  { color: var(--warning-fg) !important; }
-.update-status.warn       { color: var(--warning-fg) !important; }
-.update-status.error      { color: var(--danger-fg) !important; }
-.update-status .badge {
-  background: var(--surface-2) !important;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xs);
-  font-family: var(--font-mono);
-  letter-spacing: 0;
-}
-.update-status.available .badge {
-  background: var(--warning-bg) !important;
-  border-color: var(--warning-bd);
-  color: var(--warning-fg) !important;
-}
-.update-status.up-to-date .badge {
-  background: var(--success-bg) !important;
-  border-color: var(--success-bd);
-  color: var(--success-fg) !important;
-}
-.update-status.warn .badge {
-  background: var(--warning-bg) !important;
-  border-color: var(--warning-bd);
-  color: var(--warning-fg) !important;
-}
-
-.update-download-bar {
-  background: var(--canvas) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-pill) !important;
-  height: 6px !important;
-  overflow: hidden;
-}
-.update-download-fill {
-  background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400)) !important;
-  box-shadow: 0 0 12px rgba(249, 115, 22, 0.45);
-}
-.update-download-line { color: var(--text-muted) !important; font-family: var(--font-mono); }
-.update-download-line.error   { color: var(--danger-fg) !important; }
-.update-download-line.success { color: var(--success-fg) !important; }
-
-.help-row { color: var(--text-muted) !important; }
-.status        { color: var(--success-fg) !important; }
-.status.error  { color: var(--danger-fg) !important; }
-.todo          { color: var(--text-muted) !important; }
-.version-footer { color: var(--text-quiet) !important; font-family: var(--font-mono); }
-
-/* ---------------------------------------------------------------------
-   Logs window
-   --------------------------------------------------------------------- */
-header {
-  background: rgba(13, 14, 18, 0.92) !important;
-  border-bottom: 1px solid var(--border) !important;
-  backdrop-filter: blur(8px) saturate(140%);
-  -webkit-backdrop-filter: blur(8px) saturate(140%);
-}
-header h1 { color: var(--text) !important; font-weight: 600; letter-spacing: -0.005em; }
-header label { color: var(--text-3) !important; }
-#filter-count { color: var(--text-muted) !important; font-family: var(--font-mono); }
-#log {
-  background: var(--bg) !important;
-  color: var(--text-2) !important;
-  font-size: 12px;
-  line-height: 1.55 !important;
-}
-#log.empty { color: var(--text-quiet) !important; }
-#log .line-stderr { color: var(--kiln-300) !important; }
-
-/* ---------------------------------------------------------------------
-   About window
-   --------------------------------------------------------------------- */
-.wrap > h1, .desc, .meta, .platform, .version {
+  padding: 7px var(--space-3);
   font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+  transition: background var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out),
+              color var(--t-fast) var(--ease-out), box-shadow var(--t-fast) var(--ease-out), transform var(--t-fast) var(--ease-out);
 }
-.version, .platform { color: var(--text-muted) !important; font-family: var(--font-mono); }
-p.desc { color: var(--text-2) !important; line-height: 1.6 !important; }
-.meta { color: var(--text-muted) !important; }
-footer {
-  background: var(--surface) !important;
-  border-top: 1px solid var(--border) !important;
+.btn:hover:not(:disabled) { background: var(--surface-3); border-color: var(--border-strong); color: var(--text); }
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:disabled { opacity: 0.5; cursor: default; }
+.btn-sm { padding: 5px var(--space-3); font-size: var(--text-xs); }
+.btn-lg { padding: 9px var(--space-5); font-size: var(--text-md); }
+.btn-icon { padding: 7px; }
+.btn-icon.btn-sm { padding: 5px; }
+
+.btn-primary {
+  background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600));
+  border-color: var(--kiln-700);
+  color: var(--on-accent);
+  font-weight: 600;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 2px 8px rgba(249, 115, 22, 0.18);
 }
+.btn-primary:hover:not(:disabled) { background: linear-gradient(180deg, var(--kiln-400), var(--kiln-500)); border-color: var(--kiln-600); color: var(--on-accent); }
+.btn-primary:disabled { background: var(--ink-700); border-color: var(--border); color: var(--text-quiet); box-shadow: none; }
+
+.btn-danger { background: var(--ink-850); border-color: var(--danger-bd); color: var(--danger-fg); }
+.btn-danger:hover:not(:disabled) { background: var(--danger-bg); border-color: var(--danger-fg); color: var(--danger-fg); }
+
+.btn-ghost { background: transparent; border-color: transparent; color: var(--text-muted); }
+.btn-ghost:hover:not(:disabled) { background: rgba(255, 255, 255, 0.04); color: var(--text); border-color: transparent; }
+
+/* Restart / secondary lifecycle hint — warm ember, not cold blue */
+.btn-warm:hover:not(:disabled) { background: var(--warning-bg); border-color: var(--warning-bd); color: var(--warning-fg); }
+
+.btn .icn { color: inherit; }
+.btn-primary .icn { color: var(--on-accent); }
+
+:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; border-radius: var(--radius-sm); }
+input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 0; border-color: var(--accent); }
+
+/* Transient flash states (copy success / failure feedback) */
+.flash { background: var(--success-bg) !important; border-color: var(--success-bd) !important; color: var(--success-fg) !important; }
+.flash-warn { background: var(--danger-bg) !important; border-color: var(--danger-bd) !important; color: var(--danger-fg) !important; }
 
 /* ---------------------------------------------------------------------
-   Modals (shortcuts dialog, HF token dialog)
+   Cards
+   --------------------------------------------------------------------- */
+.card {
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  position: relative;
+}
+.card-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-4) var(--space-5); border-bottom: 1px solid var(--border); }
+.card-head h2 { margin: 0; font-size: var(--text-lg); font-weight: 600; letter-spacing: -0.01em; color: var(--text); }
+.card-head .eyebrow { font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 500; }
+.card-body { padding: var(--space-5); }
+.section-label { display: block; font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; margin-bottom: var(--space-3); }
+.eyebrow { font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; }
+
+/* ---------------------------------------------------------------------
+   State chip — shared status pill with disciplined amber.
+   amber pulse is reserved for live/training ONLY.
+   --------------------------------------------------------------------- */
+.state-chip {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 5px 11px; font-size: var(--text-xs); font-weight: 500;
+  background: var(--surface-2); color: var(--text-3);
+  border: 1px solid var(--border); border-radius: var(--radius-pill);
+  user-select: none; white-space: nowrap;
+}
+.state-chip .dot {
+  display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ink-400); flex-shrink: 0;
+  box-shadow: 0 0 0 0 transparent; transition: box-shadow var(--t-base) var(--ease-out);
+}
+.state-chip.state-stopped .dot { background: var(--ink-400); }
+.state-chip.state-starting .dot { background: var(--warning-fg); box-shadow: 0 0 8px rgba(251, 191, 36, 0.45); animation: kiln-pulse 1.6s ease-in-out infinite; }
+.state-chip.state-running .dot { background: var(--success-fg); box-shadow: 0 0 8px rgba(74, 222, 128, 0.45); }
+.state-chip.state-running .dot::after {
+  content: ''; position: absolute; inset: -3px; border-radius: 50%;
+  border: 1px solid var(--success-fg); opacity: 0; animation: ring-pulse 2.4s var(--ease-out) infinite;
+}
+.state-chip.state-running .dot { position: relative; }
+.state-chip.state-training .dot { background: var(--accent); box-shadow: 0 0 10px rgba(249, 115, 22, 0.55); animation: kiln-pulse 1.6s ease-in-out infinite; }
+.state-chip.state-error .dot { background: var(--danger-fg); box-shadow: 0 0 8px rgba(248, 113, 113, 0.45); }
+.state-chip.state-unknown .dot { background: var(--ink-400); }
+
+@keyframes kiln-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.82); } }
+@keyframes ring-pulse { 0% { transform: scale(0.9); opacity: 0.55; } 60% { transform: scale(1.7); opacity: 0; } 100% { transform: scale(1.7); opacity: 0; } }
+
+/* ---------------------------------------------------------------------
+   Copy field — click-to-copy mono base-URL (the #1 agent fact)
+   --------------------------------------------------------------------- */
+.copy-field {
+  display: flex; align-items: center; gap: var(--space-2);
+  background: var(--ink-850); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md); padding: 6px 6px 6px 12px; min-width: 0;
+}
+.copy-field code, .copy-field .copy-val {
+  flex: 1; min-width: 0; background: none; border: 0; padding: 0;
+  font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.copy-field .copy-val.empty { color: var(--text-quiet); font-family: var(--font-sans); }
+.copy-btn {
+  display: inline-flex; align-items: center; gap: 5px; flex-shrink: 0; cursor: pointer;
+  background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+  border-radius: var(--radius-sm); padding: 5px 9px; font-size: var(--text-xs); font-weight: 500;
+  transition: color var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out);
+}
+.copy-btn:hover { color: var(--text); border-color: var(--border-strong); background: var(--surface-3); }
+.copy-btn.copied, .copy-field.flash { color: var(--success-fg); border-color: var(--success-bd); background: var(--success-bg); }
+.copy-field.flash code, .copy-field.flash .copy-val { color: var(--success-fg); }
+.copy-field.flash-warn { border-color: var(--danger-bd); }
+.copy-field.flash-warn code, .copy-field.flash-warn .copy-val { color: var(--danger-fg); }
+
+/* ---------------------------------------------------------------------
+   Code blocks (connect snippets)
+   --------------------------------------------------------------------- */
+.code-block { position: relative; background: var(--ink-950); border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; }
+.code-block-path { font-family: var(--font-mono); font-size: 11px; color: var(--text-quiet); padding: 6px var(--space-4); border-bottom: 1px solid var(--border); background: var(--ink-900); }
+.code-block pre { margin: 0; padding: var(--space-3) 44px var(--space-3) var(--space-4); overflow-x: auto; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-2); white-space: pre; }
+.code-block .copy-btn { position: absolute; top: 8px; right: 8px; }
+
+/* ---------------------------------------------------------------------
+   Tabs (connect snippet switcher)
+   --------------------------------------------------------------------- */
+.tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--border); overflow-x: auto; scrollbar-width: none; }
+.tabs::-webkit-scrollbar { display: none; }
+.tab {
+  background: transparent; border: 0; border-bottom: 2px solid transparent;
+  color: var(--text-muted); font-family: var(--font-sans); font-size: var(--text-sm); font-weight: 500;
+  padding: var(--space-2) var(--space-3); cursor: pointer; margin-bottom: -1px; white-space: nowrap;
+  transition: color var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out);
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
+/* ---------------------------------------------------------------------
+   Toggle switch — custom amber switch replacing native checkboxes.
+   Markup: <label class="switch"><input type="checkbox" id=…><span class="track"></span></label>
+   --------------------------------------------------------------------- */
+.switch { position: relative; display: inline-flex; flex-shrink: 0; cursor: pointer; }
+.switch input { position: absolute; opacity: 0; width: 0; height: 0; margin: 0; }
+.switch .track {
+  width: 38px; height: 22px; border-radius: var(--radius-pill);
+  background: var(--ink-700); border: 1px solid var(--border-strong);
+  transition: background var(--t-base) var(--ease-out), border-color var(--t-base) var(--ease-out);
+  position: relative; display: inline-block;
+}
+.switch .track::after {
+  content: ''; position: absolute; top: 2px; left: 2px; width: 16px; height: 16px;
+  border-radius: 50%; background: var(--ink-200);
+  transition: transform var(--t-base) var(--ease-out), background var(--t-base) var(--ease-out);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+}
+.switch input:checked + .track { background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600)); border-color: var(--kiln-700); }
+.switch input:checked + .track::after { transform: translateX(16px); background: #fff; }
+.switch input:focus-visible + .track { outline: 2px solid var(--accent-ring); outline-offset: 2px; }
+.switch input:disabled + .track { opacity: 0.45; cursor: default; }
+.switch input:disabled { cursor: default; }
+
+/* ---------------------------------------------------------------------
+   Modal (shortcuts dialog, HF token dialog)
    --------------------------------------------------------------------- */
 .modal-overlay {
-  background: rgba(8, 9, 12, 0.66) !important;
-  backdrop-filter: blur(8px) saturate(140%);
-  -webkit-backdrop-filter: blur(8px) saturate(140%);
+  position: fixed; inset: 0; z-index: 1000; display: flex; align-items: center; justify-content: center;
+  background: rgba(10, 9, 8, 0.66); backdrop-filter: blur(8px) saturate(140%); -webkit-backdrop-filter: blur(8px) saturate(140%);
 }
+.modal-overlay.hidden { display: none !important; }
 .modal-card {
-  background: var(--surface) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-lg) !important;
-  box-shadow: var(--shadow-3) !important;
-  padding: 22px 26px !important;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-3); padding: 22px 26px; max-width: 440px; width: 90%; max-height: 84vh; overflow-y: auto;
 }
-.modal-card header {
-  background: transparent !important;
-  border: 0 !important;
-  padding: 0 !important;
-}
-.modal-card header h2 {
-  font-family: var(--font-display);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text) !important;
-}
-.modal-card header button#shortcuts-close,
-.modal-card header button#shortcuts-close:hover {
-  color: var(--text-muted) !important;
-  background: transparent !important;
-}
-.modal-card header button#shortcuts-close:hover { color: var(--text) !important; }
-.modal-card dt { color: var(--text-2) !important; }
+.modal-card header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); margin: 0 0 var(--space-4) 0; padding: 0; background: transparent; border: 0; }
+.modal-card header h2 { margin: 0; font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700; letter-spacing: var(--tracking-tight); color: var(--text); }
+.modal-card dl { display: grid; grid-template-columns: 1fr auto; column-gap: var(--space-4); row-gap: var(--space-3); margin: 0; align-items: center; }
+.modal-card dt { color: var(--text-2); font-size: var(--text-sm); }
+.modal-card dd { margin: 0; display: flex; gap: 4px; align-items: center; justify-content: flex-end; flex-wrap: wrap; }
 .modal-card kbd {
-  background: var(--canvas) !important;
-  color: var(--text-2) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: var(--radius-xs) !important;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 500;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+  display: inline-block; background: var(--canvas); color: var(--text-2);
+  border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 2px 6px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500; line-height: 1; box-shadow: 0 1px 0 rgba(0,0,0,0.3);
 }
-.modal-card p.hint { color: var(--text-muted) !important; }
+.modal-card p.hint { margin: var(--space-4) 0 0 0; color: var(--text-muted); font-size: 11px; }
+.modal-close { background: transparent; border: 0; color: var(--text-muted); padding: 2px; cursor: pointer; display: inline-flex; border-radius: var(--radius-sm); }
+.modal-close:hover { color: var(--text); background: rgba(255,255,255,0.05); }
+.modal-close .icn { width: 18px; height: 18px; }
 
-/* ---------------------------------------------------------------------
-   Index window — system tray placeholder
-   --------------------------------------------------------------------- */
-body > .wrap > h1 + p,
-body > .wrap > p,
-body > .wrap > p.hint {
-  color: var(--text-3) !important;
+/* =====================================================================
+   Dashboard — top app bar + secondary status strip + landing states
+   ===================================================================== */
+.appbar {
+  position: absolute; top: 0; left: 0; right: 0; z-index: 20;
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-2) var(--space-4); min-height: 54px;
+  background: rgba(14, 13, 11, 0.82); border-bottom: 1px solid var(--border);
+  backdrop-filter: saturate(150%) blur(12px); -webkit-backdrop-filter: saturate(150%) blur(12px);
 }
-body > .wrap > p.hint { color: var(--text-muted) !important; }
+.appbar-left { display: flex; align-items: center; gap: var(--space-3); flex-shrink: 0; }
+.appbar-center { flex: 1; min-width: 0; display: flex; justify-content: center; }
+.appbar-right { display: flex; align-items: center; gap: var(--space-2); flex-shrink: 0; }
+.appbar .brand-mark { width: 28px; height: 28px; }
+.appbar .brand-name { font-size: var(--text-lg); }
+
+/* Center base-URL copy field — the single most important agent fact. */
+.appbar-baseurl { width: 100%; max-width: 420px; }
+.appbar-baseurl.empty { opacity: 0.75; }
+.appbar-baseurl .copy-val { cursor: pointer; }
+
+.appbar .icon-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  background: var(--surface-2); color: var(--text-muted); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); padding: 6px; cursor: pointer; font-size: var(--text-xs);
+  transition: background var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+.appbar .icon-btn:hover { background: var(--surface-3); border-color: var(--border-strong); color: var(--text); }
+.appbar .icon-btn .icn { width: 17px; height: 17px; }
+.appbar .icon-btn.has-label { padding: 6px 11px; font-weight: 500; }
+
+/* Banner stack — sits in normal flow below the app bar (no magic offset). */
+.banner-stack { position: absolute; top: 54px; left: 0; right: 0; z-index: 15; display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2) var(--space-4) 0; }
+.banner {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: linear-gradient(180deg, var(--warning-bg), var(--ink-800));
+  border: 1px solid var(--warning-bd); color: var(--warning-fg);
+  border-radius: var(--radius-md); padding: 9px var(--space-3); font-size: var(--text-sm);
+  box-shadow: var(--shadow-2);
+}
+.banner .icn { color: var(--warning-fg); flex-shrink: 0; }
+.banner-text { flex: 1; min-width: 0; }
+.banner .btn { background: var(--warning-bg); color: var(--warning-fg); border-color: var(--warning-bd); }
+.banner .btn:hover { background: var(--ink-700); color: var(--warning-fg); }
+.banner .banner-dismiss { background: transparent; border-color: transparent; color: var(--warning-fg); padding: 4px; }
+.banner .banner-dismiss:hover { background: rgba(251, 191, 36, 0.1); border-color: transparent; }
+
+/* Secondary status strip — Model / VRAM / Adapter / Training; running only. */
+.status-strip {
+  position: absolute; top: 54px; left: 0; right: 0; z-index: 14;
+  display: flex; align-items: center; gap: var(--space-4); flex-wrap: wrap;
+  padding: 8px var(--space-4); background: rgba(14, 13, 11, 0.6);
+  border-bottom: 1px solid var(--border); font-size: var(--text-xs);
+}
+/* When a banner is showing, the JS-driven banner-stack already takes top:54px;
+   the strip simply follows in flow visually because both are absolute. We keep
+   the strip hidden unless the body is in a running state. */
+body:not(.is-running) .status-strip { display: none; }
+.strip-item { display: inline-flex; align-items: center; gap: 7px; color: var(--text-3); min-width: 0; max-width: 320px; }
+.strip-item .icn { width: 14px; height: 14px; color: var(--text-quiet); flex-shrink: 0; }
+.strip-item .strip-label { color: var(--text-quiet); font-size: var(--text-2xs); font-weight: 600; letter-spacing: var(--tracking-caps); text-transform: uppercase; flex-shrink: 0; }
+.strip-item code { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.strip-item code.empty { color: var(--text-quiet); font-family: var(--font-sans); }
+.strip-item.copyable { cursor: pointer; border-radius: var(--radius-sm); padding: 2px 4px; margin: -2px -4px; transition: background var(--t-fast) var(--ease-out); }
+.strip-item.copyable:hover { background: var(--surface-2); }
+.strip-item.flash { color: var(--success-fg); }
+.strip-item.flash code, .strip-item.flash .strip-label { color: var(--success-fg); }
+.strip-item.flash-warn { color: var(--danger-fg); }
+.strip-item.flash-warn code, .strip-item.flash-warn .strip-label { color: var(--danger-fg); }
+
+/* Landing states (status / install) — centered branded canvas */
+.landing {
+  position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 54px var(--space-7) var(--space-7); text-align: center; overflow-y: auto;
+  background: radial-gradient(120% 80% at 50% 0%, rgba(249, 115, 22, 0.07), transparent 60%), var(--bg);
+}
+.landing.hidden { display: none !important; }
+.landing-inner { width: 100%; max-width: 640px; display: flex; flex-direction: column; align-items: center; gap: var(--space-4); }
+.landing h1 { margin: 0; font-family: var(--font-display); font-size: var(--text-3xl); font-weight: 700; letter-spacing: var(--tracking-tight); color: var(--text); }
+.landing p { margin: 0; color: var(--text-3); font-size: var(--text-md); line-height: 1.55; max-width: 520px; }
+.landing p.help-links { color: var(--text-muted); font-size: var(--text-sm); }
+.landing code { background: var(--surface-2); color: var(--text-2); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 2px 6px; font-size: var(--text-xs); }
+.landing-actions { display: flex; gap: var(--space-2); justify-content: center; flex-wrap: wrap; }
+
+/* Connect-your-agent onboarding card — mirrors the server Connect panel. */
+.connect-card { width: 100%; max-width: 600px; text-align: left; border-color: var(--accent-ring); }
+.connect-card::before { content: ''; position: absolute; inset: 0; pointer-events: none; background: radial-gradient(620px 200px at 8% -40px, rgba(249, 115, 22, 0.1), transparent 64%); }
+.connect-card > * { position: relative; }
+.connect-steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); }
+.connect-step { display: flex; align-items: flex-start; gap: var(--space-3); padding: var(--space-2) 0; }
+.step-num {
+  flex-shrink: 0; width: 24px; height: 24px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;
+  font-size: var(--text-xs); font-weight: 700; background: var(--surface-3); color: var(--text-muted); border: 1px solid var(--border);
+}
+.connect-step.done .step-num { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
+.connect-step.done .step-num .icn { width: 14px; height: 14px; }
+.step-body { min-width: 0; flex: 1; }
+.step-title { font-size: var(--text-sm); font-weight: 600; color: var(--text); display: flex; align-items: center; gap: 7px; }
+.connect-step.done .step-title { color: var(--text-2); }
+.step-title .step-ok { font-size: var(--text-2xs); font-weight: 600; color: var(--success-fg); display: inline-flex; align-items: center; gap: 4px; }
+.step-sub { font-size: var(--text-xs); color: var(--text-muted); margin-top: 2px; line-height: 1.5; }
+
+/* Install progress (shared with settings update bars) */
+.progress-track { width: 100%; max-width: 420px; height: 8px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-pill); overflow: hidden; }
+.progress-fill { height: 100%; width: 0%; background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400)); box-shadow: 0 0 18px rgba(249, 115, 22, 0.45); transition: width var(--t-base) var(--ease-out); }
+.progress-fill.error { background: linear-gradient(90deg, var(--danger-bd), var(--danger-fg)); box-shadow: none; }
+.progress-fill.cancelled { background: linear-gradient(90deg, var(--warning-bd), var(--warning-fg)); box-shadow: none; }
+.progress-label { color: var(--text-muted); font-family: var(--font-mono); font-size: var(--text-xs); font-variant-numeric: tabular-nums; min-height: 16px; }
+
+#install.phase-ready .progress-track, #install.phase-ready .progress-label { visibility: hidden; }
+#install.phase-active #install-download-btn, #install.phase-active #install-browse-btn { display: none; }
+#install.phase-ready #install-cancel-btn, #install.phase-done #install-cancel-btn, #install.phase-failed #install-cancel-btn { display: none; }
+
+/* =====================================================================
+   Settings — two-pane layout
+   ===================================================================== */
+.settings-shell { display: flex; min-height: 100vh; }
+.settings-nav {
+  position: sticky; top: 0; align-self: flex-start; flex-shrink: 0; width: 220px; height: 100vh;
+  border-right: 1px solid var(--border); background: var(--canvas); padding: var(--space-5) var(--space-3); overflow-y: auto;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.settings-nav .nav-brand { display: flex; align-items: center; gap: var(--space-3); padding: 0 var(--space-2) var(--space-5); }
+.settings-nav .nav-brand .brand-name { font-size: var(--text-lg); }
+.nav-link {
+  display: flex; align-items: center; gap: var(--space-3); padding: 8px var(--space-3); border-radius: var(--radius-sm);
+  color: var(--text-muted); font-size: var(--text-sm); font-weight: 500; cursor: pointer; text-decoration: none;
+  border: 1px solid transparent; transition: background var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+.nav-link .icn { width: 16px; height: 16px; color: var(--text-quiet); }
+.nav-link:hover { background: var(--surface-2); color: var(--text); text-decoration: none; }
+.nav-link.active { background: var(--accent-soft); color: var(--kiln-200); border-color: var(--accent-ring); }
+.nav-link.active .icn { color: var(--accent-hover); }
+.settings-main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.settings-content { flex: 1; padding: var(--space-6) var(--space-7) 96px; max-width: 760px; width: 100%; }
+.settings-content > h1 { margin: 0 0 var(--space-5); font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 700; letter-spacing: var(--tracking-tight); }
+.settings-section { margin-bottom: var(--space-6); scroll-margin-top: var(--space-5); }
+.settings-section > .card { }
+
+.field-row {
+  display: grid; grid-template-columns: 1fr minmax(220px, auto); align-items: center; gap: var(--space-3) var(--space-5);
+  padding: var(--space-3) 0; border-bottom: 1px solid var(--border);
+}
+.field-row:last-child { border-bottom: 0; }
+.field-row .field-name { font-size: var(--text-sm); font-weight: 500; color: var(--text-2); }
+.field-row .field-control { display: flex; align-items: center; gap: var(--space-2); justify-self: end; }
+.field-row .field-hint { grid-column: 1 / -1; font-size: var(--text-xs); color: var(--text-muted); line-height: 1.45; margin-top: -2px; }
+.field-row .field-hint.agent-note { color: var(--text-3); }
+.field-row .field-hint.agent-note::before { content: '› '; color: var(--accent-hover); font-weight: 700; }
+.field-row .path-warning { grid-column: 1 / -1; display: none; align-items: center; gap: 6px; font-size: var(--text-xs); color: var(--warning-fg); line-height: 1.4; }
+.field-row .path-warning.visible { display: flex; }
+.field-row .path-warning .icn { width: 14px; height: 14px; }
+.field-row .path-ok { grid-column: 1 / -1; display: none; align-items: center; gap: 6px; font-size: var(--text-xs); color: var(--success-fg); }
+.field-row .path-ok.visible { display: flex; }
+.field-row .path-ok .icn { width: 14px; height: 14px; }
+
+.text-input {
+  background: var(--canvas); color: var(--text); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-family: var(--font-mono); font-size: var(--text-xs); padding: 7px 10px; min-width: 0;
+  transition: border-color var(--t-fast) var(--ease-out), box-shadow var(--t-fast) var(--ease-out);
+}
+.text-input:focus { outline: 0; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.text-input.w-md { width: 240px; }
+.text-input.w-sm { width: 110px; }
+.path-control { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
+.path-control .text-input { width: 200px; }
+
+/* Agents-connect live preview banner inside settings model section */
+.agents-preview {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  background: var(--ink-850); border: 1px solid var(--accent-ring); border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4); margin: var(--space-3) 0 0;
+}
+.agents-preview .ap-label { display: flex; align-items: center; gap: 7px; font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; }
+.agents-preview .ap-label .icn { color: var(--accent-hover); width: 14px; height: 14px; }
+.agents-preview .ap-url { font-family: var(--font-mono); font-size: var(--text-md); color: var(--text); font-weight: 500; }
+.agents-preview .ap-cmd { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-muted); }
+.agents-preview .ap-cmd code { color: var(--kiln-300); }
+
+/* Update stepper (collapsed staged-update flow) */
+.update-stepper { display: flex; flex-direction: column; gap: var(--space-3); }
+.update-stage-labels { display: flex; align-items: center; gap: var(--space-2); font-size: var(--text-xs); color: var(--text-quiet); }
+.update-stage-labels .stage { display: inline-flex; align-items: center; gap: 5px; }
+.update-stage-labels .stage.active { color: var(--accent-hover); font-weight: 600; }
+.update-stage-labels .stage.done { color: var(--success-fg); }
+.update-stage-labels .stage-sep { color: var(--border-strong); }
+details.update-manual { margin-top: var(--space-2); }
+details.update-manual > summary { cursor: pointer; font-size: var(--text-xs); color: var(--text-muted); list-style: none; display: inline-flex; align-items: center; gap: 6px; }
+details.update-manual > summary::-webkit-details-marker { display: none; }
+details.update-manual > summary:hover { color: var(--text-2); }
+details.update-manual[open] > summary { margin-bottom: var(--space-3); }
+.manual-actions { display: flex; gap: var(--space-2); flex-wrap: wrap; }
+
+.update-status { font-size: var(--text-xs); color: var(--text-muted); line-height: 1.4; display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.update-status.up-to-date { color: var(--success-fg); }
+.update-status.available { color: var(--warning-fg); }
+.update-status.warn { color: var(--warning-fg); }
+.update-status.error { color: var(--danger-fg); }
+.update-status .badge { font-family: var(--font-mono); font-size: 11px; padding: 1px 7px; border-radius: var(--radius-xs); background: var(--surface-2); border: 1px solid var(--border); }
+.update-status.available .badge { background: var(--warning-bg); border-color: var(--warning-bd); color: var(--warning-fg); }
+.update-status.up-to-date .badge { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
+.update-status.warn .badge { background: var(--warning-bg); border-color: var(--warning-bd); color: var(--warning-fg); }
+.update-status .icn { width: 14px; height: 14px; }
+
+.update-download { display: flex; flex-direction: column; gap: 6px; margin-top: var(--space-2); }
+.update-download.hidden { display: none; }
+.update-download-line { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); line-height: 1.4; word-break: break-all; }
+.update-download-line.error { color: var(--danger-fg); }
+.update-download-line.success { color: var(--success-fg); }
+.update-bar { height: 6px; background: var(--canvas); border: 1px solid var(--border); border-radius: var(--radius-pill); overflow: hidden; }
+.update-fill { height: 100%; width: 0%; background: linear-gradient(90deg, var(--kiln-600), var(--kiln-400)); box-shadow: 0 0 12px rgba(249, 115, 22, 0.4); transition: width var(--t-base) var(--ease-out); }
+.update-fill.error { background: linear-gradient(90deg, var(--danger-bd), var(--danger-fg)); box-shadow: none; }
+.update-fill.cancelled { background: linear-gradient(90deg, var(--warning-bd), var(--warning-fg)); box-shadow: none; }
+
+/* Sticky bottom save bar */
+.save-bar {
+  position: fixed; bottom: 0; left: 220px; right: 0; z-index: 30;
+  display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-7);
+  background: rgba(14, 13, 11, 0.92); border-top: 1px solid var(--border);
+  backdrop-filter: blur(10px) saturate(140%); -webkit-backdrop-filter: blur(10px) saturate(140%);
+}
+.save-bar .save-status { flex: 1; min-width: 0; font-size: var(--text-xs); color: var(--success-fg); }
+.save-bar .save-status.error { color: var(--danger-fg); }
+.save-bar .save-status:empty::before { content: ''; }
+.save-bar .save-actions { display: flex; gap: var(--space-2); }
+
+/* Help links row */
+.help-row { color: var(--text-muted); font-size: var(--text-xs); line-height: 1.5; margin: var(--space-3) 0 0; }
+
+/* HF modal form */
+.hf-form label { display: block; margin: var(--space-3) 0 4px; font-size: var(--text-xs); color: var(--text-2); font-weight: 500; }
+.hf-form .text-input { width: 100%; }
+.hf-form .hint { margin: 4px 0 0; color: var(--text-muted); font-size: 11px; line-height: 1.4; }
+.hf-progress { margin-top: var(--space-4); display: flex; flex-direction: column; gap: 6px; }
+.hf-progress.hidden { display: none; }
+.hf-progress-line { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); line-height: 1.4; word-break: break-all; }
+.hf-progress-line.error { color: var(--danger-fg); }
+.hf-progress-line.success { color: var(--success-fg); }
+.hf-actions { display: flex; gap: var(--space-2); justify-content: flex-end; margin-top: var(--space-4); }
+
+@media (max-width: 720px) {
+  .settings-nav { display: none; }
+  .save-bar { left: 0; }
+}
+
+/* =====================================================================
+   Logs window
+   ===================================================================== */
+.logs-header {
+  display: flex; align-items: center; gap: var(--space-3); padding: 10px var(--space-4); flex: 0 0 auto;
+  background: rgba(14, 13, 11, 0.92); border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(8px) saturate(140%); -webkit-backdrop-filter: blur(8px) saturate(140%);
+}
+.logs-header .brand-mark { width: 24px; height: 24px; }
+.logs-title { display: flex; align-items: center; gap: var(--space-2); }
+.logs-title h1 { margin: 0; font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700; letter-spacing: var(--tracking-tight); color: var(--text); }
+.logs-controls { display: flex; align-items: center; gap: var(--space-3); flex: 1; justify-content: flex-end; flex-wrap: wrap; }
+.switch-label { display: inline-flex; align-items: center; gap: 7px; font-size: var(--text-xs); color: var(--text-3); cursor: pointer; user-select: none; }
+.logs-search {
+  background: var(--canvas); color: var(--text); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 5px 10px; width: 170px; font-size: var(--text-xs); font-family: var(--font-mono); outline: none;
+  transition: border-color var(--t-fast) var(--ease-out), box-shadow var(--t-fast) var(--ease-out);
+}
+.logs-search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.tail-indicator { display: inline-flex; align-items: center; gap: 6px; font-size: var(--text-2xs); color: var(--text-muted); font-family: var(--font-mono); }
+.tail-indicator .tail-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--success-fg); box-shadow: 0 0 6px rgba(74, 222, 128, 0.5); animation: kiln-pulse 1.6s ease-in-out infinite; }
+#filter-count { font-size: var(--text-xs); color: var(--text-muted); font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+#filter-count.hidden { display: none; }
+
+#log {
+  flex: 1 1 auto; margin: 0; padding: var(--space-3) var(--space-4); background: var(--bg); color: var(--text-2);
+  font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word; overflow-y: auto; overflow-x: hidden;
+}
+#log .line { white-space: pre-wrap; }
+#log .line-stdout { color: var(--text-2); }
+#log .line-stderr { color: var(--danger-fg); border-left: 2px solid var(--danger-bd); padding-left: 8px; margin-left: -10px; }
+#log.empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-3); color: var(--text-quiet); font-style: normal; text-align: center; }
+.log-empty-state { display: none; flex-direction: column; align-items: center; gap: var(--space-3); color: var(--text-quiet); }
+#log.empty .log-empty-state { display: flex; }
+.log-empty-state .brand-mark { width: 48px; height: 48px; opacity: 0.85; }
+.log-empty-state .empty-title { font-size: var(--text-md); color: var(--text-muted); }
+.log-empty-state .empty-sub { font-size: var(--text-xs); color: var(--text-quiet); }
+
+/* =====================================================================
+   About + Index — centered branded cards
+   ===================================================================== */
+.center-page { display: flex; flex-direction: column; min-height: 100vh; }
+.center-page .center-body { flex: 1 1 auto; display: flex; align-items: center; justify-content: center; padding: var(--space-7) var(--space-6); overflow-y: auto; }
+.about-card { width: 100%; max-width: 460px; display: flex; flex-direction: column; align-items: center; gap: var(--space-4); text-align: center; }
+.about-card .brand-mark { box-shadow: var(--glow-brand), inset 0 1px 0 rgba(255,255,255,0.12); }
+.about-title { margin: 0; font-family: var(--font-display); font-size: var(--text-3xl); font-weight: 700; letter-spacing: var(--tracking-tight); color: var(--text); }
+.about-tagline { margin: 0; color: var(--text-3); font-size: var(--text-md); line-height: 1.6; max-width: 400px; }
+.spec-rows { display: flex; flex-direction: column; gap: 0; width: 100%; max-width: 360px; border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; background: var(--surface); }
+.spec-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: 9px var(--space-4); border-bottom: 1px solid var(--border); }
+.spec-row:last-child { border-bottom: 0; }
+.spec-label { font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; }
+.spec-value { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text-2); font-variant-numeric: tabular-nums; }
+.about-links { display: flex; flex-direction: column; gap: 6px; align-items: center; font-size: var(--text-xs); color: var(--text-muted); }
+.about-links .link-row { display: inline-flex; align-items: center; gap: 7px; }
+.about-links .link-row .icn { width: 14px; height: 14px; color: var(--text-quiet); }
+.about-footer { flex: 0 0 auto; display: flex; justify-content: flex-end; gap: var(--space-2); padding: var(--space-3) var(--space-4); background: var(--surface); border-top: 1px solid var(--border); }
+
+/* Index (tray placeholder) — centered fire mark + soft ambient glow */
+.tray-page { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: var(--space-7);
+  background: radial-gradient(60% 50% at 50% 45%, rgba(249, 115, 22, 0.1), transparent 70%), var(--bg); }
+.tray-card { display: flex; flex-direction: column; align-items: center; gap: var(--space-4); text-align: center; max-width: 460px; }
+.tray-card .brand-mark { box-shadow: var(--glow-brand), inset 0 1px 0 rgba(255,255,255,0.12); }
+.tray-title { margin: 0; font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 700; letter-spacing: var(--tracking-tight); color: var(--text); }
+.tray-card p { margin: 0; color: var(--text-3); font-size: var(--text-md); line-height: 1.55; max-width: 420px; }
+.tray-card p.hint { color: var(--text-muted); font-size: var(--text-sm); }

--- a/desktop/ui/about.html
+++ b/desktop/ui/about.html
@@ -10,8 +10,8 @@
         padding: 0;
         height: 100%;
         width: 100%;
-        background: #0f1115;
-        color: #e6e6e6;
+        background: var(--bg);
+        color: var(--text);
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         overflow: hidden;
       }
@@ -29,28 +29,28 @@
         font-size: 20px;
         font-weight: 600;
         margin: 0 0 4px 0;
-        color: #f0f2f6;
+        color: var(--text);
       }
       .version {
-        color: #a8aeb8;
+        color: var(--text-2);
         font-size: 13px;
         margin: 0 0 18px 0;
         font-variant-numeric: tabular-nums;
       }
       p.desc {
-        color: #cfd3da;
+        color: var(--text-2);
         font-size: 13px;
         line-height: 1.55;
         margin: 0 0 14px 0;
       }
       .meta {
-        color: #a8aeb8;
+        color: var(--text-2);
         font-size: 12px;
         line-height: 1.6;
         margin: 14px 0 0 0;
       }
       .meta a {
-        color: #5f9bff;
+        color: var(--accent);
         text-decoration: none;
       }
       .meta a:hover {
@@ -62,11 +62,11 @@
         justify-content: flex-end;
         gap: 8px;
         padding: 10px 14px;
-        background: #161922;
-        border-top: 1px solid #232733;
+        background: var(--surface);
+        border-top: 1px solid var(--border);
       }
       button {
-        background: #2a6df4;
+        background: var(--accent);
         color: #fff;
         border: 0;
         border-radius: 6px;
@@ -74,14 +74,14 @@
         font-size: 12px;
         cursor: pointer;
       }
-      button:hover { background: #3b7af5; }
+      button:hover { background: var(--accent-hover); }
       button.secondary {
-        background: #232733;
-        color: #e6e6e6;
+        background: var(--surface-2);
+        color: var(--text);
       }
-      button.secondary:hover { background: #2c313f; }
+      button.secondary:hover { background: var(--surface-3); }
       .platform {
-        color: #a8aeb8;
+        color: var(--text-2);
         font-size: 12px;
         margin: 0 0 18px 0;
         font-variant-numeric: tabular-nums;

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -5,621 +5,211 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Kiln Dashboard</title>
     <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-        background: #0f1115;
-        color: #e6e6e6;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        overflow: hidden;
-      }
-      #frame {
-        display: block;
-        width: 100vw;
-        height: 100vh;
-        border: 0;
-        background: #0f1115;
-      }
-      #status {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: 32px;
-        box-sizing: border-box;
-        text-align: center;
-        background: #0f1115;
-      }
-      #status h1 {
-        font-size: 18px;
-        margin: 0 0 8px 0;
-        font-weight: 600;
-      }
-      #status p {
-        margin: 4px 0;
-        color: #a8aeb8;
-        font-size: 14px;
-        max-width: 440px;
-      }
-      #status p.help-links {
-        margin-top: 14px;
-        font-size: 12px;
-      }
-      #status a.doc-link {
-        color: #5f9bff;
-        text-decoration: none;
-      }
-      #status a.doc-link:hover { text-decoration: underline; }
-      #status code {
-        background: #1b1e24;
-        padding: 2px 6px;
-        border-radius: 4px;
-        font-size: 13px;
-      }
-      button {
-        margin-top: 16px;
-        background: #2a6df4;
-        color: #fff;
-        border: 0;
-        border-radius: 6px;
-        padding: 8px 14px;
-        font-size: 13px;
-        cursor: pointer;
-      }
-      button:hover { background: #3b7af5; }
-      button:disabled { background: #2a2f3a; cursor: default; }
-      .hidden { display: none !important; }
-      #status-actions {
-        display: flex;
-        gap: 8px;
-        justify-content: center;
-      }
-      #install {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        padding: 32px;
-        box-sizing: border-box;
-        text-align: center;
-        background: #0f1115;
-      }
-      #install h1 {
-        font-size: 20px;
-        margin: 0 0 8px 0;
-        font-weight: 600;
-      }
-      #install p {
-        margin: 4px 0 12px 0;
-        color: #a8aeb8;
-        font-size: 14px;
-        max-width: 560px;
-        line-height: 1.5;
-      }
-      #install code {
-        background: #1b1e24;
-        padding: 2px 6px;
-        border-radius: 4px;
-        font-size: 12px;
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-      }
-      #install-progress-wrap {
-        width: 420px;
-        max-width: 80vw;
-        height: 10px;
-        background: #1b1e24;
-        border: 1px solid #2a2f3a;
-        border-radius: 5px;
-        overflow: hidden;
-        margin: 14px 0 6px 0;
-      }
-      #install-progress-bar {
-        height: 100%;
-        width: 0;
-        background: #2a6df4;
-        transition: width 120ms ease;
-      }
-      #install-progress-label {
-        color: #a8aeb8;
-        font-size: 12px;
-        font-variant-numeric: tabular-nums;
-        min-height: 16px;
-      }
-      #install-actions {
-        display: flex;
-        gap: 10px;
-        justify-content: center;
-        margin-top: 18px;
-      }
-      #install-actions button {
-        margin-top: 0;
-      }
-      #install-actions button.secondary {
-        background: #232733;
-        color: #e6e6e6;
-      }
-      #install-actions button.secondary:hover { background: #2c313f; }
-      #install a.doc-link {
-        color: #5f9bff;
-        font-size: 12px;
-        text-decoration: none;
-      }
-      #install a.doc-link:hover { text-decoration: underline; }
-      #install.phase-ready #install-progress-wrap,
-      #install.phase-ready #install-progress-label { visibility: hidden; }
-      #install.phase-active #install-download-btn,
-      #install.phase-active #install-browse-btn { display: none; }
-      #install.phase-ready #install-cancel-btn,
-      #install.phase-done #install-cancel-btn,
-      #install.phase-failed #install-cancel-btn { display: none; }
-      #toolbar {
-        position: absolute;
-        top: 8px;
-        right: 12px;
-        left: 12px;
-        max-width: calc(100vw - 24px);
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-        gap: 8px;
-        z-index: 10;
-        background: rgba(15, 17, 21, 0.85);
-        backdrop-filter: blur(4px);
-        padding: 6px 8px;
-        border-radius: 8px;
-      }
-      #toolbar button {
-        margin-top: 0;
-        background: #1b1e24;
-        color: #d8dbe2;
-        border: 1px solid #2a2f3a;
-        padding: 6px 10px;
-        font-size: 12px;
-      }
-      #toolbar button:hover { background: #232831; }
-      #update-banner {
-        position: absolute;
-        top: 58px;
-        left: 12px;
-        right: 12px;
-        max-width: calc(100vw - 24px);
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        z-index: 9;
-        background: rgba(90, 51, 36, 0.95);
-        border: 1px solid #7a432f;
-        color: #f2ddd6;
-        padding: 8px 12px;
-        border-radius: 8px;
-        font-size: 13px;
-      }
-      #update-banner-text { flex: 1; }
-      #update-banner button {
-        margin-top: 0;
-        background: #7a432f;
-        color: #f2ddd6;
-        border: 1px solid #a05a3f;
-        padding: 4px 10px;
-        font-size: 12px;
-      }
-      #update-banner button:hover { background: #a05a3f; }
-      #update-banner button.secondary {
-        background: transparent;
-        color: #f2ddd6;
-        border: 1px solid transparent;
-        padding: 2px 8px;
-        font-size: 16px;
-        line-height: 1;
-      }
-      #update-banner button.secondary:hover { background: rgba(255, 255, 255, 0.08); }
-      #toolbar button#stop-server:hover { background: #5a2424; border-color: #7a3232; color: #f2d6d6; }
-      #toolbar button#stop-server:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
-      #toolbar button#restart-server:hover { background: #3a4a6a; border-color: #4a5a7a; color: #d6e0f2; }
-      #toolbar button#restart-server:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
-      #toolbar .toolbar-divider {
-        width: 1px;
-        align-self: stretch;
-        background: #2a2f3a;
-        margin: 2px 4px;
-      }
-      #stop-server.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #restart-server.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #copy-url.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #copy-url.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #check-updates-btn.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #check-updates-btn.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #check-updates-btn:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
-      #model-path-pill.copyable { cursor: pointer; }
-      #model-path-pill.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #model-path-pill.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #model-path-pill.flash #model-path,
-      #model-path-pill.flash-warn #model-path { color: inherit; }
-      #adapter-pill.copyable { cursor: pointer; }
-      #adapter-pill.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #adapter-pill.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #adapter-pill.flash #adapter-name,
-      #adapter-pill.flash-warn #adapter-name { color: inherit; }
-      #vram-pill.copyable { cursor: pointer; }
-      #vram-pill.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #vram-pill.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #vram-pill.flash #vram-value,
-      #vram-pill.flash-warn #vram-value { color: inherit; }
-      #base-url.copyable { cursor: pointer; }
-      #base-url.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
-      #base-url.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
-      #status-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        font-size: 12px;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        user-select: none;
-      }
-      #status-badge .dot {
-        display: inline-block;
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: #6c7280;
-        flex-shrink: 0;
-      }
-      #status-badge.state-stopped .dot { background: #6c7280; }
-      #status-badge.state-starting .dot { background: #d4a64a; }
-      #status-badge.state-running .dot { background: #2f9e44; }
-      #status-badge.state-training .dot { background: #2a6df4; }
-      #status-badge.state-error .dot { background: #e03131; }
-      #status-badge.state-unknown .dot { background: #6c7280; }
-      #base-url {
-        display: inline-flex;
-        align-items: center;
-        padding: 6px 10px;
-        font-size: 12px;
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        user-select: text;
-        cursor: text;
-        max-width: 280px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      #base-url.empty {
-        color: #6c7280;
-        font-family: inherit;
-        user-select: none;
-        cursor: default;
-      }
-      #model-path-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        font-size: 12px;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        max-width: 280px;
-        overflow: hidden;
-      }
-      #model-path-pill .model-label {
-        color: #6c7280;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        flex-shrink: 0;
-      }
-      #model-path {
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: transparent;
-        padding: 0;
-        font-size: 12px;
-        color: inherit;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        user-select: text;
-        min-width: 0;
-      }
-      #model-path.empty {
-        color: #6c7280;
-        font-family: inherit;
-        user-select: none;
-      }
-      #vram-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        font-size: 12px;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        overflow: hidden;
-      }
-      #vram-pill .vram-label {
-        color: #6c7280;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        flex-shrink: 0;
-      }
-      #vram-value {
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: transparent;
-        padding: 0;
-        font-size: 12px;
-        color: inherit;
-        white-space: nowrap;
-        user-select: text;
-      }
-      #vram-value.empty {
-        color: #6c7280;
-        font-family: inherit;
-        user-select: none;
-      }
-      #adapter-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        font-size: 12px;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        max-width: 220px;
-        overflow: hidden;
-      }
-      #adapter-pill .adapter-label {
-        color: #6c7280;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        flex-shrink: 0;
-      }
-      #adapter-name {
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: transparent;
-        padding: 0;
-        font-size: 12px;
-        color: inherit;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        user-select: text;
-        min-width: 0;
-      }
-      #adapter-name.empty {
-        color: #6c7280;
-        font-family: inherit;
-        user-select: none;
-      }
-      #training-pill {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 10px;
-        font-size: 12px;
-        background: #1b1e24;
-        color: #a8aeb8;
-        border: 1px solid #2a2f3a;
-        border-radius: 6px;
-        max-width: 260px;
-        overflow: hidden;
-      }
-      #training-pill .training-label {
-        color: #6c7280;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        flex-shrink: 0;
-      }
-      #training-value {
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        background: transparent;
-        padding: 0;
-        font-size: 12px;
-        color: inherit;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        user-select: text;
-        min-width: 0;
-      }
-      #training-value.empty {
-        color: #6c7280;
-        font-family: inherit;
-        user-select: none;
-      }
-      .modal-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.55);
-        backdrop-filter: blur(4px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 1000;
-      }
-      .modal-overlay.hidden {
-        display: none !important;
-      }
-      .modal-card {
-        background: #1b1e24;
-        border: 1px solid #2a2f3a;
-        border-radius: 8px;
-        padding: 20px 24px;
-        max-width: 420px;
-        width: 90%;
-        max-height: 80vh;
-        overflow-y: auto;
-        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
-      }
-      .modal-card header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin: 0 0 14px 0;
-      }
-      .modal-card header h2 {
-        margin: 0;
-        font-size: 15px;
-        font-weight: 600;
-        color: #e6e6e6;
-      }
-      .modal-card header button#shortcuts-close {
-        margin: 0;
-        background: transparent;
-        color: #a8aeb8;
-        border: 0;
-        padding: 0 4px;
-        font-size: 22px;
-        line-height: 1;
-        cursor: pointer;
-      }
-      .modal-card header button#shortcuts-close:hover {
-        color: #e6e6e6;
-        background: transparent;
-      }
-      .modal-card dl {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        column-gap: 16px;
-        row-gap: 10px;
-        margin: 0;
-        align-items: center;
-      }
-      .modal-card dt {
-        color: #d8dbe2;
-        font-size: 13px;
-      }
-      .modal-card dd {
-        margin: 0;
-        display: flex;
-        gap: 4px;
-        align-items: center;
-        justify-content: flex-end;
-        flex-wrap: wrap;
-      }
-      .modal-card kbd {
-        display: inline-block;
-        background: #0f1115;
-        border: 1px solid #2a2f3a;
-        border-radius: 4px;
-        padding: 2px 6px;
-        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
-        font-size: 11px;
-        color: #e6e6e6;
-        line-height: 1;
-      }
-      .modal-card p.hint {
-        margin: 14px 0 0 0;
-        color: #6c7280;
-        font-size: 11px;
-      }
+      html, body { margin: 0; padding: 0; height: 100%; width: 100%; overflow: hidden; }
+      #frame { display: block; width: 100vw; height: 100vh; border: 0; background: var(--bg); }
+      #frame.hidden { display: none !important; }
+      /* Pull the framed UI / landing states below the fixed app bar + strip. */
+      body.is-running #frame { height: calc(100vh - 54px); margin-top: 54px; }
     </style>
     <link rel="stylesheet" href="_kiln-tokens.css" />
   </head>
   <body>
-    <div id="toolbar">
-      <span id="status-badge" class="state-unknown" title="Kiln server state">
-        <span class="dot"></span>
-        <span class="label">Unknown</span>
-      </span>
-      <span id="model-path-pill" title="Configured model path — not set">
-        <span class="model-label">Model:</span>
+    <!-- Icon sprite — monochrome inline SVG (Lucide-style, 24px grid,
+         currentColor), shared with the server dashboard design system. -->
+    <svg width="0" height="0" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true" focusable="false"><defs>
+      <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+      <symbol id="i-flame" viewBox="0 0 24 24"><path d="M12 3c.6 2.4 2 3.7 3.2 5C16.6 9.6 18 11.3 18 14a6 6 0 0 1-12 0c0-1.6.7-3 1.8-4 .3 1.2 1.2 2 2.2 2 1.3 0 1.7-1.4 1-3-.5-1.1-1-2.3-1-3.4C10 5.3 11 4 12 3Z"/></symbol>
+      <symbol id="i-play" viewBox="0 0 24 24"><path d="M8 5.2v13.6L19 12 8 5.2Z" fill="currentColor" stroke="none"/></symbol>
+      <symbol id="i-stop" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2.2"/></symbol>
+      <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></symbol>
+      <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+      <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+      <symbol id="i-gear" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3.2"/><path d="M19.5 14a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.1-2.7l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5 1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V10a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.4 1z"/></symbol>
+      <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+      <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+      <symbol id="i-warning" viewBox="0 0 24 24"><path d="M10.3 3.9 1.9 18a2 2 0 0 0 1.7 3h16.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9.5v4.5"/><path d="M12 17.5h.01"/></symbol>
+      <symbol id="i-download" viewBox="0 0 24 24"><path d="M12 4v11"/><path d="m7.5 10.5 4.5 4.5 4.5-4.5"/><path d="M5 20h14"/></symbol>
+      <symbol id="i-folder" viewBox="0 0 24 24"><path d="M4 7a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7Z"/></symbol>
+      <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+      <symbol id="i-layers" viewBox="0 0 24 24"><path d="m12 3 9 5-9 5-9-5 9-5Z"/><path d="m3 13 9 5 9-5"/></symbol>
+      <symbol id="i-cpu" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 1v3M15 1v3M9 20v3M15 20v3M1 9h3M1 15h3M20 9h3M20 15h3"/></symbol>
+      <symbol id="i-flask" viewBox="0 0 24 24"><path d="M9 3h6"/><path d="M10 3v6.5L5.2 18A1.6 1.6 0 0 0 6.6 21h10.8a1.6 1.6 0 0 0 1.4-3L14 9.5V3"/><path d="M7.6 14.5h8.8"/></symbol>
+      <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+      <symbol id="i-close" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></symbol>
+    </defs></svg>
+
+    <!-- Top app bar: brand + state chip · click-to-copy base URL · lifecycle CTA + tools -->
+    <header id="toolbar" class="appbar">
+      <div class="appbar-left">
+        <span class="brand">
+          <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
+          <span class="brand-name">Kiln</span>
+        </span>
+        <span id="status-badge" class="state-chip state-unknown" title="Kiln server state">
+          <span class="dot"></span>
+          <span class="label">Unknown</span>
+        </span>
+      </div>
+
+      <div class="appbar-center">
+        <div class="copy-field appbar-baseurl empty" title="OpenAI base URL — server not running">
+          <span class="copy-val empty" id="base-url">Server not running</span>
+          <button class="copy-btn" id="copy-url" type="button" title="Copy the OpenAI-compatible base URL for this server (Ctrl/Cmd+Shift+C)">
+            <svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg><span class="copy-btn-label">Copy</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="appbar-right">
+        <button id="start-toolbar" class="btn btn-primary hidden" type="button" title="Start the kiln server (Ctrl/Cmd+Shift+S)">
+          <svg class="icn icn-sm" aria-hidden="true"><use href="#i-play"></use></svg> <span class="btn-label">Start server</span>
+        </button>
+        <button id="stop-server" class="btn btn-danger hidden" type="button" title="Stop the running kiln server (Ctrl/Cmd+Shift+.)">
+          <svg class="icn icn-sm" aria-hidden="true"><use href="#i-stop"></use></svg> <span class="btn-label">Stop</span>
+        </button>
+        <button id="restart-server" class="btn btn-warm hidden" type="button" title="Restart the kiln server (Ctrl/Cmd+Shift+R)">
+          <svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> <span class="btn-label">Restart</span>
+        </button>
+        <button id="open-logs" class="icon-btn" type="button" title="Open the log viewer window (Ctrl/Cmd+L)" aria-label="View logs">
+          <svg class="icn" aria-hidden="true"><use href="#i-terminal"></use></svg>
+        </button>
+        <button id="open-settings" class="icon-btn" type="button" title="Open the settings window (Ctrl/Cmd+,)" aria-label="Settings">
+          <svg class="icn" aria-hidden="true"><use href="#i-gear"></use></svg>
+        </button>
+        <button id="check-updates-btn" class="icon-btn" type="button" title="Check for an updated version of Kiln Desktop" aria-label="Check for updates">
+          <svg class="icn" aria-hidden="true"><use href="#i-refresh"></use></svg>
+        </button>
+      </div>
+    </header>
+
+    <!-- Secondary status strip — visible only while running -->
+    <div class="status-strip" aria-live="polite">
+      <span id="model-path-pill" class="strip-item" title="Configured model path — not set">
+        <svg class="icn" aria-hidden="true"><use href="#i-layers"></use></svg>
+        <span class="strip-label">Model</span>
         <code id="model-path" class="empty">—</code>
       </span>
-      <code id="base-url" class="empty" title="OpenAI base URL — server not running">—</code>
-      <span id="vram-pill" title="Model / Total VRAM — server not running">
-        <span class="vram-label">VRAM:</span>
+      <span id="vram-pill" class="strip-item" title="Model / Total VRAM — server not running">
+        <svg class="icn" aria-hidden="true"><use href="#i-cpu"></use></svg>
+        <span class="strip-label">VRAM</span>
         <code id="vram-value" class="empty">—</code>
       </span>
-      <span id="adapter-pill" title="Active LoRA adapter — none">
-        <span class="adapter-label">Adapter:</span>
+      <span id="adapter-pill" class="strip-item" title="Active LoRA adapter — none">
+        <svg class="icn" aria-hidden="true"><use href="#i-activity"></use></svg>
+        <span class="strip-label">Adapter</span>
         <code id="adapter-name" class="empty">—</code>
       </span>
-      <span id="training-pill" title="Training status — server not running">
-        <span class="training-label">Training:</span>
+      <span id="training-pill" class="strip-item" title="Training status — server not running">
+        <svg class="icn" aria-hidden="true"><use href="#i-flask"></use></svg>
+        <span class="strip-label">Training</span>
         <code id="training-value" class="empty">—</code>
       </span>
-      <span class="toolbar-divider" aria-hidden="true"></span>
-      <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server (Ctrl/Cmd+Shift+C)">Copy OpenAI base URL</button>
-      <button id="stop-server" class="hidden" title="Stop the running kiln server (Ctrl/Cmd+Shift+.)">Stop Server</button>
-      <button id="restart-server" class="hidden" title="Restart the kiln server (Ctrl/Cmd+Shift+R)">Restart Server</button>
-      <button id="open-logs" title="Open the log viewer window (Ctrl/Cmd+L)">View Logs</button>
-      <button id="open-settings" title="Open the settings window (Ctrl/Cmd+,)">Settings</button>
-      <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
     </div>
-    <div id="update-banner" class="hidden" role="status" aria-live="polite">
-      <span id="update-banner-text">A newer kiln server is available.</span>
-      <button id="update-banner-open-settings" title="Open settings to review and install">Open Settings</button>
-      <button id="update-banner-dismiss" class="secondary" title="Dismiss this banner for this session" aria-label="Dismiss">×</button>
+
+    <!-- Banners stack in normal flow below the app bar (no magic offset) -->
+    <div class="banner-stack">
+      <div id="update-banner" class="banner hidden" role="status" aria-live="polite">
+        <svg class="icn" aria-hidden="true"><use href="#i-download"></use></svg>
+        <span id="update-banner-text" class="banner-text">A newer kiln server is available.</span>
+        <button id="update-banner-open-settings" class="btn btn-sm" type="button" title="Open settings to review and install">Open Settings</button>
+        <button id="update-banner-dismiss" class="btn btn-sm btn-icon banner-dismiss" type="button" title="Dismiss this banner for this session" aria-label="Dismiss"><svg class="icn icn-sm"><use href="#i-close"></use></svg></button>
+      </div>
     </div>
+
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
-    <div id="status">
-      <h1 id="status-title">Connecting to Kiln server…</h1>
-      <p id="status-detail">Looking up the server URL from your settings.</p>
-      <div id="status-actions">
-        <button id="start-server" class="hidden" title="Start the kiln server (Ctrl/Cmd+Shift+S)">Start Server</button>
-        <button id="retry" class="hidden">Retry</button>
-        <button id="open-settings-btn" class="hidden">Open Settings</button>
+
+    <!-- Status landing — connect-your-agent onboarding for non-running states -->
+    <div id="status" class="landing">
+      <div class="landing-inner">
+        <span class="brand-mark brand-mark-lg" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
+        <h1 id="status-title">Connecting to Kiln server…</h1>
+        <p id="status-detail">Looking up the server URL from your settings.</p>
+        <div id="status-actions" class="landing-actions">
+          <button id="start-server" class="btn btn-primary btn-lg hidden" type="button" title="Start the kiln server (Ctrl/Cmd+Shift+S)">
+            <svg class="icn icn-sm" aria-hidden="true"><use href="#i-play"></use></svg> <span class="btn-label">Start server</span>
+          </button>
+          <button id="retry" class="btn hidden" type="button"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> Retry</button>
+          <button id="open-settings-btn" class="btn hidden" type="button"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-gear"></use></svg> Open Settings</button>
+        </div>
+
+        <section class="card connect-card">
+          <div class="card-head">
+            <h2>Connect your agent</h2>
+            <span class="eyebrow">Point pi, opencode, or any OpenAI client at Kiln</span>
+          </div>
+          <div class="card-body">
+            <ol class="connect-steps">
+              <li class="connect-step" id="connect-step-model">
+                <span class="step-num"><span class="step-num-text">1</span></span>
+                <span class="step-body">
+                  <span class="step-title">Set or download a model <span class="step-ok hidden" id="connect-model-ok"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg> Configured</span></span>
+                  <span class="step-sub">Browse to local weights or pull from HuggingFace in Settings.</span>
+                </span>
+              </li>
+              <li class="connect-step" id="connect-step-start">
+                <span class="step-num"><span class="step-num-text">2</span></span>
+                <span class="step-body">
+                  <span class="step-title">Start the server</span>
+                  <span class="step-sub">Click <strong>Start server</strong> above — it serves an OpenAI-compatible API.</span>
+                </span>
+              </li>
+              <li class="connect-step" id="connect-step-point">
+                <span class="step-num"><span class="step-num-text">3</span></span>
+                <span class="step-body">
+                  <span class="step-title">Point your agent</span>
+                  <span class="step-sub">Run one of these against <code id="connect-base">http://127.0.0.1:8000/v1</code>:</span>
+                  <div class="tabs connect-tabs" role="tablist" aria-label="Client setup" style="margin-top:var(--space-2);">
+                    <button class="tab active" type="button" role="tab" data-connect-tab="pi" aria-selected="true">pi</button>
+                    <button class="tab" type="button" role="tab" data-connect-tab="opencode" aria-selected="false">opencode</button>
+                    <button class="tab" type="button" role="tab" data-connect-tab="curl" aria-selected="false">curl</button>
+                  </div>
+                  <div id="connect-snippets" style="margin-top:var(--space-2);"></div>
+                </span>
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        <p class="help-links">
+          First run? Follow the
+          <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>
+          or
+          <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
+          guide.
+        </p>
       </div>
-      <p class="help-links">
-        First run? Set your model path and kiln server binary in Settings, then follow the
-        <a class="doc-link" href="https://ericflo.github.io/kiln/quickstart.html"
-           target="_blank" rel="noopener noreferrer">Quickstart</a>
-        or
-        <a class="doc-link" href="https://ericflo.github.io/kiln/troubleshooting.html"
-           target="_blank" rel="noopener noreferrer">Troubleshooting</a>
-        guide.
-      </p>
     </div>
-    <div id="install" class="phase-ready hidden">
-      <h1 id="install-title">Kiln server isn't installed yet</h1>
-      <p id="install-detail">
-        Kiln Desktop ships as a thin wrapper. Download the signed
-        <code>kiln</code> server binary to finish setup, or point to an
-        existing local build.
-      </p>
-      <div id="install-progress-wrap"><div id="install-progress-bar"></div></div>
-      <div id="install-progress-label">&nbsp;</div>
-      <div id="install-actions">
-        <button id="install-download-btn">Download Kiln Server</button>
-        <button id="install-cancel-btn" class="secondary">Cancel</button>
-        <button id="install-browse-btn" class="secondary">Use a local build…</button>
+
+    <!-- Install landing — branded, with the same progress primitives -->
+    <div id="install" class="landing phase-ready hidden">
+      <div class="landing-inner">
+        <span class="brand-mark brand-mark-lg" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-download"></use></svg></span>
+        <h1 id="install-title">Kiln server isn't installed yet</h1>
+        <p id="install-detail">
+          Kiln Desktop ships as a thin wrapper. Download the signed
+          <code>kiln</code> server binary to finish setup, or point to an
+          existing local build.
+        </p>
+        <div id="install-progress-wrap" class="progress-track"><div id="install-progress-bar" class="progress-fill"></div></div>
+        <div id="install-progress-label" class="progress-label">&nbsp;</div>
+        <div id="install-actions" class="landing-actions">
+          <button id="install-download-btn" class="btn btn-primary btn-lg"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-download"></use></svg> Download Kiln server</button>
+          <button id="install-cancel-btn" class="btn">Cancel</button>
+          <button id="install-browse-btn" class="btn"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-folder"></use></svg> Use a local build…</button>
+        </div>
+        <p class="help-links" id="install-footnote">
+          Need setup help? Read the
+          <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>, check
+          <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>, or
+          <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" target="_blank" rel="noopener noreferrer">build from source</a>.
+        </p>
       </div>
-      <p id="install-footnote">
-        Need setup help? Read the
-        <a class="doc-link" href="https://ericflo.github.io/kiln/quickstart.html"
-           target="_blank" rel="noopener noreferrer">Quickstart</a>, check
-        <a class="doc-link" href="https://ericflo.github.io/kiln/troubleshooting.html"
-           target="_blank" rel="noopener noreferrer">Troubleshooting</a>, or
-        <a class="doc-link" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md"
-           target="_blank" rel="noopener noreferrer">build from source</a>.
-      </p>
     </div>
     <div id="shortcuts-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
       <div class="modal-card">
         <header>
           <h2 id="shortcuts-title">Keyboard Shortcuts</h2>
-          <button id="shortcuts-close" aria-label="Close">×</button>
+          <button id="shortcuts-close" class="modal-close" aria-label="Close"><svg class="icn"><use href="#i-close"></use></svg></button>
         </header>
         <dl>
           <dt>Start Server</dt>
@@ -678,8 +268,25 @@
       const detail = document.getElementById("status-detail");
       const retry = document.getElementById("retry");
       const startBtn = document.getElementById("start-server");
+      const startToolbarBtn = document.getElementById("start-toolbar");
       const settingsNeededBtn = document.getElementById("open-settings-btn");
-      const START_LABEL = "Start Server";
+      const START_LABEL = "Start server";
+
+      // Buttons carry a leading icon + a .btn-label span; write text into the
+      // span so the icon survives "Starting…"/reset transitions. Falls back to
+      // textContent for label-less elements.
+      function setBtnLabel(btn, text) {
+        if (!btn) return;
+        const span = btn.querySelector(".btn-label");
+        if (span) span.textContent = text;
+        else btn.textContent = text;
+      }
+
+      // Toggle body chrome state. The secondary status strip + framed-UI offset
+      // appear only while the server is actually running/training.
+      function setBodyRunning(on) {
+        document.body.classList.toggle("is-running", !!on);
+      }
 
       const installPane = document.getElementById("install");
       const installTitle = document.getElementById("install-title");
@@ -697,12 +304,13 @@
         frame.src = "about:blank";
         status.classList.remove("hidden");
         installPane.classList.add("hidden");
+        setBodyRunning(false);
         title.textContent = titleText;
         detail.textContent = detailText;
         retry.classList.toggle("hidden", !showRetry);
         startBtn.classList.toggle("hidden", !showStart);
         startBtn.disabled = false;
-        startBtn.textContent = START_LABEL;
+        setBtnLabel(startBtn, START_LABEL);
         settingsNeededBtn.classList.add("hidden");
       }
 
@@ -711,13 +319,14 @@
         frame.src = "about:blank";
         status.classList.remove("hidden");
         installPane.classList.add("hidden");
+        setBodyRunning(false);
         title.textContent = "Kiln is not configured yet";
         detail.textContent =
-          "Set your model path in Settings to get started. Kiln needs to know which model to load.";
+          "Set or download a model in Settings to get started — Kiln needs to know which weights to load.";
         retry.classList.add("hidden");
         startBtn.classList.add("hidden");
         startBtn.disabled = false;
-        startBtn.textContent = START_LABEL;
+        setBtnLabel(startBtn, START_LABEL);
         settingsNeededBtn.classList.remove("hidden");
       }
 
@@ -726,6 +335,7 @@
         frame.classList.remove("hidden");
         status.classList.add("hidden");
         installPane.classList.add("hidden");
+        setBodyRunning(true);
       }
 
       function hideInstallPane() {
@@ -755,6 +365,7 @@
         frame.src = "about:blank";
         status.classList.add("hidden");
         installPane.classList.remove("hidden");
+        setBodyRunning(false);
         installPlatformSupported = !!(bstatus && bstatus.platform_supported);
         if (installPlatformSupported) {
           installTitle.textContent = "Kiln server isn't installed yet";
@@ -981,14 +592,18 @@
           return;
         }
         startBtn.disabled = true;
-        startBtn.textContent = "Starting…";
+        startToolbarBtn.disabled = true;
+        setBtnLabel(startBtn, "Starting…");
+        setBtnLabel(startToolbarBtn, "Starting…");
         retry.classList.add("hidden");
         try {
           await invoke("start_server");
         } catch (err) {
           detail.textContent = String(err || "Failed to start server.");
           startBtn.disabled = false;
-          startBtn.textContent = START_LABEL;
+          startToolbarBtn.disabled = false;
+          setBtnLabel(startBtn, START_LABEL);
+          setBtnLabel(startToolbarBtn, START_LABEL);
           retry.classList.remove("hidden");
           return;
         }
@@ -1007,14 +622,19 @@
         }
         detail.textContent = "Server did not come up in time. Check the log viewer.";
         startBtn.disabled = false;
-        startBtn.textContent = START_LABEL;
+        startToolbarBtn.disabled = false;
+        setBtnLabel(startBtn, START_LABEL);
+        setBtnLabel(startToolbarBtn, START_LABEL);
         retry.classList.remove("hidden");
       }
 
       startBtn.addEventListener("click", startServerInline);
+      startToolbarBtn.addEventListener("click", startServerInline);
 
       const copyBtn = document.getElementById("copy-url");
-      const COPY_LABEL = "Copy OpenAI base URL";
+      const copyBtnLabel = copyBtn.querySelector(".copy-btn-label");
+      const copyField = copyBtn.closest(".copy-field");
+      const COPY_LABEL = "Copy";
       let copyResetTimer = null;
 
       function flashCopyBtn(label, cls) {
@@ -1022,12 +642,15 @@
           clearTimeout(copyResetTimer);
           copyResetTimer = null;
         }
-        copyBtn.textContent = label;
-        copyBtn.classList.remove("flash", "flash-warn");
-        if (cls) copyBtn.classList.add(cls);
+        if (copyBtnLabel) copyBtnLabel.textContent = label;
+        copyBtn.classList.remove("copied");
+        if (copyField) copyField.classList.remove("flash", "flash-warn");
+        if (cls === "flash") copyBtn.classList.add("copied");
+        if (cls && copyField) copyField.classList.add(cls);
         copyResetTimer = setTimeout(() => {
-          copyBtn.textContent = COPY_LABEL;
-          copyBtn.classList.remove("flash", "flash-warn");
+          if (copyBtnLabel) copyBtnLabel.textContent = COPY_LABEL;
+          copyBtn.classList.remove("copied");
+          if (copyField) copyField.classList.remove("flash", "flash-warn");
           copyResetTimer = null;
         }, 1500);
       }
@@ -1088,7 +711,7 @@
       });
 
       const stopBtn = document.getElementById("stop-server");
-      const STOP_LABEL = "Stop Server";
+      const STOP_LABEL = "Stop";
       const STOP_ACTIVE_STATES = ["Starting", "Running", "TrainingActive"];
       let stopResetTimer = null;
 
@@ -1097,11 +720,11 @@
           clearTimeout(stopResetTimer);
           stopResetTimer = null;
         }
-        stopBtn.textContent = label;
+        setBtnLabel(stopBtn, label);
         stopBtn.classList.remove("flash-warn");
         if (cls) stopBtn.classList.add(cls);
         stopResetTimer = setTimeout(() => {
-          stopBtn.textContent = STOP_LABEL;
+          setBtnLabel(stopBtn, STOP_LABEL);
           stopBtn.classList.remove("flash-warn");
           stopBtn.disabled = false;
           stopResetTimer = null;
@@ -1114,7 +737,7 @@
           return;
         }
         stopBtn.disabled = true;
-        stopBtn.textContent = "Stopping…";
+        setBtnLabel(stopBtn, "Stopping…");
         try {
           await invoke("stop_server");
         } catch (err) {
@@ -1127,7 +750,7 @@
       stopBtn.addEventListener("click", stopServer);
 
       const restartBtn = document.getElementById("restart-server");
-      const RESTART_LABEL = "Restart Server";
+      const RESTART_LABEL = "Restart";
       const RESTART_ACTIVE_STATES = ["Running", "TrainingActive", "Error"];
       let restartResetTimer = null;
 
@@ -1136,11 +759,11 @@
           clearTimeout(restartResetTimer);
           restartResetTimer = null;
         }
-        restartBtn.textContent = label;
+        setBtnLabel(restartBtn, label);
         restartBtn.classList.remove("flash-warn");
         if (cls) restartBtn.classList.add(cls);
         restartResetTimer = setTimeout(() => {
-          restartBtn.textContent = RESTART_LABEL;
+          setBtnLabel(restartBtn, RESTART_LABEL);
           restartBtn.classList.remove("flash-warn");
           restartBtn.disabled = false;
           restartResetTimer = null;
@@ -1153,7 +776,7 @@
           return;
         }
         restartBtn.disabled = true;
-        restartBtn.textContent = "Restarting…";
+        setBtnLabel(restartBtn, "Restarting…");
         try {
           await invoke("restart_server");
         } catch (err) {
@@ -1320,21 +943,22 @@
       }
 
       const baseUrlEl = document.getElementById("base-url");
-      const BASE_URL_EMPTY_LABEL = "—";
+      const baseUrlField = baseUrlEl.closest(".copy-field");
+      const BASE_URL_EMPTY_LABEL = "Server not running";
       const BASE_URL_EMPTY_TITLE = "OpenAI base URL — server not running";
       let cachedBaseUrl = null;
 
       function setBaseUrl(url) {
         if (url) {
           baseUrlEl.textContent = url;
-          baseUrlEl.title = `${url} (click to copy)`;
           baseUrlEl.classList.remove("empty");
           baseUrlEl.classList.add("copyable");
+          if (baseUrlField) { baseUrlField.classList.remove("empty"); baseUrlField.title = `${url} (click to copy)`; }
         } else {
           baseUrlEl.textContent = BASE_URL_EMPTY_LABEL;
-          baseUrlEl.title = BASE_URL_EMPTY_TITLE;
           baseUrlEl.classList.add("empty");
           baseUrlEl.classList.remove("copyable");
+          if (baseUrlField) { baseUrlField.classList.add("empty"); baseUrlField.title = BASE_URL_EMPTY_TITLE; }
         }
       }
 
@@ -1344,10 +968,12 @@
           clearTimeout(baseUrlResetTimer);
           baseUrlResetTimer = null;
         }
-        baseUrlEl.classList.remove("flash", "flash-warn");
-        if (cls) baseUrlEl.classList.add(cls);
+        if (baseUrlField) {
+          baseUrlField.classList.remove("flash", "flash-warn");
+          if (cls) baseUrlField.classList.add(cls);
+        }
         baseUrlResetTimer = setTimeout(() => {
-          baseUrlEl.classList.remove("flash", "flash-warn");
+          if (baseUrlField) baseUrlField.classList.remove("flash", "flash-warn");
           baseUrlResetTimer = null;
         }, 1200);
       }
@@ -1378,6 +1004,103 @@
       }
 
       baseUrlEl.addEventListener("click", copyBaseUrl);
+
+      // -----------------------------------------------------------------
+      // Connect-your-agent onboarding card (shown in non-running states).
+      // Mirrors the server dashboard's Connect panel: a 3-step checklist
+      // with copy-ready pi / opencode / curl snippets built from the
+      // configured host:port. Step 1 turns green once a model is set.
+      // -----------------------------------------------------------------
+      const connectBaseEl = document.getElementById("connect-base");
+      const connectSnippetsEl = document.getElementById("connect-snippets");
+      const connectStepModel = document.getElementById("connect-step-model");
+      const connectModelOk = document.getElementById("connect-model-ok");
+      let connectBaseUrl = "http://127.0.0.1:8000/v1";
+      const CONNECT_MODEL = "kiln";
+
+      function connectSnippetData(base) {
+        return {
+          pi: { note: "One command points pi at this Kiln server and makes it the default model.",
+            code: "# Point pi at this Kiln server\nkiln pi-setup" },
+          opencode: { note: "Add this provider, then run opencode and pick the model with /models.",
+            code: '{\n  "provider": {\n    "kiln": {\n      "npm": "@ai-sdk/openai-compatible",\n      "name": "Kiln (local)",\n      "options": { "baseURL": "' + base + '", "apiKey": "unused" },\n      "models": { "' + CONNECT_MODEL + '": { "name": "Kiln" } }\n    }\n  }\n}' },
+          curl: { note: "Raw HTTP — drop into any shell or script. No API key needed.",
+            code: "curl -s " + base + "/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"" + CONNECT_MODEL + "\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}'" },
+        };
+      }
+
+      function escapeForHtml(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+      }
+
+      function renderConnectSnippets(active) {
+        if (!connectSnippetsEl) return;
+        const data = connectSnippetData(connectBaseUrl);
+        connectSnippetsEl.innerHTML = Object.entries(data).map(([key, s]) => {
+          return '<div class="connect-snippet' + (key === active ? " active" : "") + '" data-connect-pane="' + key + '"' + (key === active ? "" : ' hidden') + '>' +
+            '<div class="step-sub" style="margin-bottom:6px;">' + escapeForHtml(s.note) + '</div>' +
+            '<div class="code-block"><button class="copy-btn" type="button" data-copy-code aria-label="Copy code"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button><pre>' + escapeForHtml(s.code) + '</pre></div>' +
+          '</div>';
+        }).join("");
+      }
+
+      function selectConnectTab(key) {
+        document.querySelectorAll(".connect-tabs .tab").forEach((t) => {
+          const on = t.dataset.connectTab === key;
+          t.classList.toggle("active", on);
+          t.setAttribute("aria-selected", String(on));
+        });
+        document.querySelectorAll(".connect-snippet").forEach((p) => {
+          const on = p.dataset.connectPane === key;
+          p.classList.toggle("active", on);
+          p.hidden = !on;
+        });
+      }
+
+      document.querySelectorAll(".connect-tabs .tab").forEach((t) => {
+        t.addEventListener("click", () => selectConnectTab(t.dataset.connectTab));
+      });
+      if (connectSnippetsEl) {
+        connectSnippetsEl.addEventListener("click", async (e) => {
+          const btn = e.target.closest("[data-copy-code]");
+          if (!btn) return;
+          const code = btn.parentElement.querySelector("pre");
+          if (!code) return;
+          try {
+            await navigator.clipboard.writeText(code.textContent);
+            const orig = btn.innerHTML;
+            btn.classList.add("copied");
+            btn.innerHTML = '<svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg>Copied';
+            setTimeout(() => { btn.classList.remove("copied"); btn.innerHTML = orig; }, 1500);
+          } catch (_) { /* clipboard unavailable */ }
+        });
+      }
+
+      function setConnectModelDone(done) {
+        if (!connectStepModel) return;
+        connectStepModel.classList.toggle("done", done);
+        if (connectModelOk) connectModelOk.classList.toggle("hidden", !done);
+        const num = connectStepModel.querySelector(".step-num");
+        if (num) num.innerHTML = done
+          ? '<svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg>'
+          : '<span class="step-num-text">1</span>';
+      }
+
+      async function refreshConnect() {
+        if (!invoke) { renderConnectSnippets("pi"); return; }
+        try {
+          const s = await invoke("get_settings");
+          const host = (s && s.host) || "127.0.0.1";
+          const port = (s && s.port) || 8000;
+          connectBaseUrl = "http://" + host + ":" + port + "/v1";
+          setConnectModelDone(!!(s && s.model_path && String(s.model_path).trim()));
+        } catch (_) { /* keep defaults */ }
+        if (connectBaseEl) connectBaseEl.textContent = connectBaseUrl;
+        const active = document.querySelector(".connect-snippet.active")?.dataset.connectPane
+          || document.querySelector(".connect-tabs .tab.active")?.dataset.connectTab || "pi";
+        renderConnectSnippets(active);
+      }
+      renderConnectSnippets("pi");
 
       async function refreshBaseUrl(kind) {
         if (!invoke || kind !== "Running") {
@@ -1613,7 +1336,7 @@
         stopBtn.classList.toggle("hidden", !shouldShow);
         if (!shouldShow && !stopResetTimer) {
           stopBtn.disabled = false;
-          stopBtn.textContent = STOP_LABEL;
+          setBtnLabel(stopBtn, STOP_LABEL);
         }
       }
 
@@ -1622,8 +1345,18 @@
         restartBtn.classList.toggle("hidden", !shouldShow);
         if (!shouldShow && !restartResetTimer) {
           restartBtn.disabled = false;
-          restartBtn.textContent = RESTART_LABEL;
+          setBtnLabel(restartBtn, RESTART_LABEL);
         }
+      }
+
+      // App-bar Start CTA — shown only when the server can be started right
+      // now (stopped / errored). Hidden while running/starting/training, and
+      // while a binary is missing (the install pane owns that flow).
+      const START_VISIBLE_STATES = ["Stopped", "Error"];
+      function updateStartBtnVisibility(kind) {
+        const shouldShow = START_VISIBLE_STATES.includes(kind);
+        startToolbarBtn.classList.toggle("hidden", !shouldShow);
+        if (shouldShow && !startToolbarBtn.disabled) setBtnLabel(startToolbarBtn, START_LABEL);
       }
 
       let stateFailureLogged = false;
@@ -1636,6 +1369,7 @@
           await refreshTrainingInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           updateRestartBtnVisibility("Unknown");
+          updateStartBtnVisibility("Unknown");
           return;
         }
         try {
@@ -1690,6 +1424,7 @@
           await refreshTrainingInfo(kind);
           updateStopBtnVisibility(kind);
           updateRestartBtnVisibility(kind);
+          updateStartBtnVisibility(kind);
           stateFailureLogged = false;
         } catch (err) {
           applyStatusBadge("Unknown", "Could not read server state");
@@ -1699,6 +1434,7 @@
           await refreshTrainingInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           updateRestartBtnVisibility("Unknown");
+          updateStartBtnVisibility("Unknown");
           if (!stateFailureLogged) {
             console.error("server_state poll failed", err);
             stateFailureLogged = true;
@@ -1732,6 +1468,7 @@
       }
 
       window.addEventListener("focus", refreshModelPath);
+      window.addEventListener("focus", refreshConnect);
 
       let modelPathPillResetTimer = null;
       function flashModelPathPill(cls) {
@@ -1929,6 +1666,7 @@
         load();
         pollServerState();
         refreshModelPath();
+        refreshConnect();
         setInterval(pollServerState, 2000);
         setInterval(tickUptime, 1000);
       });

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -4,35 +4,44 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Kiln Desktop</title>
+    <link rel="stylesheet" href="_kiln-tokens.css" />
     <style>
       html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        background: #0f1115;
-        color: #e6e6e6;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        margin: 0; padding: 0; height: 100%;
+        background: var(--bg);
+        color: var(--text);
+        font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
       }
+      /* Centered, framed tray-landing card so the window reads as intentional,
+         not a stranded fragment in an empty canvas. */
       .wrap {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: center;
-        height: 100%;
-        padding: 32px;
-        box-sizing: border-box;
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        gap: 14px; height: 100%; padding: 32px; box-sizing: border-box; text-align: center;
       }
-      h1 { font-size: 22px; margin: 0 0 8px 0; font-weight: 600; }
-      p  { margin: 8px 0; color: #a8aeb8; font-size: 14px; max-width: 560px; }
-      p.hint { color: #6b7280; font-size: 12px; }
+      .mark {
+        width: 56px; height: 56px; border-radius: 13px;
+        background: linear-gradient(180deg, #fbbf24 0%, #f97316 52%, #c2410c 100%);
+        display: flex; align-items: center; justify-content: center;
+        box-shadow: 0 6px 24px rgba(249, 115, 22, 0.22);
+      }
+      .mark svg { width: 32px; height: 32px; }
+      h1 { font-size: 20px; margin: 4px 0 0; font-weight: 700; letter-spacing: -0.01em; }
+      p  { margin: 0; color: var(--text-2); font-size: 14px; line-height: 1.5; max-width: 460px; }
+      p.hint { color: var(--text-muted); font-size: 12px; }
+      .tray-dot { color: var(--accent); }
     </style>
-    <link rel="stylesheet" href="_kiln-tokens.css" />
   </head>
   <body>
     <div class="wrap">
-      <h1>Kiln Desktop</h1>
-      <p>Running in the system tray. Click the Kiln icon in your menu bar or system tray to open the dashboard, change settings, view logs, or quit.</p>
-      <p class="hint">If you do not see the tray icon, check that the app is running and that your OS is showing tray icons.</p>
+      <div class="mark" aria-hidden="true">
+        <!-- stacked-layers brand mark (echoes the logo), cut from the ember cube -->
+        <svg viewBox="0 0 32 32" fill="none" stroke="#0a0908" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+          <path d="M8 12.5l8 4 8-4" /><path d="M10 17.5l6 3 6-3" /><path d="M12 22.5l4 2 4-2" />
+        </svg>
+      </div>
+      <h1>Kiln is running</h1>
+      <p>Kiln lives in your <span class="tray-dot">system tray</span>. Click the tray icon to open the dashboard, watch logs, change settings, or quit.</p>
+      <p class="hint">No tray icon? Confirm the app is running and that your OS is showing tray icons.</p>
     </div>
   </body>
 </html>

--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -10,8 +10,8 @@
         padding: 0;
         height: 100%;
         width: 100%;
-        background: #0f1115;
-        color: #e6e6e6;
+        background: var(--bg);
+        color: var(--text);
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         overflow: hidden;
       }
@@ -24,8 +24,8 @@
         align-items: center;
         gap: 12px;
         padding: 10px 14px;
-        background: #161922;
-        border-bottom: 1px solid #232733;
+        background: var(--surface);
+        border-bottom: 1px solid var(--border);
         flex: 0 0 auto;
       }
       header h1 {
@@ -33,11 +33,11 @@
         font-weight: 600;
         margin: 0;
         flex: 1 1 auto;
-        color: #cfd3dc;
+        color: var(--text-2);
       }
       header label {
         font-size: 12px;
-        color: #a8aeb8;
+        color: var(--text-muted);
         display: flex;
         align-items: center;
         gap: 6px;
@@ -45,13 +45,13 @@
         user-select: none;
       }
       header input[type="checkbox"] {
-        accent-color: #2a6df4;
+        accent-color: var(--accent);
         margin: 0;
       }
       header input[type="search"] {
-        background: #0f1115;
-        color: #e6e6e6;
-        border: 1px solid #232733;
+        background: var(--surface-2);
+        color: var(--text);
+        border: 1px solid var(--border);
         border-radius: 6px;
         padding: 4px 8px;
         width: 180px;
@@ -59,34 +59,40 @@
         outline: none;
       }
       header input[type="search"]:focus {
-        border-color: #2a6df4;
+        border-color: var(--accent-ring);
       }
       #filter-count {
         font-size: 12px;
-        color: #a8aeb8;
+        color: var(--text-muted);
         font-variant-numeric: tabular-nums;
       }
       #filter-count.hidden {
         display: none;
       }
+      /* Toolbar buttons are utilities, not a primary action — neutral by
+         default (amber stays reserved for active/primary), amber only on focus. */
       button {
-        background: #2a6df4;
-        color: #fff;
-        border: 0;
+        background: var(--surface-2);
+        color: var(--text);
+        border: 1px solid var(--border);
         border-radius: 6px;
         padding: 6px 12px;
         font-size: 12px;
         cursor: pointer;
       }
-      button:hover { background: #3b7af5; }
-      button#copy.flash, button#save.flash { background: #245a32; }
-      button#copy.flash-warn, button#save.flash-warn { background: #5a3324; }
+      button:hover { background: var(--surface-3); border-color: var(--border-strong); }
+      button:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 1px; }
+      /* Clear view discards the buffer — set it apart from Copy/Save with a
+         danger-tinted hover so it doesn't read as just another utility. */
+      button#clear:hover { border-color: var(--danger-bd); color: var(--danger-fg); }
+      button#copy.flash, button#save.flash { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
+      button#copy.flash-warn, button#save.flash-warn { background: var(--danger-bg); border-color: var(--danger-bd); color: var(--danger-fg); }
       #log {
         flex: 1 1 auto;
         margin: 0;
         padding: 12px 14px;
-        background: #0f1115;
-        color: #d6dae3;
+        background: var(--bg);
+        color: var(--text-2);
         font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
         font-size: 12px;
         line-height: 1.45;
@@ -96,14 +102,14 @@
         overflow-x: hidden;
       }
       #log.empty {
-        color: #6c7280;
+        color: var(--text-muted);
         font-style: italic;
       }
       #log .line {
         white-space: pre-wrap;
       }
       #log .line-stderr {
-        color: #f0a04a;
+        color: var(--warning-fg);
       }
       #log .line-stdout {
         color: inherit;
@@ -122,8 +128,8 @@
         display: none !important;
       }
       .modal-card {
-        background: #1b1e24;
-        border: 1px solid #2a2f3a;
+        background: var(--surface);
+        border: 1px solid var(--border);
         border-radius: 8px;
         padding: 20px 24px;
         max-width: 420px;
@@ -145,13 +151,13 @@
         margin: 0;
         font-size: 15px;
         font-weight: 600;
-        color: #e6e6e6;
+        color: var(--text);
         flex: 0 0 auto;
       }
       .modal-card header button#shortcuts-close {
         margin: 0;
         background: transparent;
-        color: #a8aeb8;
+        color: var(--text-muted);
         border: 0;
         padding: 0 4px;
         font-size: 22px;
@@ -159,7 +165,7 @@
         cursor: pointer;
       }
       .modal-card header button#shortcuts-close:hover {
-        color: #e6e6e6;
+        color: var(--text);
         background: transparent;
       }
       .modal-card dl {
@@ -171,7 +177,7 @@
         align-items: center;
       }
       .modal-card dt {
-        color: #d8dbe2;
+        color: var(--text-2);
         font-size: 13px;
       }
       .modal-card dd {
@@ -184,24 +190,29 @@
       }
       .modal-card kbd {
         display: inline-block;
-        background: #0f1115;
-        border: 1px solid #2a2f3a;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         border-radius: 4px;
         padding: 2px 6px;
         font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
         font-size: 11px;
-        color: #e6e6e6;
+        color: var(--text);
         line-height: 1;
       }
       .modal-card p.hint {
         margin: 14px 0 0 0;
-        color: #6c7280;
+        color: var(--text-quiet);
         font-size: 11px;
       }
     </style>
     <link rel="stylesheet" href="_kiln-tokens.css" />
   </head>
   <body>
+    <!-- Icon sprite — monochrome inline SVG (Lucide-style, 24px grid,
+         currentColor), shared with the server dashboard design system. -->
+    <svg width="0" height="0" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true" focusable="false"><defs>
+      <symbol id="i-close" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></symbol>
+    </defs></svg>
     <header>
       <h1>Kiln server logs</h1>
       <label><input type="checkbox" id="autoscroll" checked /> Auto-scroll</label>
@@ -218,7 +229,7 @@
       <div class="modal-card">
         <header>
           <h2 id="shortcuts-title">Keyboard Shortcuts</h2>
-          <button id="shortcuts-close" aria-label="Close">×</button>
+          <button id="shortcuts-close" aria-label="Close"><svg class="icn"><use href="#i-close"></use></svg></button>
         </header>
         <dl>
           <dt>Show this help</dt>

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -8,19 +8,19 @@
       html, body {
         margin: 0;
         padding: 0;
-        background: #0f1115;
-        color: #e6e6e6;
+        background: var(--bg);
+        color: var(--text);
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
       .wrap { padding: 24px; max-width: 520px; box-sizing: border-box; }
       h1 { font-size: 18px; margin: 0 0 16px 0; font-weight: 600; }
       fieldset {
-        border: 1px solid #2a2f3a;
+        border: 1px solid var(--border);
         border-radius: 6px;
         padding: 12px 16px 16px 16px;
         margin: 0 0 16px 0;
       }
-      legend { padding: 0 6px; color: #a8aeb8; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+      legend { padding: 0 6px; color: var(--text-muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
       label.row {
         display: flex;
         align-items: center;
@@ -30,12 +30,12 @@
         padding: 6px 0;
         font-size: 13px;
       }
-      label.row > span.name { color: #cfd3da; }
+      label.row > span.name { color: var(--text-2); }
       label.row > span.hint {
         display: block;
         flex-basis: 100%;
         font-size: 12px;
-        color: #6c7280;
+        color: var(--text-muted);
         margin: 2px 0 0 0;
         font-weight: normal;
         line-height: 1.35;
@@ -44,7 +44,7 @@
         display: none;
         flex-basis: 100%;
         font-size: 12px;
-        color: #f0b080;
+        color: var(--warning-fg);
         margin: 2px 0 0 0;
         font-weight: normal;
         line-height: 1.35;
@@ -52,9 +52,9 @@
       label.row > span.path-warning.visible { display: block; }
       label.row > input[type="text"],
       label.row > input[type="number"] {
-        background: #181b21;
-        color: #e6e6e6;
-        border: 1px solid #2a2f3a;
+        background: var(--surface-2);
+        color: var(--text);
+        border: 1px solid var(--border);
         border-radius: 4px;
         padding: 4px 8px;
         font-size: 13px;
@@ -71,15 +71,15 @@
         width: 204px;
       }
       button.browse {
-        background: #2a2f3a;
-        color: #e6e6e6;
-        border: 1px solid #3a4050;
+        background: var(--surface-3);
+        color: var(--text);
+        border: 1px solid var(--border-strong);
         border-radius: 4px;
         padding: 3px 10px;
         font-size: 12px;
         cursor: pointer;
       }
-      button.browse:hover { background: #343a46; }
+      button.browse:hover { background: var(--border-strong); }
       .update-row {
         display: flex;
         align-items: center;
@@ -89,26 +89,26 @@
       }
       .update-status {
         font-size: 12px;
-        color: #a8aeb8;
+        color: var(--text-muted);
         line-height: 1.35;
       }
-      .update-status.checking { color: #a8aeb8; }
-      .update-status.up-to-date { color: #7fbf7f; }
-      .update-status.available { color: #f0b080; }
-      .update-status.warn { color: #e6c070; }
-      .update-status.error { color: #f08080; }
+      .update-status.checking { color: var(--text-muted); }
+      .update-status.up-to-date { color: var(--success-fg); }
+      .update-status.available { color: var(--warning-fg); }
+      .update-status.warn { color: var(--warning-fg); }
+      .update-status.error { color: var(--danger-fg); }
       .update-status .badge {
         display: inline-block;
         padding: 1px 6px;
         border-radius: 3px;
-        background: #2a2f3a;
-        color: #e6e6e6;
+        background: var(--surface-3);
+        color: var(--text);
         font-size: 11px;
         margin-left: 4px;
       }
-      .update-status.available .badge { background: #5a3f1a; color: #f6d3a6; }
-      .update-status.up-to-date .badge { background: #1f3a22; color: #b7e3b9; }
-      .update-status.warn .badge { background: #4a3a1a; color: #f0d98a; }
+      .update-status.available .badge { background: var(--warning-bg); color: var(--warning-fg); }
+      .update-status.up-to-date .badge { background: var(--success-bg); color: var(--success-fg); }
+      .update-status.warn .badge { background: var(--warning-bg); color: var(--warning-fg); }
       .update-download {
         display: flex;
         flex-direction: column;
@@ -120,33 +120,33 @@
       button.browse.hidden { display: none; }
       .update-download-bar {
         height: 6px;
-        background: #0f1115;
-        border: 1px solid #2a2f3a;
+        background: var(--bg);
+        border: 1px solid var(--border);
         border-radius: 3px;
         overflow: hidden;
       }
       .update-download-fill {
         height: 100%;
         width: 0%;
-        background: #2f66f0;
+        background: var(--accent);
         transition: width 120ms linear;
       }
       .update-download-line {
         font-size: 11px;
-        color: #a8aeb8;
+        color: var(--text-muted);
         line-height: 1.4;
         word-break: break-all;
       }
-      .update-download-line.error { color: #f08080; }
-      .update-download-line.success { color: #7fbf7f; }
+      .update-download-line.error { color: var(--danger-fg); }
+      .update-download-line.success { color: var(--success-fg); }
       .help-row {
-        color: #6c7280;
+        color: var(--text-muted);
         font-size: 12px;
         line-height: 1.4;
         margin: 2px 0 10px 0;
       }
       .help-row a {
-        color: #5f9bff;
+        color: var(--accent);
         text-decoration: none;
       }
       .help-row a:hover { text-decoration: underline; }
@@ -157,7 +157,7 @@
         margin-top: 8px;
       }
       button {
-        background: #2f66f0;
+        background: var(--accent);
         color: #fff;
         border: 0;
         border-radius: 4px;
@@ -165,13 +165,13 @@
         font-size: 13px;
         cursor: pointer;
       }
-      button.secondary { background: #2a2f3a; }
+      button.secondary { background: var(--surface-3); }
       button:disabled { opacity: 0.5; cursor: default; }
-      button#save:disabled { opacity: 0.55; cursor: default; background: #1f3a78; }
-      .status { margin-top: 8px; font-size: 12px; color: #7fbf7f; min-height: 16px; }
-      .status.error { color: #f08080; }
-      .todo { color: #a8aeb8; font-size: 11px; margin-top: 4px; }
-      .version-footer { margin-top: 16px; color: #6c7280; font-size: 11px; text-align: right; }
+      button#save:disabled { opacity: 0.55; cursor: default; background: var(--accent-press); }
+      .status { margin-top: 8px; font-size: 12px; color: var(--success-fg); min-height: 16px; }
+      .status.error { color: var(--danger-fg); }
+      .todo { color: var(--text-muted); font-size: 11px; margin-top: 4px; }
+      .version-footer { margin-top: 16px; color: var(--text-muted); font-size: 11px; text-align: right; }
       .modal-overlay {
         position: fixed;
         inset: 0;
@@ -186,8 +186,8 @@
         display: none !important;
       }
       .modal-card {
-        background: #1b1e24;
-        border: 1px solid #2a2f3a;
+        background: var(--surface);
+        border: 1px solid var(--border);
         border-radius: 8px;
         padding: 20px 24px;
         max-width: 420px;
@@ -209,13 +209,13 @@
         margin: 0;
         font-size: 15px;
         font-weight: 600;
-        color: #e6e6e6;
+        color: var(--text);
         flex: 0 0 auto;
       }
       .modal-card header button#shortcuts-close {
         margin: 0;
         background: transparent;
-        color: #a8aeb8;
+        color: var(--text-muted);
         border: 0;
         padding: 0 4px;
         font-size: 22px;
@@ -223,7 +223,7 @@
         cursor: pointer;
       }
       .modal-card header button#shortcuts-close:hover {
-        color: #e6e6e6;
+        color: var(--text);
         background: transparent;
       }
       .modal-card dl {
@@ -235,7 +235,7 @@
         align-items: center;
       }
       .modal-card dt {
-        color: #d8dbe2;
+        color: var(--text-2);
         font-size: 13px;
       }
       .modal-card dd {
@@ -248,40 +248,40 @@
       }
       .modal-card kbd {
         display: inline-block;
-        background: #0f1115;
-        border: 1px solid #2a2f3a;
+        background: var(--surface-2);
+        border: 1px solid var(--border);
         border-radius: 4px;
         padding: 2px 6px;
         font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
         font-size: 11px;
-        color: #e6e6e6;
+        color: var(--text);
         line-height: 1;
       }
       .modal-card p.hint {
         margin: 14px 0 0 0;
-        color: #6c7280;
+        color: var(--text-muted);
         font-size: 11px;
       }
       .hf-form label {
         display: block;
         margin: 10px 0 4px 0;
         font-size: 12px;
-        color: #cfd3da;
+        color: var(--text-2);
       }
       .hf-form input[type="text"],
       .hf-form input[type="password"] {
         width: 100%;
         box-sizing: border-box;
-        background: #0f1115;
-        color: #e6e6e6;
-        border: 1px solid #2a2f3a;
+        background: var(--surface-2);
+        color: var(--text);
+        border: 1px solid var(--border);
         border-radius: 4px;
         padding: 6px 8px;
         font-size: 13px;
       }
       .hf-form .hint {
         margin: 4px 0 0 0;
-        color: #6c7280;
+        color: var(--text-muted);
         font-size: 11px;
       }
       .hf-progress {
@@ -292,8 +292,8 @@
       }
       .hf-progress-bar {
         height: 6px;
-        background: #0f1115;
-        border: 1px solid #2a2f3a;
+        background: var(--bg);
+        border: 1px solid var(--border);
         border-radius: 3px;
         overflow: hidden;
         margin: 6px 0;
@@ -301,20 +301,20 @@
       .hf-progress-fill {
         height: 100%;
         width: 0%;
-        background: #2f66f0;
+        background: var(--accent);
         transition: width 120ms linear;
       }
       .hf-progress-line {
         font-size: 11px;
-        color: #a8aeb8;
+        color: var(--text-muted);
         line-height: 1.4;
         word-break: break-all;
       }
       .hf-progress-line.error {
-        color: #f08080;
+        color: var(--danger-fg);
       }
       .hf-progress-line.success {
-        color: #7fbf7f;
+        color: var(--success-fg);
       }
       .hf-actions {
         display: flex;
@@ -326,6 +326,12 @@
     <link rel="stylesheet" href="_kiln-tokens.css" />
   </head>
   <body>
+    <!-- Icon sprite — monochrome inline SVG (Lucide-style, 24px grid,
+         currentColor), shared with the server dashboard design system. -->
+    <svg width="0" height="0" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true" focusable="false"><defs>
+      <symbol id="i-close" viewBox="0 0 24 24"><path d="M6 6l12 12M18 6 6 18"/></symbol>
+      <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    </defs></svg>
     <div class="wrap">
       <h1>Kiln Settings</h1>
 
@@ -442,17 +448,17 @@
       <div class="modal-card">
         <header>
           <h2 id="hf-download-title">Download from HuggingFace</h2>
-          <button id="hf-close" aria-label="Close">×</button>
+          <button id="hf-close" aria-label="Close"><svg class="icn"><use href="#i-close"></use></svg></button>
         </header>
         <div class="hf-form">
           <label for="hf_repo_id">Repo ID</label>
           <input type="text" id="hf_repo_id" placeholder="Qwen/Qwen3.5-4B" autocomplete="off" spellcheck="false" />
           <p class="hint">HuggingFace repo id, e.g. Qwen/Qwen3.5-4B. kiln requires a repo with safetensors weights.</p>
 
-          <label for="hf_revision">Revision <span style="color:#6c7280;font-weight:normal;">(optional)</span></label>
+          <label for="hf_revision">Revision <span style="color:var(--text-quiet);font-weight:normal;">(optional)</span></label>
           <input type="text" id="hf_revision" placeholder="main" autocomplete="off" spellcheck="false" />
 
-          <label for="hf_token">HuggingFace token <span style="color:#6c7280;font-weight:normal;">(optional, for gated repos)</span></label>
+          <label for="hf_token">HuggingFace token <span style="color:var(--text-quiet);font-weight:normal;">(optional, for gated repos)</span></label>
           <input type="password" id="hf_token" placeholder="hf_…" autocomplete="off" spellcheck="false" />
           <p class="hint">Not saved — used only for this download.</p>
         </div>
@@ -472,7 +478,7 @@
       <div class="modal-card">
         <header>
           <h2 id="shortcuts-title">Keyboard Shortcuts</h2>
-          <button id="shortcuts-close" aria-label="Close">×</button>
+          <button id="shortcuts-close" aria-label="Close"><svg class="icn"><use href="#i-close"></use></svg></button>
         </header>
         <dl>
           <dt>Show this help</dt>
@@ -797,7 +803,7 @@
       function resetHfModal() {
         hfProgressWrap.classList.add("hidden");
         hfProgressFill.style.width = "0%";
-        hfProgressFill.style.background = "#2f66f0";
+        hfProgressFill.style.background = "var(--accent)";
         hfProgressSummary.className = "hf-progress-line";
         hfProgressSummary.textContent = "Preparing…";
         hfProgressDetail.className = "hf-progress-line";
@@ -848,7 +854,7 @@
 
         hfProgressWrap.classList.remove("hidden");
         hfProgressFill.style.width = "0%";
-        hfProgressFill.style.background = "#2f66f0";
+        hfProgressFill.style.background = "var(--accent)";
         hfProgressSummary.className = "hf-progress-line";
         hfProgressSummary.textContent = "Listing repository files…";
         hfProgressDetail.textContent = "";
@@ -925,7 +931,7 @@
           hfProgressSummary.className = "hf-progress-line error";
           hfProgressSummary.textContent = "Download failed: " + err;
           hfProgressDetail.textContent = "";
-          hfProgressFill.style.background = "#3a2a2a";
+          hfProgressFill.style.background = "var(--danger-bg)";
           hfDownloading = false;
           hfStartBtn.disabled = false;
           hfStartBtn.textContent = "Retry";
@@ -1141,7 +1147,7 @@
           if (r.update_available) {
             setKilnUpdateStatus(
               "available",
-              "Current " + current + " → latest " + latest +
+              "Current " + current + ' <svg class="icn icn-sm" aria-hidden="true"><use href="#i-arrow-right"></use></svg> latest ' + latest +
                 ' <span class="badge">Update available</span>'
             );
             showKilnUpdateActions(r.latest);
@@ -1176,7 +1182,7 @@
           const latest = escapeHtml(p.latest);
           setKilnUpdateStatus(
             "available",
-            "Current " + current + " → latest " + latest +
+            "Current " + current + ' <svg class="icn icn-sm" aria-hidden="true"><use href="#i-arrow-right"></use></svg> latest ' + latest +
               ' <span class="badge">Update available</span>'
           );
           showKilnUpdateActions(p.latest);
@@ -1195,7 +1201,7 @@
         kilnUpdateInstallBtn.classList.add("hidden");
         kilnUpdateInstallBtn.disabled = true;
         kilnUpdateProgressWrap.classList.remove("hidden");
-        kilnUpdateProgressFill.style.background = "#2f66f0";
+        kilnUpdateProgressFill.style.background = "var(--accent)";
         kilnUpdateProgressFill.style.width = "0%";
         setKilnUpdateProgressLine("", "Starting download for v" + version + "…");
 
@@ -1257,7 +1263,7 @@
           if (!p || p.version !== version) return;
           const err = p.error || "Unknown error";
           const cancelled = !!p.cancelled;
-          kilnUpdateProgressFill.style.background = cancelled ? "#3a3a2a" : "#3a2a2a";
+          kilnUpdateProgressFill.style.background = cancelled ? "var(--warning-bg)" : "var(--danger-bg)";
           setKilnUpdateProgressLine(
             "error",
             (cancelled ? "Cancelled: " : "Download failed: ") + err
@@ -1295,7 +1301,7 @@
         kilnUpdateInstallBtn.classList.add("hidden");
         kilnUpdateInstallBtn.disabled = true;
         kilnUpdateProgressWrap.classList.remove("hidden");
-        kilnUpdateProgressFill.style.background = "#2f66f0";
+        kilnUpdateProgressFill.style.background = "var(--accent)";
         kilnUpdateProgressFill.style.width = "0%";
         setKilnUpdateProgressLine(
           "",
@@ -1356,7 +1362,7 @@
           if (!p || p.version !== version) return;
           const err = p.error || "Unknown error";
           const cancelled = !!p.cancelled;
-          kilnUpdateProgressFill.style.background = cancelled ? "#3a3a2a" : "#3a2a2a";
+          kilnUpdateProgressFill.style.background = cancelled ? "var(--warning-bg)" : "var(--danger-bg)";
           setKilnUpdateProgressLine(
             "error",
             (cancelled ? "Cancelled: " : "Extract failed: ") + err
@@ -1402,7 +1408,7 @@
         kilnUpdateInstallBtn.disabled = true;
         kilnUpdateInstallBtn.textContent = "Installing…";
         kilnUpdateProgressWrap.classList.remove("hidden");
-        kilnUpdateProgressFill.style.background = "#2f66f0";
+        kilnUpdateProgressFill.style.background = "var(--accent)";
         kilnUpdateProgressFill.style.width = "50%";
         setKilnUpdateProgressLine(
           "",
@@ -1436,7 +1442,7 @@
         const unFailed = await event.listen("install_staged_update_failed", (e) => {
           const p = (e && e.payload) || {};
           const err = p.error || "Unknown error";
-          kilnUpdateProgressFill.style.background = "#3a2a2a";
+          kilnUpdateProgressFill.style.background = "var(--danger-bg)";
           setKilnUpdateProgressLine(
             "error",
             "Install failed: " + err + " Previous binary restored."
@@ -1451,7 +1457,7 @@
         try {
           await invoke("install_staged_update");
         } catch (err) {
-          kilnUpdateProgressFill.style.background = "#3a2a2a";
+          kilnUpdateProgressFill.style.background = "var(--danger-bg)";
           setKilnUpdateProgressLine(
             "error",
             "Install failed: " + escapeHtml(String(err)) +

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -21,17 +21,35 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +57,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -88,7 +106,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -214,11 +232,23 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -556,7 +586,7 @@ curl -s -X DELETE http://localhost:8420/v1/train/queue/$JOB_ID | python3 -m json
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -21,17 +21,35 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +57,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -74,7 +92,7 @@
       overflow-x: auto;
       font-size: 13.5px;
       line-height: 1.55;
-      color: #d8dde7;
+      color: var(--text-2);
     }
     pre code { background: transparent; padding: 0; color: inherit; }
     p code, li code, td code, h2 code, h3 code {
@@ -90,7 +108,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -192,11 +210,23 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -447,7 +477,7 @@ kiln adapters list</code></pre>
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -343,7 +343,7 @@ kiln health --url http://localhost:8420</code></pre>
 
   <section id="pi-setup" class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">
-      <p class="label mb-2">Agent integration</p>
+      <p class="label mb-2">pi integration</p>
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Point pi or opencode at Kiln</h2>
       <p class="max-w-3xl mb-6" style="color: var(--fg-dim);">
         <code>kiln pi-setup</code> updates pi's OpenAI-compatible provider config without replacing the whole file. It writes a <code>kiln-local</code> provider with <code>baseUrl</code> ending in <code>/v1</code>, <code>api: "openai-completions"</code>, and model id <code>Qwen3.5-4B</code>. It also preserves existing <code>settings.json</code> keys while setting pi's default provider and model to Kiln. For opencode, add a Kiln provider block (below) — both point at <code>http://localhost:8420/v1</code> with no API key.

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -9,7 +9,25 @@
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <link rel="alternate icon" type="image/png" href="assets/logo.png">
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       --bg: #0b0a08;
       --bg-soft: #15110d;
@@ -171,10 +189,22 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -313,26 +343,41 @@ kiln health --url http://localhost:8420</code></pre>
 
   <section id="pi-setup" class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">
-      <p class="label mb-2">pi integration</p>
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Merge Kiln into pi's provider config</h2>
+      <p class="label mb-2">Agent integration</p>
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">Point pi or opencode at Kiln</h2>
       <p class="max-w-3xl mb-6" style="color: var(--fg-dim);">
-        <code>kiln pi-setup</code> updates pi's OpenAI-compatible provider config without replacing the whole file. It writes a <code>kiln-local</code> provider with <code>baseUrl</code> ending in <code>/v1</code>, <code>api: "openai-completions"</code>, and model id <code>Qwen3.5-4B</code>. It also preserves existing <code>settings.json</code> keys while setting pi's default provider and model to Kiln.
+        <code>kiln pi-setup</code> updates pi's OpenAI-compatible provider config without replacing the whole file. It writes a <code>kiln-local</code> provider with <code>baseUrl</code> ending in <code>/v1</code>, <code>api: "openai-completions"</code>, and model id <code>Qwen3.5-4B</code>. It also preserves existing <code>settings.json</code> keys while setting pi's default provider and model to Kiln. For opencode, add a Kiln provider block (below) — both point at <code>http://localhost:8420/v1</code> with no API key.
       </p>
       <div class="grid lg:grid-cols-2 gap-6">
         <div class="card p-6">
-          <h3 class="font-semibold mb-2">Local setup</h3>
+          <h3 class="font-semibold mb-2">pi &middot; local setup</h3>
 <pre class="text-sm"><code>kiln pi-setup
 pi -p "Use the bash tool to run: pwd"</code></pre>
           <p class="text-sm mt-4" style="color: var(--fg-mute);">Existing <code>models.json</code> and <code>settings.json</code> are copied to timestamped <code>.bak-...</code> files before the merge.</p>
         </div>
         <div class="card p-6">
-          <h3 class="font-semibold mb-2">Remote server</h3>
+          <h3 class="font-semibold mb-2">pi &middot; remote server</h3>
 <pre class="text-sm"><code>kiln pi-setup --kiln-url http://office-kiln:8420</code></pre>
           <p class="text-sm mt-4" style="color: var(--fg-mute);"><code>--kiln-url</code> is an alias for <code>--url</code>. If the URL omits <code>/v1</code>, Kiln appends it for pi.</p>
         </div>
       </div>
+      <div class="card p-6 mt-6">
+        <h3 class="font-semibold mb-2">opencode &middot; provider config</h3>
+        <p class="mb-3" style="color: var(--fg-dim);">Add a Kiln provider to <code>~/.config/opencode/opencode.json</code>, then run <code>opencode</code> and pick <strong style="color: var(--fg);">Kiln &middot; Qwen3.5-4B</strong> with <code>/models</code>. Uses the OpenAI-compatible AI SDK adapter — <code>apiKey</code> can be any value.</p>
+<pre class="text-sm"><code>{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "kiln": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Kiln (local)",
+      "options": { "baseURL": "http://localhost:8420/v1", "apiKey": "unused" },
+      "models": { "Qwen3.5-4B": { "name": "Kiln · Qwen3.5-4B" } }
+    }
+  }
+}</code></pre>
+      </div>
       <p class="text-sm mt-4" style="color: var(--fg-mute);">
-        Tool-calling clients receive OpenAI <code>tool_calls</code> even when Qwen3.5 internally emits its native XML tool-call form, so pi executes the tool instead of showing raw XML.
+        Tool-calling clients receive OpenAI <code>tool_calls</code> even when Qwen3.5 internally emits its native XML tool-call form, so pi and opencode execute the tool instead of showing raw XML.
       </p>
     </div>
   </section>
@@ -426,7 +471,7 @@ kiln adapters unload support-bot</code></pre>
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/docs/site/css/kiln.css
+++ b/docs/site/css/kiln.css
@@ -16,21 +16,22 @@
   --kiln-800: #9a3412;
   --kiln-900: #7c2d12;
 
-  /* Warm-charcoal ink ramp */
-  --ink-950: #08090c;
-  --ink-900: #0d0e12;
-  --ink-850: #11131a;
-  --ink-800: #14161e;
-  --ink-750: #181b24;
-  --ink-700: #1c1f29;
-  --ink-650: #232732;
-  --ink-600: #2a2f3b;
-  --ink-500: #353a48;
-  --ink-400: #6b7280;
-  --ink-300: #9aa3ae;
-  --ink-200: #b6bcc4;
-  --ink-100: #d1d5db;
-  --ink-50:  #f4f5f7;
+  /* Warm-charcoal ink ramp (true warm neutral — matches the server dashboard
+     + desktop app; R > G > B at every step). */
+  --ink-950: #0a0908;
+  --ink-900: #0e0d0b;
+  --ink-850: #131210;
+  --ink-800: #181613;
+  --ink-750: #1d1b17;
+  --ink-700: #23201b;
+  --ink-650: #2b2720;
+  --ink-600: #342f26;
+  --ink-500: #443c31;
+  --ink-400: #756b5b;
+  --ink-300: #938b79;
+  --ink-200: #b0a895;
+  --ink-100: #d9d3c7;
+  --ink-50:  #f7f4ef;
 
   /* Semantic */
   --success-fg: #4ade80; --success-bg: #0f2c1c; --success-bd: #1a4d2e;
@@ -123,7 +124,7 @@ body {
   margin: 0;
   background:
     radial-gradient(1200px 600px at 50% -120px, rgba(249,115,22,0.08), transparent 60%),
-    radial-gradient(800px 400px at 100% 0%, rgba(96,165,250,0.04), transparent 60%),
+    radial-gradient(800px 400px at 100% 0%, rgba(194,65,12,0.05), transparent 60%),
     var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
@@ -214,17 +215,35 @@ hr { border: 0; height: 1px; background: var(--border); margin: var(--space-8) 0
 .brand-mark {
   width: 30px; height: 30px; flex: none;
   border-radius: var(--radius-md);
-  background: linear-gradient(160deg, var(--kiln-700), var(--kiln-500) 55%, var(--kiln-300));
+  background:
+    radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+    linear-gradient(160deg, var(--kiln-700) 0%, var(--kiln-500) 55%, var(--kiln-300) 100%);
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
 }
-.brand-mark::before {
+/* Stacked-fire-layers cube, mirrors the server dashboard #i-stack mark. The
+   inline <svg class="brand-flame"><use href="#i-stack"></use></svg> is the dark
+   flame cut out of the glowing ember cube. Empty .brand-mark (no inline svg)
+   still gets a triangle punch-out as a graceful fallback. */
+.brand-mark .brand-flame {
+  position: absolute; inset: 0; margin: auto; width: 19px; height: 19px;
+  fill: none; stroke: var(--ink-950); stroke-width: 2;
+  stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+}
+.brand-mark:empty::before {
   content: "";
   position: absolute; inset: 6px;
   background: var(--ink-950);
   clip-path: polygon(50% 12%, 88% 88%, 12% 88%);
   opacity: 0.78;
 }
+@media (prefers-reduced-motion: no-preference) {
+  .brand-mark .brand-flame { animation: kiln-brand-ember 4.2s var(--ease-in-out) infinite; }
+}
+@keyframes kiln-brand-ember { 0%,100% { opacity: 0.82; } 50% { opacity: 0.66; } }
 .brand-version {
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
@@ -1029,9 +1048,18 @@ pre code { background: transparent; border: 0; padding: 0; color: inherit; font-
   margin: 0 0 var(--space-7);
 }
 .hero-lede strong { color: var(--text); font-weight: 600; }
+.hero-subline {
+  font-size: var(--text-xl);
+  line-height: 1.45;
+  color: var(--text-2);
+  max-width: 46ch;
+  margin: 0 0 var(--space-5);
+}
+.hero-subline strong { color: var(--accent-hover); font-weight: 600; }
 @media (max-width: 760px) {
   .hero-title { font-size: clamp(32px, 8vw, 44px); }
   .hero-lede { font-size: var(--text-lg); }
+  .hero-subline { font-size: var(--text-lg); }
 }
 
 .hero-meta {
@@ -1421,3 +1449,163 @@ pre code { background: transparent; border: 0; padding: 0; color: inherit; font-
 
 /* `.stat-cell` is the canonical class for stat-grid cells (alias for older `.stat`).
    The .stat-foot rule already exists; nothing to add. */
+
+/* ============================================================
+   Inline-SVG icon sprite helpers (mirrors the server dashboard
+   .icn — 24px viewBox, 1.7px stroke, monochrome / currentColor).
+   ============================================================ */
+.icn {
+  width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+  fill: none; stroke: currentColor; stroke-width: 1.7;
+  stroke-linecap: round; stroke-linejoin: round; flex: none;
+}
+.icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
+.icn-accent { color: var(--accent); }
+
+/* ============================================================
+   Connect-your-agent band — the onboarding centerpiece, mirrors
+   crates/kiln-server/src/ui.html .connect-panel. Static markup;
+   copy buttons ride the site.js [data-target] hook. The 5 client
+   tabs (pi | opencode | OpenAI Python | OpenAI JS | curl) use the
+   shared .tabs / role="tab" / aria-controls wiring in site.js.
+   ============================================================ */
+.connect-band {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--accent-ring);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+}
+.connect-band::before {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(720px 240px at 8% -60px, rgba(249,115,22,0.12), transparent 64%);
+}
+.connect-band > * { position: relative; }
+.connect-head {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  padding: var(--space-6) var(--space-6) 0;
+}
+.connect-head h2 { font-size: var(--text-2xl); letter-spacing: -0.015em; }
+.connect-head .eyebrow { margin-bottom: 0; text-transform: none; letter-spacing: 0; font-weight: 500; }
+.connect-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.8fr) 1.45fr;
+  gap: var(--space-6);
+  padding: var(--space-6);
+}
+@media (max-width: 900px) { .connect-grid { grid-template-columns: 1fr; } }
+.connect-facts { display: flex; flex-direction: column; gap: var(--space-4); min-width: 0; }
+.connect-field label {
+  display: block; font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-muted); font-weight: 600; margin-bottom: 6px;
+}
+.copy-field {
+  display: flex; align-items: center; gap: var(--space-2);
+  background: var(--ink-850); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md); padding: 7px 7px 7px 12px;
+}
+.copy-field code {
+  flex: 1; min-width: 0; background: none; border: 0; padding: 0;
+  font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.copy-field .copy-btn {
+  display: inline-flex; align-items: center; gap: 5px; flex: none; cursor: pointer;
+  position: static; opacity: 1;
+  background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted);
+  border-radius: var(--radius-sm); padding: 5px 9px;
+  font-family: var(--font-sans); font-size: var(--text-xs); font-weight: 500;
+  transition: color var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out);
+}
+.copy-field .copy-btn:hover { color: var(--text); border-color: var(--border-strong); background: var(--surface-3); }
+.copy-field .copy-btn[data-copied="1"] { color: var(--success-fg); border-color: var(--success-bd); background: var(--success-bg); }
+.connect-keychip {
+  display: inline-flex; align-items: center; gap: 7px; font-size: var(--text-xs);
+  color: var(--text-2); background: var(--ink-900); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 8px 12px;
+}
+.connect-keychip .icn { color: var(--success-fg); }
+.connect-keychip code { font-size: 11px; background: var(--surface-2); border: 1px solid var(--border); padding: 0 5px; border-radius: var(--radius-xs); color: var(--kiln-200); }
+.connect-note {
+  font-size: var(--text-xs); color: var(--text-muted); line-height: 1.5; margin: 0;
+}
+.connect-note strong { color: var(--text-2); }
+
+.connect-clients { display: flex; flex-direction: column; min-width: 0; }
+.connect-clients-label {
+  display: block; font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-muted); font-weight: 600; margin-bottom: var(--space-3);
+}
+/* Tab bar reused from .tabs but slim for the connect band */
+.connect-clients .tabs-bar { border-radius: var(--radius-md) var(--radius-md) 0 0; }
+.connect-clients .tab-btn { padding: 9px 14px; }
+.connect-snippet-note { font-size: var(--text-xs); color: var(--text-muted); margin: var(--space-3) 0 var(--space-2); line-height: 1.5; }
+.connect-snippet-note code { font-size: 0.85em; }
+.connect-snippet .code-shell { margin-top: var(--space-2); }
+.connect-snippet .code-shell .copy-btn {
+  opacity: 1;
+  font-family: var(--font-sans); font-weight: 600;
+  border-radius: var(--radius-sm);
+}
+.connect-snippet .code-block-path {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-quiet);
+  padding: 6px var(--space-4); border-bottom: 1px solid var(--border); background: rgba(0,0,0,0.22);
+}
+
+/* ============================================================
+   Flywheel ribbon — Agents → Traffic → Train → Eval → Hot-swap.
+   Mirrors the dashboard .flywheel; static + each node links out.
+   ============================================================ */
+.flywheel-wrap { display: flex; flex-direction: column; gap: var(--space-3); }
+.flywheel-title {
+  display: flex; align-items: center; gap: 7px; font-size: var(--text-2xs);
+  text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted);
+  font-weight: 600; padding-left: 2px;
+}
+.flywheel-title .icn { color: var(--accent-hover); }
+.flywheel-tagline { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--text-quiet); }
+.flywheel {
+  display: flex; align-items: stretch;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+}
+.flywheel-node {
+  flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 5px;
+  padding: var(--space-5) var(--space-4); position: relative; text-align: left;
+  color: var(--text); text-decoration: none;
+  transition: background var(--t-fast) var(--ease-out);
+}
+.flywheel-node:hover { background: rgba(255,255,255,0.03); color: var(--text); }
+.flywheel-node .fw-eyebrow {
+  display: flex; align-items: center; gap: 6px; font-size: var(--text-2xs);
+  text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); font-weight: 600;
+}
+.flywheel-node .fw-eyebrow .icn { width: 14px; height: 14px; color: var(--text-quiet); }
+.flywheel-node .fw-value {
+  font-family: var(--font-display); font-size: var(--text-lg); font-weight: 700;
+  letter-spacing: -0.01em; line-height: 1.15;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.flywheel-node .fw-sub { font-size: 11px; color: var(--text-quiet); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.flywheel-node.hot { background: var(--accent-soft); }
+.flywheel-node.hot .fw-eyebrow, .flywheel-node.hot .fw-eyebrow .icn { color: var(--accent-hover); }
+.flywheel-arrow {
+  display: flex; align-items: center; justify-content: center;
+  color: var(--text-quiet); flex: none; padding: 0 2px;
+}
+.flywheel-arrow .icn { width: 16px; height: 16px; }
+@media (max-width: 760px) {
+  .flywheel { flex-direction: column; }
+  .flywheel-arrow { transform: rotate(90deg); padding: var(--space-1) 0; }
+}
+
+/* Step pill — monochrome numeric marker mirroring the dashboard step style */
+.step-pill {
+  display: inline-flex; width: 28px; height: 28px; flex: none;
+  align-items: center; justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft); border: 1px solid var(--accent-ring);
+  color: var(--accent);
+  font-family: var(--font-display); font-weight: 700; font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}

--- a/docs/site/evals.html
+++ b/docs/site/evals.html
@@ -21,17 +21,35 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +57,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -79,7 +97,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -204,11 +222,23 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -484,7 +514,7 @@
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -21,17 +21,35 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +57,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -79,7 +97,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -204,11 +222,23 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -423,7 +453,7 @@
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Kiln — your model gets better every time you use it</title>
   <meta name="description" content="A pure-Rust single-GPU inference server with live LoRA training. OpenAI-compatible API, hot-swap adapters, and SFT + GRPO over HTTP. Tuned for Qwen3.5-4B on a single A6000.">
-  <meta name="theme-color" content="#0d0e12">
+  <meta name="theme-color" content="#0a0908">
   <meta name="color-scheme" content="dark">
   <link rel="canonical" href="https://ericflo.github.io/kiln/">
 
@@ -50,12 +50,29 @@
 <body>
   <a class="skip-link" href="#content">Skip to content</a>
 
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols
+       (24px viewBox, 1.7px stroke). Referenced via <use href="#i-…">. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-flask" viewBox="0 0 24 24"><path d="M9 3h6"/><path d="M10 3v6.5L5.2 18A1.6 1.6 0 0 0 6.6 21h10.8a1.6 1.6 0 0 0 1.4-3L14 9.5V3"/><path d="M7.6 14.5h8.8"/></symbol>
+    <symbol id="i-chart" viewBox="0 0 24 24"><path d="M4 20V4"/><path d="M4 20h16"/><path d="M8 20v-6"/><path d="M13 20V9"/><path d="M18 20v-4"/></symbol>
+    <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+    <symbol id="i-merge" viewBox="0 0 24 24"><path d="M7 21V8"/><path d="M17 21v-6a4 4 0 0 0-4-4H7"/><path d="m4 11 3-3 3 3"/><path d="M14 18l3 3 3-3"/></symbol>
+  </defs></svg>
+
   <header class="topbar">
     <div class="topbar-inner">
       <a href="./" class="brand" aria-current="page" aria-label="Kiln home">
-        <span class="brand-mark" aria-hidden="true"></span>
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span>kiln</span>
-        <span class="brand-version">v0.2.16</span>
+        <a class="brand-version" href="https://github.com/ericflo/kiln/releases/latest" rel="noopener">preview</a>
       </a>
       <nav class="nav site-nav" aria-label="Primary">
         <a href="quickstart.html">Quickstart</a>
@@ -81,6 +98,9 @@
         <div class="hero-copy">
           <span class="pill"><span class="pill-dot pill-dot--accent" aria-hidden="true"></span><a href="https://github.com/ericflo/kiln/releases/latest" style="color:inherit;text-decoration:none">latest release</a> · pre-1.0 preview</span>
           <h1 class="hero-title">Your model gets better<br><span class="txt-accent">every time you use it.</span></h1>
+          <p class="hero-subline">
+            Point <strong>pi</strong> or <strong>opencode</strong> at one local endpoint — every request becomes training data.
+          </p>
           <p class="hero-lede">
             Kiln is a pure-Rust, single-GPU inference server with live LoRA training <em>and</em> evals built in.
             Drop-in OpenAI API. Hot-swap adapters. <strong>SFT, GRPO, and a local eval loop over HTTP</strong> —
@@ -100,23 +120,155 @@
           </div>
         </div>
 
-        <aside class="hero-terminal" aria-label="The kiln loop">
+        <aside class="hero-terminal" aria-label="Connect your agent to Kiln">
           <div class="hero-terminal-bar">
             <span class="dot dot--r"></span><span class="dot dot--y"></span><span class="dot dot--g"></span>
-            <span class="hero-terminal-title">the kiln loop</span>
+            <span class="hero-terminal-title">connect your agent</span>
           </div>
-          <div class="hero-terminal-body"><span class="t-c"># 1. serve any OpenAI-compatible client</span>
-<span class="t-p">$</span> <span class="t-cmd">kiln serve</span> --model Qwen/Qwen3.5-4B
-<span class="t-d">  ▸ listening on :8420  • paged KV  • W4A16 marlin</span>
+          <div class="hero-terminal-body"><span class="t-c"># 1. serve Qwen3.5-4B on one local endpoint</span>
+<span class="t-p">$</span> <span class="t-cmd">kiln serve</span>
+<span class="t-d">  ▸ listening on <span class="t-a">http://localhost:8420/v1</span>  • api key: not required</span>
 
-<span class="t-c"># 2. generate, score, send rewards back</span>
-<span class="t-p">&gt;&gt;&gt;</span> <span class="t-cmd">curl /v1/train/grpo -d @rollouts.json</span>
-<span class="t-d">  ▸ adapter <span class="t-a">helpful-v3</span> hot-swapped <span class="t-ok">200 OK</span> in <span class="t-ok">1.4s</span></span>
+<span class="t-c"># 2. point your coding agent at it (pi or opencode)</span>
+<span class="t-p">$</span> <span class="t-cmd">kiln pi-setup</span>          <span class="t-d"># pi: Qwen3.5-4B is now the default</span>
+<span class="t-p">$</span> <span class="t-cmd">opencode</span>               <span class="t-d"># opencode: pick "Kiln · Qwen3.5-4B"</span>
 
-<span class="t-c"># 3. next request uses the new policy. no restart.</span>
-<span class="t-p">&gt;&gt;&gt;</span> <span class="t-cmd">openai chat.completions.create(...)</span>
-<span class="t-d">  ▸ <span class="kiln-pulse">●</span> serving with <span class="t-a">helpful-v3</span></span></div>
+<span class="t-c"># 3. every agent tool call streams into /ui as training data</span>
+<span class="t-p">&gt;</span> <span class="t-cmd">pi -p "run the tests and fix what fails"</span>
+<span class="t-d">  ▸ <span class="kiln-pulse">●</span> tool_call <span class="t-a">bash</span> · captured · serving with <span class="t-a">helpful-v3</span></span></div>
         </aside>
+      </div>
+    </section>
+
+    <!-- ===============================================================
+         Connect your agent — the #1 journey, directly under the hero.
+         Mirrors the server dashboard connect-panel: copyable Base URL +
+         Model id, "API key: not required", and the 5-tab snippet block
+         (pi | opencode | OpenAI Python | OpenAI JS | curl).
+         =============================================================== -->
+    <section class="section section--tight" id="connect" aria-label="Connect your agent">
+      <div class="page">
+        <section class="connect-band">
+          <div class="connect-head">
+            <span class="eyebrow eyebrow--accent">Connect your agent</span>
+            <h2>Point pi, opencode, or any OpenAI client at Kiln.</h2>
+            <p class="connect-note">No API key. No SDK swap. Change the base URL, keep your agent — every call it makes is captured as training data in <code>/ui</code>.</p>
+          </div>
+          <div class="connect-grid">
+            <div class="connect-facts">
+              <div class="connect-field">
+                <label for="connect-base-url">Base URL</label>
+                <div class="copy-field">
+                  <code id="connect-base-url">http://localhost:8420/v1</code>
+                  <button class="copy-btn" type="button" data-target="connect-base-url" aria-label="Copy base URL"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button>
+                </div>
+              </div>
+              <div class="connect-field">
+                <label for="connect-model">Model id <span style="text-transform:none;letter-spacing:0;font-weight:400;">(the <code style="font-size:10px;">model</code> field)</span></label>
+                <div class="copy-field">
+                  <code id="connect-model">Qwen3.5-4B</code>
+                  <button class="copy-btn" type="button" data-target="connect-model" aria-label="Copy model id"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button>
+                </div>
+              </div>
+              <div class="connect-field">
+                <label>API key</label>
+                <span class="connect-keychip">
+                  <svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg>
+                  Not required — any value works (we use <code>unused</code>)
+                </span>
+              </div>
+            </div>
+
+            <div class="connect-clients">
+              <span class="connect-clients-label">Set up your client</span>
+              <div class="tabs">
+                <div class="tabs-bar" role="tablist" aria-label="Client setup">
+                  <button class="tab-btn" role="tab" aria-selected="true" aria-controls="cx-pi" id="cxt-pi" tabindex="0">pi</button>
+                  <button class="tab-btn" role="tab" aria-selected="false" aria-controls="cx-opencode" id="cxt-opencode" tabindex="-1">opencode</button>
+                  <button class="tab-btn" role="tab" aria-selected="false" aria-controls="cx-python" id="cxt-python" tabindex="-1">OpenAI Python</button>
+                  <button class="tab-btn" role="tab" aria-selected="false" aria-controls="cx-js" id="cxt-js" tabindex="-1">OpenAI JS</button>
+                  <button class="tab-btn" role="tab" aria-selected="false" aria-controls="cx-curl" id="cxt-curl" tabindex="-1">curl</button>
+                </div>
+
+                <div class="tab-panel connect-snippet" role="tabpanel" id="cx-pi" aria-labelledby="cxt-pi" aria-hidden="false">
+                  <p class="connect-snippet-note">One command — backs up &amp; merges <code>~/.pi/agent/{models,settings}.json</code>, then makes Kiln pi&rsquo;s default model.</p>
+                  <div class="code-shell">
+                    <button class="copy-btn" type="button" data-target="cx-pi-code" aria-label="Copy code">copy</button>
+<pre id="cx-pi-code"><code># Point pi at this Kiln server
+kiln pi-setup
+
+# Remote server? pass its URL — /v1 is appended for you
+kiln pi-setup --kiln-url http://localhost:8420</code></pre>
+                  </div>
+                </div>
+
+                <div class="tab-panel connect-snippet" role="tabpanel" id="cx-opencode" aria-labelledby="cxt-opencode" aria-hidden="true" hidden>
+                  <p class="connect-snippet-note">Add this provider, then run <code>opencode</code> and pick the model with <code>/models</code>. No API key needed.</p>
+                  <div class="code-shell">
+                    <div class="code-block-path">~/.config/opencode/opencode.json</div>
+                    <button class="copy-btn" type="button" data-target="cx-opencode-code" aria-label="Copy code">copy</button>
+<pre id="cx-opencode-code"><code>{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "kiln": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Kiln (local)",
+      "options": { "baseURL": "http://localhost:8420/v1", "apiKey": "unused" },
+      "models": { "Qwen3.5-4B": { "name": "Kiln · Qwen3.5-4B" } }
+    }
+  }
+}</code></pre>
+                  </div>
+                </div>
+
+                <div class="tab-panel connect-snippet" role="tabpanel" id="cx-python" aria-labelledby="cxt-python" aria-hidden="true" hidden>
+                  <p class="connect-snippet-note">Drop-in OpenAI SDK — only <code>base_url</code> changes.</p>
+                  <div class="code-shell">
+                    <button class="copy-btn" type="button" data-target="cx-python-code" aria-label="Copy code">copy</button>
+<pre id="cx-python-code"><code>from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8420/v1", api_key="unused")
+
+resp = client.chat.completions.create(
+    model="Qwen3.5-4B",
+    messages=[{"role": "user", "content": "Hello from my agent"}],
+)
+print(resp.choices[0].message.content)</code></pre>
+                  </div>
+                </div>
+
+                <div class="tab-panel connect-snippet" role="tabpanel" id="cx-js" aria-labelledby="cxt-js" aria-hidden="true" hidden>
+                  <p class="connect-snippet-note">Drop-in OpenAI SDK for Node / Bun / Deno.</p>
+                  <div class="code-shell">
+                    <button class="copy-btn" type="button" data-target="cx-js-code" aria-label="Copy code">copy</button>
+<pre id="cx-js-code"><code>import OpenAI from "openai";
+
+const client = new OpenAI({ baseURL: "http://localhost:8420/v1", apiKey: "unused" });
+
+const resp = await client.chat.completions.create({
+  model: "Qwen3.5-4B",
+  messages: [{ role: "user", content: "Hello from my agent" }],
+});
+console.log(resp.choices[0].message.content);</code></pre>
+                  </div>
+                </div>
+
+                <div class="tab-panel connect-snippet" role="tabpanel" id="cx-curl" aria-labelledby="cxt-curl" aria-hidden="true" hidden>
+                  <p class="connect-snippet-note">Raw HTTP — drop into any shell, CI job, or script.</p>
+                  <div class="code-shell">
+                    <button class="copy-btn" type="button" data-target="cx-curl-code" aria-label="Copy code">copy</button>
+<pre id="cx-curl-code"><code>curl -s http://localhost:8420/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen3.5-4B",
+    "messages": [{"role": "user", "content": "Hello from my agent"}]
+  }'</code></pre>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
     </section>
 
@@ -325,8 +477,8 @@ requests.post("http://localhost:8420/v1/train/grpo", json={
             <p>Sarathi-style chunked prefill. Decode requests merge into a running batch without head-of-line blocking.</p>
           </div>
           <div class="feature feature--compact">
-            <h3>pi agent backend</h3>
-            <p><code>kiln pi-setup</code> backs up and merges pi config, then serves Qwen3.5-4B as <code>Qwen3.5-4B</code> with OpenAI-shaped tool calls.</p>
+            <h3>pi &amp; opencode backend</h3>
+            <p><code>kiln pi-setup</code> wires up pi; one provider block wires up opencode. Both serve <code>Qwen3.5-4B</code> with OpenAI-shaped tool calls. <a href="#connect">Connect ↑</a></p>
           </div>
           <div class="feature feature--compact">
             <h3>Paged KV cache</h3>
@@ -469,8 +621,9 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
         <p class="install-foot">
           The Kiln Desktop app and the Kiln server use
           <strong>separate GitHub release tags/version numbers</strong>
-          so each can ship at its own cadence. The latest desktop build is
-          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16"><code>desktop-v0.2.16</code></a>;
+          so each can ship at its own cadence. Grab the latest desktop build for
+          macOS, Windows, or Linux from
+          <a href="https://github.com/ericflo/kiln/releases/latest">the latest release</a>;
           the server tracks the latest <code>kiln-v*</code> tag.
         </p>
         <table class="installer-table">
@@ -480,23 +633,24 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           <tbody>
             <tr>
               <th scope="row">macOS (Apple Silicon)</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · macOS</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/latest">Kiln Desktop · macOS</a></td>
             </tr>
             <tr>
               <th scope="row">Windows</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · Windows</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/latest">Kiln Desktop · Windows</a></td>
             </tr>
             <tr>
               <th scope="row">Linux</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · Linux</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/latest">Kiln Desktop · Linux</a></td>
             </tr>
           </tbody>
         </table>
         <p class="install-foot">
-          Using pi as your terminal agent? Start Kiln, then run <code>kiln pi-setup</code>.
-          It backs up and merges pi's provider config, sets <code>Qwen3.5-4B</code>
-          as the default model, and keeps OpenAI tool calls structured for pi.
-          <a href="cli.html#pi-setup">CLI details →</a>
+          Using pi or opencode as your coding agent? Start Kiln, then run <code>kiln pi-setup</code>
+          (pi) or add a provider in <code>opencode.json</code>.
+          Both point at <code>http://localhost:8420/v1</code>, model <code>Qwen3.5-4B</code>,
+          and stream every tool call into <code>/ui</code> as training data.
+          <a href="#connect">Connect your agent ↑</a> · <a href="cli.html#pi-setup">CLI details →</a>
         </p>
       </div>
     </section>
@@ -584,7 +738,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
     <div class="page footer-inner">
       <div class="footer-brand">
         <a href="./" class="brand">
-          <span class="brand-mark" aria-hidden="true"></span>
+          <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
           <span>kiln</span>
         </a>
         <p class="footer-blurb">Pure-Rust single-GPU inference + live LoRA training. MIT licensed.</p>
@@ -621,7 +775,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
     </div>
     <div class="page footer-meta">
       <span>© 2026 Eric Florenzano</span>
-      <span>Built with kiln · <code>v0.2.16</code></span>
+      <span>Built with kiln · <a href="https://github.com/ericflo/kiln/releases/latest">latest release</a></span>
     </div>
   </footer>
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -51,7 +51,7 @@
   <a class="skip-link" href="#content">Skip to content</a>
 
   <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols
-       (24px viewBox, 1.7px stroke). Referenced via <use href="#i-…">. -->
+       (24px viewBox, 1.7px stroke). Referenced through SVG use of the symbol ids. -->
   <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
     <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
     <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
@@ -621,9 +621,8 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
         <p class="install-foot">
           The Kiln Desktop app and the Kiln server use
           <strong>separate GitHub release tags/version numbers</strong>
-          so each can ship at its own cadence. Grab the latest desktop build for
-          macOS, Windows, or Linux from
-          <a href="https://github.com/ericflo/kiln/releases/latest">the latest release</a>;
+          so each can ship at its own cadence. The latest desktop build is
+          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16"><code>desktop-v0.2.16</code></a>;
           the server tracks the latest <code>kiln-v*</code> tag.
         </p>
         <table class="installer-table">

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -21,17 +21,23 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
+  <link rel="stylesheet" href="css/kiln.css">
   <style>
+    /* Page-local tokens warmed to the canonical Kiln ink ramp (matches the
+       server dashboard + css/kiln.css). Inline rules below win over kiln.css
+       for this page's pre-existing Tailwind-era classes (.card/.pill/etc.);
+       kiln.css supplies the shared connect-band / flywheel / icon components. */
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +45,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -79,7 +85,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -155,11 +161,9 @@
       letter-spacing: 0.04em;
       text-transform: uppercase;
     }
-    .installer-table th:last-child,
-    .installer-table td:last-child {
-      width: 5.5rem;
-      text-align: right;
-      white-space: nowrap;
+    .installer-table th:first-child,
+    .installer-table td:first-child {
+      width: 11rem;
     }
     a { color: #f3c891; }
     a:hover { color: var(--accent); }
@@ -229,11 +233,28 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-flask" viewBox="0 0 24 24"><path d="M9 3h6"/><path d="M10 3v6.5L5.2 18A1.6 1.6 0 0 0 6.6 21h10.8a1.6 1.6 0 0 0 1.4-3L14 9.5V3"/><path d="M7.6 14.5h8.8"/></symbol>
+    <symbol id="i-chart" viewBox="0 0 24 24"><path d="M4 20V4"/><path d="M4 20h16"/><path d="M8 20v-6"/><path d="M13 20V9"/><path d="M18 20v-4"/></symbol>
+    <symbol id="i-refresh" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+    <symbol id="i-merge" viewBox="0 0 24 24"><path d="M7 21V8"/><path d="M17 21v-6a4 4 0 0 0-4-4H7"/><path d="m4 11 3-3 3 3"/><path d="M14 18l3 3 3-3"/></symbol>
+  </defs></svg>
+
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -257,15 +278,15 @@
     <div class="max-w-4xl mx-auto px-6 pt-16 pb-10">
       <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Quickstart &middot; 5-minute path &middot; Qwen3.5-4B</span>
       <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">
-        Run Kiln, open the UI, and send one chat request.
+        Install Kiln, start the server, point your agent at it.
       </h1>
       <p class="text-lg leading-relaxed max-w-3xl" style="color: var(--fg-dim);">
-        Start with the Desktop App if you want the shortest path. Use a server binary or Docker when you want a terminal-first setup. Every path serves the same single target model: <code>Qwen/Qwen3.5-4B</code>.
+        Three steps to a coding agent backed by your own GPU: install Kiln, start the server, then connect <strong style="color: var(--fg);">pi</strong> or <strong style="color: var(--fg);">opencode</strong> to one local endpoint. Every request your agent makes becomes training data. Every path serves the same target model: <code>Qwen/Qwen3.5-4B</code>.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
-        <a href="#install" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Choose an install path</a>
+        <a href="#install" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Install Kiln</a>
+        <a href="#pi-agent" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Connect your agent</a>
         <a href="#verify" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Verify the server</a>
-        <a href="#pi-agent" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Configure pi</a>
       </div>
     </div>
   </section>
@@ -309,45 +330,31 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">Kiln Desktop v0.2.16</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/latest">the latest Kiln Desktop build</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
           <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
             <thead>
               <tr>
                 <th scope="col">Platform</th>
                 <th scope="col">Installer</th>
-                <th scope="col">Size</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>macOS Apple Silicon</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_aarch64.dmg">Kiln.Desktop_0.2.16_aarch64.dmg</a></td>
-                <td>8.5 MB</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/latest">.dmg &middot; latest release</a></td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64-setup.exe">Kiln.Desktop_0.2.16_x64-setup.exe</a> (NSIS)</td>
-                <td>4.5 MB</td>
-              </tr>
-              <tr>
-                <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64_en-US.msi">Kiln.Desktop_0.2.16_x64_en-US.msi</a> (MSI)</td>
-                <td>6.8 MB</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/latest">.exe (NSIS) / .msi &middot; latest release</a></td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.deb">Kiln.Desktop_0.2.16_amd64.deb</a></td>
-                <td>8.8 MB</td>
-              </tr>
-              <tr>
-                <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.AppImage">Kiln.Desktop_0.2.16_amd64.AppImage</a></td>
-                <td>85.7 MB</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/latest">.deb / .AppImage &middot; latest release</a></td>
               </tr>
             </tbody>
           </table>
-          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.16</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
+          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: the Desktop app ships under <code>desktop-v*</code> tags, downloads and verifies the latest <code>kiln-v*</code> server binary for you, and the links above always resolve to the newest release.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>
@@ -391,37 +398,131 @@ Expand-Archive .\kiln-windows.zip -DestinationPath .\kiln</code></pre>
   </section>
 
   <!-- model and serve -->
-  <section class="divider">
-    <div class="max-w-5xl mx-auto px-6 py-12 grid lg:grid-cols-2 gap-6">
-      <div class="card p-6">
-        <div class="flex items-start gap-3 mb-4">
-          <span class="step">2</span>
-          <div>
-            <p class="label mb-2">Model path</p>
-            <h2 class="text-2xl font-semibold tracking-tight">Download Qwen3.5-4B</h2>
-          </div>
+  <section id="serve" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-12">
+      <div class="flex items-start gap-3 mb-6">
+        <span class="step">2</span>
+        <div>
+          <p class="label mb-2">Model path + start</p>
+          <h2 class="text-2xl font-semibold tracking-tight">Start the server</h2>
         </div>
-        <p class="mb-4" style="color: var(--fg-dim);">Point <code>KILN_MODEL_PATH</code> at a local checkout of <code>Qwen/Qwen3.5-4B</code>.</p>
+      </div>
+      <div class="grid lg:grid-cols-2 gap-6">
+        <div class="card p-6">
+          <h3 class="font-semibold mb-2">a. Download Qwen3.5-4B</h3>
+          <p class="mb-4" style="color: var(--fg-dim);">Point <code>KILN_MODEL_PATH</code> at a local checkout of <code>Qwen/Qwen3.5-4B</code>.</p>
 <pre class="text-sm"><code>pip install huggingface-hub
 huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
-      </div>
-      <div class="card p-6">
-        <div class="flex items-start gap-3 mb-4">
-          <span class="step">3</span>
-          <div>
-            <p class="label mb-2">Start</p>
-            <h2 class="text-2xl font-semibold tracking-tight">Run the server</h2>
-          </div>
         </div>
-        <p class="mb-4" style="color: var(--fg-dim);">Server binaries bind to <code>127.0.0.1:8420</code> by default.</p>
+        <div class="card p-6">
+          <h3 class="font-semibold mb-2">b. Run <code>kiln serve</code></h3>
+          <p class="mb-4" style="color: var(--fg-dim);">Server binaries bind to <code>127.0.0.1:8420</code> by default. No API key required.</p>
 <pre class="text-sm"><code>KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
-        <h3 class="font-semibold mt-6 mb-2">Docker (Linux + NVIDIA Container Toolkit)</h3>
+          <h3 class="font-semibold mt-6 mb-2">Docker (Linux + NVIDIA Container Toolkit)</h3>
 <pre class="text-sm"><code>docker run --gpus all -p 8420:8420 \
   -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
   -v "$PWD/Qwen3.5-4B:/models/Qwen3.5-4B:ro" \
   ghcr.io/ericflo/kiln-server:latest serve</code></pre>
+        </div>
       </div>
+    </div>
+  </section>
+
+  <!-- ===============================================================
+       Step 3 — Connect your agent. The centerpiece: pi + opencode side
+       by side. Anchor #pi-agent preserved (legacy deep links + hero CTA).
+       =============================================================== -->
+  <section id="pi-agent" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-14">
+      <div class="flex items-start gap-3 mb-6">
+        <span class="step">3</span>
+        <div>
+          <p class="label mb-2">The #1 thing to do with Kiln</p>
+          <h2 class="text-3xl font-bold tracking-tight">Connect your agent</h2>
+        </div>
+      </div>
+      <p class="max-w-3xl mb-8 text-lg leading-relaxed" style="color: var(--fg-dim);">
+        Point <strong style="color: var(--fg);">pi</strong> or <strong style="color: var(--fg);">opencode</strong> at the server you just started. There is no SDK to swap and no key to generate — change the base URL and keep your agent. Every request it makes streams into <code>/ui</code> as training data you can later turn into a better adapter.
+      </p>
+
+      <!-- dashboard-style fact block -->
+      <div class="grid sm:grid-cols-3 gap-4 mb-8">
+        <div class="card p-4">
+          <p class="label mb-2" style="font-size:0.66rem;">Base URL</p>
+          <div class="copy-field">
+            <code id="qs-base-url">http://localhost:8420/v1</code>
+            <button class="copy-btn" type="button" data-target="qs-base-url" aria-label="Copy base URL"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button>
+          </div>
+        </div>
+        <div class="card p-4">
+          <p class="label mb-2" style="font-size:0.66rem;">Model id</p>
+          <div class="copy-field">
+            <code id="qs-model">Qwen3.5-4B</code>
+            <button class="copy-btn" type="button" data-target="qs-model" aria-label="Copy model id"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button>
+          </div>
+        </div>
+        <div class="card p-4">
+          <p class="label mb-2" style="font-size:0.66rem;">API key</p>
+          <span class="connect-keychip" style="width:100%;">
+            <svg class="icn icn-sm" aria-hidden="true"><use href="#i-check"></use></svg>
+            Not required — any value works
+          </span>
+        </div>
+      </div>
+
+      <!-- pi + opencode side by side -->
+      <div class="grid lg:grid-cols-2 gap-6">
+        <div class="card p-6">
+          <h3 class="font-semibold mb-1 text-lg">pi</h3>
+          <p class="mb-3" style="color: var(--fg-dim);">
+            <code>kiln pi-setup</code> adds Kiln as pi's <code>kiln-local</code> provider and sets <code>Qwen3.5-4B</code> as the default model. It backs up existing <code>models.json</code> and <code>settings.json</code>, then merges the Kiln entries while preserving your other providers.
+          </p>
+<pre class="text-sm"><code>kiln pi-setup
+pi -p "Use the bash tool to run: pwd"
+
+# Remote server? /v1 is appended for you:
+kiln pi-setup --kiln-url http://office-kiln:8420</code></pre>
+          <p class="text-sm mt-3" style="color: var(--fg-mute);">Backups are written beside the originals as <code>models.json.bak-&lt;timestamp&gt;</code> and <code>settings.json.bak-&lt;timestamp&gt;</code>.</p>
+        </div>
+        <div class="card p-6">
+          <h3 class="font-semibold mb-1 text-lg">opencode</h3>
+          <p class="mb-3" style="color: var(--fg-dim);">
+            Add a Kiln provider to <code>~/.config/opencode/opencode.json</code>, then run <code>opencode</code> and pick <strong style="color: var(--fg);">Kiln · Qwen3.5-4B</strong> with <code>/models</code>. Uses the OpenAI-compatible AI SDK adapter — no API key needed.
+          </p>
+<pre class="text-sm"><code>{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "kiln": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Kiln (local)",
+      "options": {
+        "baseURL": "http://localhost:8420/v1",
+        "apiKey": "unused"
+      },
+      "models": {
+        "Qwen3.5-4B": { "name": "Kiln · Qwen3.5-4B" }
+      }
+    }
+  }
+}</code></pre>
+        </div>
+      </div>
+
+      <!-- success cue -->
+      <div class="card p-5 mt-6" style="border-color: rgba(74,222,128,0.30); background: rgba(74,222,128,0.06);">
+        <h3 class="font-semibold mb-1 flex items-center gap-2" style="color: #4ade80;">
+          <svg class="icn icn-sm" aria-hidden="true" style="color:#4ade80;"><use href="#i-check"></use></svg>
+          You should now see this request in /ui
+        </h3>
+        <p style="color: var(--fg-dim);">
+          Open <a href="http://127.0.0.1:8420/ui">http://127.0.0.1:8420/ui</a> and watch <strong style="color: var(--fg);">Recent requests</strong>. The first call from pi or opencode appears within seconds, tagged with its client — proof your agent is wired in and its traffic is being captured.
+        </p>
+      </div>
+
+      <p class="text-sm mt-4" style="color: var(--fg-mute);">
+        Qwen3.5 can emit native XML tool calls, but Kiln returns OpenAI-shaped <code>tool_calls</code> to your agent in both streaming and non-streaming responses, so pi and opencode execute tools instead of printing raw XML.
+      </p>
     </div>
   </section>
 
@@ -451,6 +552,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
 <pre class="text-sm"><code>curl -s http://127.0.0.1:8420/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
+    "model": "Qwen3.5-4B",
     "messages": [{"role": "user", "content": "What is 2+2?"}],
     "max_tokens": 64,
     "temperature": 0.7
@@ -471,40 +573,17 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
     </div>
   </section>
 
-  <section id="pi-agent" class="divider">
+  <!-- next / train -->
+  <section id="train" class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">
-      <p class="label mb-2">Agent setup</p>
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Point pi at Kiln without clobbering pi config</h2>
-      <p class="max-w-3xl mb-6" style="color: var(--fg-dim);">
-        After the server is healthy, <code>kiln pi-setup</code> adds Kiln as pi's <code>kiln-local</code> provider and sets <code>Qwen3.5-4B</code> as the default model. It backs up existing <code>models.json</code> and <code>settings.json</code>, then merges the Kiln entries while preserving other providers and settings.
-      </p>
-      <div class="grid lg:grid-cols-3 gap-4">
-        <div class="card p-5">
-          <h3 class="font-semibold mb-2">Local server</h3>
-<pre class="text-sm"><code>kiln pi-setup
-pi -p "Use the bash tool to run: pwd"</code></pre>
-        </div>
-        <div class="card p-5">
-          <h3 class="font-semibold mb-2">Remote server</h3>
-<pre class="text-sm"><code>kiln pi-setup --kiln-url http://office-kiln:8420</code></pre>
-          <p class="text-sm mt-3" style="color: var(--fg-mute);">The helper appends <code>/v1</code> when the URL does not already include it.</p>
-        </div>
-        <div class="card p-5">
-          <h3 class="font-semibold mb-2">Tool calls</h3>
-          <p style="color: var(--fg-dim);">Qwen3.5 can generate native XML tool calls, but Kiln returns OpenAI-shaped <code>tool_calls</code> to pi in both streaming and non-streaming responses.</p>
+      <div class="flex items-start gap-3 mb-6">
+        <span class="step">5</span>
+        <div>
+          <p class="label mb-2">Turn traffic into a better model</p>
+          <h2 class="text-2xl font-semibold tracking-tight">Train &amp; evaluate</h2>
         </div>
       </div>
-      <p class="text-sm mt-4" style="color: var(--fg-mute);">
-        Backup files are written beside the originals as <code>models.json.bak-&lt;timestamp&gt;</code> and <code>settings.json.bak-&lt;timestamp&gt;</code>.
-      </p>
-    </div>
-  </section>
-
-  <!-- next -->
-  <section class="divider">
-    <div class="max-w-5xl mx-auto px-6 py-12">
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
-      <div class="card p-5 mb-4" style="background: rgba(168, 85, 247, 0.08); border-color: rgba(168, 85, 247, 0.22);">
+      <div class="card p-5 mb-4" style="background: var(--bg-soft-2); border-color: var(--line-2);">
         <h3 class="font-semibold mb-2">Training file shapes at a glance</h3>
         <p style="color: var(--fg-dim);">
           <code>kiln train sft</code> reads <strong>SFT JSONL</strong>: one chat correction per line, each with a <code>messages</code> array.
@@ -552,6 +631,43 @@ pi -p "Use the bash tool to run: pwd"</code></pre>
           <p style="color: var(--fg-dim);">Understand the scheduler, block manager, GDN model path, and hot-swap design.</p>
         </a>
       </div>
+
+      <!-- The loop — flywheel ribbon echoing the dashboard. Each node links
+           to its guide: Agents → Traffic → Train → Eval → Hot-swap. -->
+      <div class="flywheel-wrap mt-10">
+        <div class="flywheel-title"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> The loop <span class="flywheel-tagline">— your model gets better every time you use it</span></div>
+        <div class="flywheel" role="group" aria-label="The improvement loop">
+          <a class="flywheel-node hot" href="#pi-agent">
+            <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-link"></use></svg> Agents</span>
+            <span class="fw-value">pi · opencode</span>
+            <span class="fw-sub">connect your agent</span>
+          </a>
+          <span class="flywheel-arrow" aria-hidden="true"><svg class="icn"><use href="#i-arrow-right"></use></svg></span>
+          <a class="flywheel-node" href="#verify">
+            <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-activity"></use></svg> Traffic</span>
+            <span class="fw-value">/ui</span>
+            <span class="fw-sub">captured requests</span>
+          </a>
+          <span class="flywheel-arrow" aria-hidden="true"><svg class="icn"><use href="#i-arrow-right"></use></svg></span>
+          <a class="flywheel-node" href="grpo.html">
+            <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-flask"></use></svg> Train</span>
+            <span class="fw-value">SFT · GRPO</span>
+            <span class="fw-sub">over HTTP</span>
+          </a>
+          <span class="flywheel-arrow" aria-hidden="true"><svg class="icn"><use href="#i-arrow-right"></use></svg></span>
+          <a class="flywheel-node" href="evals.html">
+            <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-chart"></use></svg> Eval</span>
+            <span class="fw-value">Prove it</span>
+            <span class="fw-sub">suites &amp; A/B</span>
+          </a>
+          <span class="flywheel-arrow" aria-hidden="true"><svg class="icn"><use href="#i-arrow-right"></use></svg></span>
+          <a class="flywheel-node" href="api.html#adapters">
+            <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-merge"></use></svg> Hot-swap</span>
+            <span class="fw-value">No restart</span>
+            <span class="fw-sub">live adapter</span>
+          </a>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -561,7 +677,7 @@ pi -p "Use the bash tool to run: pwd"</code></pre>
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
@@ -643,6 +759,37 @@ pi -p "Use the bash tool to run: pwd"</code></pre>
             button.classList.remove("is-copied");
           }, resetDelay);
         });
+      });
+
+      // Copy buttons that target a specific element by id (connect fact block:
+      // Base URL / Model id). These are not inside <pre>, so handle them here.
+      document.addEventListener("click", (e) => {
+        const btn = e.target.closest(".copy-btn[data-target]");
+        if (!btn) return;
+        const target = document.getElementById(btn.dataset.target);
+        if (!target) return;
+        const text = target.textContent.replace(/ /g, " ").trim();
+        const label = btn.querySelector("svg") ? null : btn;
+        const restore = btn.innerHTML;
+        const done = () => {
+          btn.dataset.copied = "1";
+          btn.classList.add("is-copied");
+          if (label) btn.textContent = "Copied"; else btn.lastChild.textContent = "Copied";
+          window.setTimeout(() => {
+            delete btn.dataset.copied;
+            btn.classList.remove("is-copied");
+            btn.innerHTML = restore;
+          }, resetDelay);
+        };
+        if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(text).then(done).catch(done);
+        } else {
+          const ta = document.createElement("textarea");
+          ta.value = text; ta.style.position = "fixed"; ta.style.opacity = "0";
+          document.body.appendChild(ta); ta.select();
+          try { document.execCommand("copy"); } catch (_) {}
+          document.body.removeChild(ta); done();
+        }
       });
     })();
   </script>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -330,7 +330,7 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/latest">the latest Kiln Desktop build</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">Kiln Desktop v0.2.16</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
           <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
             <thead>
@@ -416,7 +416,7 @@ huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         </div>
         <div class="card p-6">
-          <h3 class="font-semibold mb-2">b. Run <code>kiln serve</code></h3>
+          <h3 class="font-semibold mb-2">b. Run the server with <code>kiln serve</code></h3>
           <p class="mb-4" style="color: var(--fg-dim);">Server binaries bind to <code>127.0.0.1:8420</code> by default. No API key required.</p>
 <pre class="text-sm"><code>KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
           <h3 class="font-semibold mt-6 mb-2">Docker (Linux + NVIDIA Container Toolkit)</h3>
@@ -476,7 +476,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         <div class="card p-6">
           <h3 class="font-semibold mb-1 text-lg">pi</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            <code>kiln pi-setup</code> adds Kiln as pi's <code>kiln-local</code> provider and sets <code>Qwen3.5-4B</code> as the default model. It backs up existing <code>models.json</code> and <code>settings.json</code>, then merges the Kiln entries while preserving your other providers.
+            Configure pi in one command: <code>kiln pi-setup</code> adds Kiln as pi's <code>kiln-local</code> provider and sets <code>Qwen3.5-4B</code> as the default model. It backs up existing <code>models.json</code> and <code>settings.json</code>, then merges the Kiln entries while preserving your other providers.
           </p>
 <pre class="text-sm"><code>kiln pi-setup
 pi -p "Use the bash tool to run: pwd"
@@ -597,6 +597,7 @@ kiln pi-setup --kiln-url http://office-kiln:8420</code></pre>
           Upload an SFT or GRPO JSONL to <code>POST /v1/eval/datasets/upload</code> and synthesize a graded suite from it in one call &mdash; no separate eval-set authoring needed. Then <code>POST /v1/eval/run</code> grades any adapter, <code>/v1/eval/compare</code> runs the suite head-to-head against another adapter, and any training request can carry <code>post_eval: { suite, include_baseline: true }</code> to auto-grade itself the moment it finishes. The whole loop runs locally; the optional LLM judge is itself a LoRA you train from A/B preferences in <code>/ui</code>. See the <a href="evals.html">Evals guide</a> for the full walkthrough.
         </p>
       </div>
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <a class="card p-5 block" href="api.html#training">
           <h3 id="sft-corrections" class="font-semibold mb-2">SFT corrections</h3>
@@ -661,7 +662,7 @@ kiln pi-setup --kiln-url http://office-kiln:8420</code></pre>
             <span class="fw-sub">suites &amp; A/B</span>
           </a>
           <span class="flywheel-arrow" aria-hidden="true"><svg class="icn"><use href="#i-arrow-right"></use></svg></span>
-          <a class="flywheel-node" href="api.html#adapters">
+          <a class="flywheel-node" href="api.html#lora-lifecycle">
             <span class="fw-eyebrow"><svg class="icn" aria-hidden="true"><use href="#i-merge"></use></svg> Hot-swap</span>
             <span class="fw-value">No restart</span>
             <span class="fw-sub">live adapter</span>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -21,17 +21,35 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/fonts.css">
   <style>
+    /* Brand mark — stacked-fire-layers cube, mirrors the server dashboard. */
+    .brand-mark {
+      width: 28px; height: 28px; flex: none; border-radius: 8px; position: relative;
+      display: inline-flex; align-items: center; justify-content: center;
+      background:
+        radial-gradient(120% 120% at 30% 20%, rgba(255,255,255,0.06), transparent 60%),
+        linear-gradient(160deg, #c2410c 0%, #f97316 55%, #fdba74 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 4px 10px rgba(249,115,22,0.25);
+    }
+    .brand-mark .brand-flame {
+      position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+      fill: none; stroke: #0a0908; stroke-width: 2;
+      stroke-linecap: round; stroke-linejoin: round; opacity: 0.82;
+    }
+    .icn { width: 1.15em; height: 1.15em; display: inline-block; vertical-align: -0.18em;
+      fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+    .icn-sm { width: 1em; height: 1em; vertical-align: -0.14em; }
     :root {
       color-scheme: dark;
-      --bg: #0b0d10;
-      --bg-soft: #11141a;
-      --bg-soft-2: #161a22;
-      --line: #1f2530;
-      --line-2: #2a3140;
-      --fg: #e6e9ef;
-      --fg-dim: #a4adbb;
-      --fg-mute: #6f7888;
+      --bg: #0a0908;
+      --bg-soft: #181613;
+      --bg-soft-2: #1d1b17;
+      --line: #2b2720;
+      --line-2: #443c31;
+      --fg: #f7f4ef;
+      --fg-dim: #b0a895;
+      --fg-mute: #938b79;
       --accent: #f97316;
       --accent-soft: rgba(249, 115, 22, 0.12);
     }
@@ -39,8 +57,8 @@
     body {
       background: var(--bg);
       color: var(--fg);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-      font-feature-settings: "ss01", "cv02", "cv11";
+      font-family: 'Inter', 'Inter Fallback', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-feature-settings: "cv02", "cv03", "cv04", "cv11";
       -webkit-font-smoothing: antialiased;
     }
     .skip-link {
@@ -75,7 +93,7 @@
       overflow-x: auto;
       font-size: 13.5px;
       line-height: 1.55;
-      color: #d8dde7;
+      color: var(--text-2);
     }
     pre code {
       background: transparent;
@@ -98,7 +116,7 @@
     .hero-glow {
       background:
         radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
-        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+        radial-gradient(40% 35% at 80% 20%, rgba(249,115,22,0.05), transparent 70%);
     }
     .card {
       background: var(--bg-soft);
@@ -201,11 +219,23 @@
 </head>
 <body class="min-h-screen">
   <a class="skip-link" href="#content">Skip to content</a>
+
+  <!-- Inline icon sprite — mirrors the server dashboard #i-* symbols. -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+    <symbol id="i-stack" viewBox="0 0 24 24"><path d="M4 8.5l8 4 8-4"/><path d="M6 12.6l6 3 6-3"/><path d="M8 16.7l4 2 4-2"/></symbol>
+    <symbol id="i-arrow-right" viewBox="0 0 24 24"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></symbol>
+    <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+    <symbol id="i-bolt" viewBox="0 0 24 24"><path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13l0-8Z"/></symbol>
+    <symbol id="i-copy" viewBox="0 0 24 24"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+    <symbol id="i-link" viewBox="0 0 24 24"><path d="M9.5 14.5 14.5 9.5"/><path d="M11 6.5 12.2 5.3a4 4 0 0 1 5.7 5.7l-1.2 1.2"/><path d="M13 17.5l-1.2 1.2a4 4 0 0 1-5.7-5.7l1.2-1.2"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M3 12h4l3 8 4-16 3 8h4"/></symbol>
+    <symbol id="i-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3"/><path d="M13 15h4"/></symbol>
+  </defs></svg>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+      <a href="./" class="flex items-center gap-2.5" style="color: var(--fg);">
+        <span class="brand-mark" aria-hidden="true"><svg class="brand-flame" viewBox="0 0 24 24"><use href="#i-stack"></use></svg></span>
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
@@ -537,7 +567,7 @@ kiln adapters list --url http://gpu-box:8420</code></pre>
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
       <div class="flex items-center gap-2.5">
-        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span class="brand-mark" aria-hidden="true" style="width:20px;height:20px;"><svg class="brand-flame" viewBox="0 0 24 24" style="width:13px;height:13px;"><use href="#i-stack"></use></svg></span>
         <span>Kiln &middot; MIT licensed</span>
       </div>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -777,7 +777,10 @@ async function expectNoMobileOverflow(page) {
 
 async function expectMobilePanelFlow(page) {
   const tabPanels = [
-    { tab: 'overview', selectors: ['#server-status', '#decode-perf-panel', '#recent-requests-panel'] },
+    // Recent requests is promoted to the top of Overview — live agent traffic is
+    // the primary thing a pi/opencode operator wants to see — followed by the
+    // server-status and decode-performance panels.
+    { tab: 'overview', selectors: ['#recent-requests-panel', '#server-status', '#decode-perf-panel'] },
     { tab: 'adapters', selectors: ['#adapters-panel'] },
     { tab: 'training', selectors: ['[data-training-tabs]'] },
     { tab: 'playground', selectors: ['#chat-output'] },


### PR DESCRIPTION
Bends the whole UI toward the primary use case — a developer pointing **pi** or **opencode** at a local Kiln — and makes the improvement **flywheel legible end to end**: watch traffic → spot bad answers → correct → train → **verify it beat base** → hot-swap → repeat.

## Dashboard (`crates/kiln-server/src/ui.html`)
- **Corrections basket** — capture a bad request, write the ideal answer, train one SFT adapter. Only *edited* corrections train (never the model's own mistake); persistent "training started" receipt instead of a silent page jump.
- **"Needs attention" failure filter** + per-row one-click **Correct** button for fast triage.
- **Inspect modal** — a "Latency pi felt" TTFT/decode bar, prev/next triage nav, and **Verify A/B** (re-run the exact prompt base-vs-active in Playground compare).
- **"Did it win?" verdict** surfaced in three consistent places from one shared computation: the flywheel **Hot-swap** node (green `+X pts vs base`), the **active adapter card**, and **Evals** job cards + compare drill (lighting up the previously-dead `.delta-badge`). Per-adapter eval-score chips on the adapter list.
- Non-completed eval jobs show a **state figure**, not a misleading `0` score.
- Live, state-keyed flywheel ribbon + tooltips; **`?` keyboard cheatsheet**; clearer "can't reach Kiln" error copy.
- Agent-centric `?demo=1` fixture covering **every page** (doubles as the verification fixture + README screenshots).

## Server (Rust)
- Capture per-request `User-Agent` (`recent_requests.rs`, `api/completions.rs`) so traffic is attributable to pi / opencode / curl / OpenAI clients.

## Desktop app (`desktop/ui/*`)
- A **real** de-blue, not a token swap: 15 hardcoded blue accents → amber, ~58 cool greys → warm tokens; fixed the Logs amber-overload and rebuilt the stranded index window.

## Docs site (`docs/site/*`)
- Cleared the last leaks (a blue body radial + cool-grey code text).

## Design + verification
- Warm charcoal with **amber = alive only**; **zero blue/cool-grey leakage** across all 18 files (grep-verified).
- Headless render (Playwright/Chromium): **0 page errors** on every dashboard, desktop, and docs page.
- Multi-agent review grades the dashboard **best-in-class** with the flywheel loop closed and the "did it win?" answer glanceable.

## Deferred follow-ups (need backend or are lower-tier polish)
- Server-side "re-run corrected requests with a pass/fail regression gate" + adapter↔correction provenance lineage.
- Cold-start onboarding micro-copy; "load the winner" CTA in the compare drill; per-tag base-vs-adapter deltas; Distill advanced-toggle/recipe guidance; docs hero perf proof-strip (needs real numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)