### PR TITLE
Add Muon optimizer to all training modes and make it the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Kiln Server Changelog
 
+## Unreleased
+
+- training: **Muon is now the default optimizer** for every training mode
+  (SFT, GRPO, on-policy distillation / OPD, and the judge-LoRA flywheel that
+  rides the OPD path). Muon is momentum-orthogonalized SGD — it keeps one
+  per-parameter heavy-ball momentum buffer (vs AdamW's two moments), takes a
+  Nesterov look-ahead, and projects the LoRA A/B weight-matrix updates onto
+  the nearest semi-orthogonal matrix via a Newton-Schulz iteration before
+  stepping, rescaling by `sqrt(max(rows, cols))` so the update magnitude is
+  shape-independent. It converges LoRA fine-tunes in fewer steps than AdamW at
+  roughly half the optimizer state.
+- training: fused on-device Muon kernels for **every backend** — CUDA, ROCm,
+  Vulkan, and Metal — implementing the whole step (heavy-ball momentum +
+  Newton-Schulz orthogonalization + decoupled-weight-decay descent) in a
+  single fused per-matrix launch. Newton-Schulz is computed in gram space via
+  a `k×k` P-accumulator (`k` = LoRA rank), so the cost is dominated by two
+  skinny GEMMs over the large matrix dimension. The portable CPU reference in
+  `kiln-optim` is the parity oracle the GPU kernels are validated against.
+- API: the optimizer is still selected per training request. Omit the
+  `optimizer` field to get Muon; opt back into the old behaviour with
+  `{"optimizer": {"kind": "adam_w"}}` or `{"optimizer": {"kind": "sgd"}}`.
+  Muon accepts `momentum` (0.95), `nesterov` (true), `ns_iters` (5), and
+  `weight_decay` (0.0). Note Muon wants a larger learning rate than AdamW
+  (~2e-2 vs ~1e-4 for LoRA), since its update is orthogonalized and
+  RMS-matched to unit scale.
+
 ## kiln-v0.3.5 — 2026-06-09 — task-first dashboard interactions + embedded pi terminal
 
 UX release that rebuilds the dashboard's interactions around the pi-user's

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A 4B model continuously tuned to your specific workload — and continuously *me
 - **Judgment flywheel** — A/B-judge two adapters in `/ui`, save your picks into a judgment dataset, compile to SFT, train a *local* judge LoRA, validate it on a held-out slice. The dashboard ships a streaming side-by-side viewer with `A`/`B`/`Tie`/`Skip` keyboard shortcuts.
 - **Post-training auto-eval** — attach `post_eval` to any SFT/GRPO request and the produced adapter is graded immediately, with results back-linked to the training job.
 - **Adapter smoke tests** — pass `--adapter-smoke-test` on SFT/GRPO CLI submissions to record base-vs-adapter canary metrics in `train_receipt.json` before a full eval.
+- **Muon optimizer (default)** — momentum-orthogonalized SGD with fused on-device Newton-Schulz kernels for every backend (CUDA, ROCm, Vulkan, Metal). Converges LoRA fine-tunes in fewer steps than AdamW at roughly half the optimizer state (one momentum buffer vs Adam's two moments). AdamW and SGD remain selectable per-request via `{"optimizer": {"kind": "adam_w"}}` / `{"kind": "sgd"}`.
 - **LoRA hot-swap** — new adapter weights activate atomically at iteration boundaries. Zero downtime.
 - **Continuous batching** with chunked prefill — decode requests are never stalled by long prompts.
 - **128K+ context** on 24GB — Qwen3.5-4B's hybrid architecture (24 linear attention + 8 full attention layers) means KV cache is 4x smaller than a pure transformer.

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -18,6 +18,7 @@ use crate::lora_loader::{LoraProjectionWeights, compute_lora_delta};
 
 static CUDA_SGD_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static CUDA_ADAMW_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static CUDA_MUON_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static CUDA_LINEAR_PREFILL_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static CUDA_LINEAR_PREFILL_OFFSET_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static CUDA_FLASH_ATTN_TRACKED_DECLINES: AtomicU64 = AtomicU64::new(0);
@@ -556,6 +557,68 @@ impl OptimizerBackend for CudaBackend {
                 weight_decay,
                 step,
                 "CudaBackend::dispatch_adamw_step first call"
+            );
+        });
+        Ok(true)
+    }
+
+    fn runtime_dispatch_muon_step(
+        &self,
+        param: &kiln_tensor::Tensor,
+        grad: &kiln_tensor::Tensor,
+        momentum: &kiln_tensor::Tensor,
+        lr: f32,
+        momentum_coef: f32,
+        nesterov: bool,
+        ns_iters: u32,
+        weight_decay: f32,
+    ) -> Result<bool> {
+        if !cuda_optimizer_args_ready_for_kt(&self.resident_tensor_ids, &[param, grad, momentum]) {
+            return Ok(false);
+        }
+        // #1082: args are already kt (BackendRuntime trait flipped to kt),
+        // so there is no candle<->kt borrow - the kernel runs directly on the
+        // caller's kt tensors. Updates param + momentum in place in one launch.
+        kiln_nvtx::range!(c"kiln/muon_step_kt");
+        match param.dtype() {
+            kiln_tensor::DType::F32 => kiln_rmsnorm_kernel::muon_step_f32_kt(
+                param,
+                grad,
+                momentum,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            )
+            .map_err(|e| anyhow::anyhow!("muon_step kt: muon_step_f32_kt: {e}"))?,
+            kiln_tensor::DType::BF16 => kiln_rmsnorm_kernel::muon_step_bf16_kt(
+                param,
+                grad,
+                momentum,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            )
+            .map_err(|e| anyhow::anyhow!("muon_step kt: muon_step_bf16_kt: {e}"))?,
+            other => anyhow::bail!("muon_step kt: unsupported dtype {other:?}"),
+        }
+        CUDA_MUON_DISPATCH_SUCCESSES.fetch_add(1, Ordering::Relaxed);
+        static FIRST_CUDA_MUON_LOGGED: OnceLock<()> = OnceLock::new();
+        FIRST_CUDA_MUON_LOGGED.get_or_init(|| {
+            tracing::info!(
+                param_shape = ?param.dims(),
+                grad_shape = ?grad.dims(),
+                momentum_shape = ?momentum.dims(),
+                dtype = ?param.dtype(),
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+                "CudaBackend::dispatch_muon_step first call"
             );
         });
         Ok(true)

--- a/crates/kiln-model/src/backend/metal_runtime.rs
+++ b/crates/kiln-model/src/backend/metal_runtime.rs
@@ -318,6 +318,37 @@ impl OptimizerBackend for MetalBackend {
             step,
         )
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn runtime_dispatch_muon_step(
+        &self,
+        param: &kiln_tensor::Tensor,
+        grad: &kiln_tensor::Tensor,
+        momentum: &kiln_tensor::Tensor,
+        lr: f32,
+        momentum_coef: f32,
+        nesterov: bool,
+        ns_iters: u32,
+        weight_decay: f32,
+    ) -> Result<bool> {
+        // All three operands must be resident: no mixed resident/host update,
+        // since that would need a per-call upload and defeat on-device Muon.
+        let all_resident = metal_residency::all_registered(
+            &self.resident_activation_registry,
+            &[param, grad, momentum],
+        );
+        metal_training::dispatch_muon_step(
+            param,
+            grad,
+            momentum,
+            all_resident,
+            lr,
+            momentum_coef,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        )
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/kiln-model/src/backend/metal_training.rs
+++ b/crates/kiln-model/src/backend/metal_training.rs
@@ -130,6 +130,103 @@ pub(super) fn dispatch_adamw_step(
     Ok(true)
 }
 
+/// Fused on-device Muon step. Mirrors [`dispatch_adamw_step`]'s residency /
+/// dtype / element-count / contiguity gating, then delegates to
+/// [`kiln_tensor::metal_muon_step`], which updates `param` and `momentum` in
+/// place. Returns `Ok(true)` when handled on-device, `Ok(false)` to defer to
+/// the host `kiln_optim::Muon` reference.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn dispatch_muon_step(
+    param: &kiln_tensor::Tensor,
+    grad: &kiln_tensor::Tensor,
+    momentum: &kiln_tensor::Tensor,
+    all_operands_resident: bool,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<bool> {
+    if !all_operands_resident {
+        return Ok(false);
+    }
+
+    if param.dtype() != grad.dtype() || param.dtype() != momentum.dtype() {
+        anyhow::bail!(
+            "dispatch_muon_step: dtype mismatch (param={:?}, grad={:?}, momentum={:?})",
+            param.dtype(),
+            grad.dtype(),
+            momentum.dtype(),
+        );
+    }
+
+    let n_elements = param.element_count();
+    if n_elements != grad.element_count() || n_elements != momentum.element_count() {
+        anyhow::bail!(
+            "dispatch_muon_step: element count mismatch (param={}, grad={}, momentum={})",
+            n_elements,
+            grad.element_count(),
+            momentum.element_count(),
+        );
+    }
+
+    if !param.is_contiguous() || !grad.is_contiguous() || !momentum.is_contiguous() {
+        return Ok(false);
+    }
+
+    // F32 + BF16 run on-device (BF16 with round-to-nearest, matching the AdamW
+    // arm and the default round-to-nearest host policy). F16 declines, as does
+    // BF16 when stochastic rounding is explicitly requested, preserving the
+    // host's stochastic-rounding master update.
+    let dt = param.dtype();
+    if dt == kiln_tensor::DType::F16 {
+        return Ok(false);
+    }
+    if dt == kiln_tensor::DType::BF16 && bf16_stochastic_rounding_enabled() {
+        return Ok(false);
+    }
+
+    // Rank-2 weights orthogonalize; non-2D params fall back (inside the
+    // kernel) to plain (Nesterov) momentum SGD via the `(n, 1)` shape.
+    let shape = param.shape();
+    let (rows, cols) = if shape.len() == 2 {
+        (shape[0], shape[1])
+    } else {
+        (n_elements, 1)
+    };
+
+    static FIRST_MUON_LOGGED: OnceLock<()> = OnceLock::new();
+    FIRST_MUON_LOGGED.get_or_init(|| {
+        tracing::info!(
+            n_elements,
+            rows,
+            cols,
+            lr,
+            momentum_coef,
+            nesterov,
+            ns_iters,
+            weight_decay,
+            dtype = ?param.dtype(),
+            "MetalBackend::dispatch_muon_step first call"
+        );
+    });
+
+    kiln_tensor::metal_muon_step(
+        param,
+        grad,
+        momentum,
+        rows,
+        cols,
+        lr,
+        momentum_coef,
+        nesterov,
+        ns_iters,
+        weight_decay,
+    )
+    .context("dispatch_muon_step: metal_muon_step")?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod adamw_kt_tests {
     use super::*;

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -1630,6 +1630,32 @@ pub trait OptimizerBackend: Send + Sync + std::fmt::Debug {
     ) -> Result<bool> {
         Ok(false)
     }
+
+    /// Fused on-device Muon step (momentum-orthogonalized SGD).
+    ///
+    /// Updates `param` and the per-param heavy-ball `momentum` buffer in
+    /// place: `momentum = momentum_coef * momentum + grad`; the
+    /// (Nesterov) look-ahead is orthogonalized via Newton-Schulz for
+    /// rank-2 weights (the LoRA A/B matrices) with the RMS-matching
+    /// `sqrt(max(rows, cols))` scale, then `param = param * (1 - lr *
+    /// weight_decay) - lr * update`. Non-matrix params and ranks beyond
+    /// the kernel's shared-memory bound fall back to plain momentum SGD
+    /// inside the kernel. Returns `Ok(true)` when handled on-device,
+    /// `Ok(false)` to defer to the host `kiln_optim::Muon` reference.
+    #[allow(clippy::too_many_arguments)]
+    fn runtime_dispatch_muon_step(
+        &self,
+        _param: &kiln_tensor::Tensor,
+        _grad: &kiln_tensor::Tensor,
+        _momentum: &kiln_tensor::Tensor,
+        _lr: f32,
+        _momentum_coef: f32,
+        _nesterov: bool,
+        _ns_iters: u32,
+        _weight_decay: f32,
+    ) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 /// Focused `TrainingLossBackend` facet delegated by the current `BackendRuntime` facade.

--- a/crates/kiln-model/src/backend/rocm.rs
+++ b/crates/kiln-model/src/backend/rocm.rs
@@ -18,6 +18,7 @@ use crate::lora_loader::{LoraProjectionWeights, compute_lora_delta};
 
 static ROCM_SGD_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static ROCM_ADAMW_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static ROCM_MUON_DISPATCH_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static ROCM_LINEAR_PREFILL_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static ROCM_LINEAR_PREFILL_OFFSET_SUCCESSES: AtomicU64 = AtomicU64::new(0);
 static ROCM_FLASH_ATTN_TRACKED_DECLINES: AtomicU64 = AtomicU64::new(0);
@@ -622,6 +623,68 @@ impl OptimizerBackend for RocmBackend {
                 weight_decay,
                 step,
                 "RocmBackend::dispatch_adamw_step first call"
+            );
+        });
+        Ok(true)
+    }
+
+    fn runtime_dispatch_muon_step(
+        &self,
+        param: &kiln_tensor::Tensor,
+        grad: &kiln_tensor::Tensor,
+        momentum: &kiln_tensor::Tensor,
+        lr: f32,
+        momentum_coef: f32,
+        nesterov: bool,
+        ns_iters: u32,
+        weight_decay: f32,
+    ) -> Result<bool> {
+        if !rocm_optimizer_args_ready_for_kt(&self.resident_tensor_ids, &[param, grad, momentum]) {
+            return Ok(false);
+        }
+        // #1082: args are already kt (BackendRuntime trait flipped to kt),
+        // so there is no candle<->kt borrow - the kernel runs directly on the
+        // caller's kt tensors. Updates param + momentum in place in one launch.
+        kiln_nvtx::range!(c"kiln/muon_step_kt");
+        match param.dtype() {
+            kiln_tensor::DType::F32 => kiln_rmsnorm_kernel::muon_step_f32_kt(
+                param,
+                grad,
+                momentum,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            )
+            .map_err(|e| anyhow::anyhow!("muon_step kt: muon_step_f32_kt: {e}"))?,
+            kiln_tensor::DType::BF16 => kiln_rmsnorm_kernel::muon_step_bf16_kt(
+                param,
+                grad,
+                momentum,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            )
+            .map_err(|e| anyhow::anyhow!("muon_step kt: muon_step_bf16_kt: {e}"))?,
+            other => anyhow::bail!("muon_step kt: unsupported dtype {other:?}"),
+        }
+        ROCM_MUON_DISPATCH_SUCCESSES.fetch_add(1, Ordering::Relaxed);
+        static FIRST_ROCM_MUON_LOGGED: OnceLock<()> = OnceLock::new();
+        FIRST_ROCM_MUON_LOGGED.get_or_init(|| {
+            tracing::info!(
+                param_shape = ?param.dims(),
+                grad_shape = ?grad.dims(),
+                momentum_shape = ?momentum.dims(),
+                dtype = ?param.dtype(),
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+                "RocmBackend::dispatch_muon_step first call"
             );
         });
         Ok(true)

--- a/crates/kiln-model/src/backend/vulkan.rs
+++ b/crates/kiln-model/src/backend/vulkan.rs
@@ -477,6 +477,30 @@ impl OptimizerBackend for VulkanBackend {
             step,
         )
     }
+
+    fn runtime_dispatch_muon_step(
+        &self,
+        param: &kiln_tensor::Tensor,
+        grad: &kiln_tensor::Tensor,
+        momentum: &kiln_tensor::Tensor,
+        lr: f32,
+        momentum_coef: f32,
+        nesterov: bool,
+        ns_iters: u32,
+        weight_decay: f32,
+    ) -> Result<bool> {
+        vulkan_training::dispatch_muon_step(
+            self,
+            param,
+            grad,
+            momentum,
+            lr,
+            momentum_coef,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        )
+    }
 }
 
 impl PagedKvBackend for VulkanBackend {}

--- a/crates/kiln-model/src/backend/vulkan_training.rs
+++ b/crates/kiln-model/src/backend/vulkan_training.rs
@@ -86,6 +86,44 @@ pub fn dispatch_adamw_step_buffers(
     )
 }
 
+/// (#1082) Shared, storage-decoupled fused Muon optimizer seam over raw
+/// Vulkan device buffers (F32). Counterpart to
+/// [`dispatch_adamw_step_buffers`] for the `Optimizer::Muon` path; updates
+/// `param` AND `momentum` in place via the fused SPIR-V
+/// `dispatch_muon_step_f32` kernel (one launch per matrix). `rows`/`cols`
+/// describe the row-major param shape (`cols == 1` for a non-2D param);
+/// `n_elements == rows * cols`.
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_muon_step_buffers(
+    vk_device: &kiln_vulkan_kernel::VulkanDevice,
+    param_buffer: &kiln_vulkan_kernel::VulkanBuffer,
+    grad_buffer: &kiln_vulkan_kernel::VulkanBuffer,
+    momentum_buffer: &kiln_vulkan_kernel::VulkanBuffer,
+    n_elements: usize,
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<()> {
+    kiln_vulkan_kernel::kernels::dispatch_muon_step_f32(
+        vk_device,
+        param_buffer,
+        grad_buffer,
+        momentum_buffer,
+        n_elements,
+        rows,
+        cols,
+        lr,
+        momentum_coef,
+        nesterov,
+        ns_iters,
+        weight_decay,
+    )
+}
+
 /// (#1082) Shared, storage-decoupled SGD optimizer seam over raw Vulkan
 /// device buffers. Counterpart to [`dispatch_adamw_step_buffers`] for the
 /// `Optimizer::Sgd` path; updates `param` in place via the shared SPIR-V
@@ -270,6 +308,117 @@ pub(super) fn dispatch_adamw_step(
                 eps,
                 weight_decay,
                 step,
+            )?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn dispatch_muon_step(
+    backend: &VulkanBackend,
+    param: &kiln_tensor::Tensor,
+    grad: &kiln_tensor::Tensor,
+    momentum: &kiln_tensor::Tensor,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<bool> {
+    let Some(vk_device) = backend.vulkan_device.as_ref() else {
+        return Ok(false);
+    };
+    // Mirror the AdamW gate: param, grad, and the per-param momentum must
+    // share dtype + element count, and all three must be registry-resident
+    // for the in-place fused step to run on-device.
+    if param.dtype() != grad.dtype() || param.dtype() != momentum.dtype() {
+        anyhow::bail!(
+            "dispatch_muon_step: dtype mismatch (param={:?}, grad={:?}, momentum={:?})",
+            param.dtype(),
+            grad.dtype(),
+            momentum.dtype(),
+        );
+    }
+    let n_elements = param.element_count();
+    if n_elements != grad.element_count() || n_elements != momentum.element_count() {
+        anyhow::bail!(
+            "dispatch_muon_step: element count mismatch (param={}, grad={}, momentum={})",
+            n_elements,
+            grad.element_count(),
+            momentum.element_count(),
+        );
+    }
+    // Row-major shape for the fused kernel: rank-2 params pass (rows, cols);
+    // anything else collapses to (n, 1) and the kernel falls back to plain
+    // (Nesterov) momentum SGD (do_ortho is false) — matching the host
+    // reference which only orthogonalizes rank-2 weights.
+    let dims = param.dims();
+    let (rows, cols) = if dims.len() == 2 {
+        (dims[0], dims[1])
+    } else {
+        (n_elements, 1)
+    };
+    let p_id = param.id();
+    let g_id = grad.id();
+    let m_id = momentum.id();
+    let bufs = with_resident_registry(&backend.resident_activation_registry, |cache| {
+        let p = cache.get(&p_id).map(|entry| Arc::clone(&entry.buffer))?;
+        let g = cache.get(&g_id).map(|entry| Arc::clone(&entry.buffer))?;
+        let m = cache.get(&m_id).map(|entry| Arc::clone(&entry.buffer))?;
+        Some((p, g, m))
+    });
+    let Some((param_buf, grad_buf, mom_buf)) = bufs else {
+        return Ok(false);
+    };
+    static FIRST_MUON_LOGGED: OnceLock<()> = OnceLock::new();
+    FIRST_MUON_LOGGED.get_or_init(|| {
+        tracing::info!(
+            n_elements,
+            rows,
+            cols,
+            lr,
+            momentum_coef,
+            nesterov,
+            ns_iters,
+            weight_decay,
+            dtype = ?param.dtype(),
+            "VulkanBackend::dispatch_muon_step first call"
+        );
+    });
+    match param.dtype() {
+        kiln_tensor::DType::F32 => {
+            dispatch_muon_step_buffers(
+                vk_device,
+                &param_buf,
+                &grad_buf,
+                &mom_buf,
+                n_elements,
+                rows,
+                cols,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            )?;
+            Ok(true)
+        }
+        kiln_tensor::DType::BF16 => {
+            kiln_vulkan_kernel::kernels::dispatch_muon_step_bf16(
+                vk_device,
+                &param_buf,
+                &grad_buf,
+                &mom_buf,
+                n_elements,
+                rows,
+                cols,
+                lr,
+                momentum_coef,
+                nesterov,
+                ns_iters,
+                weight_decay,
             )?;
             Ok(true)
         }
@@ -666,6 +815,99 @@ mod tests {
         ResidencyBackend::runtime_evict_resident_activation(&backend, &grad);
         ResidencyBackend::runtime_evict_resident_activation(&backend, &m);
         ResidencyBackend::runtime_evict_resident_activation(&backend, &v);
+        Ok(())
+    }
+
+    /// Muon round-trip through the full backend dispatch path
+    /// (`runtime_dispatch_muon_step` -> residency resolve ->
+    /// `dispatch_muon_step` -> kernel). Uses a 1-D buffer so the kernel
+    /// takes the plain (Nesterov) momentum-SGD branch (no
+    /// orthogonalization), which has a closed-form reference; the
+    /// Newton-Schulz orthogonalization branch is numerically validated
+    /// on-device by `kiln-vulkan-kernel`'s `vk_muon_parity` suite.
+    /// Verifies BOTH the in-place param and momentum buffer updates.
+    #[test]
+    fn dispatch_muon_step_resident_round_trip_momentum_sgd() -> Result<()> {
+        let backend = VulkanBackend::new(kiln_tensor::Device::Cpu);
+        if !backend.has_vulkan() {
+            eprintln!("Vulkan device unavailable, skipping");
+            return Ok(());
+        }
+        let n = 16usize;
+        let lr = 0.02f32;
+        let mom = 0.95f32;
+        let wd = 0.01f32;
+        let nesterov = true;
+        let ns_iters = 5u32;
+
+        let p_data: Vec<f32> = (0..n).map(|i| (i as f32) * 0.1 - 0.5).collect();
+        let g_data: Vec<f32> = (0..n).map(|i| ((i as i32 - 8) as f32) * 0.04).collect();
+        let m_data: Vec<f32> = vec![0.0; n];
+
+        // Closed-form reference: 1-D => do_ortho=false => plain Nesterov SGD.
+        // momentum = mom*0 + g = g;  b = g + mom*momentum = g*(1+mom);
+        // param = param*(1 - lr*wd) - lr*b.
+        let exp_mom: Vec<f32> = g_data.clone();
+        let exp_param: Vec<f32> = p_data
+            .iter()
+            .zip(g_data.iter())
+            .map(|(&p, &g)| {
+                let b = g + mom * g;
+                p * (1.0 - lr * wd) - lr * b
+            })
+            .collect();
+
+        let param = kiln_tensor::Tensor::from_vec(p_data, (n,))?;
+        let grad = kiln_tensor::Tensor::from_vec(g_data, (n,))?;
+        let momentum = kiln_tensor::Tensor::from_vec(m_data, (n,))?;
+
+        ResidencyBackend::runtime_register_resident_activation(&backend, &param)?;
+        ResidencyBackend::runtime_register_resident_activation(&backend, &grad)?;
+        ResidencyBackend::runtime_register_resident_activation(&backend, &momentum)?;
+
+        let dispatched = OptimizerBackend::runtime_dispatch_muon_step(
+            &backend, &param, &grad, &momentum, lr, mom, nesterov, ns_iters, wd,
+        )?;
+        assert!(
+            dispatched,
+            "muon_step must succeed when all three buffers are resident"
+        );
+
+        let got_param: Vec<f32> = ResidencyBackend::runtime_resolve_resident_activation(
+            &backend,
+            &param,
+            &[n],
+            kiln_tensor::DType::F32,
+        )?
+        .expect("param must resolve after dispatch")
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+        let got_mom: Vec<f32> = ResidencyBackend::runtime_resolve_resident_activation(
+            &backend,
+            &momentum,
+            &[n],
+            kiln_tensor::DType::F32,
+        )?
+        .expect("momentum must resolve after dispatch")
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+
+        for (i, (g, w)) in got_param.iter().zip(exp_param.iter()).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-6,
+                "param idx {i}: got={g:.9} want={w:.9}"
+            );
+        }
+        for (i, (g, w)) in got_mom.iter().zip(exp_mom.iter()).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-6,
+                "momentum idx {i}: got={g:.9} want={w:.9}"
+            );
+        }
+
+        ResidencyBackend::runtime_evict_resident_activation(&backend, &param);
+        ResidencyBackend::runtime_evict_resident_activation(&backend, &grad);
+        ResidencyBackend::runtime_evict_resident_activation(&backend, &momentum);
         Ok(())
     }
 

--- a/crates/kiln-optim/src/lib.rs
+++ b/crates/kiln-optim/src/lib.rs
@@ -18,9 +18,15 @@
 //!   `Parameter::backward_storage`. The migration target for the
 //!   existing `crates/kiln-train/src/trainer.rs`
 //!   `HashMap<TensorId, AdamWMoments>` (Phase 0.1 audit, 30 sites).
+//! - [`Muon`] CPU reference impl — momentum-orthogonalized SGD with the
+//!   gram-space P-accumulator Newton-Schulz. This is the **oracle** the
+//!   per-backend fused Muon kernels (CUDA / ROCm / Vulkan / Metal) are
+//!   validated against. [`newton_schulz`] is exported for those parity
+//!   tests.
 //!
-//! Per-backend (CUDA / Metal / Vulkan) impls plug in via the same
-//! `OptimStep` trait in subsequent PRs.
+//! Per-backend (CUDA / Metal / Vulkan) on-device impls plug in via the
+//! `OptimizerBackend::runtime_dispatch_*_step` seam in `kiln-model`,
+//! falling back to these CPU references when operands aren't resident.
 
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
@@ -37,7 +43,7 @@ mod sgd;
 pub use accumulate_step::accumulate_then_step;
 pub use adamw::{AdamW, AdamWHyperparameters, AdamWMoments};
 pub use grad_accumulator::GradAccumulator;
-pub use lion_muon::{Lion, LionEma, Muon, MuonState};
+pub use lion_muon::{Lion, LionEma, Muon, MuonState, newton_schulz};
 pub use optim_step::{OptimStep, StepError};
 pub use policy::{MomentLocation, StochasticRoundingPolicy};
 pub use sgd::{Sgd, SgdHyperparameters, SgdMomentum};

--- a/crates/kiln-optim/src/lion_muon.rs
+++ b/crates/kiln-optim/src/lion_muon.rs
@@ -1,31 +1,25 @@
-//! `Lion` + `Muon` — Phase 6.5 issue-menu variants, today as stubs
-//! that demonstrate the trait shape generalizes.
+//! `Lion` + `Muon` — two non-AdamW optimizer variants.
 //!
 //! Per the Phase 6.5 issue bullet:
 //!
 //! > `kiln-optim` crate with `OptimStep` trait: AdamW, SGD, Lion, Muon
 //!
-//! `AdamW` (Phase 6.5) and `Sgd` (Phase 6.5.1) are the two concrete
-//! impls. `Lion` (Chen et al. 2023, "Symbolic Discovery of Optimization
-//! Algorithms") and `Muon` (Bernstein-Newhouse 2024, "Old optimizer,
-//! new norm") are scaffolds — they impl `OptimStep` but `step` returns
-//! `Err(StepError::Tensor(_))` with a "not yet implemented" message.
+//! [`Lion`] (Chen et al. 2023, "Symbolic Discovery of Optimization
+//! Algorithms") is a compact-state sign-momentum optimizer.
 //!
-//! These stubs exist so:
-//!
-//! 1. The OptimStep trait API surface is validated against three
-//!    + one optimizers (AdamW state-rich, SGD light, Lion compact-state,
-//!    Muon momentum-orthogonalized) rather than just two.
-//! 2. Downstream callers can write `match opt_kind { OptimKind::Lion => ... }`
-//!    today and not have to revisit the dispatch site when Phase 6.5.x
-//!    lands the real implementations.
+//! [`Muon`] (Bernstein-Newhouse 2024, "Old optimizer, new norm"; Jordan
+//! et al. 2024 nanoGPT speedrun) is momentum-orthogonalized SGD: it
+//! projects the (Nesterov) momentum onto the closest semi-orthogonal
+//! matrix via a Newton-Schulz iteration before each step. This is the
+//! production CPU reference — the oracle the per-backend GPU Muon
+//! kernels (CUDA / ROCm / Vulkan / Metal) are validated against.
 
 use std::collections::HashMap;
 
 use kiln_param::Parameter;
 use kiln_tensor::{CpuStorage, DType, Layout, Storage, Tensor, TensorId};
 
-use crate::{OptimStep, StepError};
+use crate::{OptimStep, StepError, StochasticRoundingPolicy};
 
 /// Lion (Chen et al. 2023). Compact-state alternative to AdamW —
 /// stores only the EMA of grads (no second moment).
@@ -71,7 +65,9 @@ impl Lion {
     pub fn default_hp() -> Self {
         // Defaults match the Chen et al. paper's recommended HP for
         // language models.
-        Lion::new(/*lr=*/ 1e-4, /*β1=*/ 0.9, /*β2=*/ 0.99, /*λ=*/ 0.0)
+        Lion::new(
+            /*lr=*/ 1e-4, /*β1=*/ 0.9, /*β2=*/ 0.99, /*λ=*/ 0.0,
+        )
     }
 
     pub fn ema_for(&self, id: TensorId) -> Option<&LionEma> {
@@ -150,8 +146,17 @@ impl OptimStep for Lion {
             entry.m[i] = self.beta2 * entry.m[i] + (1.0 - self.beta2) * g;
         }
 
-        // Write updated master back to the Parameter.
-        let new_master = build_master_tensor(policy.master_dtype, master.shape(), &master_f32)?;
+        // Write updated master back to the Parameter. Lion keeps
+        // round-to-nearest (no stochastic-rounding state); the master
+        // write moves back to the param's device.
+        let new_master = build_master_tensor(
+            policy.master_dtype,
+            master.shape(),
+            &master_f32,
+            StochasticRoundingPolicy::RoundToNearest,
+            entry.step,
+            master.device(),
+        )?;
         param.replace_backward_storage(Some(new_master));
         // #1082 Phase 2.7: end-of-optimizer-step epoch bump (see AdamW).
         param.bump_epoch();
@@ -163,14 +168,24 @@ impl OptimStep for Lion {
     }
 }
 
+/// Read a tensor (any device) into a host `Vec<f32>`, promoting from
+/// BF16/F16/F32. Device-resident tensors are D2H-copied first — the
+/// on-device GPU kernels handle the resident fast path; this is the
+/// portable host reference / fallback.
 fn read_master_to_f32(t: &Tensor) -> Result<Vec<f32>, StepError> {
-    let cpu = t
+    let host = if matches!(t.device(), kiln_tensor::Device::Cpu) {
+        t.clone()
+    } else {
+        t.to_device(kiln_tensor::Device::Cpu)
+            .map_err(StepError::Tensor)?
+    };
+    let cpu = host
         .storage()
         .as_any()
         .downcast_ref::<CpuStorage>()
         .ok_or_else(|| {
             StepError::Tensor(kiln_tensor::Error::from_str(
-                "Lion CPU: tensor storage must be CpuStorage",
+                "lion_muon: tensor storage must be CpuStorage on CPU",
             ))
         })?;
     let bytes = cpu.as_bytes();
@@ -187,32 +202,64 @@ fn read_master_to_f32(t: &Tensor) -> Result<Vec<f32>, StepError> {
         DType::BF16 => {
             for i in 0..n {
                 out.push(
-                    half::bf16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap())
-                        .to_f32(),
+                    half::bf16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap()).to_f32(),
                 );
             }
         }
         DType::F16 => {
             for i in 0..n {
                 out.push(
-                    half::f16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap())
-                        .to_f32(),
+                    half::f16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap()).to_f32(),
                 );
             }
         }
         other => {
             return Err(StepError::Tensor(kiln_tensor::Error::Msg(format!(
-                "Lion CPU: unsupported dtype {other}"
-            ))))
+                "lion_muon: unsupported dtype {other}"
+            ))));
         }
     }
     Ok(out)
 }
 
+/// Stochastically round an `f32` to a `bf16` bit pattern (mirrors
+/// `adamw.rs`). Adds a uniform 16-bit value before truncating so the
+/// carry into bit 16 fires with probability proportional to the
+/// dropped mantissa — unbiased in expectation. NaN passes through
+/// round-to-nearest.
+#[inline]
+fn f32_to_bf16_stochastic_bits(v: f32, r: u16) -> u16 {
+    let bits = v.to_bits();
+    if (bits & 0x7fff_ffff) > 0x7f80_0000 {
+        return half::bf16::from_f32(v).to_bits();
+    }
+    let rounded = bits.wrapping_add(r as u32);
+    (rounded >> 16) as u16
+}
+
+/// Deterministic per-element uniform 16-bit draw from `(seed, step,
+/// idx)` via a splitmix64 finalizer (mirrors `adamw.rs`).
+#[inline]
+fn stochastic_round_rng16(seed: u64, step: u64, idx: usize) -> u16 {
+    let mut z = seed
+        ^ step.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+        ^ (idx as u64).wrapping_mul(0xd1b5_4a32_d192_ed03);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^= z >> 31;
+    (z >> 32) as u16
+}
+
+/// Build a master `Tensor` from f32 values, in `dtype`, then move it to
+/// `device`. BF16 honours `rounding` (stochastic rounding under
+/// `KILN_BF16_STOCHASTIC_ROUND=1`, varied by `step`).
 fn build_master_tensor(
     dtype: DType,
     shape: &[usize],
     values: &[f32],
+    rounding: StochasticRoundingPolicy,
+    step: u64,
+    device: kiln_tensor::Device,
 ) -> Result<Tensor, StepError> {
     use std::sync::Arc;
     let per = dtype.size_in_bytes();
@@ -223,58 +270,98 @@ fn build_master_tensor(
                 bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
             }
         }
-        DType::BF16 => {
-            for (i, &v) in values.iter().enumerate() {
-                bytes[i * 2..i * 2 + 2]
-                    .copy_from_slice(&half::bf16::from_f32(v).to_le_bytes());
+        DType::BF16 => match rounding {
+            StochasticRoundingPolicy::Stochastic { seed } => {
+                for (i, &v) in values.iter().enumerate() {
+                    let r = stochastic_round_rng16(seed, step, i);
+                    let b = f32_to_bf16_stochastic_bits(v, r);
+                    bytes[i * 2..i * 2 + 2].copy_from_slice(&b.to_le_bytes());
+                }
             }
-        }
+            StochasticRoundingPolicy::RoundToNearest => {
+                for (i, &v) in values.iter().enumerate() {
+                    bytes[i * 2..i * 2 + 2].copy_from_slice(&half::bf16::from_f32(v).to_le_bytes());
+                }
+            }
+        },
         DType::F16 => {
             for (i, &v) in values.iter().enumerate() {
-                bytes[i * 2..i * 2 + 2]
-                    .copy_from_slice(&half::f16::from_f32(v).to_le_bytes());
+                bytes[i * 2..i * 2 + 2].copy_from_slice(&half::f16::from_f32(v).to_le_bytes());
             }
         }
         other => {
             return Err(StepError::Tensor(kiln_tensor::Error::Msg(format!(
-                "Lion CPU: unsupported master dtype {other}"
-            ))))
+                "lion_muon: unsupported master dtype {other}"
+            ))));
         }
     }
     let cpu = CpuStorage::from_bytes(dtype, bytes).map_err(StepError::Tensor)?;
     let storage: Storage = Arc::new(cpu);
-    Tensor::from_parts(storage, Layout::contiguous(shape.to_vec()), TensorId::next())
-        .map_err(StepError::Tensor)
+    let host = Tensor::from_parts(
+        storage,
+        Layout::contiguous(shape.to_vec()),
+        TensorId::next(),
+    )
+    .map_err(StepError::Tensor)?;
+    if matches!(device, kiln_tensor::Device::Cpu) {
+        Ok(host)
+    } else {
+        host.to_device(device).map_err(StepError::Tensor)
+    }
 }
 
-/// Muon (Bernstein-Newhouse 2024). Momentum-orthogonalized SGD —
-/// projects the momentum onto the closest orthogonal matrix via
-/// Newton-Schulz iteration before each step.
+// ----------------------------------------------------------------------
+// Muon — momentum-orthogonalized SGD (production CPU reference)
+// ----------------------------------------------------------------------
+
+/// Muon (Bernstein-Newhouse 2024 / Jordan et al. 2024). Heavy-ball
+/// (optionally Nesterov) momentum-orthogonalized SGD: it projects the
+/// momentum matrix onto the nearest semi-orthogonal matrix via a
+/// Newton-Schulz quintic iteration before each step, then rescales the
+/// update so its per-element RMS is shape-independent.
 ///
-/// # Algorithm (rank-2 weights)
+/// # Algorithm (per parameter, master in f32 working precision)
 ///
 /// ```text
-/// m_t = momentum * m_{t-1} + g_t            # heavy-ball momentum
-/// U_t = newton_schulz(m_t, iters)           # ≈ polar U factor of m_t
-/// p_t = p_{t-1} - lr * U_t
+/// m_t   = momentum * m_{t-1} + g_t                  # heavy-ball state
+/// b_t   = if nesterov { g_t + momentum * m_t } else { m_t }
+/// if rank-2 (matrix):
+///     O = newton_schulz(b_t, ns_iters)              # ≈ polar factor U Vᵀ
+///     O *= sqrt(max(rows, cols))                    # RMS-matching scale
+/// else:
+///     O = b_t                                       # plain momentum SGD
+/// p_t   = p_{t-1} * (1 - lr * weight_decay) - lr * O
 /// ```
 ///
-/// Newton-Schulz iteration (paper coefficients a=3.4445, b=-4.7750,
-/// c=2.0315) approximates the polar decomposition for 5 iterations.
+/// The Newton-Schulz uses the paper coefficients `(a, b, c) =
+/// (3.4445, -4.7750, 2.0315)` for `ns_iters` (default 5) iterations,
+/// computed via the gram-space P-accumulator (see [`newton_schulz`]) so
+/// the per-step cost is dominated by two skinny GEMMs over the large
+/// matrix dimension — the rest is `k×k` work where `k = min(rows, cols)`
+/// (the LoRA rank, ≈16).
 ///
 /// # Non-matrix parameters
 ///
-/// Muon is defined only for **matrix-shaped weights** (rank-2).
-/// Bias vectors / embeddings / scalar weights fall back to plain
-/// SGD-with-momentum (skip the orthogonalization).
-#[derive(Debug, Default)]
+/// Muon's orthogonalization is defined only for **rank-2** weights.
+/// Vectors / scalars fall back to plain SGD-with-(Nesterov-)momentum.
+#[derive(Debug)]
 pub struct Muon {
     pub lr: f32,
     pub momentum: f32,
+    pub nesterov: bool,
     /// Number of Newton-Schulz iterations. Paper uses 5.
     pub ns_iters: u32,
+    /// Decoupled weight decay coefficient.
+    pub weight_decay: f32,
+    rounding: StochasticRoundingPolicy,
     /// Per-parameter momentum buffer keyed on TensorId.
     momenta: HashMap<TensorId, MuonState>,
+}
+
+impl Default for Muon {
+    fn default() -> Self {
+        Muon::default_hp()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -284,17 +371,27 @@ pub struct MuonState {
 }
 
 impl Muon {
-    pub fn new(lr: f32, momentum: f32, ns_iters: u32) -> Self {
+    pub fn new(lr: f32, momentum: f32, nesterov: bool, ns_iters: u32, weight_decay: f32) -> Self {
         Muon {
             lr,
             momentum,
+            nesterov,
             ns_iters,
+            weight_decay,
+            rounding: StochasticRoundingPolicy::from_env(),
             momenta: HashMap::new(),
         }
     }
 
+    /// Recommended Muon defaults: momentum 0.95, Nesterov on, 5
+    /// Newton-Schulz iterations, no weight decay, lr 2e-2 (Muon's
+    /// orthogonalized + RMS-scaled update tolerates a larger lr than
+    /// AdamW's 1e-3).
     pub fn default_hp() -> Self {
-        Muon::new(/*lr=*/ 2e-2, /*momentum=*/ 0.95, /*ns_iters=*/ 5)
+        Muon::new(
+            /*lr=*/ 2e-2, /*momentum=*/ 0.95, /*nesterov=*/ true,
+            /*ns_iters=*/ 5, /*weight_decay=*/ 0.0,
+        )
     }
 
     pub fn momentum_for(&self, id: TensorId) -> Option<&MuonState> {
@@ -356,24 +453,48 @@ impl OptimStep for Muon {
             ))));
         }
         entry.step += 1;
-        // Heavy-ball momentum: m = β m + g.
+
+        // 1. Heavy-ball momentum: m = momentum*m + g (state update).
         for i in 0..n {
             entry.m[i] = self.momentum * entry.m[i] + grad_f32[i];
         }
-
-        // Orthogonalize for rank-2 weights; otherwise plain SGD with
-        // the heavy-ball momentum.
-        let update = if shape.len() == 2 {
-            newton_schulz(&entry.m, shape[0], shape[1], self.ns_iters)
+        // 2. Look-ahead direction b = nesterov ? g + momentum*m : m.
+        let mut b = vec![0.0f32; n];
+        if self.nesterov {
+            for i in 0..n {
+                b[i] = grad_f32[i] + self.momentum * entry.m[i];
+            }
         } else {
-            entry.m.clone()
+            b.copy_from_slice(&entry.m);
+        }
+
+        // 3. Orthogonalize for rank-2 weights; otherwise plain momentum.
+        let update = if shape.len() == 2 {
+            let (rows, cols) = (shape[0], shape[1]);
+            let mut o = newton_schulz(&b, rows, cols, self.ns_iters);
+            let scale = (rows.max(cols) as f32).sqrt();
+            for v in o.iter_mut() {
+                *v *= scale;
+            }
+            o
+        } else {
+            b
         };
 
+        // 4. Decoupled weight decay + descent step.
         for i in 0..n {
+            master_f32[i] -= self.lr * self.weight_decay * master_f32[i];
             master_f32[i] -= self.lr * update[i];
         }
 
-        let new_master = build_master_tensor(policy.master_dtype, &shape, &master_f32)?;
+        let new_master = build_master_tensor(
+            policy.master_dtype,
+            &shape,
+            &master_f32,
+            self.rounding,
+            entry.step,
+            master.device(),
+        )?;
         param.replace_backward_storage(Some(new_master));
         // #1082 Phase 2.7: end-of-optimizer-step epoch bump (see AdamW).
         param.bump_epoch();
@@ -385,123 +506,135 @@ impl OptimStep for Muon {
     }
 }
 
-/// Newton-Schulz orthogonalization for a row-major `[rows, cols]`
-/// matrix flattened into `data`. Paper coefficients
-/// `(a, b, c) = (3.4445, -4.7750, 2.0315)`. Returns the orthogonalized
-/// matrix flattened back in row-major.
-fn newton_schulz(data: &[f32], rows: usize, cols: usize, iters: u32) -> Vec<f32> {
-    debug_assert_eq!(data.len(), rows * cols);
-    // 1. Frobenius-normalize.
-    let frob: f32 = data.iter().map(|&v| v * v).sum::<f32>().sqrt();
+// ----------------------------------------------------------------------
+// Newton-Schulz orthogonalization (gram-space P-accumulator)
+// ----------------------------------------------------------------------
+
+/// Newton-Schulz orthogonalization of a row-major `[rows, cols]` matrix
+/// `w`. Returns `O ≈ U Vᵀ` (the orthogonal polar factor) flattened
+/// row-major, with `‖O‖_F ≈ sqrt(min(rows, cols))`.
+///
+/// Coefficients `(a, b, c) = (3.4445, -4.7750, 2.0315)`. The iteration
+/// `X ← a·X + (b·A + c·A²)·X` (with `A` the gram of the Frobenius-
+/// normalized `X`) is reorganized so that each iteration is a `k×k`
+/// matrix `M_i = a·I + b·A_i + c·A_i²` (`k = min(rows, cols)`), and the
+/// whole product collapses to a single `k×k` accumulator `P`:
+/// `O = (P @ W) / ‖W‖_F` when `rows ≤ cols`, or `(W @ P) / ‖W‖_F` when
+/// `rows > cols`. Only the initial gram and the final apply touch the
+/// large dimension; everything else is `k×k`.
+pub fn newton_schulz(w: &[f32], rows: usize, cols: usize, iters: u32) -> Vec<f32> {
+    debug_assert_eq!(w.len(), rows * cols);
+    let n = rows * cols;
+    let frob = w.iter().map(|&v| v * v).sum::<f32>().sqrt();
     if frob == 0.0 {
-        return data.to_vec();
+        return vec![0.0; n];
     }
-    let mut x: Vec<f32> = data.iter().map(|&v| v / frob).collect();
+    let inv_frob = 1.0 / frob;
+    // Gram in the smaller dimension. `transpose=false` → rows ≤ cols →
+    // gram = W Wᵀ (rows×rows), accumulate P on the left, O = P W.
+    // `transpose=true`  → rows >  cols → gram = Wᵀ W (cols×cols),
+    // accumulate P on the right, O = W P.
+    let transpose = rows > cols;
+    let k = rows.min(cols);
 
-    let (a, b, c) = (3.4445_f32, -4.7750_f32, 2.0315_f32);
-    let mut a_buf = vec![0.0f32; rows.min(cols) * rows.min(cols)];
-    let mut aa = a_buf.clone();
-    let mut aa_x = vec![0.0f32; rows * cols];
-
-    // Convention: if rows >= cols, use X^T X (cols x cols); else X X^T.
-    // This is the paper's recipe — operate on the smaller of the two
-    // gram matrices.
-    let transpose = rows >= cols;
-    let k = if transpose { cols } else { rows };
-
-    for _ in 0..iters {
-        // A = X^T X (when transpose=true, shape [cols, cols])
-        //     or X X^T (when transpose=false, shape [rows, rows])
-        gram(&x, rows, cols, transpose, &mut a_buf);
-        // AA = A @ A
-        matmul_square(&a_buf, k, &mut aa);
-        // Q = b * A + c * AA  (k x k)
-        for i in 0..k * k {
-            aa[i] = b * a_buf[i] + c * aa[i];
-        }
-        // X_new = a * X + Q @ X (when transpose=true)  OR  a * X + X @ Q
-        // Depending on which side the gram was computed.
-        if transpose {
-            // Q is cols x cols → multiply on the right: X = a*X + X @ Q
-            matmul_rhs(&x, &aa, rows, cols, &mut aa_x);
-        } else {
-            // Q is rows x rows → multiply on the left: X = a*X + Q @ X
-            matmul_lhs(&aa, &x, rows, cols, &mut aa_x);
-        }
-        for i in 0..rows * cols {
-            x[i] = a * x[i] + aa_x[i];
-        }
-    }
-    x
-}
-
-/// `A = X^T X` (when transpose) or `X X^T` (otherwise).
-fn gram(x: &[f32], rows: usize, cols: usize, transpose: bool, out: &mut [f32]) {
-    if transpose {
-        // out [cols, cols] = X^T [cols, rows] @ X [rows, cols]
-        debug_assert_eq!(out.len(), cols * cols);
-        for i in 0..cols {
-            for j in 0..cols {
-                let mut s = 0.0_f32;
-                for r in 0..rows {
-                    s += x[r * cols + i] * x[r * cols + j];
+    // A0 = gram(W_normalized) = (W Wᵀ or Wᵀ W) * inv_frob².
+    let inv_frob2 = inv_frob * inv_frob;
+    let mut a = vec![0.0f32; k * k];
+    if !transpose {
+        for i in 0..k {
+            for j in 0..k {
+                let mut s = 0.0f32;
+                for c in 0..cols {
+                    s += w[i * cols + c] * w[j * cols + c];
                 }
-                out[i * cols + j] = s;
+                a[i * k + j] = s * inv_frob2;
             }
         }
     } else {
-        // out [rows, rows] = X [rows, cols] @ X^T [cols, rows]
-        debug_assert_eq!(out.len(), rows * rows);
-        for i in 0..rows {
-            for j in 0..rows {
-                let mut s = 0.0_f32;
-                for c in 0..cols {
-                    s += x[i * cols + c] * x[j * cols + c];
+        for i in 0..k {
+            for j in 0..k {
+                let mut s = 0.0f32;
+                for r in 0..rows {
+                    s += w[r * cols + i] * w[r * cols + j];
                 }
-                out[i * rows + j] = s;
+                a[i * k + j] = s * inv_frob2;
             }
         }
     }
-}
 
-fn matmul_square(a: &[f32], n: usize, out: &mut [f32]) {
-    debug_assert_eq!(a.len(), n * n);
-    debug_assert_eq!(out.len(), n * n);
-    for i in 0..n {
-        for j in 0..n {
-            let mut s = 0.0_f32;
-            for k in 0..n {
-                s += a[i * n + k] * a[k * n + j];
+    // P = I_k.
+    let mut p = vec![0.0f32; k * k];
+    for i in 0..k {
+        p[i * k + i] = 1.0;
+    }
+
+    let (ca, cb, cc) = (3.4445f32, -4.7750f32, 2.0315f32);
+    let mut a2 = vec![0.0f32; k * k];
+    let mut m = vec![0.0f32; k * k];
+    let mut tmp = vec![0.0f32; k * k];
+    for _ in 0..iters {
+        // A2 = A @ A.
+        matmul_kk(&a, &a, &mut a2, k);
+        // M = a*I + b*A + c*A2.
+        for i in 0..k {
+            for j in 0..k {
+                let id = if i == j { 1.0 } else { 0.0 };
+                m[i * k + j] = ca * id + cb * a[i * k + j] + cc * a2[i * k + j];
             }
-            out[i * n + j] = s;
+        }
+        // Accumulate P: left-multiply (P = M P) when rows ≤ cols,
+        // right-multiply (P = P M) when rows > cols.
+        if !transpose {
+            matmul_kk(&m, &p, &mut tmp, k);
+        } else {
+            matmul_kk(&p, &m, &mut tmp, k);
+        }
+        p.copy_from_slice(&tmp);
+        // A = M A M  (M symmetric, so M Aᵀ Mᵀ = M A M keeps A symmetric).
+        matmul_kk(&m, &a, &mut tmp, k);
+        matmul_kk(&tmp, &m, &mut a, k);
+    }
+
+    // O = (P @ W) * inv_frob  (rows ≤ cols)  or  (W @ P) * inv_frob.
+    let mut o = vec![0.0f32; n];
+    if !transpose {
+        // O[i,c] = inv_frob * Σ_j P[i,j] W[j,c];  i ∈ [0,rows)=k rows.
+        for i in 0..rows {
+            for c in 0..cols {
+                let mut s = 0.0f32;
+                for j in 0..k {
+                    s += p[i * k + j] * w[j * cols + c];
+                }
+                o[i * cols + c] = s * inv_frob;
+            }
+        }
+    } else {
+        // O[r,c] = inv_frob * Σ_j W[r,j] P[j,c];  c ∈ [0,cols)=k cols.
+        for r in 0..rows {
+            for c in 0..cols {
+                let mut s = 0.0f32;
+                for j in 0..k {
+                    s += w[r * cols + j] * p[j * k + c];
+                }
+                o[r * cols + c] = s * inv_frob;
+            }
         }
     }
+    o
 }
 
-/// `out = x @ q` where x is `[rows, cols]`, q is `[cols, cols]`.
-fn matmul_rhs(x: &[f32], q: &[f32], rows: usize, cols: usize, out: &mut [f32]) {
-    debug_assert_eq!(out.len(), rows * cols);
-    for r in 0..rows {
-        for c in 0..cols {
-            let mut s = 0.0_f32;
-            for k in 0..cols {
-                s += x[r * cols + k] * q[k * cols + c];
+/// `out = a @ b` for row-major `k×k` matrices.
+fn matmul_kk(a: &[f32], b: &[f32], out: &mut [f32], k: usize) {
+    debug_assert_eq!(a.len(), k * k);
+    debug_assert_eq!(b.len(), k * k);
+    debug_assert_eq!(out.len(), k * k);
+    for i in 0..k {
+        for j in 0..k {
+            let mut s = 0.0f32;
+            for t in 0..k {
+                s += a[i * k + t] * b[t * k + j];
             }
-            out[r * cols + c] = s;
-        }
-    }
-}
-
-/// `out = q @ x` where q is `[rows, rows]`, x is `[rows, cols]`.
-fn matmul_lhs(q: &[f32], x: &[f32], rows: usize, cols: usize, out: &mut [f32]) {
-    debug_assert_eq!(out.len(), rows * cols);
-    for r in 0..rows {
-        for c in 0..cols {
-            let mut s = 0.0_f32;
-            for k in 0..rows {
-                s += q[r * rows + k] * x[k * cols + c];
-            }
-            out[r * cols + c] = s;
+            out[i * k + j] = s;
         }
     }
 }
@@ -515,7 +648,11 @@ mod tests {
     fn fresh_param() -> Parameter {
         let fwd = Tensor::from_slice(&[1.0f32, 2.0], vec![2]).unwrap();
         let master = Tensor::from_slice(&[1.0f32, 2.0], vec![2]).unwrap();
-        Parameter::trainable(ForwardStorage::Plain(fwd), master, AmpPolicy::fp32_reference())
+        Parameter::trainable(
+            ForwardStorage::Plain(fwd),
+            master,
+            AmpPolicy::fp32_reference(),
+        )
     }
 
     #[test]
@@ -626,17 +763,32 @@ mod tests {
 
     #[test]
     fn muon_name_and_construction() {
-        let m = Muon::new(1e-3, 0.95, 5);
+        let m = Muon::new(1e-3, 0.95, true, 5, 0.0);
         assert_eq!(m.name(), "muon");
         assert_eq!(m.momentum, 0.95);
+        assert!(m.nesterov);
         assert_eq!(m.ns_iters, 5);
+    }
+
+    #[test]
+    fn muon_default_hp() {
+        let m = Muon::default_hp();
+        assert_eq!(m.lr, 2e-2);
+        assert_eq!(m.momentum, 0.95);
+        assert!(m.nesterov);
+        assert_eq!(m.ns_iters, 5);
+        assert_eq!(m.weight_decay, 0.0);
     }
 
     fn fresh_matrix_param() -> Parameter {
         // 2x2 identity-ish matrix.
         let fwd = Tensor::from_slice(&[1.0f32, 0.0, 0.0, 1.0], vec![2, 2]).unwrap();
         let master = Tensor::from_slice(&[1.0f32, 0.0, 0.0, 1.0], vec![2, 2]).unwrap();
-        Parameter::trainable(ForwardStorage::Plain(fwd), master, AmpPolicy::fp32_reference())
+        Parameter::trainable(
+            ForwardStorage::Plain(fwd),
+            master,
+            AmpPolicy::fp32_reference(),
+        )
     }
 
     fn read_master(p: &Parameter) -> Vec<f32> {
@@ -654,11 +806,24 @@ mod tests {
     }
 
     #[test]
-    fn muon_step_rank1_falls_back_to_sgd_momentum() {
-        // For non-matrix shapes Muon = SGD with heavy-ball momentum.
-        // m_0 = 0; step 1 with grad=ones → m = ones → master -= lr * ones.
-        let mut opt = Muon::new(0.1, 0.9, 5);
+    fn muon_step_rank1_falls_back_to_momentum() {
+        // For non-matrix shapes Muon = SGD with (Nesterov) momentum.
+        // m_0 = 0; step 1 with grad=ones → m = ones.
+        // nesterov b = g + momentum*m = 1 + 0.9*1 = 1.9 → master -= lr*1.9.
+        let mut opt = Muon::new(0.1, 0.9, true, 5, 0.0);
         let mut p = fresh_param(); // shape [2]
+        let g = Tensor::from_slice(&[1.0f32, 1.0], vec![2]).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        let v = read_master(&p);
+        assert!((v[0] - (1.0 - 0.1 * 1.9)).abs() < 1e-6, "got {}", v[0]);
+        assert!((v[1] - (2.0 - 0.1 * 1.9)).abs() < 1e-6, "got {}", v[1]);
+    }
+
+    #[test]
+    fn muon_step_rank1_heavy_ball_when_not_nesterov() {
+        // Without Nesterov, b = m = ones → master -= lr*1.
+        let mut opt = Muon::new(0.1, 0.9, false, 5, 0.0);
+        let mut p = fresh_param();
         let g = Tensor::from_slice(&[1.0f32, 1.0], vec![2]).unwrap();
         opt.step(&mut p, &g).unwrap();
         let v = read_master(&p);
@@ -669,8 +834,8 @@ mod tests {
     #[test]
     fn muon_step_rank2_runs_newton_schulz() {
         // For a matrix grad, the orthogonalization changes the update
-        // direction. We just verify the step runs without error,
-        // produces finite outputs, and that the step counter advances.
+        // direction. Verify the step runs, produces finite outputs, and
+        // advances the step counter.
         let mut opt = Muon::default_hp();
         let mut p = fresh_matrix_param();
         let g = Tensor::from_slice(&[1.0f32, 0.5, 0.5, 1.0], vec![2, 2]).unwrap();
@@ -706,36 +871,79 @@ mod tests {
         assert_eq!(state.step, 3);
     }
 
-    #[test]
-    fn newton_schulz_pulls_singular_values_toward_unity() {
-        // NS is an *orthogonalizer*: it takes a matrix whose singular
-        // values are arbitrary and pulls them toward 1. Testing it on
-        // the identity matrix is a misleading check — the Muon-paper
-        // quintic `p(σ) = 3.4445σ - 4.7750σ³ + 2.0315σ⁵` is tuned for
-        // fast convergence from σ ∈ [~0.3, σ_max] toward σ ≈ 1, NOT
-        // to fix-point σ = 1 (p(1) ≈ 0.701, so it would *move away*
-        // from already-orthogonal). The right test starts from a
-        // clearly non-orthogonal input.
-        //
-        // Input: diag(0.3, 0.5). Frobenius norm = √0.34 ≈ 0.583, far
-        // from the √2 ≈ 1.414 of a 2×2 orthogonal matrix.
-        let m = vec![0.3f32, 0.0, 0.0, 0.5];
-        let input_frob = m.iter().map(|&v| v * v).sum::<f32>().sqrt();
-        let out = newton_schulz(&m, 2, 2, 5);
-        let output_frob = out.iter().map(|&v| v * v).sum::<f32>().sqrt();
-        let target = 2.0_f32.sqrt();
-        // Output should land strictly closer to √2 than the input was.
-        assert!(
-            (output_frob - target).abs() < (input_frob - target).abs(),
-            "NS didn't pull frob toward √2: input={input_frob}, output={output_frob}"
-        );
-        // And the output should land in the orthogonal ballpark — well
-        // within 0.5 of √2. (Hand-traced expectation: ~1.21 after 5
-        // iters of the diagonal recurrence.)
-        assert!(
-            (output_frob - target).abs() < 0.5,
-            "NS output frob {output_frob} too far from √2 ≈ {target}"
-        );
+    // ---- Newton-Schulz P-accumulator correctness ----
+
+    /// Singular values of a row-major `[rows, cols]` matrix via the
+    /// eigenvalues of its (small) gram, by symmetric Jacobi.
+    fn singular_values(m: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+        let k = rows.min(cols);
+        // gram = the smaller of M Mᵀ / Mᵀ M (k×k, symmetric PSD).
+        let mut g = vec![0.0f64; k * k];
+        if rows <= cols {
+            for i in 0..k {
+                for j in 0..k {
+                    let mut s = 0.0f64;
+                    for c in 0..cols {
+                        s += m[i * cols + c] as f64 * m[j * cols + c] as f64;
+                    }
+                    g[i * k + j] = s;
+                }
+            }
+        } else {
+            for i in 0..k {
+                for j in 0..k {
+                    let mut s = 0.0f64;
+                    for r in 0..rows {
+                        s += m[r * cols + i] as f64 * m[r * cols + j] as f64;
+                    }
+                    g[i * k + j] = s;
+                }
+            }
+        }
+        // Jacobi eigenvalue iteration on the symmetric k×k gram.
+        for _ in 0..100 {
+            // find largest off-diagonal
+            let (mut p, mut q, mut max) = (0, 1, 0.0f64);
+            for i in 0..k {
+                for j in (i + 1)..k {
+                    if g[i * k + j].abs() > max {
+                        max = g[i * k + j].abs();
+                        p = i;
+                        q = j;
+                    }
+                }
+            }
+            if max < 1e-12 {
+                break;
+            }
+            let app = g[p * k + p];
+            let aqq = g[q * k + q];
+            let apq = g[p * k + q];
+            let theta = 0.5 * (aqq - app).atan2(2.0 * apq);
+            // standard rotation; recompute via theta = 0.5*atan2(2apq, app-aqq)
+            let phi = 0.5 * (2.0 * apq).atan2(app - aqq);
+            let (c, s) = (phi.cos(), phi.sin());
+            let _ = theta;
+            let mut gn = g.clone();
+            for i in 0..k {
+                let gip = g[i * k + p];
+                let giq = g[i * k + q];
+                gn[i * k + p] = c * gip + s * giq;
+                gn[i * k + q] = -s * gip + c * giq;
+            }
+            g.copy_from_slice(&gn);
+            let mut gn2 = g.clone();
+            for j in 0..k {
+                let gpj = g[p * k + j];
+                let gqj = g[q * k + j];
+                gn2[p * k + j] = c * gpj + s * gqj;
+                gn2[q * k + j] = -s * gpj + c * gqj;
+            }
+            g.copy_from_slice(&gn2);
+        }
+        (0..k)
+            .map(|i| (g[i * k + i].max(0.0)).sqrt() as f32)
+            .collect()
     }
 
     #[test]
@@ -745,6 +953,200 @@ mod tests {
         for v in out {
             assert_eq!(v, 0.0);
         }
+    }
+
+    /// Naive *direct* Newton-Schulz (the un-factored `X ← a·X + (b·A +
+    /// c·A²)·X` iteration), matching the orientation choice of the
+    /// production [`newton_schulz`]. The production version factors this
+    /// into a `k×k` P-accumulator; this reference recomputes it the slow
+    /// way so the two can be cross-checked.
+    fn newton_schulz_direct(w: &[f32], rows: usize, cols: usize, iters: u32) -> Vec<f32> {
+        let frob = w.iter().map(|&v| v * v).sum::<f32>().sqrt();
+        if frob == 0.0 {
+            return vec![0.0; rows * cols];
+        }
+        let transpose = rows > cols; // match newton_schulz orientation
+        let k = rows.min(cols);
+        let mut x: Vec<f32> = w.iter().map(|&v| v / frob).collect();
+        let (ca, cb, cc) = (3.4445f32, -4.7750f32, 2.0315f32);
+        for _ in 0..iters {
+            // A = gram (k×k): X Xᵀ (rows≤cols) or Xᵀ X (rows>cols).
+            let mut a = vec![0.0f32; k * k];
+            if !transpose {
+                for i in 0..k {
+                    for j in 0..k {
+                        let mut s = 0.0;
+                        for c in 0..cols {
+                            s += x[i * cols + c] * x[j * cols + c];
+                        }
+                        a[i * k + j] = s;
+                    }
+                }
+            } else {
+                for i in 0..k {
+                    for j in 0..k {
+                        let mut s = 0.0;
+                        for r in 0..rows {
+                            s += x[r * cols + i] * x[r * cols + j];
+                        }
+                        a[i * k + j] = s;
+                    }
+                }
+            }
+            // AA = A@A; Q = b*A + c*AA (k×k).
+            let mut q = vec![0.0f32; k * k];
+            for i in 0..k {
+                for j in 0..k {
+                    let mut s = 0.0;
+                    for t in 0..k {
+                        s += a[i * k + t] * a[t * k + j];
+                    }
+                    q[i * k + j] = cb * a[i * k + j] + cc * s;
+                }
+            }
+            // X ← a*X + (Q@X if rows≤cols else X@Q).
+            let mut xn = vec![0.0f32; rows * cols];
+            if !transpose {
+                for i in 0..rows {
+                    for c in 0..cols {
+                        let mut s = 0.0;
+                        for t in 0..k {
+                            s += q[i * k + t] * x[t * cols + c];
+                        }
+                        xn[i * cols + c] = ca * x[i * cols + c] + s;
+                    }
+                }
+            } else {
+                for r in 0..rows {
+                    for c in 0..cols {
+                        let mut s = 0.0;
+                        for t in 0..k {
+                            s += x[r * cols + t] * q[t * k + c];
+                        }
+                        xn[r * cols + c] = ca * x[r * cols + c] + s;
+                    }
+                }
+            }
+            x = xn;
+        }
+        x
+    }
+
+    #[test]
+    fn newton_schulz_matches_direct_iteration() {
+        // The P-accumulator factoring must reproduce the naive direct
+        // iteration bit-closely across square / wide / tall shapes.
+        let cases: &[(usize, usize)] = &[(2, 2), (3, 3), (2, 5), (5, 2), (4, 6), (6, 4)];
+        for &(rows, cols) in cases {
+            let w: Vec<f32> = (0..rows * cols)
+                .map(|i| ((i as f32 * 0.37).sin() - 0.2 * (i as f32 * 0.11).cos()))
+                .collect();
+            let got = newton_schulz(&w, rows, cols, 5);
+            let want = newton_schulz_direct(&w, rows, cols, 5);
+            for i in 0..rows * cols {
+                assert!(
+                    (got[i] - want[i]).abs() < 1e-3,
+                    "P-accumulator != direct at {i} for {rows}x{cols}: {} vs {}",
+                    got[i],
+                    want[i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn newton_schulz_improves_conditioning() {
+        // The polar-factor iteration pulls the singular values into a
+        // tight unit band (these Keller-Jordan coefficients land them in
+        // ~[0.7, 1.0] after 5 iters — NOT exactly 1) and reduces the
+        // condition number vs the input.
+        let m = vec![0.3f32, 0.0, 0.0, 0.5];
+        let in_sv = singular_values(&m, 2, 2);
+        let out = newton_schulz(&m, 2, 2, 5);
+        let out_sv = singular_values(&out, 2, 2);
+        for &s in &out_sv {
+            assert!(
+                (0.6..=1.1).contains(&s),
+                "singular value {s} outside unit band"
+            );
+        }
+        let cond = |sv: &[f32]| {
+            sv.iter().cloned().fold(0.0f32, f32::max)
+                / sv.iter().cloned().fold(f32::INFINITY, f32::min)
+        };
+        assert!(
+            cond(&out_sv) < cond(&in_sv),
+            "conditioning not improved: in {} out {}",
+            cond(&in_sv),
+            cond(&out_sv)
+        );
+    }
+
+    #[test]
+    fn newton_schulz_short_fat_and_tall_skinny_are_transposes() {
+        // NS(Wᵀ) == NS(W)ᵀ : the orthogonalizer commutes with transpose.
+        // W is [2,3]; Wt is [3,2].
+        let w = vec![0.6f32, 0.1, -0.2, 0.3, 0.5, 0.4];
+        let wt = vec![0.6f32, 0.3, 0.1, 0.5, -0.2, 0.4];
+        let o = newton_schulz(&w, 2, 3, 5);
+        let ot = newton_schulz(&wt, 3, 2, 5);
+        // o is [2,3], ot is [3,2]; compare o[i,j] == ot[j,i].
+        for i in 0..2 {
+            for j in 0..3 {
+                assert!(
+                    (o[i * 3 + j] - ot[j * 2 + i]).abs() < 1e-4,
+                    "transpose mismatch at ({i},{j}): {} vs {}",
+                    o[i * 3 + j],
+                    ot[j * 2 + i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn muon_rms_scale_normalizes_update_magnitude() {
+        // With Nesterov off and momentum 0 the update direction for a
+        // rank-2 weight is NS(g)*sqrt(max(rows,cols)). Its RMS per
+        // element should be ≈ 1 (the RMS-matching scale), independent of
+        // shape. Check that the master moved by ≈ lr in RMS.
+        let mut opt = Muon::new(1.0, 0.0, false, 6, 0.0);
+        // wide 2x8 matrix of ones-ish.
+        let (rows, cols) = (2usize, 8usize);
+        let init: Vec<f32> = (0..rows * cols).map(|i| (i as f32 * 0.13).sin()).collect();
+        let fwd = Tensor::from_slice(&init, vec![rows, cols]).unwrap();
+        let master = Tensor::from_slice(&init, vec![rows, cols]).unwrap();
+        let mut p = Parameter::trainable(
+            ForwardStorage::Plain(fwd),
+            master,
+            AmpPolicy::fp32_reference(),
+        );
+        let g: Vec<f32> = (0..rows * cols).map(|i| (i as f32 * 0.27).cos()).collect();
+        let gt = Tensor::from_slice(&g, vec![rows, cols]).unwrap();
+        opt.step(&mut p, &gt).unwrap();
+        let after = read_master(&p);
+        let mut ss = 0.0f32;
+        for i in 0..rows * cols {
+            let d = (after[i] - init[i]).abs();
+            ss += d * d;
+        }
+        let rms = (ss / (rows * cols) as f32).sqrt();
+        // lr=1, update RMS ≈ 1, so move RMS ≈ 1 within tolerance.
+        assert!((rms - 1.0).abs() < 0.25, "update RMS {rms} not ≈ 1");
+    }
+
+    #[test]
+    fn muon_weight_decay_shrinks_master() {
+        // grad=zeros so momentum stays 0, b=0, update=0; only decoupled
+        // WD acts: master *= (1 - lr*wd).
+        let mut opt = Muon::new(0.1, 0.9, true, 5, 0.5);
+        let mut p = fresh_matrix_param();
+        let g = Tensor::from_slice(&[0.0f32; 4], vec![2, 2]).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        let v = read_master(&p);
+        // master was [1,0,0,1]; (1 - 0.1*0.5) = 0.95.
+        assert!((v[0] - 0.95).abs() < 1e-6);
+        assert!((v[3] - 0.95).abs() < 1e-6);
+        assert!(v[1].abs() < 1e-6);
     }
 
     #[test]

--- a/crates/kiln-optim/tests/epoch_bump.rs
+++ b/crates/kiln-optim/tests/epoch_bump.rs
@@ -17,7 +17,11 @@ use kiln_tensor::Tensor;
 fn make_param() -> Parameter {
     let t = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
     let master = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
-    Parameter::trainable(ForwardStorage::Plain(t), master, AmpPolicy::fp32_reference())
+    Parameter::trainable(
+        ForwardStorage::Plain(t),
+        master,
+        AmpPolicy::fp32_reference(),
+    )
 }
 
 fn grad() -> Tensor {
@@ -26,7 +30,11 @@ fn grad() -> Tensor {
 
 fn assert_steps_bump_epoch(opt: &mut dyn OptimStep, name: &str) {
     let mut p = make_param();
-    assert_eq!(p.current_epoch(), 0, "{name}: fresh parameter starts at epoch 0");
+    assert_eq!(
+        p.current_epoch(),
+        0,
+        "{name}: fresh parameter starts at epoch 0"
+    );
     opt.step(&mut p, &grad()).unwrap();
     assert_eq!(
         p.current_epoch(),
@@ -57,6 +65,6 @@ fn lion_step_bumps_epoch() {
 
 #[test]
 fn muon_step_bumps_epoch() {
-    let mut opt = Muon::new(1e-3, 0.9, 5);
+    let mut opt = Muon::new(1e-3, 0.9, true, 5, 0.0);
     assert_steps_bump_epoch(&mut opt, "Muon");
 }

--- a/crates/kiln-rmsnorm-kernel/csrc/optimizer_step.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/optimizer_step.cu
@@ -164,3 +164,286 @@ extern "C" int kiln_adamw_step_bf16(
         param, grad, m, v, lr, beta1, beta2, eps, weight_decay, bias_correction1, bias_correction2, n);
     return cudaGetLastError() == cudaSuccess ? 0 : 2;
 }
+
+// =====================================================================
+// Fused Muon optimizer step (momentum-orthogonalized SGD).
+//
+// One threadblock per matrix (gridDim.x == 1) so __syncthreads() is a
+// full barrier across the whole matrix. Updates `param` and `momentum`
+// in place; `grad` is read-only. Mirrors the CPU oracle
+// `kiln-optim::lion_muon::{Muon::step, newton_schulz}` exactly.
+//
+// K_MAX bounds the orthogonalization gram dim k = min(rows, cols):
+// four k*k float scratch buffers fit in static shared memory
+// (4 * 48 * 48 * 4 == 36 KB < 48 KB). Larger ranks (or non-matrix
+// params) fall back to plain (Nesterov) momentum SGD inside the kernel.
+// =====================================================================
+
+#define KILN_MUON_K_MAX 48
+#define KILN_MUON_BLK 256
+
+template <typename T>
+__global__ void muon_step_kernel(
+    T* param,
+    const T* grad,
+    T* momentum,
+    float lr,
+    float mom,
+    int nesterov,
+    int ns_iters,
+    float wd,
+    int rows,
+    int cols) {
+    const int tid = threadIdx.x;
+    const int64_t n = (int64_t)rows * (int64_t)cols;
+
+    const int k = rows < cols ? rows : cols;
+    const bool transpose = rows > cols;
+    const int maxdim = rows > cols ? rows : cols;
+    const float scale = sqrtf((float)maxdim);
+    const bool do_ortho = (rows >= 2 && cols >= 2 && k <= KILN_MUON_K_MAX);
+
+    __shared__ float A[KILN_MUON_K_MAX * KILN_MUON_K_MAX];
+    __shared__ float M[KILN_MUON_K_MAX * KILN_MUON_K_MAX];
+    __shared__ float P[KILN_MUON_K_MAX * KILN_MUON_K_MAX];
+    __shared__ float Tm[KILN_MUON_K_MAX * KILN_MUON_K_MAX];
+    __shared__ float red[KILN_MUON_BLK];
+
+    // STEP 1 — heavy-ball momentum update, in place:
+    //   momentum = mom * momentum + grad
+    for (int64_t idx = tid; idx < n; idx += KILN_MUON_BLK) {
+        float mnew = mom * kiln_to_float<T>(momentum[idx]) + kiln_to_float<T>(grad[idx]);
+        momentum[idx] = kiln_from_float<T>(mnew);
+    }
+    __syncthreads();
+
+    // bval(idx): the (Nesterov) look-ahead direction. `momentum` already
+    // holds the post-update heavy-ball state; `grad` stays read-only.
+    // STEP 1b — non-matrix / oversized: plain (Nesterov) momentum SGD.
+    if (!do_ortho) {
+        for (int64_t idx = tid; idx < n; idx += KILN_MUON_BLK) {
+            float b = nesterov
+                          ? (kiln_to_float<T>(grad[idx]) + mom * kiln_to_float<T>(momentum[idx]))
+                          : kiln_to_float<T>(momentum[idx]);
+            float p = kiln_to_float<T>(param[idx]);
+            p = p * (1.0f - lr * wd) - lr * b;
+            param[idx] = kiln_from_float<T>(p);
+        }
+        return;
+    }
+
+    // STEP 2 — Frobenius norm of b: frob2 = sum_idx bval(idx)^2.
+    float partial = 0.0f;
+    for (int64_t idx = tid; idx < n; idx += KILN_MUON_BLK) {
+        float b = nesterov
+                      ? (kiln_to_float<T>(grad[idx]) + mom * kiln_to_float<T>(momentum[idx]))
+                      : kiln_to_float<T>(momentum[idx]);
+        partial += b * b;
+    }
+    red[tid] = partial;
+    __syncthreads();
+    for (int s = KILN_MUON_BLK / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            red[tid] += red[tid + s];
+        }
+        __syncthreads();
+    }
+    float frob2 = red[0];
+    __syncthreads();
+
+    if (frob2 == 0.0f) {
+        // Only decoupled weight decay acts (update direction is zero).
+        for (int64_t idx = tid; idx < n; idx += KILN_MUON_BLK) {
+            float p = kiln_to_float<T>(param[idx]);
+            param[idx] = kiln_from_float<T>(p * (1.0f - lr * wd));
+        }
+        return;
+    }
+    float inv_frob = 1.0f / sqrtf(frob2);
+    float inv_frob2 = 1.0f / frob2;
+
+    // STEP 3 — gram A (k x k), normalized by inv_frob2.
+    for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+        int i = pair / k;
+        int j = pair % k;
+        float s = 0.0f;
+        if (!transpose) {
+            // A = B Bt  (rows-space gram, k == rows).
+            for (int c = 0; c < cols; ++c) {
+                float bi = nesterov
+                               ? (kiln_to_float<T>(grad[i * cols + c]) +
+                                  mom * kiln_to_float<T>(momentum[i * cols + c]))
+                               : kiln_to_float<T>(momentum[i * cols + c]);
+                float bj = nesterov
+                               ? (kiln_to_float<T>(grad[j * cols + c]) +
+                                  mom * kiln_to_float<T>(momentum[j * cols + c]))
+                               : kiln_to_float<T>(momentum[j * cols + c]);
+                s += bi * bj;
+            }
+        } else {
+            // A = Bt B  (cols-space gram, k == cols).
+            for (int r = 0; r < rows; ++r) {
+                float bi = nesterov
+                               ? (kiln_to_float<T>(grad[r * cols + i]) +
+                                  mom * kiln_to_float<T>(momentum[r * cols + i]))
+                               : kiln_to_float<T>(momentum[r * cols + i]);
+                float bj = nesterov
+                               ? (kiln_to_float<T>(grad[r * cols + j]) +
+                                  mom * kiln_to_float<T>(momentum[r * cols + j]))
+                               : kiln_to_float<T>(momentum[r * cols + j]);
+                s += bi * bj;
+            }
+        }
+        A[i * k + j] = s * inv_frob2;
+    }
+    __syncthreads();
+
+    // STEP 4 — P-accumulator Newton-Schulz. P starts = I_k.
+    const float ca = 3.4445f;
+    const float cb = -4.7750f;
+    const float cc = 2.0315f;
+    for (int idx = tid; idx < k * k; idx += KILN_MUON_BLK) {
+        P[idx] = (idx / k == idx % k) ? 1.0f : 0.0f;
+    }
+    __syncthreads();
+
+    for (int iter = 0; iter < ns_iters; ++iter) {
+        // Tm = A @ A.
+        for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+            int i = pair / k;
+            int j = pair % k;
+            float s = 0.0f;
+            for (int t = 0; t < k; ++t) {
+                s += A[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        __syncthreads();
+        // M = a*I + b*A + c*Tm.
+        for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+            int i = pair / k;
+            int j = pair % k;
+            M[pair] = ca * ((i == j) ? 1.0f : 0.0f) + cb * A[pair] + cc * Tm[pair];
+        }
+        __syncthreads();
+        // P <- (!transpose ? M @ P : P @ M).
+        for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+            int i = pair / k;
+            int j = pair % k;
+            float s = 0.0f;
+            if (!transpose) {
+                for (int t = 0; t < k; ++t) {
+                    s += M[i * k + t] * P[t * k + j];
+                }
+            } else {
+                for (int t = 0; t < k; ++t) {
+                    s += P[i * k + t] * M[t * k + j];
+                }
+            }
+            Tm[pair] = s;
+        }
+        __syncthreads();
+        for (int idx = tid; idx < k * k; idx += KILN_MUON_BLK) {
+            P[idx] = Tm[idx];
+        }
+        __syncthreads();
+        // A <- M @ A @ M  (M symmetric): Tm = M@A ; A = Tm@M.
+        for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+            int i = pair / k;
+            int j = pair % k;
+            float s = 0.0f;
+            for (int t = 0; t < k; ++t) {
+                s += M[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        __syncthreads();
+        for (int pair = tid; pair < k * k; pair += KILN_MUON_BLK) {
+            int i = pair / k;
+            int j = pair % k;
+            float s = 0.0f;
+            for (int t = 0; t < k; ++t) {
+                s += Tm[i * k + t] * M[t * k + j];
+            }
+            A[pair] = s;
+        }
+        __syncthreads();
+    }
+
+    // STEP 5 — apply: O = (P@B or B@P) * inv_frob, RMS-scaled; descent
+    // with decoupled weight decay.
+    for (int64_t idx = tid; idx < n; idx += KILN_MUON_BLK) {
+        int r = (int)(idx / cols);
+        int c = (int)(idx % cols);
+        float o = 0.0f;
+        if (!transpose) {
+            // P is rows x rows (k == rows): O[r,c] = Σ_t P[r,t] * B[t,c].
+            for (int t = 0; t < k; ++t) {
+                float bt = nesterov
+                               ? (kiln_to_float<T>(grad[t * cols + c]) +
+                                  mom * kiln_to_float<T>(momentum[t * cols + c]))
+                               : kiln_to_float<T>(momentum[t * cols + c]);
+                o += P[r * k + t] * bt;
+            }
+        } else {
+            // P is cols x cols (k == cols): O[r,c] = Σ_t B[r,t] * P[t,c].
+            for (int t = 0; t < k; ++t) {
+                float bt = nesterov
+                               ? (kiln_to_float<T>(grad[r * cols + t]) +
+                                  mom * kiln_to_float<T>(momentum[r * cols + t]))
+                               : kiln_to_float<T>(momentum[r * cols + t]);
+                o += bt * P[t * k + c];
+            }
+        }
+        o *= scale * inv_frob;
+        float p = kiln_to_float<T>(param[idx]);
+        p = p * (1.0f - lr * wd) - lr * o;
+        param[idx] = kiln_from_float<T>(p);
+    }
+}
+
+extern "C" int kiln_muon_step_f32(
+    float* param,
+    const float* grad,
+    float* m,
+    float lr,
+    float mom,
+    int nesterov,
+    int ns_iters,
+    float wd,
+    int rows,
+    int cols,
+    cudaStream_t stream) {
+    if (!param || !grad || !m || rows < 0 || cols < 0) {
+        return 1;
+    }
+    if (rows == 0 || cols == 0) {
+        return 0;
+    }
+    muon_step_kernel<float><<<1, KILN_MUON_BLK, 0, stream>>>(
+        param, grad, m, lr, mom, nesterov, ns_iters, wd, rows, cols);
+    return cudaGetLastError() == cudaSuccess ? 0 : 2;
+}
+
+extern "C" int kiln_muon_step_bf16(
+    __nv_bfloat16* param,
+    const __nv_bfloat16* grad,
+    __nv_bfloat16* m,
+    float lr,
+    float mom,
+    int nesterov,
+    int ns_iters,
+    float wd,
+    int rows,
+    int cols,
+    cudaStream_t stream) {
+    if (!param || !grad || !m || rows < 0 || cols < 0) {
+        return 1;
+    }
+    if (rows == 0 || cols == 0) {
+        return 0;
+    }
+    muon_step_kernel<__nv_bfloat16><<<1, KILN_MUON_BLK, 0, stream>>>(
+        param, grad, m, lr, mom, nesterov, ns_iters, wd, rows, cols);
+    return cudaGetLastError() == cudaSuccess ? 0 : 2;
+}

--- a/crates/kiln-rmsnorm-kernel/src/kt_api.rs
+++ b/crates/kiln-rmsnorm-kernel/src/kt_api.rs
@@ -488,6 +488,176 @@ pub fn adamw_step_f32_kt(
     Ok(())
 }
 
+/// `(rows, cols)` for a Muon step over `param`. Rank-2 params keep their
+/// `[rows, cols]` layout (the only shape the kernel orthogonalizes);
+/// every other shape collapses to `(element_count, 1)` so the kernel's
+/// non-matrix plain-momentum fallback runs over the flat buffer. The
+/// kernel takes `i32` dims (`<<<1, BLK>>>`, one block per matrix), so we
+/// reject anything past `i32::MAX`.
+fn muon_rows_cols(param: &KtTensor) -> Result<(i32, i32), RmsNormError> {
+    let shape = param.shape();
+    let (rows, cols) = if shape.len() == 2 {
+        (shape[0], shape[1])
+    } else {
+        (param.element_count(), 1)
+    };
+    if rows > i32::MAX as usize || cols > i32::MAX as usize {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step: dims ({rows}, {cols}) exceed i32 kernel envelope"
+        )));
+    }
+    Ok((rows as i32, cols as i32))
+}
+
+/// `muon_step_f32` over `kiln_tensor::Tensor` operands.
+///
+/// In-place fused Muon step: heavy-ball momentum update, then (for
+/// rank-2 weights within the kernel's shared-memory bound) Newton-Schulz
+/// orthogonalization of the (Nesterov) look-ahead with the RMS-matching
+/// `sqrt(max(rows, cols))` scale, then the decoupled-weight-decay descent
+/// step. `param` and `momentum` are mutated in place; `grad` is
+/// read-only. F32 only. Mirrors `kiln_optim::Muon::step`.
+#[allow(clippy::too_many_arguments)]
+pub fn muon_step_f32_kt(
+    param: &KtTensor,
+    grad: &KtTensor,
+    momentum: &KtTensor,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<(), RmsNormError> {
+    if param.shape() != grad.shape() || param.shape() != momentum.shape() {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step: shape mismatch — param {:?}, grad {:?}, momentum {:?}",
+            param.shape(),
+            grad.shape(),
+            momentum.shape()
+        )));
+    }
+    if param.dtype() != KtDType::F32
+        || grad.dtype() != KtDType::F32
+        || momentum.dtype() != KtDType::F32
+    {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step: dtype mismatch — param {:?}, grad {:?}, momentum {:?} (want F32)",
+            param.dtype(),
+            grad.dtype(),
+            momentum.dtype()
+        )));
+    }
+    if !param.is_contiguous() || !grad.is_contiguous() || !momentum.is_contiguous() {
+        return Err(RmsNormError::Msg(
+            "kt-muon-step: param/grad/momentum must be contiguous".to_string(),
+        ));
+    }
+    let (rows, cols) = muon_rows_cols(param)?;
+
+    // In-place op: `param` and `momentum` are mutated through their
+    // device storage. Caller convention: pass Owned for both.
+    let p_ptr = kiln_kt_bridge::device_input_ptr(param, KtDType::F32, "param")?;
+    let g_ptr = kiln_kt_bridge::device_input_ptr(grad, KtDType::F32, "grad")?;
+    let m_ptr = kiln_kt_bridge::device_input_ptr(momentum, KtDType::F32, "momentum")?;
+    let p_st = param;
+
+    let raw_stream = device_stream_raw(p_st, "p_st")?;
+
+    let status = unsafe {
+        kiln_muon_step_f32(
+            p_ptr as *mut f32,
+            g_ptr as *const f32,
+            m_ptr as *mut f32,
+            lr,
+            momentum_coef,
+            if nesterov { 1 } else { 0 },
+            ns_iters as i32,
+            weight_decay,
+            rows,
+            cols,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step: FFI returned {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// `muon_step_bf16` over `kiln_tensor::Tensor` operands.
+///
+/// BF16-master fused Muon step. `param`, `grad`, `momentum` all BF16;
+/// `param` and `momentum` are mutated in place. See [`muon_step_f32_kt`]
+/// for the F32-master variant and the full algorithm description.
+#[allow(clippy::too_many_arguments)]
+pub fn muon_step_bf16_kt(
+    param: &KtTensor,
+    grad: &KtTensor,
+    momentum: &KtTensor,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<(), RmsNormError> {
+    if param.shape() != grad.shape() || param.shape() != momentum.shape() {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step-bf16: shape mismatch — param {:?}, grad {:?}, momentum {:?}",
+            param.shape(),
+            grad.shape(),
+            momentum.shape()
+        )));
+    }
+    if param.dtype() != KtDType::BF16
+        || grad.dtype() != KtDType::BF16
+        || momentum.dtype() != KtDType::BF16
+    {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step-bf16: dtype mismatch — param {:?}, grad {:?}, momentum {:?} (want BF16)",
+            param.dtype(),
+            grad.dtype(),
+            momentum.dtype()
+        )));
+    }
+    if !param.is_contiguous() || !grad.is_contiguous() || !momentum.is_contiguous() {
+        return Err(RmsNormError::Msg(
+            "kt-muon-step-bf16: param/grad/momentum must be contiguous".to_string(),
+        ));
+    }
+    let (rows, cols) = muon_rows_cols(param)?;
+
+    let p_ptr = kiln_kt_bridge::device_input_ptr(param, KtDType::BF16, "param")?;
+    let g_ptr = kiln_kt_bridge::device_input_ptr(grad, KtDType::BF16, "grad")?;
+    let m_ptr = kiln_kt_bridge::device_input_ptr(momentum, KtDType::BF16, "momentum")?;
+    let p_st = param;
+
+    let raw_stream = device_stream_raw(p_st, "p_st")?;
+
+    let status = unsafe {
+        kiln_muon_step_bf16(
+            p_ptr as *mut _,
+            g_ptr as *const _,
+            m_ptr as *mut _,
+            lr,
+            momentum_coef,
+            if nesterov { 1 } else { 0 },
+            ns_iters as i32,
+            weight_decay,
+            rows,
+            cols,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        return Err(RmsNormError::Msg(format!(
+            "kt-muon-step-bf16: FFI returned {status}"
+        )));
+    }
+    Ok(())
+}
+
 /// `lora_decode_hidden_bf16` over `kiln_tensor::Tensor` operands.
 ///
 /// Computes the LoRA-A projection at decode time: `hidden = x @ A`,

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -119,7 +119,7 @@ pub use kt_api::{
     fused_mlp_silu_mul_kt, fused_mlp_silu_mul_packed_kt, fused_rmsnorm_backward_kt,
     fused_rmsnorm_kt, fused_rotary_one_bwd_kt, fused_rotary_one_kt, fused_rotary_qk_kt,
     fused_sigmoid_mul_kt, lora_add_inplace_f32_kt, lora_decode_add_full_kt, lora_decode_add_kt,
-    lora_decode_hidden_kt, sgd_step_bf16_kt, sgd_step_f32_kt,
+    lora_decode_hidden_kt, muon_step_bf16_kt, muon_step_f32_kt, sgd_step_bf16_kt, sgd_step_f32_kt,
     silu_inplace_save_sigmoid_f32_kt, supports_attn_decode_qkv_prep_kt,
     supports_l2_qk_norm_gqa_kt, supports_l2_qk_norm_kt, supports_lora_decode_add_kt,
     supports_mlp_silu_mul_kt, supports_mlp_silu_mul_packed_kt, supports_optimizer_step_kt,
@@ -410,6 +410,34 @@ unsafe extern "C" {
         bias_correction1: f32,
         bias_correction2: f32,
         n: i64,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_muon_step_f32(
+        param: *mut f32,
+        grad: *const f32,
+        momentum: *mut f32,
+        lr: f32,
+        mom: f32,
+        nesterov: i32,
+        ns_iters: i32,
+        weight_decay: f32,
+        rows: i32,
+        cols: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_muon_step_bf16(
+        param: *mut core::ffi::c_void,
+        grad: *const core::ffi::c_void,
+        momentum: *mut core::ffi::c_void,
+        lr: f32,
+        mom: f32,
+        nesterov: i32,
+        ns_iters: i32,
+        weight_decay: f32,
+        rows: i32,
+        cols: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
 }

--- a/crates/kiln-rmsnorm-kernel/tests/muon_cuda_parity.rs
+++ b/crates/kiln-rmsnorm-kernel/tests/muon_cuda_parity.rs
@@ -1,0 +1,309 @@
+//! Numerical parity for the fused CUDA Muon optimizer kernel
+//! (`muon_step_f32_kt` / `muon_step_bf16_kt`) against a CPU reference that
+//! replicates the exact algorithm (heavy-ball momentum -> Nesterov
+//! look-ahead -> gram-space P-accumulator Newton-Schulz -> RMS-matching
+//! scale -> decoupled-weight-decay descent). The CPU reference mirrors
+//! `kiln_optim::lion_muon::{Muon::step, newton_schulz}`; the *algorithm*
+//! is separately validated by kiln-optim's
+//! `newton_schulz_matches_direct_iteration` test (and on real GPU silicon
+//! by `kiln-vulkan-kernel`'s `vk_muon_parity`), so this test's job is to
+//! confirm the CUDA kernel *executes* that algorithm correctly (the same
+//! `optimizer_step.cu` source is compiled for ROCm via hipcc).
+//!
+//! Constructs CUDA tensors via `Tensor::cuda_from_slice` and reads results
+//! back with `cuda_to_host_copy`, mirroring the `kt_v2_smoke` /
+//! `gated_rms_norm_parity` precedent. CUDA-only (`cuda_from_slice` is
+//! `cfg(feature = "cuda")`). Skips cleanly when no CUDA device is present.
+#![cfg(feature = "cuda")]
+
+use half::bf16;
+
+use kiln_rmsnorm_kernel::{muon_step_bf16_kt, muon_step_f32_kt};
+use kiln_tensor::{DType, Tensor, cuda_to_host_copy};
+
+fn cuda_available() -> bool {
+    kiln_tensor::primary_cuda_context(0).is_ok()
+}
+
+// ---- CPU reference (mirrors kiln_optim::lion_muon) ----
+
+fn matmul_kk(a: &[f32], b: &[f32], out: &mut [f32], k: usize) {
+    for i in 0..k {
+        for j in 0..k {
+            let mut s = 0.0f32;
+            for t in 0..k {
+                s += a[i * k + t] * b[t * k + j];
+            }
+            out[i * k + j] = s;
+        }
+    }
+}
+
+fn newton_schulz(w: &[f32], rows: usize, cols: usize, iters: u32) -> Vec<f32> {
+    let n = rows * cols;
+    let frob = w.iter().map(|&v| v * v).sum::<f32>().sqrt();
+    if frob == 0.0 {
+        return vec![0.0; n];
+    }
+    let inv_frob = 1.0 / frob;
+    let inv_frob2 = inv_frob * inv_frob;
+    let transpose = rows > cols;
+    let k = rows.min(cols);
+    let mut a = vec![0.0f32; k * k];
+    for i in 0..k {
+        for j in 0..k {
+            let mut s = 0.0f32;
+            if !transpose {
+                for c in 0..cols {
+                    s += w[i * cols + c] * w[j * cols + c];
+                }
+            } else {
+                for r in 0..rows {
+                    s += w[r * cols + i] * w[r * cols + j];
+                }
+            }
+            a[i * k + j] = s * inv_frob2;
+        }
+    }
+    let mut p = vec![0.0f32; k * k];
+    for i in 0..k {
+        p[i * k + i] = 1.0;
+    }
+    let (ca, cb, cc) = (3.4445f32, -4.7750f32, 2.0315f32);
+    let mut a2 = vec![0.0f32; k * k];
+    let mut m = vec![0.0f32; k * k];
+    let mut tmp = vec![0.0f32; k * k];
+    for _ in 0..iters {
+        matmul_kk(&a, &a, &mut a2, k);
+        for i in 0..k {
+            for j in 0..k {
+                let id = if i == j { 1.0 } else { 0.0 };
+                m[i * k + j] = ca * id + cb * a[i * k + j] + cc * a2[i * k + j];
+            }
+        }
+        if !transpose {
+            matmul_kk(&m, &p, &mut tmp, k);
+        } else {
+            matmul_kk(&p, &m, &mut tmp, k);
+        }
+        p.copy_from_slice(&tmp);
+        matmul_kk(&m, &a, &mut tmp, k);
+        matmul_kk(&tmp, &m, &mut a, k);
+    }
+    let mut o = vec![0.0f32; n];
+    for r in 0..rows {
+        for c in 0..cols {
+            let mut s = 0.0f32;
+            if !transpose {
+                for j in 0..k {
+                    s += p[r * k + j] * w[j * cols + c];
+                }
+            } else {
+                for j in 0..k {
+                    s += w[r * cols + j] * p[j * k + c];
+                }
+            }
+            o[r * cols + c] = s * inv_frob;
+        }
+    }
+    o
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cpu_muon(
+    param: &[f32],
+    grad: &[f32],
+    mom_in: &[f32],
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    mom: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    wd: f32,
+) -> (Vec<f32>, Vec<f32>) {
+    let n = rows * cols;
+    let mut momentum = mom_in.to_vec();
+    for i in 0..n {
+        momentum[i] = mom * momentum[i] + grad[i];
+    }
+    let b: Vec<f32> = (0..n)
+        .map(|i| {
+            if nesterov {
+                grad[i] + mom * momentum[i]
+            } else {
+                momentum[i]
+            }
+        })
+        .collect();
+    let k = rows.min(cols);
+    // K_MAX for the CUDA kernel is 48.
+    let do_ortho = rows >= 2 && cols >= 2 && k <= 48;
+    let update = if do_ortho {
+        let mut o = newton_schulz(&b, rows, cols, ns_iters);
+        let scale = (rows.max(cols) as f32).sqrt();
+        for v in o.iter_mut() {
+            *v *= scale;
+        }
+        o
+    } else {
+        b
+    };
+    let mut p = param.to_vec();
+    for i in 0..n {
+        p[i] = p[i] * (1.0 - lr * wd) - lr * update[i];
+    }
+    (p, momentum)
+}
+
+fn det_fill(seed: u64, len: usize, scale: f32) -> Vec<f32> {
+    let mut z = seed;
+    (0..len)
+        .map(|_| {
+            z = z.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut x = z;
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            x ^= x >> 31;
+            let u = (x >> 40) as f32 / (1u32 << 24) as f32;
+            (u * 2.0 - 1.0) * scale
+        })
+        .collect()
+}
+
+/// Copy a (possibly BF16) CUDA tensor to host and read it as F32. The
+/// `to_dtype(F32)` is a no-op for F32 tensors and the BF16->F32 promotion
+/// for BF16 ones (so `to_vec1::<f32>` always sees an F32 host tensor).
+fn host_f32(t: &Tensor) -> Vec<f32> {
+    cuda_to_host_copy(t)
+        .expect("cuda_to_host_copy")
+        .to_dtype(DType::F32)
+        .expect("to_dtype f32")
+        .flatten_all()
+        .expect("flatten")
+        .to_vec1::<f32>()
+        .expect("to_vec1")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_case_f32(rows: usize, cols: usize, nesterov: bool, wd: f32, seed: u64) {
+    let n = rows * cols;
+    let (lr, mom, ns_iters) = (0.02f32, 0.95f32, 5u32);
+    let param_data = det_fill(seed, n, 1.0);
+    let grad_data = det_fill(seed ^ 0xa5a5, n, 0.5);
+    let mom_data = det_fill(seed ^ 0x1234, n, 0.3);
+
+    let (exp_param, exp_mom) = cpu_muon(
+        &param_data,
+        &grad_data,
+        &mom_data,
+        rows,
+        cols,
+        lr,
+        mom,
+        nesterov,
+        ns_iters,
+        wd,
+    );
+
+    let param = Tensor::cuda_from_slice(&param_data, vec![rows, cols], 0).expect("param");
+    let grad = Tensor::cuda_from_slice(&grad_data, vec![rows, cols], 0).expect("grad");
+    let momentum = Tensor::cuda_from_slice(&mom_data, vec![rows, cols], 0).expect("momentum");
+
+    muon_step_f32_kt(&param, &grad, &momentum, lr, mom, nesterov, ns_iters, wd)
+        .expect("muon_step_f32_kt");
+
+    let got_param = host_f32(&param);
+    let got_mom = host_f32(&momentum);
+
+    let tol = 2e-3f32;
+    for i in 0..n {
+        assert!(
+            (got_param[i] - exp_param[i]).abs() < tol,
+            "param[{i}] {rows}x{cols} nesterov={nesterov} wd={wd}: gpu={} cpu={}",
+            got_param[i],
+            exp_param[i]
+        );
+        assert!(
+            (got_mom[i] - exp_mom[i]).abs() < tol,
+            "momentum[{i}] {rows}x{cols}: gpu={} cpu={}",
+            got_mom[i],
+            exp_mom[i]
+        );
+    }
+}
+
+#[test]
+fn muon_cuda_parity_f32_shapes() {
+    if !cuda_available() {
+        eprintln!("CUDA not available; skipping muon_cuda_parity_f32_shapes");
+        return;
+    }
+    // short-fat (k=rows), tall-skinny (k=cols), square — all k<=48.
+    let cases: &[(usize, usize)] = &[(8, 32), (32, 8), (16, 16), (4, 96), (96, 4), (48, 48)];
+    for (idx, &(rows, cols)) in cases.iter().enumerate() {
+        run_case_f32(rows, cols, true, 0.0, 0x1000 + idx as u64);
+        run_case_f32(rows, cols, false, 0.0, 0x2000 + idx as u64);
+        run_case_f32(rows, cols, true, 0.01, 0x3000 + idx as u64);
+    }
+}
+
+#[test]
+fn muon_cuda_parity_non_matrix_falls_back_to_momentum_sgd() {
+    if !cuda_available() {
+        eprintln!("CUDA not available; skipping muon_cuda_parity_non_matrix");
+        return;
+    }
+    // [1, N] has min dim 1 -> do_ortho false -> plain (Nesterov) momentum SGD.
+    run_case_f32(1, 64, true, 0.0, 0xbeef);
+    run_case_f32(64, 1, false, 0.0, 0xcafe);
+}
+
+#[test]
+fn muon_cuda_parity_bf16_runs_and_is_close() {
+    if !cuda_available() {
+        eprintln!("CUDA not available; skipping muon_cuda_parity_bf16");
+        return;
+    }
+    // BF16 path: compare against the f32 oracle within a bf16 budget (a
+    // lane-addressing bug would corrupt values far beyond bf16 rounding).
+    let (rows, cols) = (16usize, 16usize);
+    let n = rows * cols;
+    let (lr, mom, ns_iters) = (0.02f32, 0.95f32, 5u32);
+    let round = |v: f32| bf16::from_f32(v).to_f32();
+    let param_data: Vec<f32> = det_fill(0x55, n, 1.0).iter().map(|&v| round(v)).collect();
+    let grad_data: Vec<f32> = det_fill(0x66, n, 0.5).iter().map(|&v| round(v)).collect();
+    let mom_data: Vec<f32> = det_fill(0x77, n, 0.3).iter().map(|&v| round(v)).collect();
+
+    let (exp_param, _exp_mom) = cpu_muon(
+        &param_data,
+        &grad_data,
+        &mom_data,
+        rows,
+        cols,
+        lr,
+        mom,
+        true,
+        ns_iters,
+        0.0,
+    );
+
+    let to_bf16 = |d: &[f32]| -> Vec<bf16> { d.iter().map(|&v| bf16::from_f32(v)).collect() };
+    let param = Tensor::cuda_from_slice(&to_bf16(&param_data), vec![rows, cols], 0).expect("param");
+    let grad = Tensor::cuda_from_slice(&to_bf16(&grad_data), vec![rows, cols], 0).expect("grad");
+    let momentum =
+        Tensor::cuda_from_slice(&to_bf16(&mom_data), vec![rows, cols], 0).expect("momentum");
+
+    muon_step_bf16_kt(&param, &grad, &momentum, lr, mom, true, ns_iters, 0.0)
+        .expect("muon_step_bf16_kt");
+
+    let got_param = host_f32(&param);
+    for i in 0..n {
+        assert!(
+            (got_param[i] - exp_param[i]).abs() <= 6e-2 * (1.0 + exp_param[i].abs()),
+            "bf16 param[{i}]: gpu={} cpu={}",
+            got_param[i],
+            exp_param[i]
+        );
+    }
+}

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -170,7 +170,7 @@ pub use metal_storage::{
     MetalStorage, host_to_metal_copy, metal_activation_unary, metal_adamw_step, metal_cast,
     metal_compare, metal_copy_in_place, metal_cumsum_axis, metal_deep_copy,
     metal_elementwise_binary, metal_index_select_dim0, metal_layernorm_last_axis,
-    metal_log_softmax_last_axis, metal_rmsnorm_last_axis, metal_sdpa_last_axis,
+    metal_log_softmax_last_axis, metal_muon_step, metal_rmsnorm_last_axis, metal_sdpa_last_axis,
     metal_softmax_last_axis, metal_to_host_copy, metal_where_select, metal_write_host_in_place,
     primary_metal_companion,
 };

--- a/crates/kiln-tensor/src/metal_kernels.rs
+++ b/crates/kiln-tensor/src/metal_kernels.rs
@@ -611,6 +611,319 @@ kernel void {entry}(
         param[gid] = ({ty})p;
     }}
 }}
+
+// ----------------------------------------------------------------------
+// muon_step — kiln-owned fused on-device Muon (momentum-orthogonalized SGD;
+// mirrors kiln_optim::Muon::step + newton_schulz — the CPU oracle)
+// ----------------------------------------------------------------------
+
+/// The kernel's Newton-Schulz shared-memory rank bound. `k = min(rows, cols)`
+/// must satisfy `k <= K_MAX` for the on-device orthogonalization to run;
+/// larger ranks fall back (in the kernel) to plain (Nesterov) momentum SGD.
+///
+/// At `K_MAX = 32` the four `K_MAX*K_MAX` float scratch tiles cost
+/// `4 * 32 * 32 * 4 = 16 KiB`, comfortably under Metal's 32 KiB threadgroup
+/// limit (the `red[256]` reduction scratch adds another 1 KiB).
+pub(crate) const MUON_K_MAX: usize = 32;
+
+/// Fused in-place Muon step over one `rows x cols` matrix (`n = rows*cols`
+/// contiguous, row-major). Updates `param` and `momentum` IN PLACE; reads
+/// `grad` (read-only). Dispatched as ONE threadgroup of 256 threads with
+/// threadgroup-memory Newton-Schulz — NOT one thread per element.
+///
+/// Each lane is promoted to `float`; the heavy-ball momentum update, the
+/// Newton-Schulz orthogonalization (gram-space P-accumulator), and the
+/// RMS-scaled decoupled-weight-decay descent are all computed in `float`,
+/// then written back as `dtype`. Bit-faithful to `kiln_optim::Muon::step` +
+/// `kiln_optim::newton_schulz`.
+///
+/// `param`/`grad`/`momentum` share `dtype` (the float triple; F32 identity
+/// promotion, BF16/F16 native `(float)`/`(dtype)` casts as in `adamw_step`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn muon_step(
+    companion: &MetalCompanion,
+    param: &MetalBuffer,
+    grad: &MetalBuffer,
+    momentum: &MetalBuffer,
+    dtype: DType,
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<()> {
+    let ty = msl_ty(dtype)?;
+    let entry = format!("kt_muon_step_{ty}");
+    let k_max = MUON_K_MAX;
+    // BLK threads per (single) threadgroup; matches the launch below.
+    let blk = 256usize;
+    let src = format!(
+        r#"
+#include <metal_stdlib>
+using namespace metal;
+
+// Newton-Schulz quintic coefficients (Keller-Jordan), matching the oracle.
+constant float NS_A = 3.4445f;
+constant float NS_B = -4.7750f;
+constant float NS_C = 2.0315f;
+
+kernel void {entry}(
+    device {ty}* param          [[buffer(0)]],
+    device const {ty}* grad     [[buffer(1)]],
+    device {ty}* momentum       [[buffer(2)]],
+    constant uint& n            [[buffer(3)]],
+    constant uint& rows         [[buffer(4)]],
+    constant uint& cols         [[buffer(5)]],
+    constant uint& ns_iters     [[buffer(6)]],
+    constant float& lr          [[buffer(7)]],
+    constant float& mom         [[buffer(8)]],
+    constant uint& nesterov     [[buffer(9)]],
+    constant float& wd          [[buffer(10)]],
+    uint tid       [[thread_index_in_threadgroup]],
+    uint block_dim [[threads_per_threadgroup]])
+{{
+    // Shared scratch: four k_max*k_max float tiles + a BLK-float reduction.
+    threadgroup float A[{k_max} * {k_max}];
+    threadgroup float M[{k_max} * {k_max}];
+    threadgroup float P[{k_max} * {k_max}];
+    threadgroup float Tm[{k_max} * {k_max}];
+    threadgroup float red[{blk}];
+
+    const uint k = (rows < cols) ? rows : cols;
+    const bool transpose = (rows > cols);
+    const float scale = sqrt((float)((rows > cols) ? rows : cols));
+    const bool do_ortho = (rows >= 2u) && (cols >= 2u) && (k <= {k_max}u);
+
+    // STEP 1 — heavy-ball momentum update, in place:
+    //   momentum = mom*momentum + grad.
+    for (uint idx = tid; idx < n; idx += block_dim) {{
+        float mv = mom * (float)momentum[idx] + (float)grad[idx];
+        momentum[idx] = ({ty})mv;
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // bval(idx): nesterov ? grad + mom*momentum : momentum. momentum[] is
+    // already updated (step 1); grad[] stays read-only throughout.
+    // (Inlined at each use as MSL has no closures.)
+
+    // STEP 1b — non-matrix / oversized rank: plain (Nesterov) momentum SGD.
+    if (!do_ortho) {{
+        for (uint idx = tid; idx < n; idx += block_dim) {{
+            float b = (nesterov != 0u)
+                ? ((float)grad[idx] + mom * (float)momentum[idx])
+                : (float)momentum[idx];
+            float p = (float)param[idx];
+            p = p * (1.0f - lr * wd) - lr * b;
+            param[idx] = ({ty})p;
+        }}
+        return;
+    }}
+
+    // STEP 2 — Frobenius norm of b: frob2 = sum_idx bval(idx)^2.
+    {{
+        float local = 0.0f;
+        for (uint idx = tid; idx < n; idx += block_dim) {{
+            float b = (nesterov != 0u)
+                ? ((float)grad[idx] + mom * (float)momentum[idx])
+                : (float)momentum[idx];
+            local += b * b;
+        }}
+        red[tid] = local;
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    // Tree reduction over the BLK reduction scratch.
+    for (uint stride = block_dim >> 1u; stride > 0u; stride >>= 1u) {{
+        if (tid < stride) {{
+            red[tid] += red[tid + stride];
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }}
+    float frob2 = red[0];
+
+    if (frob2 == 0.0f) {{
+        // b is identically zero — only decoupled weight decay acts.
+        for (uint idx = tid; idx < n; idx += block_dim) {{
+            float p = (float)param[idx];
+            param[idx] = ({ty})(p * (1.0f - lr * wd));
+        }}
+        return;
+    }}
+    float inv_frob = 1.0f / sqrt(frob2);
+    float inv_frob2 = 1.0f / frob2;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // STEP 3 — gram A (k x k), normalized by inv_frob2.
+    for (uint pair = tid; pair < k * k; pair += block_dim) {{
+        uint i = pair / k;
+        uint j = pair % k;
+        float s = 0.0f;
+        if (!transpose) {{
+            // A = B Bt: sum over columns.
+            for (uint c = 0u; c < cols; ++c) {{
+                float bi = (nesterov != 0u)
+                    ? ((float)grad[i * cols + c] + mom * (float)momentum[i * cols + c])
+                    : (float)momentum[i * cols + c];
+                float bj = (nesterov != 0u)
+                    ? ((float)grad[j * cols + c] + mom * (float)momentum[j * cols + c])
+                    : (float)momentum[j * cols + c];
+                s += bi * bj;
+            }}
+        }} else {{
+            // A = Bt B: sum over rows.
+            for (uint r = 0u; r < rows; ++r) {{
+                float bi = (nesterov != 0u)
+                    ? ((float)grad[r * cols + i] + mom * (float)momentum[r * cols + i])
+                    : (float)momentum[r * cols + i];
+                float bj = (nesterov != 0u)
+                    ? ((float)grad[r * cols + j] + mom * (float)momentum[r * cols + j])
+                    : (float)momentum[r * cols + j];
+                s += bi * bj;
+            }}
+        }}
+        A[i * k + j] = s * inv_frob2;
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // STEP 4 — P starts = I_k, Newton-Schulz over ns_iters.
+    for (uint idx = tid; idx < k * k; idx += block_dim) {{
+        P[idx] = (idx / k == idx % k) ? 1.0f : 0.0f;
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint iter = 0u; iter < ns_iters; ++iter) {{
+        // Tm = A @ A.
+        for (uint pair = tid; pair < k * k; pair += block_dim) {{
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0f;
+            for (uint t = 0u; t < k; ++t) {{
+                s += A[i * k + t] * A[t * k + j];
+            }}
+            Tm[pair] = s;
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // M = a*I + b*A + c*Tm.
+        for (uint pair = tid; pair < k * k; pair += block_dim) {{
+            uint i = pair / k;
+            uint j = pair % k;
+            float id = (i == j) ? 1.0f : 0.0f;
+            M[pair] = NS_A * id + NS_B * A[pair] + NS_C * Tm[pair];
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // P <- (!transpose ? M @ P : P @ M); stage into Tm, then copy back.
+        for (uint pair = tid; pair < k * k; pair += block_dim) {{
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0f;
+            if (!transpose) {{
+                for (uint t = 0u; t < k; ++t) {{
+                    s += M[i * k + t] * P[t * k + j];
+                }}
+            }} else {{
+                for (uint t = 0u; t < k; ++t) {{
+                    s += P[i * k + t] * M[t * k + j];
+                }}
+            }}
+            Tm[pair] = s;
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < k * k; idx += block_dim) {{
+            P[idx] = Tm[idx];
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        // A <- M @ A @ M  (M symmetric): Tm = M@A ; A = Tm@M.
+        for (uint pair = tid; pair < k * k; pair += block_dim) {{
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0f;
+            for (uint t = 0u; t < k; ++t) {{
+                s += M[i * k + t] * A[t * k + j];
+            }}
+            Tm[pair] = s;
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint pair = tid; pair < k * k; pair += block_dim) {{
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0f;
+            for (uint t = 0u; t < k; ++t) {{
+                s += Tm[i * k + t] * M[t * k + j];
+            }}
+            A[pair] = s;
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }}
+
+    // STEP 5 — apply: O = (P@B or B@P) * scale * inv_frob; decoupled-WD descent.
+    for (uint idx = tid; idx < n; idx += block_dim) {{
+        uint r = idx / cols;
+        uint c = idx % cols;
+        float o = 0.0f;
+        if (!transpose) {{
+            // P is rows x rows (k=rows): O[r,c] = sum_t P[r,t] * b[t,c].
+            for (uint t = 0u; t < k; ++t) {{
+                float bt = (nesterov != 0u)
+                    ? ((float)grad[t * cols + c] + mom * (float)momentum[t * cols + c])
+                    : (float)momentum[t * cols + c];
+                o += P[r * k + t] * bt;
+            }}
+        }} else {{
+            // P is cols x cols (k=cols): O[r,c] = sum_t b[r,t] * P[t,c].
+            for (uint t = 0u; t < k; ++t) {{
+                float bt = (nesterov != 0u)
+                    ? ((float)grad[r * cols + t] + mom * (float)momentum[r * cols + t])
+                    : (float)momentum[r * cols + t];
+                o += bt * P[t * k + c];
+            }}
+        }}
+        o *= scale * inv_frob;
+        float p = (float)param[idx];
+        p = p * (1.0f - lr * wd) - lr * o;
+        param[idx] = ({ty})p;
+    }}
+}}
+"#
+    );
+    let pipeline = op_pipeline(companion, &src, &entry)?;
+    let encoder = companion
+        .command_encoder()
+        .map_err(|e| Error::Msg(format!("metal_kernels::muon_step: encoder: {e:?}")))?;
+    encoder.set_label("kt_muon_step");
+    encoder.set_compute_pipeline_state(&pipeline);
+    encoder.set_buffer(0, Some(param), 0);
+    encoder.set_buffer(1, Some(grad), 0);
+    encoder.set_buffer(2, Some(momentum), 0);
+    let n_u = (rows * cols) as u32;
+    let rows_u = rows as u32;
+    let cols_u = cols as u32;
+    let ns_u = ns_iters;
+    let nesterov_u: u32 = if nesterov { 1 } else { 0 };
+    encoder.set_bytes(3, &n_u);
+    encoder.set_bytes(4, &rows_u);
+    encoder.set_bytes(5, &cols_u);
+    encoder.set_bytes(6, &ns_u);
+    encoder.set_bytes(7, &lr);
+    encoder.set_bytes(8, &momentum_coef);
+    encoder.set_bytes(9, &nesterov_u);
+    encoder.set_bytes(10, &weight_decay);
+    // ONE threadgroup of BLK threads (threadgroup-memory Newton-Schulz needs
+    // full barriers, so all work lives in a single threadgroup per matrix).
+    let groups = objc2_metal::MTLSize {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+    let threads = objc2_metal::MTLSize {
+        width: blk,
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(groups, threads);
+    drop(encoder);
+    Ok(())
+}
 "#
     );
     let pipeline = op_pipeline(companion, &src, &entry)?;

--- a/crates/kiln-tensor/src/metal_storage.rs
+++ b/crates/kiln-tensor/src/metal_storage.rs
@@ -2350,6 +2350,99 @@ pub fn metal_adamw_step(
 }
 
 // ----------------------------------------------------------------------
+// metal_muon_step — fused on-device Muon (momentum-orthogonalized SGD)
+// ----------------------------------------------------------------------
+
+/// Fused in-place Muon step on Metal. Updates `param` and the per-param
+/// heavy-ball `momentum` buffer IN PLACE in their `MetalStorage` buffers;
+/// reads `grad` (read-only). No host round-trip — the `StorageModeShared` UMA
+/// buffers are mutated directly by a single threadgroup running the
+/// Newton-Schulz orthogonalization in threadgroup memory. The math is a
+/// bit-faithful port of [`kiln_optim::Muon::step`] + `kiln_optim::newton_schulz`.
+///
+/// All three tensors must be Metal-backed, contiguous, share `dtype` (the
+/// float triple), and have the same element count. `rows`/`cols` come from the
+/// param shape (a rank-2 weight orthogonalizes; otherwise the kernel falls back
+/// to plain (Nesterov) momentum SGD — callers pass `(n, 1)` for non-2D params).
+#[allow(clippy::too_many_arguments)]
+pub fn metal_muon_step(
+    param: &crate::Tensor,
+    grad: &crate::Tensor,
+    momentum: &crate::Tensor,
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<()> {
+    let dtype = param.dtype();
+    // F32/BF16/F16 master+momentum — the kernel reads each as its dtype,
+    // computes in float, and writes back as the dtype (round-to-nearest for
+    // BF16/F16). BF16 momentum follows the on-device master-dtype convention,
+    // as on CUDA/Vulkan.
+    if !matches!(dtype, DType::F32 | DType::BF16 | DType::F16) {
+        return Err(Error::Msg(format!(
+            "metal_muon_step: unsupported dtype {dtype} (expected F32/BF16/F16)"
+        )));
+    }
+    if grad.dtype() != dtype || momentum.dtype() != dtype {
+        return Err(Error::Msg(format!(
+            "metal_muon_step: dtype mismatch (param={dtype}, grad={}, momentum={})",
+            grad.dtype(),
+            momentum.dtype()
+        )));
+    }
+    let n = param.element_count();
+    if rows * cols != n {
+        return Err(Error::Msg(format!(
+            "metal_muon_step: rows*cols ({rows}*{cols}) != param element count ({n})"
+        )));
+    }
+    if grad.element_count() != n || momentum.element_count() != n {
+        return Err(Error::Msg(format!(
+            "metal_muon_step: element count mismatch (param={n}, grad={}, momentum={})",
+            grad.element_count(),
+            momentum.element_count()
+        )));
+    }
+    if !param.is_contiguous() || !grad.is_contiguous() || !momentum.is_contiguous() {
+        return Err(Error::Msg(
+            "metal_muon_step: all operands must be contiguous".to_string(),
+        ));
+    }
+
+    fn downcast<'a>(t: &'a crate::Tensor, name: &str) -> Result<&'a MetalStorage> {
+        t.storage()
+            .as_any()
+            .downcast_ref::<MetalStorage>()
+            .ok_or_else(|| Error::Msg(format!("metal_muon_step: {name} must be Metal-backed")))
+    }
+    let kt_param = downcast(param, "param")?;
+    let kt_grad = downcast(grad, "grad")?;
+    let kt_momentum = downcast(momentum, "momentum")?;
+
+    let companion = kt_param.companion()?;
+
+    crate::metal_kernels::muon_step(
+        &companion,
+        kt_param.buffer().as_ref(),
+        kt_grad.buffer().as_ref(),
+        kt_momentum.buffer().as_ref(),
+        dtype,
+        rows,
+        cols,
+        lr,
+        momentum_coef,
+        nesterov,
+        ns_iters,
+        weight_decay,
+    )?;
+    Ok(())
+}
+
+// ----------------------------------------------------------------------
 // metal_activation_unary — Phase 4 Metal substrate op (#1082)
 // ----------------------------------------------------------------------
 

--- a/crates/kiln-train/examples/long_context_grpo_bench.rs
+++ b/crates/kiln-train/examples/long_context_grpo_bench.rs
@@ -433,6 +433,19 @@ fn run_cuda_record(
             weight_decay,
             &state.device,
         )?),
+        Optimizer::Muon {
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        } => Some(params.allocate_muon_state(
+            config.learning_rate,
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+            &state.device,
+        )?),
         Optimizer::Sgd => None,
     };
     if let Some(state_opt) = opt_state.as_ref() {

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -164,16 +164,29 @@ pub struct SftRequest {
 
 /// Optimizer selection for training.
 ///
-/// `Sgd` is plain stochastic gradient descent (`param -= lr * grad`) — the
-/// historical default; dispatched on-device via `dispatch_sgd_step` when the
-/// backend supports residency, otherwise via candle CPU autograd.
+/// `Muon` (Bernstein-Newhouse 2024 / Jordan et al. 2024) is the
+/// **default**: momentum-orthogonalized SGD. It keeps a single per-param
+/// heavy-ball momentum buffer, takes a (Nesterov) look-ahead, and — for
+/// the rank-2 LoRA A/B weight matrices — projects it onto the nearest
+/// semi-orthogonal matrix via a Newton-Schulz iteration before stepping,
+/// then rescales by `sqrt(max(rows, cols))` so the update magnitude is
+/// shape-independent. Dispatched on-device via `dispatch_muon_step`
+/// (fused per-matrix Newton-Schulz kernels — CUDA / ROCm / Vulkan /
+/// Metal) when operands are resident; otherwise the `kiln_optim::Muon`
+/// CPU reference. Muon converges LoRA fine-tunes in fewer steps than
+/// AdamW at roughly half the optimizer state (one momentum buffer vs
+/// Adam's m+v).
 ///
 /// `AdamW` is decoupled-weight-decay Adam (Loshchilov & Hutter 2019);
-/// dispatched on-device via `dispatch_adamw_step` when the backend supports
-/// residency. The trainer allocates per-parameter first/second moment Vars at
-/// init, registers them in the resident-activation registry alongside the
-/// param/grad, and updates all three in-place per step. The CPU fallback runs
-/// the same update via candle ops.
+/// dispatched on-device via `dispatch_adamw_step` when the backend
+/// supports residency. The trainer allocates per-parameter first/second
+/// moment tensors at init, registers them in the resident-activation
+/// registry alongside the param/grad, and updates all three in-place per
+/// step. Select with `{"optimizer": {"kind": "adam_w"}}`.
+///
+/// `Sgd` is plain stochastic gradient descent (`param -= lr * grad`);
+/// dispatched on-device via `dispatch_sgd_step` when the backend
+/// supports residency. Select with `{"optimizer": {"kind": "sgd"}}`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum Optimizer {
@@ -188,15 +201,29 @@ pub enum Optimizer {
         #[serde(default = "default_weight_decay")]
         weight_decay: f32,
     },
+    /// Momentum-orthogonalized SGD (the default). `momentum` is the
+    /// heavy-ball coefficient; `nesterov` toggles the look-ahead;
+    /// `ns_iters` is the Newton-Schulz iteration count (paper uses 5);
+    /// `weight_decay` is decoupled.
+    Muon {
+        #[serde(default = "default_muon_momentum")]
+        momentum: f32,
+        #[serde(default = "default_muon_nesterov")]
+        nesterov: bool,
+        #[serde(default = "default_muon_ns_iters")]
+        ns_iters: u32,
+        #[serde(default = "default_muon_weight_decay")]
+        weight_decay: f32,
+    },
 }
 
 impl Default for Optimizer {
     fn default() -> Self {
-        Optimizer::AdamW {
-            beta1: default_beta1(),
-            beta2: default_beta2(),
-            eps: default_eps(),
-            weight_decay: default_weight_decay(),
+        Optimizer::Muon {
+            momentum: default_muon_momentum(),
+            nesterov: default_muon_nesterov(),
+            ns_iters: default_muon_ns_iters(),
+            weight_decay: default_muon_weight_decay(),
         }
     }
 }
@@ -211,6 +238,18 @@ fn default_eps() -> f32 {
     1e-8
 }
 fn default_weight_decay() -> f32 {
+    0.0
+}
+fn default_muon_momentum() -> f32 {
+    0.95
+}
+fn default_muon_nesterov() -> bool {
+    true
+}
+fn default_muon_ns_iters() -> u32 {
+    5
+}
+fn default_muon_weight_decay() -> f32 {
     0.0
 }
 
@@ -997,6 +1036,79 @@ mod tests {
         let config: GrpoConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.checkpoint_interval, Some(10));
         assert_eq!(config.kl_coeff, 0.1); // default preserved
+    }
+
+    #[test]
+    fn optimizer_default_is_muon() {
+        match Optimizer::default() {
+            Optimizer::Muon {
+                momentum,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            } => {
+                assert_eq!(momentum, 0.95);
+                assert!(nesterov);
+                assert_eq!(ns_iters, 5);
+                assert_eq!(weight_decay, 0.0);
+            }
+            other => panic!("default optimizer should be Muon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn optimizer_muon_serializes_with_kind_muon() {
+        let opt = Optimizer::default();
+        let v: serde_json::Value = serde_json::to_value(opt).unwrap();
+        assert_eq!(v["kind"], "muon");
+        // momentum is an f32 widened to f64 in JSON — compare with tolerance.
+        assert!((v["momentum"].as_f64().unwrap() - 0.95).abs() < 1e-6);
+        assert_eq!(v["nesterov"], true);
+        assert_eq!(v["ns_iters"], 5);
+    }
+
+    #[test]
+    fn optimizer_muon_round_trips() {
+        let opt = Optimizer::Muon {
+            momentum: 0.9,
+            nesterov: false,
+            ns_iters: 7,
+            weight_decay: 0.01,
+        };
+        let json = serde_json::to_string(&opt).unwrap();
+        let back: Optimizer = serde_json::from_str(&json).unwrap();
+        assert_eq!(opt, back);
+    }
+
+    #[test]
+    fn optimizer_muon_minimal_json_fills_defaults() {
+        // Bare `{"kind": "muon"}` must fill every Muon field from defaults.
+        let opt: Optimizer = serde_json::from_str(r#"{"kind": "muon"}"#).unwrap();
+        assert_eq!(opt, Optimizer::default());
+    }
+
+    #[test]
+    fn optimizer_adamw_and_sgd_still_deserialize() {
+        // Back-compat: the old optimizer kinds remain selectable.
+        let adamw: Optimizer = serde_json::from_str(r#"{"kind": "adam_w"}"#).unwrap();
+        assert!(matches!(adamw, Optimizer::AdamW { .. }));
+        let sgd: Optimizer = serde_json::from_str(r#"{"kind": "sgd"}"#).unwrap();
+        assert_eq!(sgd, Optimizer::Sgd);
+    }
+
+    #[test]
+    fn configs_default_to_muon_optimizer() {
+        // Every training-mode config defaults to Muon when no optimizer is given.
+        assert!(matches!(
+            SftConfig::default().optimizer,
+            Optimizer::Muon { .. }
+        ));
+        assert!(matches!(
+            GrpoConfig::default().optimizer,
+            Optimizer::Muon { .. }
+        ));
+        let sft: SftConfig = serde_json::from_str(r#"{"epochs": 2}"#).unwrap();
+        assert!(matches!(sft.optimizer, Optimizer::Muon { .. }));
     }
 
     #[test]

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -2492,6 +2492,23 @@ pub fn opd_train(
             state.register_with_backend(&*backend_rt)?;
             Some(state)
         }
+        Optimizer::Muon {
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        } => {
+            let state = params.allocate_muon_state(
+                config.learning_rate,
+                momentum,
+                nesterov,
+                ns_iters,
+                weight_decay,
+                &device_kt,
+            )?;
+            state.register_with_backend(&*backend_rt)?;
+            Some(state)
+        }
     };
 
     // Tokenize every prompt up-front (cheap relative to the forward

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -497,7 +497,9 @@ use crate::cd_types::*;
 // forward storage) and the optimizer is `kiln_optim::AdamW` (`OptimStep`
 // keyed by `Parameter::tensor_id()`). These REPLACE the candle `Var` +
 // `AdamWMoments{m,v:Var}` + `OptimizerState` machinery.
-use kiln_optim::{AdamW as KtAdamW, AdamWHyperparameters as KtAdamWHyperparameters, OptimStep};
+use kiln_optim::{
+    AdamW as KtAdamW, AdamWHyperparameters as KtAdamWHyperparameters, Muon as KtMuon, OptimStep,
+};
 use kiln_param::{AmpPolicy as KtAmpPolicy, ForwardStorage as KtForwardStorage, Parameter};
 // kt tensor types used directly for LoRA param construction + grads.
 use kiln_tensor::{DType as KtDType, Tensor as KtTensor};
@@ -1017,9 +1019,39 @@ impl TrainableLoraParams {
                 .with_context(|| "allocating AdamW second-moment tensor")?;
             moments.insert(param.tensor_id(), KtAdamWMoments { m, v });
         }
-        Ok(OptimizerState {
+        Ok(OptimizerState::AdamW {
             adamw: KtAdamW::new(hp),
             moments,
+            step: 0,
+        })
+    }
+
+    /// (#1082) Allocate kt-native Muon optimizer state: one zero-init
+    /// device momentum tensor per LoRA `Parameter` (same shape+dtype as
+    /// the param master, on the param's own device so the on-device
+    /// Newton-Schulz kernel's same-device/same-dtype/contiguous gate
+    /// passes), plus the CPU reference `kiln_optim::Muon` host fallback.
+    pub fn allocate_muon_state(
+        &self,
+        lr: f64,
+        momentum: f32,
+        nesterov: bool,
+        ns_iters: u32,
+        weight_decay: f32,
+        _device: &Device,
+    ) -> Result<OptimizerState> {
+        let mut momenta: HashMap<KtTensorId, KtMuonMomentum> = HashMap::new();
+        for param in self.all_params() {
+            let primary = param.forward_storage().primary_tensor();
+            let dims: Vec<usize> = primary.dims().to_vec();
+            let dtype = primary.dtype();
+            let m = KtTensor::zeros_on(primary.device(), dims, dtype)
+                .with_context(|| "allocating Muon momentum tensor")?;
+            momenta.insert(param.tensor_id(), KtMuonMomentum { m });
+        }
+        Ok(OptimizerState::Muon {
+            muon: KtMuon::new(lr as f32, momentum, nesterov, ns_iters, weight_decay),
+            momenta,
             step: 0,
         })
     }
@@ -1045,57 +1077,119 @@ pub struct KtAdamWMoments {
     pub v: KtTensor,
 }
 
-/// (#1082) kt-native optimizer state.
+/// (#1082) Muon per-parameter momentum device tensor.
 ///
-/// - `moments`: per-param device `m`/`v` (keyed by `Parameter::tensor_id()`)
-///   that the on-device CUDA AdamW kernel updates in place. This is the
-///   real Adam state on the resident/device path.
-/// - `adamw`: the CPU reference `kiln_optim::AdamW` — the genuine host
-///   fallback for the non-resident path (owns its own host-side moments).
-/// - `step`: global 1-indexed step counter, bumped once per optimizer step
-///   (all params share it — standard AdamW bias correction). Restores the
-///   pre-flip `OptimizerState.step`. Used as the `step` argument the CUDA
-///   kernel turns into the bias-correction terms.
+/// `m` is a zero-init kt tensor of the same shape+dtype as the LoRA
+/// param master, allocated on the param's device. The on-device Muon
+/// kernel (`runtime_dispatch_muon_step`) reads+writes it in place each
+/// step (heavy-ball momentum), then orthogonalizes the look-ahead and
+/// updates the param. Unlike AdamW there is no second moment — Muon's
+/// state is a single momentum buffer per parameter.
+pub struct KtMuonMomentum {
+    pub m: KtTensor,
+}
+
+/// (#1082) kt-native optimizer state. One variant per stateful
+/// optimizer; SGD is stateless and passes `None`.
+///
+/// - [`OptimizerState::AdamW`]: per-param device `m`/`v` (the real Adam
+///   state on the resident/device path) + the CPU reference
+///   `kiln_optim::AdamW` host fallback + a global 1-indexed `step`
+///   counter (standard AdamW bias correction).
+/// - [`OptimizerState::Muon`]: per-param device momentum `m` (the
+///   heavy-ball state the on-device Newton-Schulz kernel updates) + the
+///   CPU reference `kiln_optim::Muon` host fallback + a global `step`
+///   counter (used only as a stochastic-rounding decorrelator on the
+///   host path; Muon needs no bias correction).
 ///
 /// The wrapper keeps the trainer's `opt_state: Option<&mut OptimizerState>`
-/// signatures unchanged; SGD passes `None`, AdamW passes `Some(&mut state)`.
-pub struct OptimizerState {
-    pub adamw: KtAdamW,
-    pub moments: HashMap<KtTensorId, KtAdamWMoments>,
-    pub step: u32,
+/// signatures unchanged across all dispatch sites.
+pub enum OptimizerState {
+    AdamW {
+        adamw: KtAdamW,
+        moments: HashMap<KtTensorId, KtAdamWMoments>,
+        step: u32,
+    },
+    Muon {
+        muon: KtMuon,
+        momenta: HashMap<KtTensorId, KtMuonMomentum>,
+        step: u32,
+    },
 }
 
 impl OptimizerState {
-    /// Register every per-param `m`/`v` device tensor as a resident
-    /// activation so `dispatch_adamw_step`'s `has_resident_activation(m/v)`
-    /// gate passes and the on-device kernel fires (otherwise it returns
-    /// `false` → host fallback). Restores the pre-flip
-    /// `OptimizerState::register_with_backend`, which the candle-drop interim
-    /// had turned into a no-op (leaving the on-device kernel running with
-    /// garbage m/v).
+    /// Register every per-param device state tensor as a resident
+    /// activation so the on-device kernel's `has_resident_activation`
+    /// gate passes (otherwise it returns `false` → host fallback). For
+    /// AdamW that is `m`+`v`; for Muon the single momentum `m`.
     ///
     /// No-op on backends without resident-activation support (the host
-    /// `kiln_optim::AdamW` fallback handles those).
+    /// `kiln_optim` references handle those).
     pub fn register_with_backend(&self, backend: &dyn BackendRuntime) -> Result<()> {
         if !ResidencyBackend::runtime_supports_resident_activation(backend) {
             return Ok(());
         }
-        for moments in self.moments.values() {
-            ResidencyBackend::runtime_register_resident_activation(backend, &moments.m)?;
-            ResidencyBackend::runtime_register_resident_activation(backend, &moments.v)?;
+        match self {
+            OptimizerState::AdamW { moments, .. } => {
+                for m in moments.values() {
+                    ResidencyBackend::runtime_register_resident_activation(backend, &m.m)?;
+                    ResidencyBackend::runtime_register_resident_activation(backend, &m.v)?;
+                }
+            }
+            OptimizerState::Muon { momenta, .. } => {
+                for mom in momenta.values() {
+                    ResidencyBackend::runtime_register_resident_activation(backend, &mom.m)?;
+                }
+            }
         }
         Ok(())
     }
 
-    /// Inverse of [`Self::register_with_backend`]: release every moment
+    /// Inverse of [`Self::register_with_backend`]: release every state
     /// tensor from the resident registry at training completion.
     pub fn evict_from_backend(&self, backend: &dyn BackendRuntime) {
         if !ResidencyBackend::runtime_supports_resident_activation(backend) {
             return;
         }
-        for moments in self.moments.values() {
-            ResidencyBackend::runtime_evict_resident_activation(backend, &moments.m);
-            ResidencyBackend::runtime_evict_resident_activation(backend, &moments.v);
+        match self {
+            OptimizerState::AdamW { moments, .. } => {
+                for m in moments.values() {
+                    ResidencyBackend::runtime_evict_resident_activation(backend, &m.m);
+                    ResidencyBackend::runtime_evict_resident_activation(backend, &m.v);
+                }
+            }
+            OptimizerState::Muon { momenta, .. } => {
+                for mom in momenta.values() {
+                    ResidencyBackend::runtime_evict_resident_activation(backend, &mom.m);
+                }
+            }
+        }
+    }
+
+    /// The global 1-indexed optimizer step counter (shared by both
+    /// stateful variants).
+    pub fn step_count(&self) -> u32 {
+        match self {
+            OptimizerState::AdamW { step, .. } => *step,
+            OptimizerState::Muon { step, .. } => *step,
+        }
+    }
+
+    /// AdamW per-param moment map, if this is AdamW state (diagnostic /
+    /// test accessor).
+    pub fn adamw_moments(&self) -> Option<&HashMap<KtTensorId, KtAdamWMoments>> {
+        match self {
+            OptimizerState::AdamW { moments, .. } => Some(moments),
+            OptimizerState::Muon { .. } => None,
+        }
+    }
+
+    /// Muon per-param momentum map, if this is Muon state (diagnostic /
+    /// test accessor).
+    pub fn muon_momenta(&self) -> Option<&HashMap<KtTensorId, KtMuonMomentum>> {
+        match self {
+            OptimizerState::Muon { momenta, .. } => Some(momenta),
+            OptimizerState::AdamW { .. } => None,
         }
     }
 }
@@ -1122,6 +1216,19 @@ fn make_opt_state(
             beta1,
             beta2,
             eps,
+            weight_decay,
+            device,
+        )?)),
+        Optimizer::Muon {
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        } => Ok(Some(params.allocate_muon_state(
+            lr,
+            momentum,
+            nesterov,
+            ns_iters,
             weight_decay,
             device,
         )?)),
@@ -6958,6 +7065,114 @@ fn apply_adamw_update_kt(
     Ok(())
 }
 
+/// (#1082) Apply one Muon step to a single LoRA `Parameter`.
+///
+/// On-device path (resident): when the param **and** its per-param
+/// momentum device tensor are both resident, dispatch the fused Muon
+/// kernel (`runtime_dispatch_muon_step`) which updates **param and
+/// momentum in place** in one launch — heavy-ball momentum, then (for
+/// rank-2 matrices) Newton-Schulz orthogonalization of the (Nesterov)
+/// look-ahead with the RMS-matching scale, then the decoupled-weight-
+/// decay descent step. The forward storage shares the master tensor
+/// (LoRA A/B are plain dense BF16, forward primary == master), so the
+/// in-place update is immediately visible to the next forward.
+///
+/// Host fallback (non-resident): drive the CPU reference
+/// `kiln_optim::Muon` (`OptimStep::step`), which owns its own host-side
+/// momentum keyed by `Parameter::tensor_id()` and installs the new
+/// master via `replace_backward_storage` (preserving `tensor_id`). The
+/// forward storage is refreshed from the new master.
+///
+/// `lr` and the Muon hyperparameters are threaded directly from the
+/// optimizer config each step (honouring the LR schedule).
+#[allow(clippy::too_many_arguments)]
+fn apply_muon_update_kt(
+    backend: &dyn BackendRuntime,
+    param: &mut Parameter,
+    muon: &mut KtMuon,
+    momentum_state: Option<&KtMuonMomentum>,
+    grad: &KtTensor,
+    lr: f64,
+    momentum: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+    resident_activation: bool,
+) -> Result<()> {
+    let primary = param.forward_storage().primary_tensor().clone();
+    // On-device registry path: param + grad + the per-param momentum
+    // must all be resident, then the kernel updates param/momentum in
+    // place.
+    if let Some(momentum_state) = momentum_state {
+        if resident_activation
+            && ResidencyBackend::runtime_has_resident_activation(backend, &primary)
+            && ResidencyBackend::runtime_has_resident_activation(backend, &momentum_state.m)
+        {
+            ResidencyBackend::runtime_register_resident_activation(backend, grad)?;
+            let dispatched = match OptimizerBackend::runtime_dispatch_muon_step(
+                backend,
+                &primary,
+                grad,
+                &momentum_state.m,
+                lr as f32,
+                momentum,
+                nesterov,
+                ns_iters,
+                weight_decay,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    ResidencyBackend::runtime_evict_resident_activation(backend, grad);
+                    return Err(e);
+                }
+            };
+            if dispatched {
+                // The kernel updated param/momentum in place. Forward
+                // primary IS the master for LoRA params, so the update
+                // is already live; re-assert residency for the next fwd.
+                ResidencyBackend::runtime_evict_resident_activation(backend, grad);
+                ResidencyBackend::runtime_update_resident_activation(backend, &primary)?;
+                return Ok(());
+            }
+            ResidencyBackend::runtime_evict_resident_activation(backend, grad);
+        }
+    }
+
+    ensure_training_optimizer_fallback_allowed(backend, primary.device(), "Muon")?;
+    // Host fallback: drive the CPU reference `kiln_optim::Muon`. Thread
+    // the scheduled lr + config hyperparameters in so the host path
+    // honours the LR schedule and keeps the optimizer config the single
+    // source of truth. The host Muon owns its own host-side momentum +
+    // step counter keyed by `tensor_id`.
+    muon.lr = lr as f32;
+    muon.momentum = momentum;
+    muon.nesterov = nesterov;
+    muon.ns_iters = ns_iters;
+    muon.weight_decay = weight_decay;
+    let want = param.amp_policy().backward_compute_dtype;
+    let grad_cast = if grad.dtype() == want {
+        grad.clone()
+    } else {
+        grad.to_dtype(want)
+            .map_err(|e| anyhow::anyhow!("apply_muon_update_kt: grad to {want:?}: {e}"))?
+    };
+    muon.step(param, &grad_cast)
+        .map_err(|e| anyhow::anyhow!("apply_muon_update_kt: kiln_optim Muon step: {e}"))?;
+    // `Muon::step` swaps the master via `replace_backward_storage`
+    // (preserving tensor_id). Refresh the forward storage from the new
+    // master so the next forward reads the updated weights.
+    if let Some(new_master) = param.backward_storage().cloned() {
+        param.replace_forward_storage(KtForwardStorage::Plain(new_master));
+    }
+    if resident_activation {
+        ResidencyBackend::runtime_update_resident_activation(
+            backend,
+            param.forward_storage().primary_tensor(),
+        )?;
+    }
+    Ok(())
+}
+
 /// (#1082) Accumulate kt gradients from a kt-native [`kiln_autograd::GradStore`]
 /// (keyed by `Parameter::tensor_id()`) into `dst` (a kt `GradMap`).
 /// Creates entries for any LoRA param with a grad in `src` but not yet in
@@ -7036,39 +7251,88 @@ pub(crate) fn optimizer_step_from_map(
             let state = opt_state.ok_or_else(|| {
                 anyhow::anyhow!("optimizer_step_from_map: AdamW requires OptimizerState")
             })?;
+            let resident_activation =
+                ResidencyBackend::runtime_supports_resident_activation(backend);
             // Global 1-indexed step counter (shared by all params), bumped
             // once per optimizer step for AdamW bias correction. Disjoint
             // borrows of `adamw` (mut, host fallback) vs `moments` (shared,
-            // device m/v) via destructuring.
-            state.step = state.step.saturating_add(1);
-            let OptimizerState {
-                adamw,
-                moments,
-                step,
-            } = state;
-            let step = *step;
+            // device m/v) via the match binding.
+            match state {
+                OptimizerState::AdamW {
+                    adamw,
+                    moments,
+                    step,
+                } => {
+                    *step = step.saturating_add(1);
+                    let step = *step;
+                    for param in params.all_params_mut() {
+                        if let Some(grad) = grads.get(&param.tensor_id()) {
+                            let m = moments.get(&param.tensor_id());
+                            apply_adamw_update_kt(
+                                backend,
+                                param,
+                                adamw,
+                                m,
+                                grad,
+                                lr,
+                                beta1,
+                                beta2,
+                                eps,
+                                weight_decay,
+                                step,
+                                resident_activation,
+                            )?;
+                        }
+                    }
+                    Ok(())
+                }
+                _ => anyhow::bail!(
+                    "optimizer_step_from_map: AdamW optimizer requires AdamW OptimizerState"
+                ),
+            }
+        }
+        Optimizer::Muon {
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        } => {
+            let state = opt_state.ok_or_else(|| {
+                anyhow::anyhow!("optimizer_step_from_map: Muon requires OptimizerState")
+            })?;
             let resident_activation =
                 ResidencyBackend::runtime_supports_resident_activation(backend);
-            for param in params.all_params_mut() {
-                if let Some(grad) = grads.get(&param.tensor_id()) {
-                    let m = moments.get(&param.tensor_id());
-                    apply_adamw_update_kt(
-                        backend,
-                        param,
-                        adamw,
-                        m,
-                        grad,
-                        lr,
-                        beta1,
-                        beta2,
-                        eps,
-                        weight_decay,
-                        step,
-                        resident_activation,
-                    )?;
+            match state {
+                OptimizerState::Muon {
+                    muon,
+                    momenta,
+                    step,
+                } => {
+                    *step = step.saturating_add(1);
+                    for param in params.all_params_mut() {
+                        if let Some(grad) = grads.get(&param.tensor_id()) {
+                            let mom = momenta.get(&param.tensor_id());
+                            apply_muon_update_kt(
+                                backend,
+                                param,
+                                muon,
+                                mom,
+                                grad,
+                                lr,
+                                momentum,
+                                nesterov,
+                                ns_iters,
+                                weight_decay,
+                                resident_activation,
+                            )?;
+                        }
+                    }
+                    Ok(())
                 }
+                _ => anyhow::bail!(
+                    "optimizer_step_from_map: Muon optimizer requires Muon OptimizerState"
+                ),
             }
-            Ok(())
         }
     }
 }
@@ -7114,39 +7378,88 @@ pub(crate) fn optimizer_step_from_kt_grad_store(
             let state = opt_state.ok_or_else(|| {
                 anyhow::anyhow!("optimizer_step_from_kt_grad_store: AdamW requires OptimizerState")
             })?;
+            let resident_activation =
+                ResidencyBackend::runtime_supports_resident_activation(backend);
             // Global 1-indexed step counter (shared by all params), bumped
             // once per optimizer step for AdamW bias correction. Disjoint
             // borrows of `adamw` (mut, host fallback) vs `moments` (shared,
-            // device m/v) via destructuring.
-            state.step = state.step.saturating_add(1);
-            let OptimizerState {
-                adamw,
-                moments,
-                step,
-            } = state;
-            let step = *step;
+            // device m/v) via the match binding.
+            match state {
+                OptimizerState::AdamW {
+                    adamw,
+                    moments,
+                    step,
+                } => {
+                    *step = step.saturating_add(1);
+                    let step = *step;
+                    for param in params.all_params_mut() {
+                        if let Some(kt_grad) = grads.get(param.tensor_id()) {
+                            let m = moments.get(&param.tensor_id());
+                            apply_adamw_update_kt(
+                                backend,
+                                param,
+                                adamw,
+                                m,
+                                kt_grad,
+                                lr,
+                                beta1,
+                                beta2,
+                                eps,
+                                weight_decay,
+                                step,
+                                resident_activation,
+                            )?;
+                        }
+                    }
+                    Ok(())
+                }
+                _ => anyhow::bail!(
+                    "optimizer_step_from_kt_grad_store: AdamW optimizer requires AdamW OptimizerState"
+                ),
+            }
+        }
+        Optimizer::Muon {
+            momentum,
+            nesterov,
+            ns_iters,
+            weight_decay,
+        } => {
+            let state = opt_state.ok_or_else(|| {
+                anyhow::anyhow!("optimizer_step_from_kt_grad_store: Muon requires OptimizerState")
+            })?;
             let resident_activation =
                 ResidencyBackend::runtime_supports_resident_activation(backend);
-            for param in params.all_params_mut() {
-                if let Some(kt_grad) = grads.get(param.tensor_id()) {
-                    let m = moments.get(&param.tensor_id());
-                    apply_adamw_update_kt(
-                        backend,
-                        param,
-                        adamw,
-                        m,
-                        kt_grad,
-                        lr,
-                        beta1,
-                        beta2,
-                        eps,
-                        weight_decay,
-                        step,
-                        resident_activation,
-                    )?;
+            match state {
+                OptimizerState::Muon {
+                    muon,
+                    momenta,
+                    step,
+                } => {
+                    *step = step.saturating_add(1);
+                    for param in params.all_params_mut() {
+                        if let Some(kt_grad) = grads.get(param.tensor_id()) {
+                            let mom = momenta.get(&param.tensor_id());
+                            apply_muon_update_kt(
+                                backend,
+                                param,
+                                muon,
+                                mom,
+                                kt_grad,
+                                lr,
+                                momentum,
+                                nesterov,
+                                ns_iters,
+                                weight_decay,
+                                resident_activation,
+                            )?;
+                        }
+                    }
+                    Ok(())
                 }
+                _ => anyhow::bail!(
+                    "optimizer_step_from_kt_grad_store: Muon optimizer requires Muon OptimizerState"
+                ),
             }
-            Ok(())
         }
     }
 }
@@ -11695,10 +12008,11 @@ pub(crate) mod tests {
         // `m`/`v`), so we read `OptimizerState.step` (the C1-restored global
         // counter) and validate the DEVICE moment tensors directly.
         assert_eq!(
-            opt_state.step as usize, finite_steps,
+            opt_state.step_count() as usize,
+            finite_steps,
             "CP-4 convergence: global AdamW step counter should equal finite steps taken \
              ({finite_steps}), got {}",
-            opt_state.step
+            opt_state.step_count()
         );
         // Every LoRA param must have a real per-param device `m`/`v` moment
         // tensor, and after the on-device updates both must stay finite (no
@@ -11709,7 +12023,7 @@ pub(crate) mod tests {
         let mut stepped = 0usize;
         let mut any_v_nonzero = false;
         for id in params.all_params().iter().map(|p| p.tensor_id()) {
-            if let Some(moments) = opt_state.moments.get(&id) {
+            if let Some(moments) = opt_state.adamw_moments().and_then(|m| m.get(&id)) {
                 stepped += 1;
                 for (name, t) in [("m", &moments.m), ("v", &moments.v)] {
                     let vals = t

--- a/crates/kiln-vulkan-kernel/build.rs
+++ b/crates/kiln-vulkan-kernel/build.rs
@@ -317,6 +317,8 @@ const SHADERS: &[(&str, &str)] = &[
     ("sgd_step_bf16", "SPIR_V_SGD_STEP_BF16"),
     ("adamw_step_f32", "SPIR_V_ADAMW_STEP_F32"),
     ("adamw_step_bf16", "SPIR_V_ADAMW_STEP_BF16"),
+    ("muon_step_f32", "SPIR_V_MUON_STEP_F32"),
+    ("muon_step_bf16", "SPIR_V_MUON_STEP_BF16"),
     // vk-native training shaders (Phase A)
     (
         "vk_elementwise_binary_f32",

--- a/crates/kiln-vulkan-kernel/csrc/shaders/muon_step_bf16.comp
+++ b/crates/kiln-vulkan-kernel/csrc/shaders/muon_step_bf16.comp
@@ -1,0 +1,372 @@
+// Fused Muon parameter update for BF16 buffers (momentum-orthogonalized SGD).
+//
+// Muon (Bernstein-Newhouse 2024 / Jordan et al. 2024). One workgroup
+// per matrix: heavy-ball momentum update in place, then (for rank-2
+// weights small enough to fit the gram in shared memory) a Newton-Schulz
+// quintic orthogonalization of the (Nesterov) look-ahead direction with
+// the RMS-matching `sqrt(max(rows, cols))` scale, then a decoupled-weight-
+// decay descent step. Non-matrix params and ranks beyond K_MAX fall back
+// to plain (Nesterov) momentum SGD inside the kernel.
+//
+// This mirrors EXACTLY the production CPU reference / oracle
+// `kiln_optim::lion_muon::Muon::step` + `newton_schulz` (the gram-space
+// P-accumulator factoring): `O = (P @ B) / ‖B‖_F` when rows ≤ cols, or
+// `(B @ P) / ‖B‖_F` when rows > cols, with the per-iteration k×k matrix
+// `M = a·I + b·A + c·A²` and coefficients `(a, b, c) = (3.4445, -4.7750,
+// 2.0315)`.
+//
+// param, grad, momentum are all BF16-packed (2 lanes per u32 word, same
+// `(hi << 16) | lo` encoding as `adamw_step_bf16.comp` /
+// `extract_tensor_packed_bf16_bytes`). They share the same row-major
+// [rows, cols] layout (cols == 1 for a non-2D param) and the same element
+// count `n = rows*cols`. param AND momentum are updated in place; grad is
+// read-only. All gram / apply math runs in f32 (bf16↔f32 bit-expansion);
+// the in-place writes are WORD-indexed (one thread per u32 word updates
+// both lanes) so adjacent elements sharing a word never race, while the
+// read-only element-addressable reads unpack the single bf16 lane for an
+// arbitrary element index. The last u32 may have only its lo lane valid
+// when n is odd, in which case the hi lane is preserved on write.
+//
+// ONE workgroup of 256 threads; ALL barriers are full workgroup barriers
+// (single block). Used by `dispatch_muon_step_bf16` against registry-
+// resident LoRA param + grad + momentum buffers. Dispatched (1,1,1) —
+// one launch per matrix.
+
+#version 450
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+// K_MAX: gram side bound. 4 shared k×k float scratch matrices at K_MAX=32
+// are 4*32*32*4 = 16 KiB, safe across Vulkan GPUs (incl. RTX 6000 Ada).
+const uint K_MAX = 32u;
+const uint BLK = 256u;
+
+layout(push_constant) uniform Parameters {
+    uint n;            // total bf16 element count = rows*cols
+    uint rows;
+    uint cols;
+    uint ns_iters;     // Newton-Schulz iterations (paper: 5)
+    float lr;
+    float mom;         // heavy-ball momentum coefficient
+    uint nesterov;     // 0 | 1
+    float wd;          // decoupled weight decay
+};
+
+layout(binding = 0) buffer ParamBuf { uint data_param[]; };
+layout(binding = 1) readonly buffer GradBuf { uint data_grad[]; };
+layout(binding = 2) buffer MomentumBuf { uint data_mom[]; };
+
+// Shared k×k scratch. All float. Total = 4 * 32*32 * 4 = 16 KiB, the
+// Vulkan spec minimum for maxComputeSharedMemorySize — safe across all
+// Vulkan GPUs (incl. the RTX 6000 Ada target). The STEP 2 Frobenius
+// block reduction reuses `Tm` (BLK=256 <= K_MAX*K_MAX=1024 floats) since
+// it runs before any of A/M/P/Tm hold gram state.
+shared float A[K_MAX * K_MAX];
+shared float M[K_MAX * K_MAX];
+shared float P[K_MAX * K_MAX];
+shared float Tm[K_MAX * K_MAX];
+
+float bf16_to_f32(uint bits16) {
+    return uintBitsToFloat(bits16 << 16);
+}
+
+uint f32_to_bf16(float v) {
+    uint b = floatBitsToUint(v);
+    // Round-to-nearest-even truncation (matches adamw_step_bf16.comp).
+    uint rounded = b + ((b >> 16) & 1u) + 0x7fffu;
+    return rounded >> 16;
+}
+
+// Element-addressable single-lane bf16 read for an arbitrary element
+// index, returning f32. (Same lane layout as the packed word: even
+// element -> lo 16 bits, odd element -> hi 16 bits.)
+float load_bf16(uint elem, uint base) {
+    // `base` selects the buffer: 0 = param, 1 = grad, 2 = momentum.
+    uint word_idx = elem >> 1;
+    uint w;
+    if (base == 1u) {
+        w = data_grad[word_idx];
+    } else if (base == 2u) {
+        w = data_mom[word_idx];
+    } else {
+        w = data_param[word_idx];
+    }
+    uint lane16 = ((elem & 1u) == 0u) ? (w & 0xffffu) : (w >> 16);
+    return bf16_to_f32(lane16);
+}
+
+// bval(idx) = nesterov ? (grad + mom*momentum) : momentum, reading the
+// already-updated momentum buffer (STEP 1 must run first).
+float bval(uint elem) {
+    float m = load_bf16(elem, 2u);
+    if (nesterov != 0u) {
+        return load_bf16(elem, 1u) + mom * m;
+    }
+    return m;
+}
+
+void main() {
+    uint tid = gl_LocalInvocationID.x;
+    uint num_words = (n + 1u) >> 1;
+
+    // Derived shape quantities (same on every thread).
+    uint k = min(rows, cols);
+    bool transpose = (rows > cols);      // false => gram in row space (k=rows)
+    float scale = sqrt(float(max(rows, cols)));
+    bool do_ortho = (rows >= 2u) && (cols >= 2u) && (k <= K_MAX);
+
+    // STEP 1 — heavy-ball momentum update, in place:
+    //   momentum = mom*momentum + grad
+    // WORD-indexed so both lanes are updated by one thread (no race);
+    // odd-length last word preserves its hi lane.
+    for (uint w = tid; w < num_words; w += BLK) {
+        uint base = w * 2u;
+        uint m_word = data_mom[w];
+        uint g_word = data_grad[w];
+        float m0 = mom * bf16_to_f32(m_word & 0xffffu) + bf16_to_f32(g_word & 0xffffu);
+        float m1 = mom * bf16_to_f32(m_word >> 16) + bf16_to_f32(g_word >> 16);
+        uint m0_b = f32_to_bf16(m0);
+        uint m1_b = f32_to_bf16(m1);
+        if (base + 1u < n) {
+            data_mom[w] = m0_b | (m1_b << 16);
+        } else if (base < n) {
+            data_mom[w] = (m_word & 0xffff0000u) | (m0_b & 0xffffu);
+        }
+    }
+    // momentum[] is an SSBO written above by THIS thread (word-indexed) and read
+    // CROSS-THREAD in STEP 2/3/5 (load_bf16 reads lanes owned by other
+    // invocations). `memoryBarrierShared()` only orders shared memory, so the
+    // buffer write must be released with workgroup-scope buffer ordering BEFORE
+    // the control barrier publishes it. `groupMemoryBarrier()` covers buffer +
+    // shared at workgroup scope.
+    groupMemoryBarrier();
+    barrier();
+    // momentum[] is now updated and visible workgroup-wide; bval reads it below.
+
+    // STEP 1b — if NOT do_ortho: plain (Nesterov) momentum SGD, then return.
+    // WORD-indexed in-place param write.
+    if (!do_ortho) {
+        for (uint w = tid; w < num_words; w += BLK) {
+            uint base = w * 2u;
+            uint p_word = data_param[w];
+            float b0 = bval(base);
+            float b1 = bval(base + 1u);
+            float p0 = bf16_to_f32(p_word & 0xffffu);
+            float p1 = bf16_to_f32(p_word >> 16);
+            p0 = p0 * (1.0 - lr * wd) - lr * b0;
+            p1 = p1 * (1.0 - lr * wd) - lr * b1;
+            uint p0_b = f32_to_bf16(p0);
+            uint p1_b = f32_to_bf16(p1);
+            if (base + 1u < n) {
+                data_param[w] = p0_b | (p1_b << 16);
+            } else if (base < n) {
+                data_param[w] = (p_word & 0xffff0000u) | (p0_b & 0xffffu);
+            }
+        }
+        return;
+    }
+
+    // STEP 2 — Frobenius norm of b: frob2 = sum_idx bval(idx)^2.
+    float partial = 0.0;
+    for (uint idx = tid; idx < n; idx += BLK) {
+        float b = bval(idx);
+        partial += b * b;
+    }
+    Tm[tid] = partial;
+    barrier();
+    memoryBarrierShared();
+    // Tree reduction over the 256-wide block (scratch in Tm[0..BLK)).
+    [[unroll]] for (uint stride = BLK >> 1; stride > 0u; stride >>= 1) {
+        if (tid < stride) {
+            Tm[tid] += Tm[tid + stride];
+        }
+        barrier();
+        memoryBarrierShared();
+    }
+    float frob2 = Tm[0];
+    barrier();
+    memoryBarrierShared();
+
+    if (frob2 == 0.0) {
+        // Only weight decay acts. WORD-indexed in-place write.
+        for (uint w = tid; w < num_words; w += BLK) {
+            uint base = w * 2u;
+            uint p_word = data_param[w];
+            float p0 = bf16_to_f32(p_word & 0xffffu) * (1.0 - lr * wd);
+            float p1 = bf16_to_f32(p_word >> 16) * (1.0 - lr * wd);
+            uint p0_b = f32_to_bf16(p0);
+            uint p1_b = f32_to_bf16(p1);
+            if (base + 1u < n) {
+                data_param[w] = p0_b | (p1_b << 16);
+            } else if (base < n) {
+                data_param[w] = (p_word & 0xffff0000u) | (p0_b & 0xffffu);
+            }
+        }
+        return;
+    }
+    float inv_frob = 1.0 / sqrt(frob2);
+    float inv_frob2 = 1.0 / frob2;
+
+    // STEP 3 — gram A (k x k), normalized by inv_frob2.
+    for (uint pair = tid; pair < k * k; pair += BLK) {
+        uint i = pair / k;
+        uint j = pair % k;
+        float s = 0.0;
+        if (!transpose) {
+            // A = B Bt : rows of B (length cols).
+            for (uint c = 0u; c < cols; ++c) {
+                s += bval(i * cols + c) * bval(j * cols + c);
+            }
+        } else {
+            // A = Bt B : columns of B (length rows).
+            for (uint r = 0u; r < rows; ++r) {
+                s += bval(r * cols + i) * bval(r * cols + j);
+            }
+        }
+        A[pair] = s * inv_frob2;
+    }
+    barrier();
+    memoryBarrierShared();
+
+    // STEP 4 — P-accumulator Newton-Schulz.
+    // P starts = I_k.
+    for (uint idx = tid; idx < k * k; idx += BLK) {
+        P[idx] = (idx / k == idx % k) ? 1.0 : 0.0;
+    }
+    barrier();
+    memoryBarrierShared();
+
+    const float ca = 3.4445;
+    const float cb = -4.7750;
+    const float cc = 2.0315;
+
+    for (uint iter = 0u; iter < ns_iters; ++iter) {
+        // Tm = A @ A.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += A[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // M = a*I + b*A + c*Tm.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float id = (i == j) ? 1.0 : 0.0;
+            M[pair] = ca * id + cb * A[pair] + cc * Tm[pair];
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // P <- (NOT transpose ? M @ P : P @ M).
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            if (!transpose) {
+                for (uint t = 0u; t < k; ++t) {
+                    s += M[i * k + t] * P[t * k + j];
+                }
+            } else {
+                for (uint t = 0u; t < k; ++t) {
+                    s += P[i * k + t] * M[t * k + j];
+                }
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+        for (uint idx = tid; idx < k * k; idx += BLK) {
+            P[idx] = Tm[idx];
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // A <- M @ A @ M  (M symmetric): Tm = M@A ; A = Tm@M.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += M[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += Tm[i * k + t] * M[t * k + j];
+            }
+            A[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+    }
+
+    // STEP 5 — apply: O = (P@B or B@P) * inv_frob, RMS-scaled; descent
+    // with decoupled WD. WORD-indexed in-place param write: each thread
+    // owns one u32 word (two elements), computing O for each lane via the
+    // element-addressable bval reads against P in shared memory.
+    for (uint w = tid; w < num_words; w += BLK) {
+        uint base = w * 2u;
+        uint p_word = data_param[w];
+
+        // lane 0 = element `base`, lane 1 = element `base + 1`.
+        float o0 = 0.0;
+        float o1 = 0.0;
+
+        {
+            uint idx = base;
+            uint r = idx / cols;
+            uint c = idx % cols;
+            if (!transpose) {
+                for (uint t = 0u; t < k; ++t) {
+                    o0 += P[r * k + t] * bval(t * cols + c);
+                }
+            } else {
+                for (uint t = 0u; t < k; ++t) {
+                    o0 += bval(r * cols + t) * P[t * k + c];
+                }
+            }
+            o0 *= scale * inv_frob;
+        }
+        if (base + 1u < n) {
+            uint idx = base + 1u;
+            uint r = idx / cols;
+            uint c = idx % cols;
+            if (!transpose) {
+                for (uint t = 0u; t < k; ++t) {
+                    o1 += P[r * k + t] * bval(t * cols + c);
+                }
+            } else {
+                for (uint t = 0u; t < k; ++t) {
+                    o1 += bval(r * cols + t) * P[t * k + c];
+                }
+            }
+            o1 *= scale * inv_frob;
+        }
+
+        float p0 = bf16_to_f32(p_word & 0xffffu);
+        float p1 = bf16_to_f32(p_word >> 16);
+        p0 = p0 * (1.0 - lr * wd) - lr * o0;
+        p1 = p1 * (1.0 - lr * wd) - lr * o1;
+        uint p0_b = f32_to_bf16(p0);
+        uint p1_b = f32_to_bf16(p1);
+        if (base + 1u < n) {
+            data_param[w] = p0_b | (p1_b << 16);
+        } else if (base < n) {
+            data_param[w] = (p_word & 0xffff0000u) | (p0_b & 0xffffu);
+        }
+    }
+}

--- a/crates/kiln-vulkan-kernel/csrc/shaders/muon_step_f32.comp
+++ b/crates/kiln-vulkan-kernel/csrc/shaders/muon_step_f32.comp
@@ -1,0 +1,289 @@
+// Fused Muon parameter update for F32 buffers (momentum-orthogonalized SGD).
+//
+// Muon (Bernstein-Newhouse 2024 / Jordan et al. 2024). One workgroup
+// per matrix: heavy-ball momentum update in place, then (for rank-2
+// weights small enough to fit the gram in shared memory) a Newton-Schulz
+// quintic orthogonalization of the (Nesterov) look-ahead direction with
+// the RMS-matching `sqrt(max(rows, cols))` scale, then a decoupled-weight-
+// decay descent step. Non-matrix params and ranks beyond K_MAX fall back
+// to plain (Nesterov) momentum SGD inside the kernel.
+//
+// This mirrors EXACTLY the production CPU reference / oracle
+// `kiln_optim::lion_muon::Muon::step` + `newton_schulz` (the gram-space
+// P-accumulator factoring): `O = (P @ B) / ‖B‖_F` when rows ≤ cols, or
+// `(B @ P) / ‖B‖_F` when rows > cols, with the per-iteration k×k matrix
+// `M = a·I + b·A + c·A²` and coefficients `(a, b, c) = (3.4445, -4.7750,
+// 2.0315)`.
+//
+// param, grad, momentum are all F32, share the same row-major [rows, cols]
+// layout (cols == 1 for a non-2D param) and the same element count
+// `n = rows*cols`. param AND momentum are updated in place; grad is
+// read-only. ONE workgroup of 256 threads; ALL barriers are full
+// workgroup barriers (single block).
+//
+// Used by `dispatch_muon_step_f32` against registry-resident LoRA
+// param + grad + momentum buffers. Dispatched (1,1,1) — one launch per
+// matrix.
+
+#version 450
+#extension GL_EXT_control_flow_attributes : enable
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+// K_MAX: gram side bound. 4 shared k×k float scratch matrices at K_MAX=32
+// are 4*32*32*4 = 16 KiB, safe across Vulkan GPUs (incl. RTX 6000 Ada).
+const uint K_MAX = 32u;
+const uint BLK = 256u;
+
+layout(push_constant) uniform Parameters {
+    uint n;            // total element count = rows*cols
+    uint rows;
+    uint cols;
+    uint ns_iters;     // Newton-Schulz iterations (paper: 5)
+    float lr;
+    float mom;         // heavy-ball momentum coefficient
+    uint nesterov;     // 0 | 1
+    float wd;          // decoupled weight decay
+};
+
+layout(binding = 0) buffer ParamBuf { float data_param[]; };
+layout(binding = 1) readonly buffer GradBuf { float data_grad[]; };
+layout(binding = 2) buffer MomentumBuf { float data_mom[]; };
+
+// Shared k×k scratch. All float. Total = 4 * 32*32 * 4 = 16 KiB, the
+// Vulkan spec minimum for maxComputeSharedMemorySize — safe across all
+// Vulkan GPUs (incl. the RTX 6000 Ada target). The STEP 2 Frobenius
+// block reduction reuses `Tm` (BLK=256 <= K_MAX*K_MAX=1024 floats) since
+// it runs before any of A/M/P/Tm hold gram state.
+shared float A[K_MAX * K_MAX];
+shared float M[K_MAX * K_MAX];
+shared float P[K_MAX * K_MAX];
+shared float Tm[K_MAX * K_MAX];
+
+// F32 to_f / from_f are identity (BF16 variant overrides these).
+float to_f(float x) { return x; }
+float from_f(float x) { return x; }
+
+void main() {
+    uint tid = gl_LocalInvocationID.x;
+
+    // Derived shape quantities (same on every thread).
+    uint k = min(rows, cols);
+    bool transpose = (rows > cols);      // false => gram in row space (k=rows)
+    float scale = sqrt(float(max(rows, cols)));
+    bool do_ortho = (rows >= 2u) && (cols >= 2u) && (k <= K_MAX);
+
+    // STEP 1 — heavy-ball momentum update, in place:
+    //   momentum = mom*momentum + grad
+    for (uint idx = tid; idx < n; idx += BLK) {
+        float new_m = mom * to_f(data_mom[idx]) + to_f(data_grad[idx]);
+        data_mom[idx] = from_f(new_m);
+    }
+    // momentum[] is an SSBO written above by THIS thread and read CROSS-THREAD
+    // in STEP 2/3/5 (bval reads data_mom[i*cols+c] for indices owned by other
+    // invocations). `memoryBarrierShared()` only orders shared memory, so the
+    // buffer write must be released with workgroup-scope buffer ordering BEFORE
+    // the control barrier publishes it. `groupMemoryBarrier()` covers buffer +
+    // shared at workgroup scope.
+    groupMemoryBarrier();
+    barrier();
+    // momentum[] is now updated and visible workgroup-wide; bval reads it below.
+
+    // bval(idx) = nesterov ? (grad + mom*momentum) : momentum.
+    // (inlined where needed since GLSL can't index buffers from a helper
+    //  cleanly across both paths — recompute per use.)
+
+    // STEP 1b — if NOT do_ortho: plain (Nesterov) momentum SGD, then return.
+    if (!do_ortho) {
+        for (uint idx = tid; idx < n; idx += BLK) {
+            float b = (nesterov != 0u)
+                ? (to_f(data_grad[idx]) + mom * to_f(data_mom[idx]))
+                : to_f(data_mom[idx]);
+            float p = to_f(data_param[idx]);
+            p = p * (1.0 - lr * wd) - lr * b;
+            data_param[idx] = from_f(p);
+        }
+        return;
+    }
+
+    // STEP 2 — Frobenius norm of b: frob2 = sum_idx bval(idx)^2.
+    float partial = 0.0;
+    for (uint idx = tid; idx < n; idx += BLK) {
+        float b = (nesterov != 0u)
+            ? (to_f(data_grad[idx]) + mom * to_f(data_mom[idx]))
+            : to_f(data_mom[idx]);
+        partial += b * b;
+    }
+    Tm[tid] = partial;
+    barrier();
+    memoryBarrierShared();
+    // Tree reduction over the 256-wide block (scratch in Tm[0..BLK)).
+    [[unroll]] for (uint stride = BLK >> 1; stride > 0u; stride >>= 1) {
+        if (tid < stride) {
+            Tm[tid] += Tm[tid + stride];
+        }
+        barrier();
+        memoryBarrierShared();
+    }
+    float frob2 = Tm[0];
+    barrier();
+    memoryBarrierShared();
+
+    if (frob2 == 0.0) {
+        // Only weight decay acts.
+        for (uint idx = tid; idx < n; idx += BLK) {
+            float p = to_f(data_param[idx]);
+            data_param[idx] = from_f(p * (1.0 - lr * wd));
+        }
+        return;
+    }
+    float inv_frob = 1.0 / sqrt(frob2);
+    float inv_frob2 = 1.0 / frob2;
+
+    // STEP 3 — gram A (k x k), normalized by inv_frob2.
+    for (uint pair = tid; pair < k * k; pair += BLK) {
+        uint i = pair / k;
+        uint j = pair % k;
+        float s = 0.0;
+        if (!transpose) {
+            // A = B Bt : rows of B (length cols).
+            for (uint c = 0u; c < cols; ++c) {
+                float bi = (nesterov != 0u)
+                    ? (to_f(data_grad[i * cols + c]) + mom * to_f(data_mom[i * cols + c]))
+                    : to_f(data_mom[i * cols + c]);
+                float bj = (nesterov != 0u)
+                    ? (to_f(data_grad[j * cols + c]) + mom * to_f(data_mom[j * cols + c]))
+                    : to_f(data_mom[j * cols + c]);
+                s += bi * bj;
+            }
+        } else {
+            // A = Bt B : columns of B (length rows).
+            for (uint r = 0u; r < rows; ++r) {
+                float bi = (nesterov != 0u)
+                    ? (to_f(data_grad[r * cols + i]) + mom * to_f(data_mom[r * cols + i]))
+                    : to_f(data_mom[r * cols + i]);
+                float bj = (nesterov != 0u)
+                    ? (to_f(data_grad[r * cols + j]) + mom * to_f(data_mom[r * cols + j]))
+                    : to_f(data_mom[r * cols + j]);
+                s += bi * bj;
+            }
+        }
+        A[pair] = s * inv_frob2;
+    }
+    barrier();
+    memoryBarrierShared();
+
+    // STEP 4 — P-accumulator Newton-Schulz.
+    // P starts = I_k.
+    for (uint idx = tid; idx < k * k; idx += BLK) {
+        P[idx] = (idx / k == idx % k) ? 1.0 : 0.0;
+    }
+    barrier();
+    memoryBarrierShared();
+
+    const float ca = 3.4445;
+    const float cb = -4.7750;
+    const float cc = 2.0315;
+
+    for (uint iter = 0u; iter < ns_iters; ++iter) {
+        // Tm = A @ A.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += A[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // M = a*I + b*A + c*Tm.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float id = (i == j) ? 1.0 : 0.0;
+            M[pair] = ca * id + cb * A[pair] + cc * Tm[pair];
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // P <- (NOT transpose ? M @ P : P @ M).
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            if (!transpose) {
+                for (uint t = 0u; t < k; ++t) {
+                    s += M[i * k + t] * P[t * k + j];
+                }
+            } else {
+                for (uint t = 0u; t < k; ++t) {
+                    s += P[i * k + t] * M[t * k + j];
+                }
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+        for (uint idx = tid; idx < k * k; idx += BLK) {
+            P[idx] = Tm[idx];
+        }
+        barrier();
+        memoryBarrierShared();
+
+        // A <- M @ A @ M  (M symmetric): Tm = M@A ; A = Tm@M.
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += M[i * k + t] * A[t * k + j];
+            }
+            Tm[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+        for (uint pair = tid; pair < k * k; pair += BLK) {
+            uint i = pair / k;
+            uint j = pair % k;
+            float s = 0.0;
+            for (uint t = 0u; t < k; ++t) {
+                s += Tm[i * k + t] * M[t * k + j];
+            }
+            A[pair] = s;
+        }
+        barrier();
+        memoryBarrierShared();
+    }
+
+    // STEP 5 — apply: O = (P@B or B@P) * inv_frob, RMS-scaled; descent
+    // with decoupled WD.
+    for (uint idx = tid; idx < n; idx += BLK) {
+        uint r = idx / cols;
+        uint c = idx % cols;
+        float o = 0.0;
+        if (!transpose) {
+            // P is rows x rows (k = rows). O[r,c] = Σ_t P[r,t] B[t,c].
+            for (uint t = 0u; t < k; ++t) {
+                float bt = (nesterov != 0u)
+                    ? (to_f(data_grad[t * cols + c]) + mom * to_f(data_mom[t * cols + c]))
+                    : to_f(data_mom[t * cols + c]);
+                o += P[r * k + t] * bt;
+            }
+        } else {
+            // P is cols x cols (k = cols). O[r,c] = Σ_t B[r,t] P[t,c].
+            for (uint t = 0u; t < k; ++t) {
+                float bt = (nesterov != 0u)
+                    ? (to_f(data_grad[r * cols + t]) + mom * to_f(data_mom[r * cols + t]))
+                    : to_f(data_mom[r * cols + t]);
+                o += bt * P[t * k + c];
+            }
+        }
+        o *= scale * inv_frob;
+        float p = to_f(data_param[idx]);
+        p = p * (1.0 - lr * wd) - lr * o;
+        data_param[idx] = from_f(p);
+    }
+}

--- a/crates/kiln-vulkan-kernel/src/kernels.rs
+++ b/crates/kiln-vulkan-kernel/src/kernels.rs
@@ -11165,3 +11165,137 @@ pub fn dispatch_adamw_step_f32(
     )
     .context("adamw_step_f32: kernel dispatch")
 }
+
+/// Fused Muon (momentum-orthogonalized SGD) for registry-resident F32
+/// buffers.
+///
+/// Updates `param` and the per-param heavy-ball `momentum` buffer in
+/// place — one launch per matrix. All three buffers (param, grad,
+/// momentum) hold F32 in the same row-major `[rows, cols]` layout
+/// (`cols == 1` for a non-2D param) and share the same element count
+/// `n_elements == rows * cols`. The fused kernel runs the heavy-ball
+/// momentum update, then (for rank-2 weights with `min(rows,cols)`
+/// fitting the kernel's shared gram bound) a Newton-Schulz quintic
+/// orthogonalization of the (Nesterov) look-ahead with the RMS-matching
+/// `sqrt(max(rows,cols))` scale, then the decoupled-weight-decay descent
+/// step. Non-matrix params / over-bound ranks fall back to plain
+/// (Nesterov) momentum SGD inside the kernel.
+///
+/// Dispatched ONE workgroup of 256 threads (`(1, 1, 1)`): the whole step
+/// for one matrix is a single threadblock using full workgroup barriers
+/// between every shared phase.
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_muon_step_f32(
+    vk_device: &VulkanDevice,
+    param_buffer: &VulkanBuffer,
+    grad_buffer: &VulkanBuffer,
+    momentum_buffer: &VulkanBuffer,
+    n_elements: usize,
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<()> {
+    anyhow::ensure!(n_elements > 0, "muon_step_f32: n_elements must be > 0");
+    anyhow::ensure!(
+        rows.saturating_mul(cols) == n_elements,
+        "muon_step_f32: rows*cols ({}) != n_elements ({n_elements})",
+        rows.saturating_mul(cols),
+    );
+    let glsl_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/csrc/shaders/muon_step_f32.comp"
+    );
+    let spirv = crate::pipeline::ShaderPipeline::compile_shader(glsl_path)
+        .context("muon_step_f32: shader compile/load")?;
+    let push_constants: [u32; 8] = [
+        n_elements as u32,
+        rows as u32,
+        cols as u32,
+        ns_iters,
+        lr.to_bits(),
+        momentum_coef.to_bits(),
+        if nesterov { 1u32 } else { 0u32 },
+        weight_decay.to_bits(),
+    ];
+    let all_handles = vec![
+        param_buffer.handle(),
+        grad_buffer.handle(),
+        momentum_buffer.handle(),
+    ];
+    // One workgroup per matrix.
+    run_compute_pipeline(
+        vk_device,
+        &spirv,
+        &all_handles,
+        all_handles.len(),
+        &push_constants,
+        1,
+    )
+    .context("muon_step_f32: kernel dispatch")
+}
+
+/// Fused Muon (momentum-orthogonalized SGD) for registry-resident BF16
+/// buffers. BF16 variant of [`dispatch_muon_step_f32`].
+///
+/// All three buffers (param, grad, momentum) hold packed BF16 (2 bf16 per
+/// u32 word) in the `extract_tensor_packed_bf16_bytes` encoding, share the
+/// same row-major `[rows, cols]` layout and element count
+/// `n_elements == rows * cols`. `param` and `momentum` are updated in
+/// place. Dispatched ONE workgroup of 256 threads (`(1, 1, 1)`).
+#[allow(clippy::too_many_arguments)]
+pub fn dispatch_muon_step_bf16(
+    vk_device: &VulkanDevice,
+    param_buffer: &VulkanBuffer,
+    grad_buffer: &VulkanBuffer,
+    momentum_buffer: &VulkanBuffer,
+    n_elements: usize,
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    momentum_coef: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    weight_decay: f32,
+) -> Result<()> {
+    anyhow::ensure!(n_elements > 0, "muon_step_bf16: n_elements must be > 0");
+    anyhow::ensure!(
+        rows.saturating_mul(cols) == n_elements,
+        "muon_step_bf16: rows*cols ({}) != n_elements ({n_elements})",
+        rows.saturating_mul(cols),
+    );
+    let glsl_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/csrc/shaders/muon_step_bf16.comp"
+    );
+    let spirv = crate::pipeline::ShaderPipeline::compile_shader(glsl_path)
+        .context("muon_step_bf16: shader compile/load")?;
+    let push_constants: [u32; 8] = [
+        n_elements as u32,
+        rows as u32,
+        cols as u32,
+        ns_iters,
+        lr.to_bits(),
+        momentum_coef.to_bits(),
+        if nesterov { 1u32 } else { 0u32 },
+        weight_decay.to_bits(),
+    ];
+    let all_handles = vec![
+        param_buffer.handle(),
+        grad_buffer.handle(),
+        momentum_buffer.handle(),
+    ];
+    // One workgroup per matrix.
+    run_compute_pipeline(
+        vk_device,
+        &spirv,
+        &all_handles,
+        all_handles.len(),
+        &push_constants,
+        1,
+    )
+    .context("muon_step_bf16: kernel dispatch")
+}

--- a/crates/kiln-vulkan-kernel/tests/vk_muon_parity.rs
+++ b/crates/kiln-vulkan-kernel/tests/vk_muon_parity.rs
@@ -1,0 +1,391 @@
+//! Numerical parity for the fused Vulkan Muon optimizer kernel
+//! (`dispatch_muon_step_f32`) against a CPU reference that replicates the
+//! exact algorithm (heavy-ball momentum -> Nesterov look-ahead ->
+//! gram-space P-accumulator Newton-Schulz -> RMS-matching scale ->
+//! decoupled-weight-decay descent). The CPU reference here mirrors
+//! `kiln_optim::lion_muon::{Muon::step, newton_schulz}`; the *algorithm*
+//! is separately validated by kiln-optim's `newton_schulz_matches_direct_iteration`
+//! test, so this test's job is to confirm the GPU kernel *executes* that
+//! algorithm correctly on real hardware (barriers, indexing, push-constant
+//! ABI, BF16/F32 lanes). Skips cleanly when no Vulkan device is present.
+//! (candle-free; #1082)
+
+use anyhow::Result;
+use kiln_vulkan_kernel::VulkanDevice;
+use kiln_vulkan_kernel::kernels::{dispatch_muon_step_bf16, dispatch_muon_step_f32};
+use kiln_vulkan_kernel::vk_tensor::VkTensor;
+use std::sync::Arc;
+
+/// Round an f32 to its nearest bf16 grid point and back (RNE), matching
+/// the shader's f32->bf16 lane write, so input rounding isn't charged to
+/// the GPU-vs-oracle error budget.
+fn bf16_round(v: f32) -> f32 {
+    let bits = v.to_bits();
+    if (bits & 0x7fff_ffff) > 0x7f80_0000 {
+        return v; // NaN
+    }
+    let rounded = bits.wrapping_add(0x7fff + ((bits >> 16) & 1));
+    f32::from_bits(rounded & 0xffff_0000)
+}
+
+fn vk_dev() -> Option<Arc<VulkanDevice>> {
+    if !VulkanDevice::probe() {
+        return None;
+    }
+    VulkanDevice::new().ok().map(Arc::new)
+}
+
+// ---- CPU reference (mirrors kiln_optim::lion_muon) ----
+
+fn matmul_kk(a: &[f32], b: &[f32], out: &mut [f32], k: usize) {
+    for i in 0..k {
+        for j in 0..k {
+            let mut s = 0.0f32;
+            for t in 0..k {
+                s += a[i * k + t] * b[t * k + j];
+            }
+            out[i * k + j] = s;
+        }
+    }
+}
+
+fn newton_schulz(w: &[f32], rows: usize, cols: usize, iters: u32) -> Vec<f32> {
+    let n = rows * cols;
+    let frob = w.iter().map(|&v| v * v).sum::<f32>().sqrt();
+    if frob == 0.0 {
+        return vec![0.0; n];
+    }
+    let inv_frob = 1.0 / frob;
+    let inv_frob2 = inv_frob * inv_frob;
+    let transpose = rows > cols;
+    let k = rows.min(cols);
+    let mut a = vec![0.0f32; k * k];
+    if !transpose {
+        for i in 0..k {
+            for j in 0..k {
+                let mut s = 0.0f32;
+                for c in 0..cols {
+                    s += w[i * cols + c] * w[j * cols + c];
+                }
+                a[i * k + j] = s * inv_frob2;
+            }
+        }
+    } else {
+        for i in 0..k {
+            for j in 0..k {
+                let mut s = 0.0f32;
+                for r in 0..rows {
+                    s += w[r * cols + i] * w[r * cols + j];
+                }
+                a[i * k + j] = s * inv_frob2;
+            }
+        }
+    }
+    let mut p = vec![0.0f32; k * k];
+    for i in 0..k {
+        p[i * k + i] = 1.0;
+    }
+    let (ca, cb, cc) = (3.4445f32, -4.7750f32, 2.0315f32);
+    let mut a2 = vec![0.0f32; k * k];
+    let mut m = vec![0.0f32; k * k];
+    let mut tmp = vec![0.0f32; k * k];
+    for _ in 0..iters {
+        matmul_kk(&a, &a, &mut a2, k);
+        for i in 0..k {
+            for j in 0..k {
+                let id = if i == j { 1.0 } else { 0.0 };
+                m[i * k + j] = ca * id + cb * a[i * k + j] + cc * a2[i * k + j];
+            }
+        }
+        if !transpose {
+            matmul_kk(&m, &p, &mut tmp, k);
+        } else {
+            matmul_kk(&p, &m, &mut tmp, k);
+        }
+        p.copy_from_slice(&tmp);
+        matmul_kk(&m, &a, &mut tmp, k);
+        matmul_kk(&tmp, &m, &mut a, k);
+    }
+    let mut o = vec![0.0f32; n];
+    if !transpose {
+        for i in 0..rows {
+            for c in 0..cols {
+                let mut s = 0.0f32;
+                for j in 0..k {
+                    s += p[i * k + j] * w[j * cols + c];
+                }
+                o[i * cols + c] = s * inv_frob;
+            }
+        }
+    } else {
+        for r in 0..rows {
+            for c in 0..cols {
+                let mut s = 0.0f32;
+                for j in 0..k {
+                    s += w[r * cols + j] * p[j * k + c];
+                }
+                o[r * cols + c] = s * inv_frob;
+            }
+        }
+    }
+    o
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cpu_muon(
+    param: &[f32],
+    grad: &[f32],
+    mom_in: &[f32],
+    rows: usize,
+    cols: usize,
+    lr: f32,
+    mom: f32,
+    nesterov: bool,
+    ns_iters: u32,
+    wd: f32,
+) -> (Vec<f32>, Vec<f32>) {
+    let n = rows * cols;
+    let mut momentum = mom_in.to_vec();
+    for i in 0..n {
+        momentum[i] = mom * momentum[i] + grad[i];
+    }
+    let b: Vec<f32> = (0..n)
+        .map(|i| {
+            if nesterov {
+                grad[i] + mom * momentum[i]
+            } else {
+                momentum[i]
+            }
+        })
+        .collect();
+    let k = rows.min(cols);
+    let do_ortho = rows >= 2 && cols >= 2 && k <= 32;
+    let update = if do_ortho {
+        let mut o = newton_schulz(&b, rows, cols, ns_iters);
+        let scale = (rows.max(cols) as f32).sqrt();
+        for v in o.iter_mut() {
+            *v *= scale;
+        }
+        o
+    } else {
+        b
+    };
+    let mut p = param.to_vec();
+    for i in 0..n {
+        p[i] = p[i] * (1.0 - lr * wd) - lr * update[i];
+    }
+    (p, momentum)
+}
+
+fn det_fill(seed: u64, len: usize, scale: f32) -> Vec<f32> {
+    // splitmix64 -> uniform-ish in [-scale, scale]
+    let mut z = seed;
+    (0..len)
+        .map(|_| {
+            z = z.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut x = z;
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            x ^= x >> 31;
+            let u = (x >> 40) as f32 / (1u32 << 24) as f32; // [0,1)
+            (u * 2.0 - 1.0) * scale
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_case(
+    dev: &Arc<VulkanDevice>,
+    rows: usize,
+    cols: usize,
+    nesterov: bool,
+    wd: f32,
+    seed: u64,
+) -> Result<()> {
+    let n = rows * cols;
+    let (lr, mom, ns_iters) = (0.02f32, 0.95f32, 5u32);
+    let param_data = det_fill(seed, n, 1.0);
+    let grad_data = det_fill(seed ^ 0xa5a5, n, 0.5);
+    let mom_data = det_fill(seed ^ 0x1234, n, 0.3);
+
+    let (exp_param, exp_mom) = cpu_muon(
+        &param_data,
+        &grad_data,
+        &mom_data,
+        rows,
+        cols,
+        lr,
+        mom,
+        nesterov,
+        ns_iters,
+        wd,
+    );
+
+    let param = VkTensor::from_f32_slice(&param_data, vec![rows, cols], Arc::clone(dev))?;
+    let grad = VkTensor::from_f32_slice(&grad_data, vec![rows, cols], Arc::clone(dev))?;
+    let momentum = VkTensor::from_f32_slice(&mom_data, vec![rows, cols], Arc::clone(dev))?;
+
+    dispatch_muon_step_f32(
+        dev,
+        param.buffer(),
+        grad.buffer(),
+        momentum.buffer(),
+        n,
+        rows,
+        cols,
+        lr,
+        mom,
+        nesterov,
+        ns_iters,
+        wd,
+    )?;
+
+    let got_param = param.to_vec_f32()?;
+    let got_mom = momentum.to_vec_f32()?;
+
+    let tol = 2e-3f32;
+    for i in 0..n {
+        assert!(
+            (got_param[i] - exp_param[i]).abs() < tol,
+            "param[{i}] shape {rows}x{cols} nesterov={nesterov} wd={wd}: gpu={} cpu={}",
+            got_param[i],
+            exp_param[i]
+        );
+        assert!(
+            (got_mom[i] - exp_mom[i]).abs() < tol,
+            "momentum[{i}] shape {rows}x{cols}: gpu={} cpu={}",
+            got_mom[i],
+            exp_mom[i]
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn vk_muon_parity_orthogonalized_shapes() -> Result<()> {
+    let Some(dev) = vk_dev() else {
+        eprintln!("Vulkan device unavailable, skipping vk_muon_parity_orthogonalized_shapes");
+        return Ok(());
+    };
+    // short-fat (k=rows), tall-skinny (k=cols), square — all rank-2 with k<=32.
+    let cases: &[(usize, usize)] = &[(8, 32), (32, 8), (16, 16), (4, 96), (96, 4), (24, 24)];
+    for (idx, &(rows, cols)) in cases.iter().enumerate() {
+        run_case(&dev, rows, cols, true, 0.0, 0x1000 + idx as u64)?;
+        run_case(&dev, rows, cols, false, 0.0, 0x2000 + idx as u64)?;
+        run_case(&dev, rows, cols, true, 0.01, 0x3000 + idx as u64)?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_case_bf16(
+    dev: &Arc<VulkanDevice>,
+    rows: usize,
+    cols: usize,
+    nesterov: bool,
+    wd: f32,
+    seed: u64,
+) -> Result<()> {
+    let n = rows * cols;
+    let (lr, mom, ns_iters) = (0.02f32, 0.95f32, 5u32);
+    // Round inputs to the bf16 grid up front so the GPU and the f32 oracle
+    // start from identical values; the remaining gap is the GPU's
+    // intermediate bf16 rounding (momentum + param stored bf16).
+    let param_data: Vec<f32> = det_fill(seed, n, 1.0)
+        .iter()
+        .map(|&v| bf16_round(v))
+        .collect();
+    let grad_data: Vec<f32> = det_fill(seed ^ 0xa5a5, n, 0.5)
+        .iter()
+        .map(|&v| bf16_round(v))
+        .collect();
+    let mom_data: Vec<f32> = det_fill(seed ^ 0x1234, n, 0.3)
+        .iter()
+        .map(|&v| bf16_round(v))
+        .collect();
+
+    let (exp_param, exp_mom) = cpu_muon(
+        &param_data,
+        &grad_data,
+        &mom_data,
+        rows,
+        cols,
+        lr,
+        mom,
+        nesterov,
+        ns_iters,
+        wd,
+    );
+
+    let param = VkTensor::from_f32_slice_as_bf16(&param_data, vec![rows, cols], Arc::clone(dev))?;
+    let grad = VkTensor::from_f32_slice_as_bf16(&grad_data, vec![rows, cols], Arc::clone(dev))?;
+    let momentum = VkTensor::from_f32_slice_as_bf16(&mom_data, vec![rows, cols], Arc::clone(dev))?;
+
+    dispatch_muon_step_bf16(
+        dev,
+        param.buffer(),
+        grad.buffer(),
+        momentum.buffer(),
+        n,
+        rows,
+        cols,
+        lr,
+        mom,
+        nesterov,
+        ns_iters,
+        wd,
+    )?;
+
+    let got_param = param.to_vec_f32()?;
+    let got_mom = momentum.to_vec_f32()?;
+
+    // bf16 carries ~8 mantissa bits; the gram sum over `cols` terms + the NS
+    // iterations compound that, so use a relative+absolute bf16 budget. A
+    // lane-addressing bug would corrupt values FAR beyond this, so the test
+    // still discriminates correct vs wrong lane access.
+    let close = |g: f32, e: f32| (g - e).abs() <= 6e-2 * (1.0 + e.abs());
+    for i in 0..n {
+        assert!(
+            close(got_param[i], exp_param[i]),
+            "bf16 param[{i}] {rows}x{cols} nesterov={nesterov} wd={wd}: gpu={} cpu={}",
+            got_param[i],
+            exp_param[i]
+        );
+        assert!(
+            close(got_mom[i], exp_mom[i]),
+            "bf16 momentum[{i}] {rows}x{cols}: gpu={} cpu={}",
+            got_mom[i],
+            exp_mom[i]
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn vk_muon_parity_bf16_shapes() -> Result<()> {
+    let Some(dev) = vk_dev() else {
+        eprintln!("Vulkan device unavailable, skipping vk_muon_parity_bf16_shapes");
+        return Ok(());
+    };
+    // Even and odd cols exercise the bf16 lane pack/unpack (2 lanes/word)
+    // and the odd-length last-word path.
+    let cases: &[(usize, usize)] = &[(8, 32), (32, 8), (16, 16), (4, 96), (5, 31), (31, 5)];
+    for (idx, &(rows, cols)) in cases.iter().enumerate() {
+        run_case_bf16(&dev, rows, cols, true, 0.0, 0x7000 + idx as u64)?;
+        run_case_bf16(&dev, rows, cols, false, 0.01, 0x8000 + idx as u64)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn vk_muon_parity_non_matrix_falls_back_to_momentum_sgd() -> Result<()> {
+    let Some(dev) = vk_dev() else {
+        eprintln!("Vulkan device unavailable, skipping vk_muon_parity_non_matrix");
+        return Ok(());
+    };
+    // A [1, N] "matrix" has min dim 1 -> do_ortho is false -> plain
+    // (Nesterov) momentum SGD on both GPU and the CPU reference.
+    run_case(&dev, 1, 64, true, 0.0, 0xbeef)?;
+    run_case(&dev, 64, 1, false, 0.0, 0xcafe)?;
+    Ok(())
+}

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -66,6 +66,19 @@ inference_memory_fraction = 0.7       # Fraction of VRAM for inference (rest for
 # grad_checkpoint_segments = 4       # Segments for gradient checkpointing
 no_grad_checkpoint = false
 # checkpoint_interval = 50           # Save adapter every N training steps
+#
+# Optimizer: the default is Muon (momentum-orthogonalized SGD) — it
+# converges LoRA fine-tunes in fewer steps than AdamW at roughly half the
+# optimizer state (one momentum buffer vs Adam's two moments), and ships
+# fused on-device Newton-Schulz kernels for every backend (CUDA, ROCm,
+# Vulkan, Metal). The optimizer is chosen per-request in the SFT/GRPO/OPD
+# JSON body, e.g.:
+#   "optimizer": {"kind": "muon", "momentum": 0.95, "nesterov": true, "ns_iters": 5, "weight_decay": 0.0}
+#   "optimizer": {"kind": "adam_w", "beta1": 0.9, "beta2": 0.999, "eps": 1e-8, "weight_decay": 0.0}
+#   "optimizer": {"kind": "sgd"}
+# Omit the field entirely to use the Muon default. Muon uses a larger
+# learning rate than AdamW (its orthogonalized, RMS-matched update is
+# ~unit scale): ~2e-2 vs AdamW's ~1e-4 for LoRA.
 # webhook_url = "https://example.com/hook"  # POST training completion JSON to this URL.
                                               # Fields: job_id, job_type (sft|grpo),
                                               # status (completed|failed), adapter_name,


### PR DESCRIPTION
## Summary

Makes **Muon** (momentum-orthogonalized SGD) the default optimizer for **every training mode** — SFT, GRPO, on-policy distillation (OPD), and the judge-LoRA flywheel — and ships **fast fused on-device kernels for every backend** (CUDA, ROCm, Vulkan, Metal). AdamW and SGD stay selectable per request via `{"optimizer": {"kind": "adam_w"}}` / `{"kind": "sgd"}`.

Muon keeps one per-parameter heavy-ball momentum buffer (vs AdamW's two moments), takes a Nesterov look-ahead, and projects the rank-2 LoRA A/B weight-matrix updates onto the nearest semi-orthogonal matrix via a Newton-Schulz iteration before stepping, rescaling by `sqrt(max(rows, cols))` so the update magnitude is shape-independent.

## Key idea: cheap Newton-Schulz for low-rank LoRA

For a rank-`r` LoRA matrix the Newton-Schulz iteration collapses to a tiny `k×k` (`k = r`) **gram-space P-accumulator** plus two skinny GEMMs over the large dimension, so the whole optimizer step is a single fused per-matrix kernel launch.

## Backends

| Backend | Kernel | Validation |
|---|---|---|
| CUDA + ROCm | one portable `optimizer_step.cu` (nvcc + hipcc) + FFI + dispatch | adversarial review + FFI-ABI/math audit; gated parity test |
| Vulkan | `muon_step_{f32,bf16}.comp` + dispatch | **numerically validated on real GPU hardware** (f32 + bf16, incl. odd-length lane packing) |
| Metal | fused inline-MSL `kt_muon_step` in `metal_kernels.rs` + dispatch | adversarial review + buffer-ABI audit |
| CPU | `kiln_optim::Muon` | the portable reference / parity oracle (91 tests) |

## Wiring

- `Optimizer::Muon` config variant (serde, new default across `SftConfig` / `GrpoConfig` / `OpdConfig`).
- `OptimizerState` refactored to an enum (`AdamW | Muon`); `allocate_muon_state`, `apply_muon_update_kt`.
- New `OptimizerBackend::runtime_dispatch_muon_step` seam, implemented per backend.

## Tests

- CPU oracle correctness incl. P-accumulator == naive Newton-Schulz iteration.
- `Optimizer` serde round-trips + default-is-Muon.
- **On-device Vulkan parity** vs the CPU oracle (f32 + bf16) on real hardware, plus a Vulkan backend round-trip.
- Gated CUDA/ROCm parity test (`muon_cuda_parity.rs`) for CUDA CI.

Docs updated: README, CHANGELOG, `kiln.example.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)