### PR TITLE
Fix Metal build: muon_step inserted mid-raw-string inside adamw_step

### DIFF
--- a/crates/kiln-tensor/src/metal_kernels.rs
+++ b/crates/kiln-tensor/src/metal_kernels.rs
@@ -611,6 +611,31 @@ kernel void {entry}(
         param[gid] = ({ty})p;
     }}
 }}
+"#
+    );
+    let pipeline = op_pipeline(companion, &src, &entry)?;
+    let encoder = companion
+        .command_encoder()
+        .map_err(|e| Error::Msg(format!("metal_kernels::adamw_step: encoder: {e:?}")))?;
+    encoder.set_label("kt_adamw_step");
+    encoder.set_compute_pipeline_state(&pipeline);
+    encoder.set_buffer(0, Some(param), 0);
+    encoder.set_buffer(1, Some(grad), 0);
+    encoder.set_buffer(2, Some(first_moment), 0);
+    encoder.set_buffer(3, Some(second_moment), 0);
+    let n_u = n as u32;
+    encoder.set_bytes(4, &n_u);
+    encoder.set_bytes(5, &lr);
+    encoder.set_bytes(6, &beta1);
+    encoder.set_bytes(7, &beta2);
+    encoder.set_bytes(8, &eps);
+    encoder.set_bytes(9, &weight_decay);
+    encoder.set_bytes(10, &bc1);
+    encoder.set_bytes(11, &bc2);
+    dispatch_1d(&encoder, n);
+    drop(encoder);
+    Ok(())
+}
 
 // ----------------------------------------------------------------------
 // muon_step — kiln-owned fused on-device Muon (momentum-orthogonalized SGD;
@@ -921,31 +946,6 @@ kernel void {entry}(
         depth: 1,
     };
     encoder.dispatch_thread_groups(groups, threads);
-    drop(encoder);
-    Ok(())
-}
-"#
-    );
-    let pipeline = op_pipeline(companion, &src, &entry)?;
-    let encoder = companion
-        .command_encoder()
-        .map_err(|e| Error::Msg(format!("metal_kernels::adamw_step: encoder: {e:?}")))?;
-    encoder.set_label("kt_adamw_step");
-    encoder.set_compute_pipeline_state(&pipeline);
-    encoder.set_buffer(0, Some(param), 0);
-    encoder.set_buffer(1, Some(grad), 0);
-    encoder.set_buffer(2, Some(first_moment), 0);
-    encoder.set_buffer(3, Some(second_moment), 0);
-    let n_u = n as u32;
-    encoder.set_bytes(4, &n_u);
-    encoder.set_bytes(5, &lr);
-    encoder.set_bytes(6, &beta1);
-    encoder.set_bytes(7, &beta2);
-    encoder.set_bytes(8, &eps);
-    encoder.set_bytes(9, &weight_decay);
-    encoder.set_bytes(10, &bc1);
-    encoder.set_bytes(11, &bc2);
-    dispatch_1d(&encoder, n);
     drop(encoder);
     Ok(())
 }


### PR DESCRIPTION
Main's **macOS / Metal** CI job has been red since #1468: the fused Muon kernel function was inserted into the middle of `adamw_step`'s `format!(r#"..."#)` MSL shader string in `crates/kiln-tensor/src/metal_kernels.rs`, stranding AdamW's closing `"#` + encoder tail 313 lines below and cascading into 40 parse errors (`unknown start of token: \`, unterminated strings). Linux jobs never parse this file (`mod metal_kernels` is cfg-gated to the `metal` feature), so only the Mac leg caught it.

**Fix** — a pure line move, no content changes: `adamw_step`'s shader source is reunited with its encoder tail, and the `muon_step` block (section comment + `MUON_K_MAX` + function) now follows the complete `adamw_step`.

**Verification on Linux:**
- `rustc --emit=metadata` standalone parse of the file: 38 token errors on main → 0 on this branch (remaining errors are the expected unresolved-crate ones for a standalone module compile)
- `cargo check -p kiln-tensor --features metal --target aarch64-apple-darwin`: **clean** (full type-check of the fixed code on the Apple target; workspace-level cross-check is blocked only by ring/onig_sys C build scripts needing an Apple toolchain)
- `metal_storage.rs::metal_muon_step` call site matches the `muon_step` signature (12 args)

The PR's own macOS CI job is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)