### PR TITLE
kiln.example.toml: safe defaults + non-loopback warning in kiln config

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -1192,6 +1192,24 @@ pub async fn run_health(url: &str, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Warning text when the configured host listens beyond loopback, since the
+/// HTTP surface (inference AND training) ships with no built-in auth. Pure so
+/// tests can assert the wording.
+pub(crate) fn non_loopback_host_warning(host: &str) -> Option<String> {
+    let is_loopback = host == "localhost"
+        || host
+            .parse::<std::net::IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false);
+    (!is_loopback).then(|| {
+        format!(
+            "host \"{host}\" listens beyond loopback. Kiln has no built-in auth: anyone \
+who can reach this port can run inference and submit training data. Front it with an \
+authenticated reverse proxy or keep it on a private network (see README \"Security model\")."
+        )
+    })
+}
+
 /// Run the `config check` CLI subcommand: validate config without starting.
 pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
     use crate::config::KilnConfig;
@@ -1237,6 +1255,10 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
                 style("Speculative:").dim(),
                 config.speculative.enabled
             );
+            if let Some(warning) = non_loopback_host_warning(&config.server.host) {
+                println!();
+                println!("  {} {}", style("⚠").yellow().bold(), warning);
+            }
             Ok(())
         }
         Err(e) => {
@@ -2755,6 +2777,25 @@ mod tests {
             config: None,
             verbose,
             quiet,
+        }
+    }
+
+    #[test]
+    fn non_loopback_host_warning_skips_loopback_hosts() {
+        assert_eq!(non_loopback_host_warning("127.0.0.1"), None);
+        assert_eq!(non_loopback_host_warning("localhost"), None);
+        assert_eq!(non_loopback_host_warning("::1"), None);
+        assert_eq!(non_loopback_host_warning("127.0.0.2"), None);
+    }
+
+    #[test]
+    fn non_loopback_host_warning_names_host_and_security_model() {
+        for host in ["0.0.0.0", "::", "192.168.1.10", "my-box.example.com"] {
+            let warning = non_loopback_host_warning(host)
+                .unwrap_or_else(|| panic!("expected warning for host {host}"));
+            assert!(warning.contains(host));
+            assert!(warning.contains("no built-in auth"));
+            assert!(warning.contains("Security model"));
         }
     }
 

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -17,7 +17,10 @@
 # weights). See QUICKSTART.md or https://ericflo.github.io/kiln/quickstart.html.
 
 [server]
-host = "0.0.0.0"
+host = "127.0.0.1"                    # Kiln has no built-in auth. Set "0.0.0.0" to accept
+                                      # remote connections ONLY behind an authenticated
+                                      # reverse proxy or on a private network (WireGuard,
+                                      # Tailscale) — see README "Security model".
 port = 8420
 request_timeout_secs = 600
 shutdown_timeout_secs = 5
@@ -89,7 +92,7 @@ no_grad_checkpoint = false
 
 [logging]
 level = "info"                        # trace, debug, info, warn, error, or a filter directive
-format = "json"                       # json, pretty, text, human
+format = "auto"                       # auto (pretty on TTY, JSON otherwise), json, pretty, text, human
 
 [prefix_cache]
 enabled = true                        # Reuse KV cache blocks for shared prompt prefixes
@@ -100,7 +103,8 @@ enabled = true                        # Reuse KV cache blocks for shared prompt 
 
 [speculative]
 enabled = false                       # Self-speculative decoding (skip-layer draft)
-num_speculative_tokens = 4            # Tokens to draft per step (3-8 typical)
+num_speculative_tokens = 256          # Upper bound on drafted tokens per step (the paged
+                                      # skip-layer draft adapts within this budget)
 draft_layers = 8                      # First N layers used as draft model
                                       # Also settable via KILN_SPEC_ENABLED, KILN_SPEC_NUM_TOKENS,
                                       # KILN_SPEC_DRAFT_LAYERS env vars


### PR DESCRIPTION
## Problem

`kiln.example.toml` opens with **"all values shown are defaults"** but sets three values that are not the defaults — most importantly `host = "0.0.0.0"`. Anyone who copies the example as their starting `kiln.toml` (the documented workflow) silently exposes the auth-free HTTP surface — including `/v1/train/sft`, which applies a faithful gradient update to whatever is POSTed — to their network. The README's own Security model section says the default listen address is loopback precisely so 'a fresh install isn't reachable from the network'.

Also drifted: `logging.format = "json"` (actual default `auto`) and `num_speculative_tokens = 4` with a "(3-8 typical)" comment (actual default 256 since the paged skip-layer draft).

## Changes

- `kiln.example.toml`: `host = "127.0.0.1"` with a comment pointing at the README Security model for going non-loopback safely; `format = "auto"`; `num_speculative_tokens = 256` with an honest comment.
- `kiln config` now prints a warning when the configured host listens beyond loopback (pure helper + unit tests covering loopback IPs, `localhost`, `127.0.0.2`, `0.0.0.0`, `::`, hostnames).

## Validation

- `cargo test -p kiln-server --lib non_loopback` / `--lib config` — green
- `kiln config --file kiln.example.toml` → `Server: 127.0.0.1:8420`, `Log format: auto`, no warning, exit 0
- `kiln config --file <toml with host=0.0.0.0>` → prints the ⚠ warning naming the host and the no-auth model

🤖 Generated with [Claude Code](https://claude.com/claude-code)