### PR TITLE
docs: replace dead huggingface-cli download with hf download

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,7 +19,7 @@ All paths share these requirements:
 
 - **GPU + memory**: NVIDIA with 24GB+ VRAM and CUDA 12.4+ driver/runtime (RTX 3090, 4090, A6000, etc.), AMD Linux GPU with ROCm/HIP 7.2.4+ runtime, AMD/Intel Linux GPU with Vulkan 1.2+ runtime, or Apple Silicon Mac with 16GB+ unified memory. Intel Macs are not supported.
 - **Disk**: ~20GB free for the server binary, model weights, and adapters (Source / CLI builds also share this with build artifacts).
-- **Model**: `Qwen/Qwen3.5-4B` weights — downloaded by the Desktop App, by `huggingface-cli` for the Server binary path, or mounted into the container.
+- **Model**: `Qwen/Qwen3.5-4B` weights — downloaded by the Desktop App, by the `hf` CLI for the Server binary path, or mounted into the container.
 
 Build-tooling deltas by path:
 
@@ -142,8 +142,8 @@ The binary is at `target/release/kiln`.
 Kiln targets **Qwen3.5-4B**. Download the weights from Hugging Face:
 
 ```bash
-pip install huggingface-hub
-huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+pip install -U huggingface_hub
+hf download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 ```
 
 This downloads ~8GB of safetensors weights plus the tokenizer.

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ See [docs/EVAL_GUIDE.md](docs/EVAL_GUIDE.md) for the full scorer reference, data
 **Get the model weights** (Paths 2–4 share this step; the Desktop App handles it automatically):
 
 ```bash
-pip install huggingface-hub
-huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+pip install -U huggingface_hub
+hf download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 ```
 
 This downloads `Qwen/Qwen3.5-4B` into `./Qwen3.5-4B`, which the commands below reference directly.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -24,7 +24,7 @@ The desktop installer bundles only the wrapper. On first launch the app offers t
 
 ## Model weights
 
-Settings has a **Download from HuggingFace…** button next to the Model Path picker. Enter a repo id (e.g. `Qwen/Qwen3.5-4B`), optionally a revision and a token for gated repos, and the app will stream the safetensors shards, tokenizer, and config into `app_data_dir/models/<repo>/` and auto-fill the Model Path field. You still need to click Save to apply it. Users who prefer the CLI can keep using `huggingface-cli download …` and point the Model Path picker at the result.
+Settings has a **Download from HuggingFace…** button next to the Model Path picker. Enter a repo id (e.g. `Qwen/Qwen3.5-4B`), optionally a revision and a token for gated repos, and the app will stream the safetensors shards, tokenizer, and config into `app_data_dir/models/<repo>/` and auto-fill the Model Path field. You still need to click Save to apply it. Users who prefer the CLI can keep using `hf download …` and point the Model Path picker at the result.
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 

--- a/docs/site/demo/SCRIPT.md
+++ b/docs/site/demo/SCRIPT.md
@@ -18,7 +18,7 @@ The companion file [`README.md`](README.md) inventories the full six-cast demo s
 Get the host into this exact state **before** opening `asciinema`. Do not include any of these in the recording itself.
 
 - Kiln binary available through `KILN_BIN`. It defaults to `./target/release/kiln`, but can point at an extracted release artifact or a source-built release binary (`--features cuda` on Linux/Windows or `--features metal` on macOS). See [`QUICKSTART.md` §1](../../../QUICKSTART.md).
-- Model weights at `./Qwen3.5-4B/` (downloaded via `huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B`). See [`QUICKSTART.md` §2](../../../QUICKSTART.md).
+- Model weights at `./Qwen3.5-4B/` (downloaded via `hf download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B`). See [`QUICKSTART.md` §2](../../../QUICKSTART.md).
 - A clean shell working dir at the kiln repo root.
 - `asciinema` 2.4 or newer installed (`asciinema --version`). On Linux: `pip install asciinema` or distro package; on macOS: `brew install asciinema`.
 - Terminal sized **120 columns × 32 rows** exactly. The asciinema player renders responsively, but matching the recording aspect ratio keeps text crisp on the page. Set this with `printf '\e[8;32;120t'` in xterm/iTerm/most terminals, or resize the window manually.

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -411,8 +411,8 @@ Expand-Archive .\kiln-windows.zip -DestinationPath .\kiln</code></pre>
         <div class="card p-6">
           <h3 class="font-semibold mb-2">a. Download Qwen3.5-4B</h3>
           <p class="mb-4" style="color: var(--fg-dim);">Point <code>KILN_MODEL_PATH</code> at a local checkout of <code>Qwen/Qwen3.5-4B</code>.</p>
-<pre class="text-sm"><code>pip install huggingface-hub
-huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+<pre class="text-sm"><code>pip install -U huggingface_hub
+hf download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         </div>
         <div class="card p-6">


### PR DESCRIPTION
## Problem

`huggingface_hub` 1.x replaced the `huggingface-cli` entry point with the `hf` CLI — `huggingface-cli download` is now a deprecation stub that exits 1. The model-weights step in the main onboarding path (README Quick Start, QUICKSTART §2, the website quickstart, the demo recording prep notes, and the desktop README) was therefore broken for fresh installs at step 2.

## Changes

`pip install huggingface-hub` + `huggingface-cli download …` → `pip install -U huggingface_hub` + `hf download …` across README.md, QUICKSTART.md, docs/site/quickstart.html, docs/site/demo/SCRIPT.md, desktop/README.md (prose mention).

This matches what BENCHMARKS.md and deploy/runpod/kiln-setup.sh already use. Remaining `huggingface-cli` mentions live only in docs/archive, capability archive notes, a code comment, and the RunPod dev-image tool list (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)