### PR TITLE
ci: stop the nightly perf gate queueing 24h against the offline A6000 runner

### DIFF
--- a/.github/workflows/perf-regression-nightly.yml
+++ b/.github/workflows/perf-regression-nightly.yml
@@ -244,12 +244,22 @@ jobs:
           print('OK — null baseline was seeded:', b)
           "
 
+      - name: Warn when the A6000 perf leg is offline
+        if: ${{ vars.KILN_A6000_ONLINE != 'true' }}
+        run: |
+          echo "::warning::A6000 perf leg offline (repo variable KILN_A6000_ONLINE != 'true') — the Tier-2 hardware perf gate is not running. Set the variable to 'true' after registering a cuda-a6000 self-hosted runner."
+
   # -------------------------------------------------------------------
   # Tier 2 / Tier 3: actual perf gate against the A6000 baseline.
   #
-  # Self-hosted runner labelled `cuda-a6000`. Until one is wired up
-  # this job is conditionally skipped — `gate-self-test` above still
-  # validates the regression-check script on every dispatch.
+  # Self-hosted runner labelled `cuda-a6000`. The job only runs when the
+  # repository variable KILN_A6000_ONLINE is set to 'true' — without the
+  # gate, every nightly cron queued against the (usually offline,
+  # spun-up-on-demand) runner for 24h and was auto-cancelled, producing
+  # zero perf signal plus daily Actions noise. Flip the variable on
+  # (Settings → Secrets and variables → Actions → Variables) after
+  # registering a runner; no workflow edit needed. `gate-self-test`
+  # above still validates the regression-check script on every dispatch.
   #
   # When the runner IS online, this job:
   #   1. Builds kiln-bench --release --features cuda
@@ -262,7 +272,7 @@ jobs:
     name: A6000 perf gate (${{ matrix.trainer }})
     runs-on: [self-hosted, linux, cuda-a6000]
     needs: gate-self-test
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.latency_fixture_id == 'none') }}
+    if: ${{ vars.KILN_A6000_ONLINE == 'true' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.latency_fixture_id == 'none')) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The `cuda-bench` job in **Perf regression nightly** targets the `cuda-a6000` self-hosted runner, which is spun up on demand and usually offline. Every nightly cron therefore queued for 24h and was auto-cancelled by GitHub (runs 27190770400, 27123889790; 27261117999 was queued ~11h when this PR was opened). The perf gate has been producing zero signal plus a daily cancelled-run notification.

## Changes

- `cuda-bench` now also requires the repository variable `KILN_A6000_ONLINE == 'true'` (same dead-runner situation `opd-bench-gate.yml` handles by being dispatch-only). When a runner is registered, flip the variable under Settings → Secrets and variables → Actions → Variables — no workflow edit needed.
- `gate-self-test` emits a `::warning` while the hardware leg is offline, so the skip stays visible instead of silently shrinking coverage.
- The dispatch-only `backend-latency-fixture` job is unchanged (explicit manual action with caller-supplied runner labels).

The currently-queued phantom run will be cancelled after merge.

## Validation

- YAML parses; this workflow's own `pull_request` paths filter triggers `gate-self-test` on this PR (it self-tests the regression-check script).
- After merge: next 06:00 UTC cron should complete green in ~1 min with `cuda-bench` skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)