### PR TITLE
ci: auto-publish desktop releases (desktop-v0.2.16 sat in draft for 26 days)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -210,3 +210,28 @@ jobs:
             desktop/target/aarch64-apple-darwin/release/bundle/macos/*.app
           if-no-files-found: ignore
           retention-days: 14
+
+  # Each platform leg builds into the same draft release that tauri-action
+  # creates for the tag. Nothing ever flipped the draft off, so finished
+  # desktop releases (signed + notarized) sat invisible until someone
+  # clicked Publish by hand — desktop-v0.2.16 was drafted for ~26 days
+  # while the README linked its (404ing) assets. Mirror the server
+  # pipeline's publish job (server-release.yml). `--latest=false` keeps
+  # the repo-wide /releases/latest pointer on the kiln-v* server line,
+  # which the README install one-liner and the desktop app's own server
+  # downloader resolve.
+  publish:
+    name: Publish desktop release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/desktop-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --draft=false --latest=false


### PR DESCRIPTION
## Problem

`desktop-build.yml` builds into a **draft** release (tauri-action's `releaseDraft: true`, needed so the three platform legs can upload artifacts), but unlike `server-release.yml` it has no publish job — so finished, signed, notarized desktop releases stay invisible until someone clicks Publish by hand. `desktop-v0.2.16` sat in draft for ~26 days while the README's download table linked its assets; draft assets 404 for anonymous users (verified with an unauthenticated curl before fixing).

## Changes

- **Done out-of-band:** `desktop-v0.2.16` is now published (`--draft=false --latest=false`); its assets return 200 anonymously and `/releases/latest` still resolves to `kiln-v0.3.5`.
- **This PR:** add a `publish` job mirroring `server-release.yml:649` — `needs: build` (implicit `success()` means any failed platform leg blocks publishing), `if: startsWith(github.ref, 'refs/tags/desktop-v')`, `gh release edit --draft=false --latest=false`. The `--latest=false` keeps the repo-wide latest pointer on the server line that the README install one-liner and the desktop app's server-binary downloader rely on.

## Validation

- YAML parses (`yaml.safe_load`); job graph: `build` → `publish`.
- The job is exercised end-to-end on the next `desktop-v*` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)