### PR TITLE
serve: friendly diagnostic when the port is already in use

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -979,6 +979,25 @@ pub fn print_ready_line(host: &str, port: u16) {
     let _ = writeln!(stderr);
 }
 
+/// Body of the `kiln serve` failed-bind diagnostic when the address is
+/// already in use. Pure so tests can assert the wording.
+pub(crate) fn bind_addr_in_use_message(host: &str, port: u16) -> String {
+    format!(
+        "{host}:{port} is already in use — another kiln (or another service) is likely listening there.\n  \
+         Run `kiln health` to check for a live server, stop the other process,\n  \
+         or pick a different port via KILN_PORT or `[server] port` in kiln.toml."
+    )
+}
+
+/// Print the AddrInUse diagnostic for a failed `kiln serve` listener bind.
+pub fn print_bind_addr_in_use(host: &str, port: u16) {
+    eprintln!(
+        "{} {}",
+        style("✗").red().bold(),
+        bind_addr_in_use_message(host, port)
+    );
+}
+
 /// Format a uptime duration in seconds as a compact human string ("1h 23m 4s",
 /// "5m 30s", "12s"). Drops leading zero units. Used by the pretty health view.
 fn format_uptime_secs(total: u64) -> String {
@@ -2778,6 +2797,15 @@ mod tests {
             verbose,
             quiet,
         }
+    }
+
+    #[test]
+    fn bind_addr_in_use_message_names_addr_and_remedies() {
+        let msg = bind_addr_in_use_message("127.0.0.1", 8420);
+        assert!(msg.contains("127.0.0.1:8420"));
+        assert!(msg.contains("kiln health"));
+        assert!(msg.contains("KILN_PORT"));
+        assert!(msg.contains("[server] port"));
     }
 
     #[test]

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -592,7 +592,16 @@ async fn main() -> Result<()> {
     let app = api::router(state);
 
     let addr = format!("{host}:{port}");
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            cli::print_bind_addr_in_use(host, port);
+            std::process::exit(1);
+        }
+        Err(e) => {
+            return Err(anyhow::Error::new(e).context(format!("failed to bind {addr}")));
+        }
+    };
     tracing::debug!(
         host = %host,
         port = port,


### PR DESCRIPTION
## Problem

Starting `kiln serve` while another process holds the port died with the bare anyhow chain:

```
Error: Address already in use (os error 98)
```

No address, no cause, no remediation — and the most common cause (a kiln already running, e.g. via systemd or the Desktop app) is exactly the case where a new user has no idea what happened.

## Changes

- `main.rs` matches `AddrInUse` at the bind site and prints a styled diagnostic naming `host:port`, suggesting `kiln health` (is a kiln already up?), and pointing at `KILN_PORT` / `[server] port`; exits 1.
- Other bind errors keep propagating, now with `failed to bind <addr>` context attached.
- Message body is a pure function with a unit test.

## Validation

- `cargo test -p kiln-server --lib bind_addr` — green
- Live: `python3 -m http.server 18429` + `KILN_PORT=18429 kiln serve` (mock mode) →
  ```
  ✗ 127.0.0.1:18429 is already in use — another kiln (or another service) is likely listening there.
    Run `kiln health` to check for a live server, stop the other process,
    or pick a different port via KILN_PORT or `[server] port` in kiln.toml.
  ```
  exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)