### PR TITLE
kiln-train: fix post-Muon default doc-rot + pin defaults with a snapshot test

### DIFF
--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -286,8 +286,9 @@ pub struct SftConfig {
     /// so the run is still exactly reproducible.
     #[serde(default)]
     pub seed: Option<u64>,
-    /// Optimizer selection. Defaults to AdamW (decoupled weight decay) per
-    /// LoRA fine-tuning best practice. Plain SGD is available via
+    /// Optimizer selection. Defaults to Muon (momentum-orthogonalized SGD
+    /// with fused on-device Newton-Schulz). AdamW remains available via
+    /// `{"optimizer": {"kind": "adam_w"}}` and plain SGD via
     /// `{"optimizer": {"kind": "sgd"}}` for backwards-compatible runs.
     #[serde(default)]
     pub optimizer: Optimizer,
@@ -528,7 +529,8 @@ pub enum KlEstimator {
     K1,
     /// Schulman k3: `KL_t = exp(-log_ratio_t) - 1 + log_ratio_t`. Always
     /// non-negative; value-correct but the gradient is biased. DeepSeekMath
-    /// uses this form. Candle path only; not implemented on vk-native.
+    /// uses this form. Implemented on the shared kt tape path and the
+    /// Vulkan kernel (`VK_GRPO_KL_MODE_K3`).
     K3,
     /// No KL penalty. The reference forward still runs (still needed for the
     /// importance ratio); only the KL contribution to the loss is zeroed.
@@ -569,12 +571,14 @@ pub struct GrpoConfig {
     /// sides.
     #[serde(default)]
     pub clip_eps_high: Option<f64>,
-    /// Advantage normalization mode. Defaults to `Vanilla` (historical
-    /// kiln behavior). Set to `DrGrpo` to drop std-normalization.
+    /// Advantage normalization mode. Defaults to `DrGrpo` (drops
+    /// std-normalization per arXiv:2503.20783). Set to `Vanilla` for the
+    /// historical DeepSeekMath/R1 form.
     #[serde(default)]
     pub advantage_mode: AdvantageMode,
-    /// Surrogate-loss aggregation mode. Defaults to `PerSample` (historical
-    /// kiln behavior). Set to `TokenLevel` for the DAPO Token-Level Loss.
+    /// Surrogate-loss aggregation mode. Defaults to `TokenLevel` (the DAPO
+    /// Token-Level Loss, arXiv:2503.14476). Set to `PerSample` for the
+    /// historical per-completion form.
     #[serde(default)]
     pub loss_aggregation: LossAggregation,
     /// KL penalty estimator. Defaults to `K1` (historical kiln behavior).
@@ -1001,6 +1005,38 @@ pub struct TrainingResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pin the serde shape of the training-policy defaults. A future default
+    /// flip must update this snapshot in the same commit, which forces the
+    /// field/enum docs (and CHANGELOG) to be revisited together — the Muon
+    /// flip left "Defaults to AdamW" doc-rot behind precisely because nothing
+    /// tied the default to a literal.
+    #[test]
+    fn training_policy_defaults_match_pinned_snapshots() {
+        assert_eq!(
+            serde_json::to_value(Optimizer::default()).unwrap(),
+            serde_json::json!({
+                "kind": "muon",
+                // f32 fields widen to f64 in serde_json, so pin via casts.
+                "momentum": 0.95f32 as f64,
+                "nesterov": true,
+                "ns_iters": 5,
+                "weight_decay": 0.0f32 as f64
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(AdvantageMode::default()).unwrap(),
+            serde_json::json!("dr_grpo")
+        );
+        assert_eq!(
+            serde_json::to_value(LossAggregation::default()).unwrap(),
+            serde_json::json!("token_level")
+        );
+        assert_eq!(
+            serde_json::to_value(KlEstimator::default()).unwrap(),
+            serde_json::json!("k1")
+        );
+    }
 
     #[test]
     fn test_sft_config_default_checkpoint_interval_is_none() {

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -685,7 +685,8 @@ pub struct OpdConfig {
     #[serde(default)]
     pub seed: Option<u64>,
 
-    /// Optimizer. Defaults to AdamW per kiln convention.
+    /// Optimizer. Defaults to Muon (momentum-orthogonalized SGD), matching
+    /// SFT/GRPO; AdamW and SGD remain selectable per-request.
     #[serde(default)]
     pub optimizer: Optimizer,
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -12308,19 +12308,12 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    // #1082: `kiln_model::forward::rms_norm_fallback` is now a kt op, so the
-    // candle `Var`/`loss.backward()` autograd oracle this test relies on is
-    // SEVERED — candle's tape cannot trace through the kt RMSNorm, so
-    // `grads.get(hidden_var)` would not reflect the analytic formula. Per the
-    // documented policy (`kiln-candle-autograd-drops-attn-conv-grads`), the
-    // oracle must be ported to a kt-tape / finite-diff comparison (CP-4); this
-    // test is `#[ignore]`d rather than bridged into a falsely-passing/failing
-    // state. The body is bridged kt<->candle on the host purely so it still
-    // type-checks.
+    // The #1082 candle-drop left an `#[ignore]` here that belonged to a
+    // since-deleted candle-autograd gradient oracle; this test is pure CPU
+    // segment-boundary arithmetic and runs fine. The gradient oracle's
+    // replacement is `analytic_sft_tail_grad_matches_finite_difference`,
+    // already unignored.
     #[test]
-    #[ignore = "#1082: candle-autograd oracle severed by kt rms_norm_fallback; \
-                port to kt-tape/finite-diff oracle (CP-4)"]
-
     fn test_segment_boundaries() {
         // 32 layers, 4 segments → 8 each
         let segs = compute_segment_boundaries(32, 4);


### PR DESCRIPTION
## Problem

Three waves of changes (Muon default #1468, the Dr.GRPO/DAPO Phase-1 default flips, the #1082 candle removal) left the config docs contradicting the code:

| Doc said | Code does |
|---|---|
| `SftConfig.optimizer`: "Defaults to AdamW … per LoRA fine-tuning best practice" | `Optimizer::default()` = **Muon** |
| `OpdConfig.optimizer`: "Defaults to AdamW per kiln convention" | **Muon** |
| `advantage_mode`: "Defaults to `Vanilla`" | `#[default]` = **DrGrpo** |
| `loss_aggregation`: "Defaults to `PerSample`" | `#[default]` = **TokenLevel** |
| `KlEstimator::K3`: "Candle path only; not implemented on vk-native" | implemented on the kt tape path and mapped to `VK_GRPO_KL_MODE_K3` |

These are the docs an integrator reads to decide what their training requests do — wrong defaults here are worse than no docs.

## Changes

- Field docs corrected (verified against `#[default]` attrs, `Default` impls, and `grpo_tape_shim.rs`).
- New `training_policy_defaults_match_pinned_snapshots` test pins the serde shape of all four defaults — the next default flip fails CI until the docs are revisited in the same commit.
- `test_segment_boundaries` (pure CPU arithmetic) carried a misattached `#[ignore]` from a since-deleted candle-autograd oracle — removed; it passes. The remaining `#[ignore]` in the crate (checkpointing reverse) is legitimately documented.

## Validation

`cargo test -p kiln-train --lib` — 258 passed, 0 failed (was 256 + 2 newly running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)