### PR TITLE
trace-suite hardening: fix 8 confirmed-major review findings from #1383

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "futures",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "regex",

--- a/crates/kiln-eval/Cargo.toml
+++ b/crates/kiln-eval/Cargo.toml
@@ -25,3 +25,7 @@ clap = { version = "4", features = ["derive", "env"] }
 futures = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { workspace = true }
+
+[[example]]
+name = "trace_api_eval"
+test = true

--- a/crates/kiln-eval/examples/trace_api_eval.rs
+++ b/crates/kiln-eval/examples/trace_api_eval.rs
@@ -5,10 +5,18 @@
 //! and scores responses locally with the same scorer stack the Kiln server
 //! uses. It is useful for comparing a generated production trace suite against
 //! hosted models without starting a Kiln model server.
+//!
+//! One caveat to the "same scorer stack" claim: suites built with
+//! `--require-qwen-xml` cannot measure output *format* through this
+//! transport. OpenAI-compatible servers that parse tool calls return them as
+//! structured `message.tool_calls`, erasing whatever wire format the model
+//! actually emitted. For those responses the XML-format requirement is
+//! disabled (with a one-time warning) and only tool-call semantics are
+//! scored; pass `--no-tools` to receive raw completions if format matters.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
@@ -59,6 +67,10 @@ struct Args {
     /// previous serial behavior.
     #[arg(long, default_value_t = 1)]
     concurrency: usize,
+    /// Total per-request timeout in seconds. A hung endpoint fails that
+    /// example instead of stalling the run forever.
+    #[arg(long, default_value_t = 120)]
+    timeout_secs: u64,
     /// Do not send the suite/example tool catalogue to the API.
     #[arg(long)]
     no_tools: bool,
@@ -87,7 +99,10 @@ async fn main() -> Result<()> {
         .or_else(|| std::env::var(&args.api_key_env).ok())
         .filter(|s| !s.is_empty());
     let extra_body = parse_extra_body(args.extra_body_json.as_deref())?;
-    let client = reqwest::Client::builder().build()?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(args.timeout_secs))
+        .connect_timeout(Duration::from_secs(10))
+        .build()?;
     let started_at = chrono::Utc::now();
 
     let mut runs = Vec::new();
@@ -386,6 +401,10 @@ async fn call_chat_api(
     Ok(ApiCompletion::from_response(value)?)
 }
 
+/// Printed at most once per process when XML-format enforcement has to be
+/// waived because the transport returned pre-parsed tool calls.
+static XML_FORMAT_WAIVED_WARNING: std::sync::Once = std::sync::Once::new();
+
 fn score_api_response(
     scorer: &Scorer,
     example: &kiln_eval::EvalExample,
@@ -394,6 +413,35 @@ fn score_api_response(
     latency_ms: f64,
     suite: &EvalSuite,
 ) -> Result<(ExampleOutcome, Option<String>, Option<(u32, u32)>)> {
+    // API-native tool calls arrive pre-parsed: the serving layer already
+    // converted whatever the model emitted (possibly genuine Qwen XML) into
+    // structured JSON. Marking those Invalid would blame the model for the
+    // transport, so waive require_xml_format and score semantics only.
+    let scorer = match scorer {
+        Scorer::ToolCall {
+            require_xml_format: true,
+            ..
+        } if response.tool_calls_were_api_native => {
+            XML_FORMAT_WAIVED_WARNING.call_once(|| {
+                eprintln!(
+                    "warning: suite sets require_xml_format but the API returned structured \
+                     tool_calls; the transport erases the model's raw output format, so \
+                     XML-format enforcement is disabled for those responses. Pass --no-tools \
+                     (or rebuild the suite without --require-qwen-xml) to measure format."
+                );
+            });
+            let mut waived = scorer.clone();
+            if let Scorer::ToolCall {
+                require_xml_format, ..
+            } = &mut waived
+            {
+                *require_xml_format = false;
+            }
+            std::borrow::Cow::Owned(waived)
+        }
+        other => std::borrow::Cow::Borrowed(other),
+    };
+    let scorer = scorer.as_ref();
     let mut predicted_tool = None;
     let mut schema_violation = None;
     if matches!(scorer, Scorer::ToolCall { .. }) {
@@ -429,6 +477,10 @@ struct ApiCompletion {
     completion_text: String,
     prompt_tokens: Option<usize>,
     completion_tokens: Option<usize>,
+    /// True when the completion's tool calls came back as structured
+    /// `message.tool_calls` — the serving layer already parsed them, so the
+    /// raw output format the model emitted is unknowable here.
+    tool_calls_were_api_native: bool,
 }
 
 impl ApiCompletion {
@@ -454,14 +506,17 @@ impl ApiCompletion {
             answer.push_str(&content);
             answer.push('\n');
         }
+        let mut tool_calls_were_api_native = false;
         if let Some(tool_calls) = tool_calls.filter(|calls| !calls.is_empty()) {
             answer.push_str(&serde_json::to_string(
                 &json!({ "tool_calls": tool_calls }),
             )?);
+            tool_calls_were_api_native = true;
         }
         let usage = value.get("usage");
         Ok(Self {
             completion_text: answer,
+            tool_calls_were_api_native,
             prompt_tokens: usage
                 .and_then(|u| u.get("prompt_tokens"))
                 .and_then(|v| v.as_u64())
@@ -529,6 +584,122 @@ fn suite_hash(suite: &EvalSuite) -> Result<String> {
         out.push_str(&format!("{byte:02x}"));
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_eval::EvalExample;
+    use kiln_eval::scorers::{ArgsScoring, NameMatch};
+
+    fn xml_required_scorer() -> Scorer {
+        Scorer::ToolCall {
+            name_match: NameMatch::CaseInsensitive,
+            args: ArgsScoring::Auto,
+            weights: None,
+            require_xml_format: true,
+        }
+    }
+
+    fn suite_with_example(scorer: Scorer) -> EvalSuite {
+        EvalSuite {
+            name: "test".into(),
+            description: None,
+            default_scorer: scorer,
+            generation: EvalGenerationParams::default(),
+            system_prompt: None,
+            examples: vec![EvalExample {
+                messages: vec![kiln_eval::EvalChatMessage::new("user", "run pwd")],
+                target: Some(
+                    r#"{"tool_calls":[{"name":"Bash","arguments":{"command":"pwd"}}]}"#.into(),
+                ),
+                ..Default::default()
+            }],
+            schema_version: 1,
+            tools: None,
+        }
+    }
+
+    #[test]
+    fn timeout_secs_defaults_and_parses() {
+        let args = Args::parse_from(["trace_api_eval", "--suite", "s.json", "--model", "m"]);
+        assert_eq!(args.timeout_secs, 120);
+        let args = Args::parse_from([
+            "trace_api_eval",
+            "--suite",
+            "s.json",
+            "--model",
+            "m",
+            "--timeout-secs",
+            "7",
+        ]);
+        assert_eq!(args.timeout_secs, 7);
+    }
+
+    #[test]
+    fn from_response_marks_api_native_tool_calls() {
+        let native = ApiCompletion::from_response(json!({
+            "choices": [{"message": {"content": null, "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "Bash", "arguments": "{\"command\":\"pwd\"}"}
+            }]}}]
+        }))
+        .unwrap();
+        assert!(native.tool_calls_were_api_native);
+        let textual = ApiCompletion::from_response(json!({
+            "choices": [{"message": {"content": "{\"tool_calls\":[{\"name\":\"Bash\",\"arguments\":{\"command\":\"pwd\"}}]}"}}]
+        }))
+        .unwrap();
+        assert!(!textual.tool_calls_were_api_native);
+    }
+
+    #[test]
+    fn require_xml_format_is_waived_for_api_native_tool_calls() {
+        let suite = suite_with_example(xml_required_scorer());
+        let response = ApiCompletion::from_response(json!({
+            "choices": [{"message": {"content": null, "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "Bash", "arguments": "{\"command\":\"pwd\"}"}
+            }]}}]
+        }))
+        .unwrap();
+        let (outcome, predicted_tool, _) = score_api_response(
+            &suite.default_scorer,
+            &suite.examples[0],
+            0,
+            response,
+            1.0,
+            &suite,
+        )
+        .unwrap();
+        // The transport parsed the call; XML enforcement must not mark it
+        // Invalid — the call is semantically correct and should Pass.
+        assert_eq!(outcome.kind, EvalOutcomeKind::Pass, "{:?}", outcome.detail);
+        assert_eq!(predicted_tool.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn require_xml_format_still_applies_to_textual_completions() {
+        let suite = suite_with_example(xml_required_scorer());
+        // The model itself emitted a JSON-shaped call as text — that IS a
+        // format regression and stays Invalid.
+        let response = ApiCompletion::from_response(json!({
+            "choices": [{"message": {"content": "{\"tool_calls\":[{\"name\":\"Bash\",\"arguments\":{\"command\":\"pwd\"}}]}"}}]
+        }))
+        .unwrap();
+        let (outcome, _, _) = score_api_response(
+            &suite.default_scorer,
+            &suite.examples[0],
+            0,
+            response,
+            1.0,
+            &suite,
+        )
+        .unwrap();
+        assert_eq!(outcome.kind, EvalOutcomeKind::Invalid, "{:?}", outcome.detail);
+    }
 }
 
 fn print_summary(result: &EvalResult, started_at: chrono::DateTime<chrono::Utc>) {

--- a/crates/kiln-eval/src/production_trace.rs
+++ b/crates/kiln-eval/src/production_trace.rs
@@ -27,7 +27,7 @@ use rand_core::Rng as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::qwen3::{ParsedToolCall, extract_tool_calls};
+use crate::qwen3::{ParsedToolCall, extract_tool_calls, tool_calls_from_value};
 use crate::scorers::{ArgsScoring, NameMatch, Scorer};
 use crate::suite::{EvalChatMessage, EvalExample, EvalGenerationParams, EvalSuite};
 use crate::trajectory::{AnthropicBlock, AnthropicMessage, anthropic_turn_to_sft_conversation};
@@ -37,6 +37,13 @@ use crate::trajectory::{AnthropicBlock, AnthropicMessage, anthropic_turn_to_sft_
 #[serde(rename_all = "snake_case")]
 pub enum ProductionTraceFormat {
     /// Inspect each row and pick the first recognized trace row shape.
+    /// Routing rules, in order: an explicit per-row `format`/`trace_format`
+    /// label wins; `prompt_messages` + `chosen` → prompt-chosen; an
+    /// `assistant_response` field → Anthropic single-turn; `messages` with
+    /// Anthropic `tool_use`/`tool_result` blocks → Anthropic trajectory;
+    /// `messages` with `tool`-role entries or multiple assistant `tool_calls`
+    /// turns → OpenAI trajectory; any other `messages` row → OpenAI
+    /// single-turn (last assistant message is the target).
     Auto,
     /// Rows with `prompt_messages` plus a separate `chosen` assistant message.
     PromptChosenJsonl,
@@ -154,6 +161,11 @@ pub struct ProductionTraceSuiteStats {
     pub sample_kept: u64,
     pub skipped_parse_error: u64,
     pub skipped_no_tool_call: u64,
+    /// Turns whose structured `tool_calls` array had at least one entry that
+    /// could not be parsed. Scoring a partial target would silently change
+    /// what the eval measures, so the whole turn is skipped instead.
+    #[serde(default)]
+    pub skipped_malformed_tool_call: u64,
     pub skipped_empty_prompt: u64,
     pub skipped_prompt_too_long: u64,
     pub skipped_target_too_long: u64,
@@ -340,6 +352,7 @@ where
             line_no,
             input.source_path.as_deref(),
             config.input_format,
+            config.sampling.max_prompt_chars,
         ) {
             Ok(row) => row,
             Err(err) => {
@@ -361,12 +374,23 @@ where
         }
 
         for turn in parsed_row.turns {
-            let Some((target, target_tools)) = target_tool_call_json(&turn.chosen) else {
-                stats.skipped_no_tool_call += 1;
-                continue;
+            let (target, target_tools) = match target_tool_calls(&turn.chosen) {
+                TargetToolCalls::Target { json, tools } => (json, tools),
+                TargetToolCalls::None => {
+                    stats.skipped_no_tool_call += 1;
+                    continue;
+                }
+                TargetToolCalls::Malformed => {
+                    stats.skipped_malformed_tool_call += 1;
+                    continue;
+                }
             };
             stats.eligible_tool_turns += 1;
 
+            if turn.prompt_oversize {
+                stats.skipped_prompt_too_long += 1;
+                continue;
+            }
             if turn.prompt_messages.is_empty() {
                 stats.skipped_empty_prompt += 1;
                 continue;
@@ -499,6 +523,7 @@ fn parse_trace_row(
     line_no: usize,
     source_path: Option<&str>,
     requested: ProductionTraceFormat,
+    max_prompt_chars: usize,
 ) -> Result<ParsedTraceRow, ProductionTraceError> {
     let value: serde_json::Value =
         serde_json::from_str(line).map_err(|e| ProductionTraceError::Parse {
@@ -506,17 +531,17 @@ fn parse_trace_row(
             message: format!("invalid JSON: {e}"),
         })?;
     match requested {
-        ProductionTraceFormat::Auto => parse_auto(&value, line_no, source_path),
+        ProductionTraceFormat::Auto => parse_auto(&value, line_no, source_path, max_prompt_chars),
         ProductionTraceFormat::PromptChosenJsonl => {
             parse_prompt_chosen(&value, line_no, source_path)
         }
         ProductionTraceFormat::OpenAiJsonl => parse_openai_messages(&value, line_no, source_path),
         ProductionTraceFormat::OpenAiTrajectoryJsonl => {
-            parse_openai_trajectory(&value, line_no, source_path)
+            parse_openai_trajectory(&value, line_no, source_path, max_prompt_chars)
         }
         ProductionTraceFormat::AnthropicJsonl => parse_anthropic_turn(&value, line_no, source_path),
         ProductionTraceFormat::AnthropicTrajectoryJsonl => {
-            parse_anthropic_trajectory(&value, line_no, source_path)
+            parse_anthropic_trajectory(&value, line_no, source_path, max_prompt_chars)
         }
     }
 }
@@ -525,6 +550,7 @@ fn parse_auto(
     value: &serde_json::Value,
     line_no: usize,
     source_path: Option<&str>,
+    max_prompt_chars: usize,
 ) -> Result<ParsedTraceRow, ProductionTraceError> {
     if let Some(format) = explicit_row_format(value)? {
         match format {
@@ -536,13 +562,13 @@ fn parse_auto(
                 return parse_openai_messages(value, line_no, source_path);
             }
             ProductionTraceFormat::OpenAiTrajectoryJsonl => {
-                return parse_openai_trajectory(value, line_no, source_path);
+                return parse_openai_trajectory(value, line_no, source_path, max_prompt_chars);
             }
             ProductionTraceFormat::AnthropicJsonl => {
                 return parse_anthropic_turn(value, line_no, source_path);
             }
             ProductionTraceFormat::AnthropicTrajectoryJsonl => {
-                return parse_anthropic_trajectory(value, line_no, source_path);
+                return parse_anthropic_trajectory(value, line_no, source_path, max_prompt_chars);
             }
         }
     }
@@ -554,7 +580,10 @@ fn parse_auto(
     }
     if value.get("messages").is_some() {
         if looks_like_anthropic_messages(value.get("messages")) {
-            return parse_anthropic_trajectory(value, line_no, source_path);
+            return parse_anthropic_trajectory(value, line_no, source_path, max_prompt_chars);
+        }
+        if looks_like_openai_trajectory(value.get("messages")) {
+            return parse_openai_trajectory(value, line_no, source_path, max_prompt_chars);
         }
         return parse_openai_messages(value, line_no, source_path);
     }
@@ -677,6 +706,7 @@ fn parse_openai_trajectory(
     value: &serde_json::Value,
     line_no: usize,
     source_path: Option<&str>,
+    max_prompt_chars: usize,
 ) -> Result<ParsedTraceRow, ProductionTraceError> {
     let messages = value
         .get("messages")
@@ -691,20 +721,35 @@ fn parse_openai_trajectory(
     }
     let tools = normalized_tools(value.get("tools"));
     let mut turns = Vec::new();
+    // Prefix size is monotone in `chosen_idx`, so once the running count
+    // crosses the prompt-size guard every later turn is over it too. Emit
+    // marker turns instead of materializing those prefixes — a long agent
+    // session would otherwise clone O(turns × messages) data only for the
+    // consumer to throw it away.
+    let mut prefix_chars = 0usize;
     for (chosen_idx, chosen) in parsed.iter().enumerate() {
-        if chosen.role != "assistant" || target_tool_call_json(chosen).is_none() {
-            continue;
+        let eligible = chosen.role == "assistant"
+            && !matches!(target_tool_calls(chosen), TargetToolCalls::None);
+        if eligible {
+            let prompt_oversize = prefix_chars > max_prompt_chars;
+            let mut turn = TraceTurn::from_export(
+                value,
+                line_no,
+                "openai_trajectory_jsonl",
+                if prompt_oversize {
+                    Vec::new()
+                } else {
+                    parsed[..chosen_idx].to_vec()
+                },
+                chosen.clone(),
+                tools.clone(),
+                Some(chosen_idx),
+                source_path,
+            );
+            turn.prompt_oversize = prompt_oversize;
+            turns.push(turn);
         }
-        turns.push(TraceTurn::from_export(
-            value,
-            line_no,
-            "openai_trajectory_jsonl",
-            parsed[..chosen_idx].to_vec(),
-            chosen.clone(),
-            tools.clone(),
-            Some(chosen_idx),
-            source_path,
-        ));
+        prefix_chars = prefix_chars.saturating_add(message_chars(chosen));
     }
     Ok(ParsedTraceRow::many("openai_trajectory_jsonl", turns))
 }
@@ -769,6 +814,7 @@ fn parse_anthropic_trajectory(
     value: &serde_json::Value,
     line_no: usize,
     source_path: Option<&str>,
+    max_prompt_chars: usize,
 ) -> Result<ParsedTraceRow, ProductionTraceError> {
     let raw: RawAnthropicTurn =
         serde_json::from_value(value.clone()).map_err(|e| ProductionTraceError::Parse {
@@ -781,16 +827,14 @@ fn parse_anthropic_trajectory(
         .map(normalize_tool_schema)
         .collect::<Vec<_>>();
     let mut turns = Vec::new();
+    // Converted prefixes only grow with `chosen_idx`, so once one crosses the
+    // prompt-size guard every later one does too. Emit marker turns instead
+    // of converting/cloning the rest of the row's prefixes.
+    let mut prefix_oversize = false;
     for (chosen_idx, chosen) in raw.messages.iter().enumerate() {
         if chosen.role != "assistant" || !anthropic_message_has_tool_use(chosen) {
             continue;
         }
-        let prefix_conv = anthropic_turn_to_sft_conversation(
-            &raw.messages[..chosen_idx],
-            &[],
-            raw.system_prompt.as_deref(),
-            Some(&tools),
-        );
         let chosen_conv = anthropic_turn_to_sft_conversation(
             &[],
             anthropic_assistant_response_blocks(chosen)
@@ -802,12 +846,28 @@ fn parse_anthropic_trajectory(
         let Some(chosen_msg) = chosen_conv.messages.last() else {
             continue;
         };
-        let prompt_messages = prefix_conv
-            .messages
-            .iter()
-            .map(sft_to_chat_message)
-            .collect();
-        turns.push(TraceTurn::from_export(
+        let prompt_messages = if prefix_oversize {
+            Vec::new()
+        } else {
+            let prefix_conv = anthropic_turn_to_sft_conversation(
+                &raw.messages[..chosen_idx],
+                &[],
+                raw.system_prompt.as_deref(),
+                Some(&tools),
+            );
+            let prompt: Vec<EvalChatMessage> = prefix_conv
+                .messages
+                .iter()
+                .map(sft_to_chat_message)
+                .collect();
+            if prompt_chars(&prompt) > max_prompt_chars {
+                prefix_oversize = true;
+                Vec::new()
+            } else {
+                prompt
+            }
+        };
+        let mut turn = TraceTurn::from_export(
             value,
             line_no,
             "anthropic_trajectory_jsonl",
@@ -816,7 +876,9 @@ fn parse_anthropic_trajectory(
             tools.clone(),
             Some(chosen_idx),
             source_path,
-        ));
+        );
+        turn.prompt_oversize = prefix_oversize;
+        turns.push(turn);
     }
     Ok(ParsedTraceRow::many("anthropic_trajectory_jsonl", turns))
 }
@@ -838,6 +900,34 @@ fn looks_like_anthropic_messages(messages: Option<&serde_json::Value>) -> bool {
                     })
                     .unwrap_or(false)
             })
+        })
+        .unwrap_or(false)
+}
+
+/// Auto-detect full OpenAI-style trajectories so they get per-turn
+/// materialization, symmetric with the Anthropic heuristic above. A
+/// `tool`-role message or more than one assistant `tool_calls` message means
+/// the row is a trajectory, not a single prompt+response turn. Single-turn
+/// rows ending in an assistant tool call stay on the openai_jsonl path,
+/// which materializes the identical example.
+fn looks_like_openai_trajectory(messages: Option<&serde_json::Value>) -> bool {
+    messages
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            let has_tool_role = arr
+                .iter()
+                .any(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("tool"));
+            let assistant_tool_call_msgs = arr
+                .iter()
+                .filter(|msg| {
+                    msg.get("role").and_then(|r| r.as_str()) == Some("assistant")
+                        && msg
+                            .get("tool_calls")
+                            .and_then(|t| t.as_array())
+                            .is_some_and(|t| !t.is_empty())
+                })
+                .count();
+            has_tool_role || assistant_tool_call_msgs > 1
         })
         .unwrap_or(false)
 }
@@ -880,6 +970,8 @@ fn value_to_chat_message(
     let content = match obj.get("content") {
         None | Some(serde_json::Value::Null) => String::new(),
         Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Array(parts)) => flatten_content_parts(parts)
+            .unwrap_or_else(|| serde_json::Value::Array(parts.clone()).to_string()),
         Some(other) => other.to_string(),
     };
     let tool_calls = obj
@@ -901,6 +993,29 @@ fn value_to_chat_message(
     })
 }
 
+/// Flatten OpenAI-style content-part arrays
+/// (`[{"type":"text","text":"…"}, …]`) into the plain text the production
+/// model actually saw. Bare-string parts are accepted too; non-text parts
+/// (images, audio) are skipped. Returns `None` when no part carries text so
+/// genuinely unknown shapes keep the raw-JSON fallback.
+fn flatten_content_parts(parts: &[serde_json::Value]) -> Option<String> {
+    let texts: Vec<&str> = parts
+        .iter()
+        .filter_map(|part| match part.get("type").and_then(|v| v.as_str()) {
+            None | Some("text") => part
+                .get("text")
+                .and_then(|v| v.as_str())
+                .or_else(|| part.as_str()),
+            _ => None,
+        })
+        .collect();
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join(""))
+    }
+}
+
 fn sft_to_chat_message(m: &crate::synthesis::SftMessage) -> EvalChatMessage {
     EvalChatMessage {
         role: m.role.clone(),
@@ -911,18 +1026,39 @@ fn sft_to_chat_message(m: &crate::synthesis::SftMessage) -> EvalChatMessage {
     }
 }
 
-fn target_tool_call_json(chosen: &EvalChatMessage) -> Option<(String, Vec<String>)> {
+/// Outcome of extracting the eval target from a chosen assistant message.
+enum TargetToolCalls {
+    /// Canonical `{"tool_calls":[…]}` JSON plus the tool names.
+    Target { json: String, tools: Vec<String> },
+    /// The message carried no tool call.
+    None,
+    /// The message had structured `tool_calls` entries but at least one did
+    /// not parse. A partial target would silently misrepresent the recorded
+    /// turn, so the caller skips it under a dedicated stats counter.
+    Malformed,
+}
+
+fn target_tool_calls(chosen: &EvalChatMessage) -> TargetToolCalls {
     let calls = if let Some(tool_calls) = chosen.tool_calls.as_ref().filter(|tc| !tc.is_empty()) {
-        let raw = serde_json::json!({ "tool_calls": tool_calls }).to_string();
-        extract_tool_calls(&raw)
+        // Structured entries parse directly — never through the text
+        // scanners, whose XML pass would let an argument value containing
+        // `<tool_call>…</tool_call>` markup hijack the target.
+        let value = serde_json::json!({ "tool_calls": tool_calls });
+        match tool_calls_from_value(&value) {
+            Some(calls) if calls.len() == tool_calls.len() => calls,
+            _ => return TargetToolCalls::Malformed,
+        }
     } else {
         extract_tool_calls(&chosen.content)
     };
     if calls.is_empty() {
-        return None;
+        return TargetToolCalls::None;
     }
-    let tool_names = calls.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
-    Some((canonical_target_json(&calls), tool_names))
+    let tools = calls.iter().map(|c| c.name.clone()).collect::<Vec<_>>();
+    TargetToolCalls::Target {
+        json: canonical_target_json(&calls),
+        tools,
+    }
 }
 
 fn canonical_target_json(calls: &[ParsedToolCall]) -> String {
@@ -983,27 +1119,26 @@ fn sanitize_tag_value(value: &str) -> Option<String> {
 }
 
 fn prompt_chars(messages: &[EvalChatMessage]) -> usize {
-    messages
-        .iter()
-        .map(|m| {
-            m.role.chars().count()
-                + m.content.chars().count()
-                + m.tool_calls
-                    .as_ref()
-                    .map(|tc| {
-                        serde_json::to_string(tc)
-                            .unwrap_or_default()
-                            .chars()
-                            .count()
-                    })
-                    .unwrap_or(0)
-                + m.name.as_ref().map(|s| s.chars().count()).unwrap_or(0)
-                + m.tool_call_id
-                    .as_ref()
-                    .map(|s| s.chars().count())
-                    .unwrap_or(0)
-        })
-        .sum()
+    messages.iter().map(message_chars).sum()
+}
+
+fn message_chars(m: &EvalChatMessage) -> usize {
+    m.role.chars().count()
+        + m.content.chars().count()
+        + m.tool_calls
+            .as_ref()
+            .map(|tc| {
+                serde_json::to_string(tc)
+                    .unwrap_or_default()
+                    .chars()
+                    .count()
+            })
+            .unwrap_or(0)
+        + m.name.as_ref().map(|s| s.chars().count()).unwrap_or(0)
+        + m.tool_call_id
+            .as_ref()
+            .map(|s| s.chars().count())
+            .unwrap_or(0)
 }
 
 fn example_hash(messages: &[EvalChatMessage], target: &str) -> String {
@@ -1132,6 +1267,10 @@ struct TraceTurn {
     chosen: EvalChatMessage,
     tools: Vec<serde_json::Value>,
     source_metadata: serde_json::Map<String, serde_json::Value>,
+    /// True when the trajectory parser already knows the prompt prefix
+    /// exceeds the configured size guard and skipped materializing it.
+    /// `prompt_messages` is empty for these marker turns.
+    prompt_oversize: bool,
 }
 
 impl TraceTurn {
@@ -1183,6 +1322,7 @@ impl TraceTurn {
             chosen,
             tools,
             source_metadata,
+            prompt_oversize: false,
         }
     }
 
@@ -1711,6 +1851,191 @@ mod tests {
             Some("claude_3.7_sonnet_prod".to_string())
         );
         assert_eq!(sanitize_tag_value("   "), None);
+    }
+
+    #[test]
+    fn structured_tool_calls_with_embedded_xml_are_not_hijacked() {
+        // A structured tool_calls entry whose argument value contains a
+        // compact, well-formed Qwen XML snippet (a coding agent writing docs
+        // about the format). The materialized target must stay the real
+        // production call, not the `Foo` embedded in the argument.
+        let embedded =
+            "Example: <tool_call><function=Foo><parameter=x>1</parameter></function></tool_call>";
+        let line = serde_json::json!({
+            "prompt_messages": [{"role":"user", "content":"document the tool-call format"}],
+            "chosen": {"role":"assistant", "content":"", "tool_calls":[{
+                "id":"call_1",
+                "type":"function",
+                "function":{
+                    "name":"Write",
+                    "arguments": serde_json::json!({"file_path":"/tmp/doc.md", "content": embedded}).to_string()
+                }
+            }]}
+        });
+        let (suite, stats) = build(&format!("{line}\n"), None);
+        assert_eq!(stats.eligible_tool_turns, 1);
+        let target: serde_json::Value =
+            serde_json::from_str(suite.examples[0].target.as_deref().unwrap()).unwrap();
+        let calls = target["tool_calls"].as_array().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["name"], serde_json::json!("Write"));
+        assert_eq!(calls[0]["arguments"]["content"], serde_json::json!(embedded));
+        assert_eq!(stats.sampled_tool_histogram.get("Write"), Some(&1));
+        assert!(!stats.sampled_tool_histogram.contains_key("Foo"));
+        assert!(suite.examples[0].tags.contains(&"tool:Write".to_string()));
+    }
+
+    #[test]
+    fn partially_malformed_structured_tool_calls_skip_turn() {
+        // Two structured entries, one missing its name: scoring a silently
+        // truncated 1-call target would misrepresent the recorded turn, so
+        // the whole turn is skipped under a dedicated counter.
+        let malformed = serde_json::json!({
+            "prompt_messages": [{"role":"user", "content":"do two things"}],
+            "chosen": {"role":"assistant", "tool_calls":[
+                {"type":"function", "function":{"name":"Read", "arguments":"{\"path\":\"/a\"}"}},
+                {"type":"function", "function":{"arguments":"{\"path\":\"/b\"}"}}
+            ]}
+        });
+        let valid = serde_json::json!({
+            "prompt_messages": [{"role":"user", "content":"run pwd"}],
+            "chosen": {"role":"assistant", "tool_calls":[{
+                "type":"function",
+                "function":{"name":"Bash", "arguments":"{\"command\":\"pwd\"}"}
+            }]}
+        });
+        let (suite, stats) = build(&format!("{malformed}\n{valid}\n"), None);
+        assert_eq!(stats.skipped_malformed_tool_call, 1);
+        assert_eq!(stats.eligible_tool_turns, 1);
+        assert_eq!(suite.examples.len(), 1);
+        assert!(
+            suite.examples[0]
+                .target
+                .as_deref()
+                .unwrap()
+                .contains("\"Bash\"")
+        );
+    }
+
+    #[test]
+    fn openai_content_parts_flatten_to_text() {
+        let line = serde_json::json!({
+            "messages": [
+                {"role":"user", "content":[{"type":"text","text":"Run ls in /tmp"}]},
+                {"role":"assistant", "content":"", "tool_calls":[{
+                    "type":"function",
+                    "function":{"name":"Bash", "arguments":"{\"command\":\"ls /tmp\"}"}
+                }]}
+            ]
+        });
+        let (suite, _) = build(&format!("{line}\n"), None);
+        assert_eq!(suite.examples[0].messages.len(), 1);
+        assert_eq!(suite.examples[0].messages[0].content, "Run ls in /tmp");
+        assert!(!suite.examples[0].messages[0].content.contains("{\"type\""));
+    }
+
+    #[test]
+    fn auto_detects_openai_trajectory_rows() {
+        // No explicit format label: a full OpenAI trajectory ending in a
+        // plain-text assistant turn must still yield its tool-call turn
+        // under Auto instead of being skipped as a no-tool-call row.
+        let line = serde_json::json!({
+            "messages": [
+                {"role":"system", "content":"You are a coding agent."},
+                {"role":"user", "content":"run the tests"},
+                {"role":"assistant", "content":"", "tool_calls":[{
+                    "id":"call_1",
+                    "type":"function",
+                    "function":{"name":"Bash", "arguments":"{\"command\":\"cargo test\"}"}
+                }]},
+                {"role":"tool", "tool_call_id":"call_1", "content":"ok"},
+                {"role":"assistant", "content":"All tests passed."}
+            ]
+        });
+        let (suite, stats) = build(&format!("{line}\n"), None);
+        assert_eq!(stats.eligible_tool_turns, 1);
+        assert_eq!(suite.examples.len(), 1);
+        assert_eq!(
+            stats
+                .sampled_source_format_counts
+                .get("openai_trajectory_jsonl"),
+            Some(&1)
+        );
+        assert_eq!(suite.examples[0].messages.len(), 2);
+        let call = extract_first_tool_call(suite.examples[0].target.as_deref().unwrap()).unwrap();
+        assert_eq!(call.name, "Bash");
+    }
+
+    #[test]
+    fn trajectory_prefix_cap_skips_oversize_turns() {
+        // Turn 1's prefix fits the guard; a huge tool result pushes every
+        // later prefix over it. The parser stops materializing prefixes but
+        // the skip is still counted as prompt_too_long.
+        let big = "x".repeat(4096);
+        let line = serde_json::json!({
+            "format": "openai_trajectory_jsonl",
+            "messages": [
+                {"role":"user", "content":"inspect, then build"},
+                {"role":"assistant", "content":"", "tool_calls":[{
+                    "type":"function",
+                    "function":{"name":"Read", "arguments":"{\"path\":\"/a\"}"}
+                }]},
+                {"role":"tool", "content": big},
+                {"role":"assistant", "content":"", "tool_calls":[{
+                    "type":"function",
+                    "function":{"name":"Bash", "arguments":"{\"command\":\"cargo build\"}"}
+                }]},
+                {"role":"tool", "content": big},
+                {"role":"assistant", "content":"", "tool_calls":[{
+                    "type":"function",
+                    "function":{"name":"Bash", "arguments":"{\"command\":\"cargo test\"}"}
+                }]}
+            ]
+        });
+        let mut cfg = ProductionTraceSuiteConfig::new("prefix-cap");
+        cfg.sampling.seed = Some(3);
+        cfg.sampling.max_examples = None;
+        cfg.sampling.max_prompt_chars = 1024;
+        let (suite, stats) =
+            synthesize_production_trace_suite(std::io::Cursor::new(format!("{line}\n")), &cfg)
+                .unwrap();
+        assert_eq!(stats.eligible_tool_turns, 3);
+        assert_eq!(stats.skipped_prompt_too_long, 2);
+        assert_eq!(suite.examples.len(), 1);
+        let call = extract_first_tool_call(suite.examples[0].target.as_deref().unwrap()).unwrap();
+        assert_eq!(call.name, "Read");
+    }
+
+    #[test]
+    fn anthropic_trajectory_prefix_cap_skips_oversize_turns() {
+        let big = "x".repeat(4096);
+        let line = serde_json::json!({
+            "format": "anthropic_trajectory_jsonl",
+            "messages": [
+                {"role":"user", "content":"inspect, then build"},
+                {"role":"assistant", "content":[{
+                    "type":"tool_use", "id":"t1", "name":"Read", "input":{"path":"/a"}
+                }]},
+                {"role":"user", "content":[{
+                    "type":"tool_result", "tool_use_id":"t1", "content": big
+                }]},
+                {"role":"assistant", "content":[{
+                    "type":"tool_use", "id":"t2", "name":"Bash", "input":{"command":"cargo build"}
+                }]}
+            ]
+        });
+        let mut cfg = ProductionTraceSuiteConfig::new("anthropic-prefix-cap");
+        cfg.sampling.seed = Some(3);
+        cfg.sampling.max_examples = None;
+        cfg.sampling.max_prompt_chars = 1024;
+        let (suite, stats) =
+            synthesize_production_trace_suite(std::io::Cursor::new(format!("{line}\n")), &cfg)
+                .unwrap();
+        assert_eq!(stats.eligible_tool_turns, 2);
+        assert_eq!(stats.skipped_prompt_too_long, 1);
+        assert_eq!(suite.examples.len(), 1);
+        let call = extract_first_tool_call(suite.examples[0].target.as_deref().unwrap()).unwrap();
+        assert_eq!(call.name, "Read");
     }
 
     #[test]

--- a/crates/kiln-eval/src/qwen3.rs
+++ b/crates/kiln-eval/src/qwen3.rs
@@ -273,6 +273,18 @@ pub fn extract_first_tool_call(raw: &str) -> Option<ParsedToolCall> {
     extract_tool_calls(raw).into_iter().next()
 }
 
+/// Parse tool calls from already-structured JSON (a `{"tool_calls": [...]}`
+/// envelope or a bare tool-call object), without running any of the text
+/// scanners. Use this whenever the calls arrive as structured data —
+/// scanning serialized JSON would let an argument *value* that happens to
+/// contain tool-call markup (e.g. a Write call whose `content` mentions
+/// `<tool_call>…</tool_call>`) hijack the result. Individual entries that
+/// fail to parse are dropped, so callers holding the original array should
+/// compare lengths to detect partial parses.
+pub fn tool_calls_from_value(value: &serde_json::Value) -> Option<Vec<ParsedToolCall>> {
+    json_to_tool_calls(value)
+}
+
 /// Parse every `<tool_call>…</tool_call>` block in `text`. Returns an empty
 /// vec when none are found.
 fn extract_qwen3_xml_tool_calls(text: &str) -> Vec<ParsedToolCall> {

--- a/crates/kiln-eval/src/scorers/bash.rs
+++ b/crates/kiln-eval/src/scorers/bash.rs
@@ -337,8 +337,16 @@ fn is_shell_program(program: &str) -> bool {
     matches!(program, "bash" | "sh" | "zsh" | "dash")
 }
 
-fn is_shell_c_flag(token: &str) -> bool {
-    token.starts_with('-') && token[1..].chars().any(|c| c == 'c')
+/// True for short-option clusters that include `-c` (`-c`, `-lc`, `-xec`).
+/// Long options are excluded — `--norc` / `--rcfile` contain a `c` but do
+/// not introduce inline shell code.
+pub(crate) fn is_shell_c_flag(token: &str) -> bool {
+    let Some(cluster) = token.strip_prefix('-') else {
+        return false;
+    };
+    !cluster.is_empty()
+        && cluster.chars().all(|c| c.is_ascii_alphabetic())
+        && cluster.contains('c')
 }
 
 fn is_inline_program_flag(lang: &str, token: &str) -> bool {
@@ -584,6 +592,28 @@ mod tests {
         let intro = introspect("");
         assert_eq!(intro.program, "");
         assert!(intro.inline_language.is_none());
+    }
+
+    #[test]
+    fn shell_c_flag_matches_short_clusters_only() {
+        assert!(is_shell_c_flag("-c"));
+        assert!(is_shell_c_flag("-lc"));
+        assert!(is_shell_c_flag("-xec"));
+        assert!(!is_shell_c_flag("--norc"));
+        assert!(!is_shell_c_flag("--rcfile"));
+        assert!(!is_shell_c_flag("-l"));
+        assert!(!is_shell_c_flag("script.sh"));
+        assert!(!is_shell_c_flag("-"));
+    }
+
+    #[test]
+    fn introspect_long_option_does_not_become_inline_code() {
+        let intro = introspect("bash --norc script.sh");
+        assert!(intro.inline_code.is_none());
+        assert!(intro.inline_language.is_none());
+        let intro = introspect(r#"bash --rcfile /tmp/rc -c "echo hi""#);
+        assert_eq!(intro.inline_language.as_deref(), Some("bash"));
+        assert_eq!(intro.inline_code.as_deref(), Some("echo hi"));
     }
 
     #[test]

--- a/crates/kiln-eval/src/scorers/tool_call.rs
+++ b/crates/kiln-eval/src/scorers/tool_call.rs
@@ -19,7 +19,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::qwen3::{ParsedToolCall, ToolCallFormat, extract_tool_calls, split_thinking};
+use crate::qwen3::{
+    ParsedToolCall, ToolCallFormat, extract_tool_calls, split_thinking, tool_calls_from_value,
+};
 use crate::result::EvalOutcomeKind;
 use crate::scorers::{
     JudgeRunner, Scorer, ScorerError, bash, code::extract_block, score_completion,
@@ -100,8 +102,11 @@ pub struct ToolCallWeights {
 const TOOL_CALL_PASS_THRESHOLD: f32 = 0.8;
 /// Score awarded when the predicted bash command shares the program but
 /// not the subcommand (e.g. `git commit` vs `git push`). Partial credit
-/// — same family, but the model picked the wrong action.
-const BASH_SAME_PROGRAM_DIFF_SUBCOMMAND: f32 = 0.35;
+/// — same family, but the model picked the wrong action. Must stay below
+/// `(TOOL_CALL_PASS_THRESHOLD - name_w - struct_w) / content_w` (1/3 under
+/// default weights): a single-`command`-arg call gets name and structure
+/// for free, so anything higher lets `git push` vs `git pull` Pass.
+const BASH_SAME_PROGRAM_DIFF_SUBCOMMAND: f32 = 0.25;
 /// Score awarded when the predicted bash command's classification doesn't
 /// match the target's at all (e.g. `python_inline` vs `pip_install`).
 const BASH_WRONG_FAMILY: f32 = 0.1;
@@ -137,7 +142,14 @@ pub(super) fn score(
         .target
         .as_deref()
         .ok_or(ScorerError::MissingTarget { kind: "tool_call" })?;
-    let target_calls = extract_tool_calls(target_raw);
+    // Targets are normally stored as canonical `{"tool_calls":[…]}` JSON, so
+    // parse them structurally first. The text scanners are only a fallback
+    // for prose/XML-shaped targets — running them on canonical JSON would
+    // let an argument value containing tool-call markup hijack the target.
+    let target_calls = serde_json::from_str::<serde_json::Value>(target_raw)
+        .ok()
+        .and_then(|v| tool_calls_from_value(&v))
+        .unwrap_or_else(|| extract_tool_calls(target_raw));
     if target_calls.is_empty() {
         return Err(ScorerError::MissingTarget {
             kind: "tool_call (target had no parseable tool call)",
@@ -659,9 +671,18 @@ fn score_shell_wrapper_pair(
     let predicted_shell = shell_wrapper_inner(predicted_intro);
     match (target_shell, predicted_shell) {
         (Some(t_inner), Some(p_inner)) => {
-            let raw_similarity = code_token_similarity(t_inner, p_inner);
             let recursive = score_bash_command_depth(t_inner, p_inner, depth + 1);
-            Some(raw_similarity.max(recursive))
+            // Raw token overlap only breaks ties between commands the
+            // introspector agrees on. When the inner classifications differ
+            // (wrong subcommand / wrong family), the semantic verdict stands
+            // — `git push` vs `git pull` share 3 of 4 tokens and would
+            // otherwise be rescued by the jaccard score.
+            if bash::introspect(t_inner).classification()
+                != bash::introspect(p_inner).classification()
+            {
+                return Some(recursive);
+            }
+            Some(code_token_similarity(t_inner, p_inner).max(recursive))
         }
         (Some(t_inner), None) => Some(score_bash_command_depth(t_inner, predicted_raw, depth + 1)),
         (None, Some(p_inner)) => Some(score_bash_command_depth(target_raw, p_inner, depth + 1)),
@@ -822,7 +843,10 @@ fn python_command_from_call_args(args: &str) -> Option<String> {
 
 fn python_command_from_string_list(parts: &[String]) -> Option<String> {
     let program = parts.first()?.as_str();
-    if matches!(program, "bash" | "sh" | "zsh") && parts.len() >= 3 && parts[1].contains('c') {
+    if matches!(program, "bash" | "sh" | "zsh")
+        && parts.len() >= 3
+        && bash::is_shell_c_flag(&parts[1])
+    {
         return Some(parts[2].clone());
     }
     Some(parts.join(" "))
@@ -1274,6 +1298,80 @@ mod tests {
         .unwrap();
         assert!(s > 0.95, "score was {s}");
         assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn wrong_git_subcommand_fails() {
+        let (s, kind, detail) =
+            score_bash_tool_commands("git push origin main", "git pull origin main");
+        assert_eq!(kind, EvalOutcomeKind::Fail, "{detail:?}");
+        assert!(s < 0.8, "score was {s}");
+    }
+
+    #[test]
+    fn wrong_git_subcommand_fails_under_shell_wrapper() {
+        let (s, kind, detail) = score_bash_tool_commands(
+            r#"bash -lc "git push origin main""#,
+            r#"bash -lc "git pull origin main""#,
+        );
+        assert_eq!(kind, EvalOutcomeKind::Fail, "{detail:?}");
+        assert!(s < 0.8, "score was {s}");
+    }
+
+    #[test]
+    fn pip_uninstall_vs_install_fails() {
+        let (s, kind, detail) = score_bash_tool_commands("pip install x", "pip uninstall x");
+        assert_eq!(kind, EvalOutcomeKind::Fail, "{detail:?}");
+        assert!(s < 0.8, "score was {s}");
+    }
+
+    #[test]
+    fn equal_commands_still_pass() {
+        let (s, kind, detail) =
+            score_bash_tool_commands("git push origin main", "git push origin main");
+        assert_eq!(kind, EvalOutcomeKind::Pass, "{detail:?}");
+        assert!(s > 0.95, "score was {s}");
+        let (s, kind, detail) = score_bash_tool_commands(
+            r#"bash -lc "git push origin main""#,
+            r#"bash -lc "git push origin main""#,
+        );
+        assert_eq!(kind, EvalOutcomeKind::Pass, "{detail:?}");
+        assert!(s > 0.95, "score was {s}");
+    }
+
+    #[test]
+    fn target_json_with_embedded_xml_markup_is_not_hijacked() {
+        // The canonical JSON target's argument value mentions tool-call XML
+        // (a Write call whose file content documents the format). The target
+        // must stay `Write`, not the `Foo` inside the argument string — a
+        // model that actually calls `Foo` has to fail.
+        let target = serde_json::json!({
+            "tool_calls": [{
+                "name": "Write",
+                "arguments": {
+                    "file_path": "/tmp/doc.md",
+                    "content": "Example: <tool_call><function=Foo><parameter=x>1</parameter></function></tool_call>"
+                }
+            }]
+        })
+        .to_string();
+        let pred = "<tool_call>\n<function=Foo>\n<parameter=x>\n1\n</parameter>\n</function>\n</tool_call>";
+        let (s, kind, detail) = score(
+            &ex(&target),
+            pred,
+            &NameMatch::CaseInsensitive,
+            &ArgsScoring::Auto,
+            None,
+            false,
+            &NoopJudgeRunner,
+        )
+        .unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Fail, "{detail:?}");
+        assert!(s < 0.5, "score was {s}; detail={detail:?}");
+        assert!(
+            detail.as_deref().unwrap().contains("expected `Write`"),
+            "detail={detail:?}"
+        );
     }
 
     #[test]

--- a/crates/kiln-server/src/bin/kiln_eval_cli.rs
+++ b/crates/kiln-server/src/bin/kiln_eval_cli.rs
@@ -158,7 +158,11 @@ struct TraceSuiteArgs {
     description: Option<String>,
     /// Input format: auto | prompt_chosen_jsonl | openai_jsonl |
     /// openai_trajectory_jsonl | anthropic_jsonl |
-    /// anthropic_trajectory_jsonl.
+    /// anthropic_trajectory_jsonl. `auto` inspects each row: explicit
+    /// per-row `format` labels win; OpenAI or Anthropic `messages` arrays
+    /// that look like full trajectories (tool-role messages, tool_use
+    /// blocks, or multiple tool-calling assistant turns) get per-turn
+    /// materialization; other `messages` rows score the final assistant.
     #[arg(long, default_value = "auto", value_parser = parse_trace_format)]
     format: ProductionTraceFormat,
     /// Reservoir sample size. Omit to use the production-trace default.
@@ -229,12 +233,17 @@ fn parse_trace_format(s: &str) -> std::result::Result<ProductionTraceFormat, Str
         "openai_trajectory_jsonl" | "openai-trajectory-jsonl" | "openai_trajectory" => {
             Ok(ProductionTraceFormat::OpenAiTrajectoryJsonl)
         }
-        "anthropic_jsonl" | "anthropic-jsonl" | "jsonl" => {
-            Ok(ProductionTraceFormat::AnthropicJsonl)
-        }
+        "anthropic_jsonl" | "anthropic-jsonl" => Ok(ProductionTraceFormat::AnthropicJsonl),
         "anthropic_trajectory_jsonl" | "anthropic-trajectory-jsonl" | "anthropic_trajectory" => {
             Ok(ProductionTraceFormat::AnthropicTrajectoryJsonl)
         }
+        // `jsonl` used to silently alias anthropic_jsonl, quietly skipping
+        // every non-Anthropic row. Too ambiguous to guess.
+        "jsonl" => Err(
+            "ambiguous trace format `jsonl`; pass an explicit format (auto | prompt_chosen_jsonl \
+             | openai_jsonl | openai_trajectory_jsonl | anthropic_jsonl | anthropic_trajectory_jsonl)"
+                .to_string(),
+        ),
         other => Err(format!(
             "unknown trace format `{other}` (try auto | prompt_chosen_jsonl | openai_jsonl | openai_trajectory_jsonl | anthropic_jsonl | anthropic_trajectory_jsonl)"
         )),
@@ -385,7 +394,8 @@ fn cmd_trace_suite(args: TraceSuiteArgs) -> Result<()> {
     let suite_json = serde_json::to_string_pretty(&suite)?;
     if args.stdout {
         println!("{suite_json}");
-    } else if let Some(output) = args.output.as_ref() {
+    }
+    if let Some(output) = args.output.as_ref() {
         write_string_file(output, &suite_json)?;
     }
 
@@ -420,14 +430,16 @@ fn cmd_trace_suite(args: TraceSuiteArgs) -> Result<()> {
     }
     if stats.skipped_parse_error > 0
         || stats.skipped_no_tool_call > 0
+        || stats.skipped_malformed_tool_call > 0
         || stats.skipped_prompt_too_long > 0
         || stats.skipped_target_too_long > 0
         || stats.skipped_duplicate > 0
     {
         eprintln!(
-            "skipped: parse_error={} no_tool_call={} empty_prompt={} prompt_too_long={} target_too_long={} duplicate={}",
+            "skipped: parse_error={} no_tool_call={} malformed_tool_call={} empty_prompt={} prompt_too_long={} target_too_long={} duplicate={}",
             stats.skipped_parse_error,
             stats.skipped_no_tool_call,
+            stats.skipped_malformed_tool_call,
             stats.skipped_empty_prompt,
             stats.skipped_prompt_too_long,
             stats.skipped_target_too_long,
@@ -457,7 +469,8 @@ fn cmd_panel_suite(args: PanelSuiteArgs) -> Result<()> {
     let panel_json = serde_json::to_string_pretty(&panel)?;
     if args.stdout {
         println!("{panel_json}");
-    } else if let Some(output) = args.output.as_ref() {
+    }
+    if let Some(output) = args.output.as_ref() {
         write_string_file(output, &panel_json)?;
     }
 
@@ -1449,4 +1462,54 @@ fn compute_flip_diff(result: &EvalResultPayload) -> Option<kiln_eval::FlipDiff> 
         error: None,
     };
     synthetic.flip_diff()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonl_format_alias_is_rejected() {
+        let err = parse_trace_format("jsonl").unwrap_err();
+        assert!(err.contains("ambiguous"), "{err}");
+        assert!(err.contains("anthropic_jsonl"), "{err}");
+        assert!(parse_trace_format("anthropic_jsonl").is_ok());
+        assert!(parse_trace_format("auto").is_ok());
+    }
+
+    #[test]
+    fn trace_suite_writes_output_file_even_with_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("trace.jsonl");
+        let row = serde_json::json!({
+            "prompt_messages": [{"role":"user", "content":"run pwd"}],
+            "chosen": {"role":"assistant", "tool_calls":[{
+                "type":"function",
+                "function":{"name":"Bash", "arguments":"{\"command\":\"pwd\"}"}
+            }]}
+        });
+        std::fs::write(&input, format!("{row}\n")).unwrap();
+        let output = dir.path().join("suite.json");
+        let args = TraceSuiteArgs {
+            input: vec![input],
+            output: Some(output.clone()),
+            stats_output: None,
+            suite_name: "stdout-and-output".into(),
+            description: None,
+            format: ProductionTraceFormat::Auto,
+            max_examples: None,
+            seed: Some(1),
+            max_prompt_chars: None,
+            max_target_chars: None,
+            dedupe: false,
+            require_qwen_xml: false,
+            max_tokens: None,
+            temperature: None,
+            stdout: true,
+        };
+        cmd_trace_suite(args).unwrap();
+        let suite: EvalSuite =
+            serde_json::from_slice(&std::fs::read(&output).unwrap()).unwrap();
+        assert_eq!(suite.examples.len(), 1);
+    }
 }

--- a/docs/EVAL_GUIDE.md
+++ b/docs/EVAL_GUIDE.md
@@ -147,8 +147,12 @@ Pass `--format openai_trajectory_jsonl` when every row is a full trajectory,
 pass `--format anthropic_trajectory_jsonl` for Anthropic full trajectories, or
 include `"format": "openai_trajectory_jsonl"` / `"trace_format": ...` on
 individual rows when mixing row shapes under `--format auto`. Auto-detection
-also recognizes Anthropic `messages` arrays that contain `tool_use` or
-`tool_result` content blocks.
+recognizes both vendors' trajectories: Anthropic `messages` arrays that
+contain `tool_use` or `tool_result` content blocks, and OpenAI `messages`
+arrays that contain `tool`-role messages or more than one assistant
+`tool_calls` turn. Both get per-turn materialization; remaining `messages`
+rows fall back to single-turn `openai_jsonl` scoring of the final assistant
+message.
 
 Rows without a current-turn tool call are skipped. Eligible rows are
 reservoir-sampled, so large exports can stream through without loading the
@@ -207,7 +211,17 @@ the target API's normal chat-completions surface, converts structured
 `message.tool_calls` responses back into canonical `tool_calls` JSON for
 scoring, and still accepts raw Qwen XML / fenced / inline JSON completions.
 This keeps the eval focused on tool-call semantics while letting each provider
-apply its own ideal chat/tool format.
+apply its own ideal chat/tool format. Requests carry a total per-request
+timeout (`--timeout-secs`, default 120) plus a 10s connect timeout, so a hung
+endpoint fails that example instead of stalling the run.
+
+One transport caveat: suites built with `--require-qwen-xml` cannot measure
+output *format* through this runner when tools are sent. An OpenAI-compatible
+server that parses tool calls returns them as structured `message.tool_calls`,
+erasing whatever wire format the model actually emitted — possibly genuine
+Qwen XML. For those responses the runner disables the XML-format requirement
+(with a one-time warning) and scores semantics only. Pass `--no-tools` to
+receive raw completions if format enforcement matters.
 
 For shell-heavy traces, the tool-call scorer compares beneath common wrappers:
 `bash -lc`, `python -c`, and Python here-doc/stdin forms are normalized before
@@ -696,7 +710,10 @@ shell layers (`bash -c` / `bash -lc`) and compares inline code from
 `python -c` or `python - <<'PY' ... PY` by token similarity instead of raw
 string equality. This catches the production pattern where the real action is
 buried inside a shell call without turning inconsequential wrapping changes
-into eval failures.
+into eval failures. "Right program, wrong action" predictions stay failures:
+a same-program subcommand mismatch (`git push` vs `git pull`,
+`pip install` vs `pip uninstall`) scores below the pass threshold under
+default weights, even when the command is wrapped in `bash -lc`.
 
 ### 3. Tools belong on the suite
 


### PR DESCRIPTION
## Context

Before merging #1383 I ran a 12-agent review workflow over its code diff (4 dimension reviewers → adversarial verification of every blocker/major finding). **8 major findings were confirmed, 0 refuted.** #1383 was merged as-is to keep the diff reviewable; this PR fixes all 8 confirmed majors plus 3 cheap minors, each with a regression test.

## Fixes

1. **XML-hijack of structured targets** — `target_tool_call_json` round-tripped structured `tool_calls` through a string and re-ran the text scanners, so an argument *value* containing `<tool_call>…` markup silently replaced the eval target. Now parses strictly-JSON-first (new `qwen3::tool_calls_from_value`); the same hijack existed at scoring time in `tool_call.rs::score()` and is fixed there too. Partial parse-drops now count (`skipped_malformed_tool_call`) instead of silently shrinking 2-call targets to 1.
2. **Content-parts arrays** — OpenAI `content: [{type:"text",…}]` was dumped into prompts as a raw JSON blob; now flattened to text (matching the Anthropic path).
3+6. **Auto-detection vendor asymmetry** — `--format auto` could never select `openai_trajectory`, so unlabeled OpenAI trajectories lost every intermediate tool-call turn (most rows skipped entirely). Auto now recognizes them (role:"tool" present or >1 assistant tool_calls turns) symmetrically with Anthropic.
4. **No HTTP timeout** in `trace_api_eval` — one hung endpoint froze the whole run forever. New `--timeout-secs` (default 120) + 10s connect timeout.
5. **Quadratic transient memory** — trajectory parsers materialized every turn's full message-prefix clone before any size filtering; now the prompt-size cap threads into the parsers (monotone prefix growth → stop early, counted as `skipped_prompt_too_long`).
7. **Wrong-subcommand Bash calls PASSED** — `git push` vs `git pull` scored 0.805 ≥ 0.8 under default weights (and 0.88 when `bash -lc`-wrapped, where raw token similarity overrode the semantic verdict). `BASH_SAME_PROGRAM_DIFF_SUBCOMMAND` 0.35→0.25 and wrapper-pair scoring no longer lets raw similarity override a semantic mismatch. Regression tests: `git push`/`git pull` (plain + wrapped) and `pip install`/`pip uninstall` must Fail; equal commands still Pass.
8. **`require_xml_format` vs API transport** — servers that parse tool calls natively erase the raw output format, so XML-strict suites scored 100% Invalid through `trace_api_eval`. API-native tool calls now waive the XML check with a one-time loud warning.

Minors: `--format jsonl` alias no longer silently selects the Anthropic parser (now an error naming the explicit formats); `is_shell_c_flag` no longer treats `--norc`/`--rcfile` as `-c`; `--stdout` + `--output` writes both. `docs/EVAL_GUIDE.md` updated for all documented-behavior changes.

## Validation

- `cargo test -p kiln-eval` — 200 lib + 14 integration + 4 example tests green (13 new regression tests; the example target now compiles with `test = true` so its tests actually run)
- `cargo test -p kiln-server --lib` — 485 green; `cargo check -p kiln-server --bins` clean

Full review findings: 12-agent workflow, 8/8 confirmed majors fixed, 22 minors triaged (3 fixed here, rest are tracked candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)