### PR TITLE
training: reject path-traversal and reserved adapter names at submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "futures",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "regex",

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -951,12 +951,14 @@ fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
-/// Reject names that aren't safe single-segment identifiers. Read-only export
-/// of managed adapters only — never absolute paths, never path traversal.
-fn validate_adapter_name(name: &str) -> Result<(), ApiError> {
+/// Reject names that aren't safe single-segment identifiers — never absolute
+/// paths, never path traversal, never the dot-prefixed names reserved for
+/// kiln internals (`.composed/`, `.upload-tmp-*/`, `.eval/`). Shared by the
+/// adapter-management and training-submission surfaces so every adapter that
+/// training can create is one the API can manage.
+pub(crate) fn validate_adapter_name(name: &str) -> Result<(), ApiError> {
     if name.is_empty()
-        || name == "."
-        || name == ".."
+        || name.starts_with('.')
         || name.contains('/')
         || name.contains('\\')
         || name.contains("..")

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -475,6 +475,9 @@ fn count_adapter_dirs(dir: &std::path::Path) -> usize {
             entries
                 .filter_map(|e| e.ok())
                 .filter(|e| e.path().is_dir())
+                // Dot-prefixed names are kiln internals (.composed,
+                // .upload-tmp-*, .eval, .requests, .kiln-jobs), not adapters.
+                .filter(|e| !e.file_name().to_string_lossy().starts_with('.'))
                 .count()
         })
         .unwrap_or(0)

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -271,6 +271,9 @@ async fn submit_sft(
 
     let num_examples = req.examples.len();
     let job_id = uuid::Uuid::new_v4().to_string();
+    if let Some(name) = req.config.output_name.as_deref() {
+        super::adapters::validate_adapter_name(name)?;
+    }
     let adapter_name = req
         .config
         .output_name
@@ -433,6 +436,9 @@ async fn submit_grpo(
         }
     };
     let job_id = uuid::Uuid::new_v4().to_string();
+    if let Some(name) = req.config.output_name.as_deref() {
+        super::adapters::validate_adapter_name(name)?;
+    }
     let adapter_name = req
         .config
         .output_name
@@ -593,6 +599,9 @@ async fn submit_opd(
     }
 
     let job_id = uuid::Uuid::new_v4().to_string();
+    if let Some(name) = req.config.output_name.as_deref() {
+        super::adapters::validate_adapter_name(name)?;
+    }
     let adapter_name = req
         .config
         .output_name
@@ -712,6 +721,7 @@ async fn submit_distill_refresh(
             "DistillRefresh: `name` must be non-empty".to_string(),
         ));
     }
+    super::adapters::validate_adapter_name(&req.name)?;
     if req.behavioural_teacher.trim().is_empty() {
         return Err(ApiError::training_invalid_request(
             "DistillRefresh: `behavioural_teacher` alias must be non-empty".to_string(),
@@ -802,6 +812,7 @@ async fn submit_distill_merge(
             "distill_merge: `name` must be non-empty".to_string(),
         ));
     }
+    super::adapters::validate_adapter_name(&req.name)?;
     enforce_queue_caps(&state)?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();
@@ -833,6 +844,7 @@ async fn submit_distill_pump(
             "distill/pump: `teacher` alias must be non-empty".to_string(),
         ));
     }
+    super::adapters::validate_adapter_name(&req.name)?;
     enforce_queue_caps(&state)?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();
@@ -864,6 +876,7 @@ async fn submit_distill_self(
             "distill/self: `name` must be non-empty".to_string(),
         ));
     }
+    super::adapters::validate_adapter_name(&req.name)?;
     enforce_queue_caps(&state)?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();

--- a/crates/kiln-server/tests/training_output_name_validation.rs
+++ b/crates/kiln-server/tests/training_output_name_validation.rs
@@ -1,0 +1,186 @@
+//! Integration test: training-submission adapter names are validated.
+//!
+//! `output_name` (SFT/GRPO/OPD) and `name` (distill endpoints) become
+//! directory names under `adapter_dir`. Unvalidated, `../evil` escapes the
+//! adapter root and `.composed` collides with kiln's reserved internals —
+//! and the resulting adapters can't be managed by the (validated) adapter
+//! API. Every submission endpoint must reject unsafe names with 400
+//! `invalid_adapter_name` before any queue/registration work happens.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state() -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "Qwen3.5-4B".to_string(),
+    )
+}
+
+async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+const BAD_NAMES: &[&str] = &["../evil", "a/b", "/abs", ".composed", "..", "a\\b"];
+
+fn sft_body(name: &str) -> Value {
+    json!({
+        "examples": [{"messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"}
+        ]}],
+        "config": {"output_name": name},
+    })
+}
+
+fn grpo_body(name: &str) -> Value {
+    json!({
+        "groups": [{
+            "messages": [{"role": "user", "content": "hi"}],
+            "completions": [
+                {"text": "a", "reward": 1.0},
+                {"text": "b", "reward": 0.0}
+            ],
+        }],
+        "config": {"output_name": name},
+    })
+}
+
+fn opd_body(name: &str) -> Value {
+    json!({
+        "prompts": [{"messages": [{"role": "user", "content": "hi"}]}],
+        "teacher": "qwen3.6-27b@local",
+        "config": {"output_name": name},
+    })
+}
+
+async fn assert_invalid_name(app: &axum::Router, path: &str, body: Value, name: &str) {
+    let (status, response) = post(app, path, body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "{path} must reject name {name:?}, got {status}: {response}"
+    );
+    assert_eq!(
+        response["error"]["code"], "invalid_adapter_name",
+        "{path} name {name:?}: {response}"
+    );
+}
+
+#[tokio::test]
+async fn sft_grpo_opd_reject_unsafe_output_names() {
+    let app = api::router(make_state());
+    for name in BAD_NAMES {
+        assert_invalid_name(&app, "/v1/train/sft", sft_body(name), name).await;
+        assert_invalid_name(&app, "/v1/train/grpo", grpo_body(name), name).await;
+        assert_invalid_name(&app, "/v1/train/opd", opd_body(name), name).await;
+    }
+}
+
+#[tokio::test]
+async fn distill_endpoints_reject_unsafe_names() {
+    let app = api::router(make_state());
+    for name in BAD_NAMES {
+        assert_invalid_name(
+            &app,
+            "/v1/adapters/distill_merge",
+            json!({
+                "name": name,
+                "sources": [
+                    {"adapter": "a", "weight": 1.0},
+                    {"adapter": "b", "weight": 1.0}
+                ],
+            }),
+            name,
+        )
+        .await;
+        assert_invalid_name(
+            &app,
+            "/v1/distill/self",
+            json!({ "name": name, "mode": "conciseness" }),
+            name,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn valid_output_name_proceeds_past_validation() {
+    // Mock mode can't actually train; reaching the mock-mode rejection (or
+    // any non-validation error) proves the name itself was accepted.
+    let app = api::router(make_state());
+    let (status, response) = post(&app, "/v1/train/sft", sft_body("my-adapter_v2")).await;
+    assert_ne!(
+        response["error"]["code"], "invalid_adapter_name",
+        "safe name must pass validation: {response}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "mock mode rejects training AFTER validation: {response}"
+    );
+}


### PR DESCRIPTION
## Problem

Training submission endpoints never validated the adapter name that becomes a directory under `adapter_dir`:

- `output_name: "../evil"` on `/v1/train/{sft,grpo,opd}` escapes the adapter root (the training worker creates the directory; the write path is attacker-shaped if anything network-reachable can submit training jobs — which is the documented threat surface).
- `a/b` creates nested dirs the adapter API can't address; `.composed` / `.upload-tmp-*` collide with kiln's reserved internals.
- The adapter management API validates names strictly (`validate_adapter_name`), so training could mint adapters that load/delete/download then refuse to touch — unmanageable artifacts.
- `/v1/distill/pump` had **no** name check at all (not even non-empty).

## Changes

- `validate_adapter_name` promoted to `pub(crate)`, extended to reject dot-prefixed names (reserved namespace), and called at all seven submission sites (`submit_sft`/`grpo`/`opd` on `output_name`; `distill_refresh`/`merge`/`pump`/`self` on `name`) before any queue/registration work.
- Drive-by, same theme: `/health`'s `adapters_loaded` counted reserved dot-dirs (`.eval`, `.kiln-jobs`) as adapters — now filtered.

## Validation

New integration suite: 6 hostile names (`../evil`, `a/b`, `/abs`, `.composed`, `..`, `a\b`) × 5 endpoints → 400 `invalid_adapter_name`; a safe name passes validation and reaches the mock-mode rejection (proving order). `cargo test -p kiln-server --lib` 485/485; adapter path-traversal/upload/download/merge suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)