### PR TITLE
eval scorers: numeric target strictness, composite outcome propagation, MCQ detection rewrite

### DIFF
--- a/crates/kiln-eval/src/scorers/mod.rs
+++ b/crates/kiln-eval/src/scorers/mod.rs
@@ -361,6 +361,7 @@ pub fn score_completion(
             } else {
                 let mut sum = 0.0f32;
                 let mut all_pass = true;
+                let mut all_invalid = true;
                 let mut details = Vec::new();
                 let mut any_error = false;
                 for s in scorers {
@@ -368,6 +369,9 @@ pub fn score_completion(
                     sum += outcome.score;
                     if !matches!(outcome.kind, EvalOutcomeKind::Pass) {
                         all_pass = false;
+                    }
+                    if !matches!(outcome.kind, EvalOutcomeKind::Invalid) {
+                        all_invalid = false;
                     }
                     if matches!(outcome.kind, EvalOutcomeKind::Error) {
                         any_error = true;
@@ -380,6 +384,11 @@ pub fn score_completion(
                     EvalOutcomeKind::Error
                 } else if all_pass {
                     EvalOutcomeKind::Pass
+                } else if all_invalid {
+                    // Every branch declined to judge (e.g. judge scorers
+                    // without a runner) — the composite has no verdict,
+                    // which must not masquerade as a model failure.
+                    EvalOutcomeKind::Invalid
                 } else {
                     EvalOutcomeKind::Fail
                 };
@@ -404,6 +413,8 @@ pub fn score_completion(
             } else {
                 let mut best = 0.0f32;
                 let mut any_pass = false;
+                let mut any_error = false;
+                let mut all_invalid = true;
                 let mut details = Vec::new();
                 for s in scorers {
                     let outcome = score_completion(s, example, completion_text, judge_runner)?;
@@ -413,12 +424,24 @@ pub fn score_completion(
                     if matches!(outcome.kind, EvalOutcomeKind::Pass) {
                         any_pass = true;
                     }
+                    if matches!(outcome.kind, EvalOutcomeKind::Error) {
+                        any_error = true;
+                    }
+                    if !matches!(outcome.kind, EvalOutcomeKind::Invalid) {
+                        all_invalid = false;
+                    }
                     if let Some(d) = outcome.detail {
                         details.push(format!("{}: {d}", s.kind_label()));
                     }
                 }
+                // Pass wins (the contract of Any); otherwise surface the
+                // most informative non-verdict, mirroring the All arm.
                 let kind = if any_pass {
                     EvalOutcomeKind::Pass
+                } else if any_error {
+                    EvalOutcomeKind::Error
+                } else if all_invalid {
+                    EvalOutcomeKind::Invalid
                 } else {
                     EvalOutcomeKind::Fail
                 };
@@ -685,6 +708,60 @@ mod tests {
         assert_eq!(out.kind, EvalOutcomeKind::Pass);
         let out = score_completion(&scorer, &e, "no match here", &NoopJudgeRunner).unwrap();
         assert_eq!(out.kind, EvalOutcomeKind::Fail);
+    }
+
+    #[test]
+    fn any_composite_of_only_invalid_branches_is_invalid_not_fail() {
+        // A judge-only Any with no runner has no verdict at all — reporting
+        // Fail would count "couldn't judge" as a model failure.
+        let scorer = Scorer::Any {
+            scorers: vec![Scorer::LlmJudge {
+                judge_adapter: None,
+                template: llm_judge::default_judge_template(),
+                score_regex: llm_judge::default_judge_regex(),
+            }],
+        };
+        let e = ex(Some("hi"));
+        let out = score_completion(&scorer, &e, "anything", &NoopJudgeRunner).unwrap();
+        assert_eq!(out.kind, EvalOutcomeKind::Invalid);
+    }
+
+    #[test]
+    fn any_composite_mixed_invalid_and_fail_is_fail() {
+        let scorer = Scorer::Any {
+            scorers: vec![
+                Scorer::LlmJudge {
+                    judge_adapter: None,
+                    template: llm_judge::default_judge_template(),
+                    score_regex: llm_judge::default_judge_regex(),
+                },
+                Scorer::Contains {
+                    phrases: vec!["needle".into()],
+                    mode: contains::ContainsMode::Any,
+                    case_sensitive: false,
+                },
+            ],
+        };
+        let e = ex(Some("hi"));
+        let out = score_completion(&scorer, &e, "no match", &NoopJudgeRunner).unwrap();
+        assert_eq!(out.kind, EvalOutcomeKind::Fail);
+        // ...and a real pass still wins over the invalid branch.
+        let out = score_completion(&scorer, &e, "the needle", &NoopJudgeRunner).unwrap();
+        assert_eq!(out.kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn all_composite_of_only_invalid_branches_is_invalid() {
+        let scorer = Scorer::All {
+            scorers: vec![Scorer::LlmJudge {
+                judge_adapter: None,
+                template: llm_judge::default_judge_template(),
+                score_regex: llm_judge::default_judge_regex(),
+            }],
+        };
+        let e = ex(Some("hi"));
+        let out = score_completion(&scorer, &e, "anything", &NoopJudgeRunner).unwrap();
+        assert_eq!(out.kind, EvalOutcomeKind::Invalid);
     }
 
     #[test]

--- a/crates/kiln-eval/src/scorers/multiple_choice.rs
+++ b/crates/kiln-eval/src/scorers/multiple_choice.rs
@@ -59,29 +59,96 @@ pub(super) fn score(
 
 fn detect_answer(text: &str, valid: &[String]) -> Option<String> {
     let upper = text.to_uppercase();
-    // Look for the strongest signal first.
+    // Strongest signal: explicit answer markers. Models revise themselves
+    // ("the answer is A... no wait, the answer is C"), so the LAST marker
+    // occurrence wins, not the first.
+    let mut marker_hit: Option<(usize, String)> = None;
     for marker in ["ANSWER:", "ANSWER IS", "FINAL ANSWER:", "FINAL ANSWER IS"] {
-        if let Some(idx) = upper.find(marker) {
+        for (idx, _) in upper.match_indices(marker) {
             let tail = &upper[idx + marker.len()..];
-            if let Some(letter) = next_letter(tail, valid) {
-                return Some(letter);
+            // Colon forms ("Answer: X") are deliberate label slots — take
+            // the first valid token verbatim. Prose forms ("answer is …")
+            // need the article guard: "the answer is A bit tricky" must
+            // not read the article as choice A.
+            let letter = if marker.ends_with(':') {
+                next_letter(tail, valid, false)
+            } else {
+                next_letter(tail, valid, true)
+            };
+            if let Some(letter) = letter {
+                if marker_hit.as_ref().is_none_or(|(pos, _)| idx >= *pos) {
+                    marker_hit = Some((idx, letter));
+                }
             }
         }
     }
-    // Leading patterns like "B)", "(B)", "B." — check the trimmed start
-    let stripped = upper.trim_start();
-    if let Some(letter) = next_letter(stripped, valid) {
+    if let Some((_, letter)) = marker_hit {
         return Some(letter);
     }
-    // Final fallback: any standalone letter token anywhere.
-    next_letter(&upper, valid)
+    // Leading patterns like "B)", "(B)", "B." — by definition only the
+    // FIRST token can be "leading"; scanning further belongs to the
+    // fallback below (where the article guard applies).
+    if let Some(letter) = first_token(upper.trim_start(), valid) {
+        return Some(letter);
+    }
+    // Final fallback: the LAST standalone valid token anywhere — a model
+    // that weighs options ("I considered A but the right choice is D")
+    // states its conclusion last.
+    next_letter_from_end(&upper, valid)
 }
 
-fn next_letter(s: &str, valid: &[String]) -> Option<String> {
+/// True when a single-letter candidate at `..end` reads as English ("A"
+/// article / "I" pronoun) rather than an answer: i.e. it is immediately
+/// followed by whitespace and another word. Punctuation or end-of-text
+/// after the letter means it stands alone as an answer.
+fn looks_like_article(s: &str, token: &str, end: usize) -> bool {
+    if token != "A" && token != "I" {
+        return false;
+    }
+    let rest = &s[end..];
+    let trimmed = rest.trim_start();
+    trimmed.len() < rest.len() && trimmed.starts_with(|c: char| c.is_ascii_alphanumeric())
+}
+
+/// First valid token scanning forward. With `guard_articles`, skips
+/// "A"/"I" hits that read as English words.
+fn next_letter(s: &str, valid: &[String], guard_articles: bool) -> Option<String> {
+    for (token, end) in tokens(s) {
+        if valid.iter().any(|c| c == token) {
+            if guard_articles && looks_like_article(s, token, end) {
+                continue;
+            }
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
+/// Last valid token in the text, with the article guard always on.
+fn next_letter_from_end(s: &str, valid: &[String]) -> Option<String> {
+    let mut last: Option<String> = None;
+    for (token, end) in tokens(s) {
+        if valid.iter().any(|c| c == token) && !looks_like_article(s, token, end) {
+            last = Some(token.to_string());
+        }
+    }
+    last
+}
+
+/// The first alphanumeric run only — for leading-pattern detection.
+fn first_token(s: &str, valid: &[String]) -> Option<String> {
+    let (token, _) = tokens(s).next()?;
+    valid
+        .iter()
+        .any(|c| c == token)
+        .then(|| token.to_string())
+}
+
+/// Iterator over (token, end_byte_offset) alphanumeric runs.
+fn tokens(s: &str) -> impl Iterator<Item = (&str, usize)> {
     let bytes = s.as_bytes();
     let mut i = 0;
-    while i < bytes.len() {
-        // Skip non-alphanumerics.
+    std::iter::from_fn(move || {
         while i < bytes.len() && !bytes[i].is_ascii_alphanumeric() {
             i += 1;
         }
@@ -89,18 +156,8 @@ fn next_letter(s: &str, valid: &[String]) -> Option<String> {
         while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
             i += 1;
         }
-        if start == i {
-            break;
-        }
-        let token = &s[start..i];
-        // Single-letter answers and multi-character labels like "AB" both supported.
-        if valid.iter().any(|c| c == token) {
-            return Some(token.to_string());
-        }
-        // Special case: the marker "X" inside parentheses is followed by a `)`.
-        // We've already split on non-alnum, so the bare letter is what we see.
-    }
-    None
+        (start < i).then(|| (&s[start..i], i))
+    })
 }
 
 #[cfg(test)]
@@ -154,6 +211,64 @@ mod tests {
     fn multi_char_label_supported() {
         let choices = vec!["AB".into(), "CD".into()];
         let (_, kind, _) = score(&ex("AB"), "Answer: AB", &choices).unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn last_marker_wins_over_self_revision() {
+        let (_, kind, _) = score(
+            &ex("C"),
+            "The answer is A... wait, re-reading the question, the answer is C.",
+            &choices(),
+        )
+        .unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn article_a_after_answer_is_does_not_match() {
+        let (_, kind, _) = score(
+            &ex("C"),
+            "Well, the answer is a bit tricky here, but it's C",
+            &choices(),
+        )
+        .unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn deliberation_resolves_to_final_mention() {
+        let (_, kind, detail) = score(
+            &ex("D"),
+            "I considered A but the correct choice is D",
+            &choices(),
+        )
+        .unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass, "{detail:?}");
+    }
+
+    #[test]
+    fn leading_pattern_only_matches_first_token() {
+        // "It seems B..." has no leading-letter pattern; the fallback picks
+        // the last standalone mention.
+        let (_, kind, _) = score(&ex("B"), "It seems clear that B is right", &choices()).unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn roman_numeral_choices_work_with_pronoun_guard() {
+        let roman: Vec<String> = vec!["I".into(), "II".into(), "III".into()];
+        let (_, kind, _) = score(&ex("II"), "The answer is II", &roman).unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+        // A bare English "I think..." must not read the pronoun as choice I.
+        let (_, kind, _) = score(&ex("III"), "I think the answer is III", &roman).unwrap();
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    fn answer_colon_a_with_following_word_still_matches() {
+        // Colon form is a deliberate label slot — no article guard.
+        let (_, kind, _) = score(&ex("A"), "Answer: A because it is prime", &choices()).unwrap();
         assert_eq!(kind, EvalOutcomeKind::Pass);
     }
 

--- a/crates/kiln-eval/src/scorers/numeric.rs
+++ b/crates/kiln-eval/src/scorers/numeric.rs
@@ -41,11 +41,20 @@ pub(super) fn score(
     let target_raw = example.target.as_deref().ok_or(ScorerError::MissingTarget {
         kind: "numeric_tolerance",
     })?;
-    let target = match parse_number(target_raw) {
-        Some(v) => v,
-        None => {
+    // The target must contain exactly ONE number. The old char-filter
+    // parser silently fused multi-number targets ("3 of 10" -> 310),
+    // turning authoring mistakes into wrong-but-passing examples.
+    let numbers = extract_numbers(target_raw);
+    let target = match numbers.as_slice() {
+        [v] => *v,
+        [] => {
             return Err(ScorerError::MissingTarget {
-                kind: "numeric_tolerance (unparseable target)",
+                kind: "numeric_tolerance (no number in target)",
+            });
+        }
+        _ => {
+            return Err(ScorerError::MissingTarget {
+                kind: "numeric_tolerance (ambiguous target: multiple numbers)",
             });
         }
     };
@@ -81,17 +90,14 @@ pub(super) fn score(
     }
 }
 
-fn parse_number(s: &str) -> Option<f64> {
-    let cleaned: String = s
-        .chars()
-        .filter(|c| {
-            c.is_ascii_digit() || matches!(c, '.' | '-' | '+' | 'e' | 'E')
-        })
-        .collect();
-    cleaned.parse::<f64>().ok()
+fn extract_last_number(text: &str) -> Option<f64> {
+    extract_numbers(text).last().copied()
 }
 
-fn extract_last_number(text: &str) -> Option<f64> {
+/// Every number in `text`, in order, using the same scrubbing rules the
+/// completion side has always used (commas stripped as thousands
+/// separators, `$`/`%` treated as boundaries).
+fn extract_numbers(text: &str) -> Vec<f64> {
     // Strip common decorations. Commas inside a number are thousands
     // separators (`1,234.50`) and must be removed without replacing them
     // with whitespace, or "1,234" would parse as "234" only.
@@ -103,7 +109,7 @@ fn extract_last_number(text: &str) -> Option<f64> {
             other => Some(other),
         })
         .collect();
-    let mut last: Option<f64> = None;
+    let mut found: Vec<f64> = Vec::new();
     let bytes = scrubbed.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -142,14 +148,14 @@ fn extract_last_number(text: &str) -> Option<f64> {
                     .unwrap_or("")
                     .parse::<f64>()
                 {
-                    last = Some(val);
+                    found.push(val);
                 }
             }
         } else {
             i += 1;
         }
     }
-    last
+    found
 }
 
 #[cfg(test)]
@@ -173,6 +179,59 @@ mod tests {
         assert_eq!(extract_last_number("price is $1,234.50"), Some(1234.50));
         assert_eq!(extract_last_number("no number here"), None);
         assert_eq!(extract_last_number("1.5e3 kg"), Some(1500.0));
+    }
+
+    #[test]
+    fn multi_number_target_errors_instead_of_fusing_digits() {
+        // "3 of 10" used to char-filter into 310 and silently score
+        // against the wrong target.
+        let err = score(
+            &ex("3 of 10"),
+            "310",
+            &NumericTolerance {
+                atol: 0.0,
+                rtol: 0.0,
+                integer_only: false,
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("ambiguous"), "{err}");
+    }
+
+    #[test]
+    fn numberless_target_errors() {
+        let err = score(
+            &ex("no digits at all"),
+            "42",
+            &NumericTolerance {
+                atol: 0.0,
+                rtol: 0.0,
+                integer_only: false,
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("no number"), "{err}");
+    }
+
+    #[test]
+    fn decorated_single_number_targets_still_parse() {
+        for (target, completion) in [
+            ("42 meters", "42"),
+            ("$1,234.50", "1234.5"),
+            ("1.5e3 kg", "1500"),
+        ] {
+            let (_, kind, detail) = score(
+                &ex(target),
+                completion,
+                &NumericTolerance {
+                    atol: 0.0,
+                    rtol: 0.0,
+                    integer_only: false,
+                },
+            )
+            .unwrap();
+            assert_eq!(kind, EvalOutcomeKind::Pass, "target {target:?}: {detail:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three scorer-correctness fixes from the round-2 discovery sweep, all silently distorting eval accuracy:

## NumericTolerance: multi-number targets fused into garbage
`parse_number("3 of 10")` char-filtered to **310** and the example scored against the wrong value — authoring mistakes became wrong-but-passing examples. Targets now must contain exactly one number (using the same scrubbing the completion side always used: thousands-separator commas, $/% boundaries); zero or multiple numbers error with a named reason. `42 meters`, `$1,234.50`, `1.5e3 kg` all still parse.

## Any/All composites: "couldn't judge" counted as model failure
`Any{[LlmJudge]}` with no judge runner reported **Fail**, and `Any` ignored sub-scorer Errors entirely. Both arms now report Invalid when every branch declined to judge, Any propagates Error; mixed Fail+Invalid stays Fail and Pass still wins Any.

## MultipleChoice: three first-match traps
- *"the answer is **a** bit tricky… it's C"* → scored as choice **A** (the article matched). Prose markers now carry an A/I article/pronoun guard; `Answer:` label slots stay verbatim.
- The "leading pattern" step scanned the whole text, so *"**I considered A** but the correct choice is D"* → **A**. It now checks only the first token; the fallback takes the **last** standalone valid mention (models state conclusions last).
- Self-revisions (*"answer is A… wait, the answer is C"*) now resolve to the last marker.
- Roman-numeral choice sets (`I/II/III`) work with the pronoun guard.

## Validation

11 new regression tests across the three scorers (incl. all the trap cases above as literals); all existing tests green: `cargo test -p kiln-eval` 224 passed / 0 failed, kiln-server eval module 48/48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)