### PR TITLE
docs: fix copy-paste-broken GRPO sample, stale lr pins, api.html drift; document log mining

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -424,7 +424,6 @@ Submit training examples via `POST /v1/train/sft`:
     {"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
   ],
   "num_epochs": 3,
-  "learning_rate": 1e-4,
   "rank": 8
 }
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -308,7 +308,6 @@ curl -s http://localhost:8420/v1/train/sft \
     ],
     "config": {
       "output_name": "default",
-      "learning_rate": 1e-4,
       "epochs": 3
     }
   }' | python3 -m json.tool
@@ -795,6 +794,8 @@ Key settings:
 | `logging.format` | `KILN_LOG_FORMAT` | auto | Log format: `auto` (pretty on TTY, JSON otherwise), `json`, `pretty`, `text`, `human` |
 | `prefix_cache.enabled` | `KILN_PREFIX_CACHE_ENABLED` | true | Reuse KV cache for shared prefixes |
 | `prefix_cache.max_entries` | `KILN_PREFIX_CACHE_MAX_ENTRIES` | auto | Cap cached GDN state snapshots (~49 MiB each; auto budget ≤1 GiB) |
+| `request_log.enabled` | `KILN_REQUEST_LOG_ENABLED` | true | Durable JSONL log of every inference request/response (the mine→train corpus) |
+| `request_log.dir` | `KILN_REQUEST_LOG_DIR` | `<adapter_dir>/.requests` | Request log directory (size-rotated, gzipped, retention-capped) |
 
 ## Running with Docker
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A 4B model continuously tuned to your specific workload — and continuously *me
 - **Adapter composition** — stack multiple LoRAs per request with per-adapter scaling, or merge them server-side via weighted_average / TIES / concatenation.
 - **Embedded web dashboard** at `/ui` — live server status, VRAM donut, adapter cards, training queue with live loss curves, full eval workflow (datasets / suites / jobs / judgments) with drill-in per-example modal, A/B compare playground, and a `⌘K` command palette across all of it. No extra service to run.
 - **Prometheus metrics** at `/metrics` — request latency, throughput, training progress, memory usage.
-- **Durable request log** — every inference request/response (SSE streams reassembled) lands as one JSONL row under `<adapter_dir>/.requests`, size-rotated, gzipped, retention-capped. Production traffic becomes a corpus you can mine into SFT data or a `kiln-eval trace-suite` eval with one `jq` line.
+- **Durable request log** — every inference request/response (SSE streams reassembled) lands as one JSONL row under `<adapter_dir>/.requests`, size-rotated, gzipped, retention-capped, attributed to the serving adapter. Production traffic becomes a corpus you can mine into SFT data or a `kiln-eval trace-suite` eval with one `jq` line — see [docs/EVAL_GUIDE.md § Mine your own request log](docs/EVAL_GUIDE.md#mine-your-own-request-log).
 - **Training webhooks** — POST a JSON event to a configured URL on training job completion or failure.
 - **Pure Rust** — single binary, single process. No Python. No sidecar. No second model in memory.
 

--- a/docs/EVAL_GUIDE.md
+++ b/docs/EVAL_GUIDE.md
@@ -114,7 +114,39 @@ Most users never hand-author a suite. The canonical flow is:
 
 ## Production trace tool-call evals
 
-For production agent workloads, use `kiln-eval trace-suite` to turn a JSONL
+### Mine your own request log
+
+Every inference request kiln serves is already a recorded production trace:
+the server appends one JSON row per request/response to
+`<adapter_dir>/.requests/` (`requests-current.jsonl` plus rotated
+`requests-<ts>.jsonl.gz`, size-rotated and retention-capped; SSE streams are
+reassembled into the final-message shape). Each row carries the wire-format
+`request` and `response`, the HTTP `status`, the `user_agent`, and the
+`adapter` that served it (key omitted for base-model rows), so the corpus
+splits cleanly per adapter.
+
+```bash
+# SFT dataset from successful chats (request messages + assistant reply):
+zcat -f ~/models/Qwen3.5-4B/adapters/.requests/requests-*.jsonl* \
+  | jq -c 'select(.status == 200 and .route == "/v1/chat/completions")
+      | {messages: (.request.messages + [.response.choices[0].message])}' > mined-sft.jsonl
+
+# Or feed the importer below directly for a tool-call eval suite:
+zcat -f ~/models/Qwen3.5-4B/adapters/.requests/requests-*.jsonl* \
+  | jq -c 'select(.status == 200)
+      | {messages: (.request.messages + [.response.choices[0].message]), tools: .request.tools}' \
+  > mined-traces.jsonl
+kiln-eval trace-suite --input mined-traces.jsonl --format openai_jsonl \
+  --output mined-tool-calls.json --suite-name mined-tool-calls
+```
+
+(`zcat -f` reads the gzipped rotations and the plain active file in one
+stream. Rows whose final assistant message has no tool call are counted as
+`skipped_no_tool_call` by the importer — expected for plain chat traffic.)
+
+### Importing external traces
+
+For traces exported from other systems, `kiln-eval trace-suite` turns a JSONL
 export of recorded tool-calling turns into an eval suite:
 
 ```bash

--- a/docs/GRPO_GUIDE.md
+++ b/docs/GRPO_GUIDE.md
@@ -117,7 +117,6 @@ print(f"mean reward this round: {mean_reward:.3f}")
 job = requests.post(f"{KILN}/v1/train/grpo", json={
     "groups": groups,
     "config": {
-        "learning_rate": 1e-5,
         "kl_coeff":      0.1,
         "clip_epsilon":  0.2,
         "lora_rank":     16,
@@ -177,7 +176,7 @@ for item in batch["completions"]:
 
 requests.post(f"{KILN}/v1/train/grpo", json={
     "groups": groups,
-    "config": {"learning_rate": 1e-5, "lora_rank": 16, "output_name": "json-format"},
+    "config": {"lora_rank": 16, "output_name": "json-format"},
 }).raise_for_status()
 ```
 
@@ -260,7 +259,7 @@ for item in batch["completions"]:
 
 requests.post(f"{KILN}/v1/train/grpo", json={
     "groups": [group],
-    "config": {"learning_rate": 1e-5, "lora_rank": 16, "output_name": "code-runs"},
+    "config": {"lora_rank": 16, "output_name": "code-runs"},
 }).raise_for_status()
 ```
 
@@ -277,8 +276,14 @@ server-side default, so omit anything you don't want to override:
 - **`n` (in the batch request)** — group size. Defaults to 1; for GRPO use
   `>= 4`. 8 is the usual starting point; smaller groups have higher variance,
   larger groups eat the 64-completion batch cap faster.
-- **`learning_rate`** — defaults to `1e-5`. Halve it if you see reward
-  oscillate or KL spike; double it if reward improves but slowly.
+- **`learning_rate`** — omit it: the server resolves the default per
+  optimizer (Muon, the default: `2e-3` for GRPO; AdamW/SGD: legacy `1e-5`)
+  and the train receipt records the resolved value. If you do pin it, halve
+  on reward oscillation / KL spikes, double if reward improves but slowly —
+  and mind that Muon's band is ~200x AdamW's.
+- **`optimizer`** — defaults to Muon (momentum-orthogonalized SGD with fused
+  on-device kernels). Select AdamW/SGD per request via
+  `{"optimizer": {"kind": "adam_w"}}` / `{"kind": "sgd"}`.
 - **`kl_coeff`** — defaults to `0.1`. Higher keeps the adapter closer to the
   base model (more conservative, slower). Lower lets the adapter drift faster
   but risks mode collapse onto whatever scored highest in early rounds.

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -357,7 +357,7 @@
       {"role": "user", "content": "Hi"},
       {"role": "assistant", "content": "Hey there!"}
     ]}],
-    "config": {"output_name": "default", "learning_rate": 1e-4, "epochs": 3}
+    "config": {"output_name": "default", "epochs": 3}
   }' \
   | python3 -m json.tool</code></pre>
           </section>
@@ -373,7 +373,7 @@
         {"text": "Blue", "reward": 0.0}
       ]
     }],
-    "config": {"output_name": "grpo-demo", "learning_rate": 1e-5, "kl_coeff": 0.1}
+    "config": {"output_name": "grpo-demo", "kl_coeff": 0.1}
   }' \
   | python3 -m json.tool</code></pre>
           </section>
@@ -468,6 +468,7 @@ kiln serve --config kiln.toml</code></pre>
         <h2 id="generation" class="text-2xl font-semibold mb-4">OpenAI-compatible generation</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">POST</span> <code>/v1/chat/completions</code> &mdash; chat completions with OpenAI-shaped request and response bodies, including SSE streaming and normalized tool-call deltas.</div>
+          <div class="endpoint"><span class="method">POST</span> <code>/v1/completions</code> &mdash; vLLM-compatible prompt-logprobs scoring for remote OPD teachers (no generation-only mode, no streaming; prompts capped at 4096 tokens).</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/completions/batch</code> &mdash; multi-prompt batch generation for efficient GRPO rollouts.</div>
         </div>
       </article>
@@ -480,6 +481,8 @@ kiln serve --config kiln.toml</code></pre>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/load</code> &mdash; load an adapter from disk.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/unload</code> &mdash; unload the active adapter.</div>
           <div class="endpoint"><span class="method">DELETE</span> <code>/v1/adapters/{name}</code> &mdash; delete an adapter.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters/{name}/detail</code> &mdash; files, training history, and eval history for one adapter.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters/{name}/receipt</code> &mdash; the adapter's train_receipt.json.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters/{name}/download</code> &mdash; export an adapter as a tar.gz archive.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/upload</code> &mdash; import an adapter from a multipart tar.gz archive.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/merge</code> &mdash; combine adapters with weighted average, TIES, or concatenation.</div>
@@ -492,8 +495,11 @@ kiln serve --config kiln.toml</code></pre>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">POST</span> <code>/v1/train/sft</code> &mdash; submit supervised fine-tuning examples.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/train/grpo</code> &mdash; submit a GRPO batch of prompts, completions, and rewards.</div>
+          <div class="endpoint"><span class="method">POST</span> <code>/v1/train/agentic</code> &mdash; canonical alias of <code>/v1/train/grpo</code> for multi-turn trajectory rollouts (ECHO applies automatically).</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/status</code> &mdash; summarize training queue and job state.</div>
-          <div class="endpoint"><span class="method">GET</span> <code>/v1/train/status/{job_id}</code> &mdash; inspect one training job; there is no separate <code>/v1/train/jobs/{job_id}</code> route.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/train/status/{job_id}</code> &mdash; inspect one training job.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/train/jobs/{job_id}</code> &mdash; rich job detail (loss curve + linked-eval back-references).</div>
+          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/jobs/{job_id}</code> &mdash; remove an archived terminal job.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/queue</code> &mdash; list queued training jobs.</div>
           <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/queue/{job_id}</code> &mdash; cancel a queued job.</div>
         </div>
@@ -520,6 +526,7 @@ curl -s -X DELETE http://localhost:8420/v1/train/queue/$JOB_ID | python3 -m json
           <div class="endpoint"><span class="method">POST</span> <code>/v1/eval/compare</code> &mdash; run one suite across multiple adapters head-to-head.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/eval/jobs</code> &mdash; list eval jobs and headline accuracies.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/eval/jobs/{id}</code> &mdash; fetch one eval job with full per-example outcomes.</div>
+          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/eval/jobs/{id}</code> &mdash; cancel a queued/running eval (partial outcomes kept), or delete a terminal job from tracking.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/eval/jobs/{id}/rerun</code> &mdash; re-run only the failures from a completed job.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/eval/datasets/upload</code> &mdash; multipart upload of an SFT or GRPO JSONL file.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/eval/datasets/{name}/synthesize</code> &mdash; decompose a dataset into a graded suite via <code>final_assistant</code>, <code>first_assistant_turn</code>, <code>every_assistant_turn</code>, or <code>tool_call_predict</code>.</div>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -357,7 +357,6 @@
       ]
     }],
     "config": {
-      "learning_rate": 1e-5,
       "kl_coeff": 0.1,
       "clip_epsilon": 0.2,
       "lora_rank": 16,
@@ -371,7 +370,7 @@
           <div class="endpoint">
             <h3 class="font-semibold mb-2">Common config fields</h3>
             <ul class="space-y-2 text-sm" style="color: var(--fg-dim);">
-              <li><code>learning_rate</code>, <code>kl_coeff</code>, and <code>clip_epsilon</code> tune the GRPO update.</li>
+              <li><code>kl_coeff</code> and <code>clip_epsilon</code> tune the GRPO update; <code>learning_rate</code> is resolved per optimizer when omitted (Muon default: 2e-3).</li>
               <li><code>lora_rank</code> and <code>lora_alpha</code> control adapter capacity.</li>
               <li><code>base_adapter</code> continues from an existing adapter.</li>
               <li><code>output_name</code> names the saved adapter.</li>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -384,16 +384,15 @@ rollouts = [client.chat.completions.create(
     for _ in range(8)]
 
 # 2. Score with whatever reward you want.
-import requests  # noqa: F811 — same module, kept inline for clarity
-rewards = [score(prompt, r) for r in rollouts]
+scored = [{"text": r, "reward": score(prompt, r)} for r in rollouts]
 
 # 3. Send the batch back. Adapter is live on the next request.
 requests.post("http://localhost:8420/v1/train/grpo", json={
-    "adapter":       "helpful-v3",
-    "prompt":        prompt,
-    "completions":   rollouts,
-    "rewards":       rewards,
-    "learning_rate": 1e-4,
+    "groups": [{
+        "messages": [{"role": "user", "content": prompt}],
+        "completions": scored,
+    }],
+    "config": {"output_name": "helpful-v3"},
 })</code></pre>
           </div>
 

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -162,7 +162,10 @@ const expectedApiEndpoints = [
   '/v1/train/queue',
 ];
 
-const staleTrainingJobEndpoint = '/v1/train/jobs/{job_id}';
+// /v1/train/jobs/{job_id} is a REAL route (GET job detail + DELETE archived
+// job — see crates/kiln-server/src/api/training.rs routes); the api page
+// must document it rather than deny it.
+const trainingJobDetailEndpoint = '/v1/train/jobs/{job_id}';
 const staleAdapterListPhrases = [
   'List loaded adapters',
   'List loaded and available adapters',
@@ -1967,15 +1970,12 @@ async function runSmoke() {
           fail(`${sitePage.path}: missing API endpoint coverage: ${missingEndpoints.join(', ')}`);
         }
 
-        const normalizedStaleEndpoint = staleTrainingJobEndpoint.toLowerCase();
-        if (apiResult.endpointRoutes.includes(normalizedStaleEndpoint)) {
-          fail(`${sitePage.path}: stale route ${staleTrainingJobEndpoint} is presented as a real API endpoint; use /v1/train/status/{job_id} instead`);
+        const normalizedJobDetailEndpoint = trainingJobDetailEndpoint.toLowerCase();
+        if (!apiResult.endpointRoutes.includes(normalizedJobDetailEndpoint)) {
+          fail(`${sitePage.path}: missing ${trainingJobDetailEndpoint} endpoint (rich job detail; GET + DELETE)`);
         }
-        if (
-          apiResult.bodyText.includes(normalizedStaleEndpoint)
-          && !apiResult.bodyText.includes(`no separate ${normalizedStaleEndpoint} route`)
-        ) {
-          fail(`${sitePage.path}: stale route ${staleTrainingJobEndpoint} must appear only in explicit negative wording`);
+        if (apiResult.bodyText.includes(`no separate ${normalizedJobDetailEndpoint} route`)) {
+          fail(`${sitePage.path}: ${trainingJobDetailEndpoint} is a real route — remove the denial wording`);
         }
 
         for (const phrase of staleAdapterListPhrases) {


### PR DESCRIPTION
## The headline fix

The landing page's hero GRPO sample — the first code a visitor copies — posts a payload `/v1/train/grpo` rejects with 400 (flat `adapter/prompt/completions/rewards/learning_rate` fields that were never the wire shape). Replaced with the real `groups`/`completions` shape. **Verified live in mock mode: old payload → 400, new payload parses through to the mock-mode response.**

## Also

- **Stale lr pins purged** from every doc training example (QUICKSTART, GRPO_GUIDE ×3, api.html ×2, grpo.html, ARCHITECTURE) — after #1489 these examples were actively harmful, silently pinning Muon 200× cold. GRPO_GUIDE's knob list now explains per-optimizer resolution and gains an `optimizer` bullet.
- **api.html route table trued up against the real router**: removed the false "there is no `/v1/train/jobs/{job_id}` route" claim (GET+DELETE both exist), added `/v1/train/agentic`, `/v1/completions` (prompt-logprobs scoring), adapter `detail`/`receipt`, `DELETE /v1/eval/jobs/{id}`.
- **EVAL_GUIDE § "Mine your own request log"**: the `.requests` layout, row schema (incl. adapter attribution from #1490), and a `zcat -f | jq` pipeline for SFT data and trace-suite suites — **run verbatim against a live mock server** to confirm it produces valid transcripts. README links it; QUICKSTART's key-settings table gains the `request_log` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)