### PR TITLE
dashboard: 'Add to corrections' on failing eval outcomes

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -5660,12 +5660,24 @@ function loadCorrections() {
   catch { correctionsBasket = []; }
 }
 function saveCorrections() { try { localStorage.setItem(CORR_KEY, JSON.stringify(correctionsBasket)); } catch {} }
+// Shared basket insert for every capture surface (recent requests, eval
+// drill). Dedupes on request_id; persists + repaints + toasts.
+function addCorrectionItem(item) {
+  if (correctionsBasket.some(c => c.request_id === item.request_id)) {
+    toast('Already in your corrections', 'info');
+    return false;
+  }
+  correctionsBasket.unshift(item);
+  saveCorrections();
+  renderCorrections();
+  toast(`Added to corrections (${correctionsBasket.length}) — ${item.ideal ? 'review the ideal answer, then Train' : 'write the ideal answer, then Train'}`, 'ok');
+  return true;
+}
+
 function addCorrectionFromRequest(r) {
   if (!r) return false;
-  const rid = r.id || ('req-' + Date.now());
-  if (correctionsBasket.some(c => c.request_id === rid)) { toast('Already in your corrections', 'info'); return false; }
-  correctionsBasket.unshift({
-    request_id: rid,
+  return addCorrectionItem({
+    request_id: r.id || ('req-' + Date.now()),
     agent: (clientFromUA(r.user_agent) || {}).label || 'client',
     ts: r.timestamp_unix_ms || Date.now(),
     model: r.model || '', adapter: r.adapter || 'base',
@@ -5678,10 +5690,34 @@ function addCorrectionFromRequest(r) {
     // untouched must never silently train the model on its own mistake.
     ideal: '',
   });
-  saveCorrections();
-  renderCorrections();
-  toast(`Added to corrections (${correctionsBasket.length}) — write the ideal answer, then Train`, 'ok');
-  return true;
+}
+
+// Eval-drill capture: turn a failing outcome into a correction. The ideal
+// answer is pre-seeded from the example target ONLY for scorers whose
+// target IS the verbatim expected reply (exact_match / contains) — for
+// everything else the target is a pattern/choice/number, not a reply, and
+// pre-seeding would train garbage. corrTrainable still requires the ideal
+// to differ from the model's output before anything trains.
+function addCorrectionFromEvalOutcome(o, example, scorerKind) {
+  const rid = `eval-${drillJob?.job_id || 'job'}-${o.example_id}-${o.completion_index || 0}`;
+  const userMsg = example && example.messages
+    ? (example.messages.filter(m => m.role === 'user').pop()?.content || '')
+    : '';
+  if (!userMsg) { toast('Suite content unavailable — cannot capture this outcome', 'err'); return false; }
+  const seedIdeal = (scorerKind === 'exact_match' || scorerKind === 'contains')
+    ? (example.target || '')
+    : '';
+  return addCorrectionItem({
+    request_id: rid,
+    agent: 'eval:' + (drillJob?.suite_name || 'suite'),
+    ts: Date.now(),
+    model: '',
+    adapter: drillJob?.adapters?.[drillSelectedRun] ?? 'base',
+    user: userMsg,
+    original: o.completion_text || '',
+    truncated: false,
+    ideal: seedIdeal,
+  });
 }
 function removeCorrection(rid) { correctionsBasket = correctionsBasket.filter(c => c.request_id !== rid); saveCorrections(); renderCorrections(); }
 function clearCorrections() {
@@ -10663,6 +10699,7 @@ function renderOutcomeDetail(o) {
     <button type="button" class="btn btn-sm" data-outcome-copy="completion" title="Copy the model's output"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> Copy output</button>
     ${promptForReplay ? `<button type="button" class="btn btn-sm" data-outcome-copy="prompt" title="Copy the full prompt as role-prefixed text"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> Copy prompt</button>` : ''}
     ${userMsg ? `<button type="button" class="btn btn-sm" data-outcome-replay="1" title="Drop the last user message into the playground so you can iterate"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-chat"></use></svg> Replay in playground</button>` : ''}
+    ${(o.kind === 'fail' || o.kind === 'invalid') && userMsg ? `<button type="button" class="btn btn-sm" data-outcome-correct="1" title="Capture this failing example into the corrections basket — write the ideal answer, then train"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-pencil"></use></svg> Add to corrections</button>` : ''}
   </div>`;
   detail.innerHTML = `
     <div class="detail-section">
@@ -10686,6 +10723,11 @@ function renderOutcomeDetail(o) {
       const key = btn.dataset.outcomeCopy;
       const text = key === 'completion' ? (o.completion_text || '') : promptForReplay;
       navigator.clipboard.writeText(text).then(() => toast(`Copied ${key}`, 'ok'), () => toast('Copy failed', 'err'));
+    });
+  });
+  detail.querySelectorAll('[data-outcome-correct]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      addCorrectionFromEvalOutcome(o, example, scorerKind);
     });
   });
   detail.querySelectorAll('[data-outcome-replay]').forEach(btn => {

--- a/crates/kiln-server/tests/ui_eval_corrections.rs
+++ b/crates/kiln-server/tests/ui_eval_corrections.rs
@@ -1,0 +1,102 @@
+//! Contract test for the eval-drill → corrections capture surface.
+//!
+//! The eval drill modal's "Add to corrections" button closes the
+//! observe→correct loop for eval failures the same way the recent-requests
+//! capture does for live traffic. ui.html is `include_str!`-baked, so a
+//! redesign can silently drop the wiring without a compile error — this
+//! pins the markup hooks and the safety property that non-verbatim scorer
+//! targets are never pre-seeded as the ideal answer.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+fn tiny_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state() -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        tiny_tokenizer(),
+        300,
+        "Qwen3.5-4B".to_string(),
+    )
+}
+
+#[tokio::test]
+async fn ui_carries_eval_drill_correction_capture() {
+    let app = api::router(make_state());
+    let response = app
+        .oneshot(Request::builder().uri("/ui").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = String::from_utf8(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+
+    // The capture button renders for failing outcomes...
+    assert!(
+        html.contains("data-outcome-correct"),
+        "eval drill must offer Add to corrections on failing outcomes"
+    );
+    // ...through the shared basket-insert helper...
+    assert!(html.contains("function addCorrectionItem"));
+    assert!(html.contains("function addCorrectionFromEvalOutcome"));
+    // ...and both capture surfaces go through it.
+    assert!(
+        html.matches("addCorrectionItem(").count() >= 3,
+        "recent-requests and eval-drill captures must share addCorrectionItem"
+    );
+    // Safety property: only verbatim-target scorers pre-seed the ideal —
+    // a pattern/choice target must never be trained as a reply.
+    assert!(
+        html.contains("scorerKind === 'exact_match' || scorerKind === 'contains'"),
+        "ideal pre-seeding must stay restricted to verbatim-target scorers"
+    );
+}


### PR DESCRIPTION
## Gap

The eval drill modal shows you exactly which examples failed — and offered nothing to do about it. The observe→correct→train loop existed only for live traffic (the recent-requests Correct button). Eval failures, the *highest-signal* correction candidates, dead-ended.

## Change

Failing/invalid outcomes in the drill modal gain **Add to corrections**: captures the example's last user message + the model's wrong output into the corrections basket with agent tag `eval:<suite>`, the selected run's adapter, and per job/example/completion dedup. From there the existing flow applies: write the ideal answer → Train → verify.

Safety property preserved: the ideal is pre-seeded from the example target **only** for verbatim-target scorers (`exact_match`/`contains`) — regex/MCQ/numeric targets are patterns, not replies. The basket's `corrTrainable` rule still refuses to train until the ideal differs from the original output.

Both capture surfaces (recent requests + eval drill) now share one `addCorrectionItem` helper.

## Validation

- New `ui_eval_corrections` contract test pins the button markup, the shared helper, and the pre-seeding restriction
- `node scripts/check_server_ui_smoke.mjs` — all scenarios green, zero pageerrors
- `cargo build -p kiln-server` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)