### PR TITLE
eval compare: gate 'beats base' verdicts on a paired sign test

### DIFF
--- a/crates/kiln-eval/src/result.rs
+++ b/crates/kiln-eval/src/result.rs
@@ -650,6 +650,55 @@ impl EvalResult {
     }
 }
 
+/// Paired sign test over a [`FlipDiff`]'s discordant examples. The
+/// concordant pairs (both_pass / both_fail) carry no information about
+/// which adapter is better; under the null hypothesis each discordant
+/// example improves or regresses with probability 1/2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SignTest {
+    pub improved: u32,
+    pub regressed: u32,
+    /// Two-sided exact binomial p-value. 1.0 when there are no discordant
+    /// pairs (no evidence either way).
+    pub p_value: f64,
+}
+
+impl SignTest {
+    /// Conventional 5% significance gate used by the CLI and dashboard
+    /// verdicts.
+    pub fn significant(&self) -> bool {
+        self.p_value < 0.05
+    }
+}
+
+/// Two-sided exact binomial sign test: probability of seeing a split at
+/// least as lopsided as (b, c) under p=1/2. Log-space so large suites
+/// don't underflow.
+pub fn sign_test(improved: u32, regressed: u32) -> SignTest {
+    let n = improved + regressed;
+    let p_value = if n == 0 {
+        1.0
+    } else {
+        let k = improved.min(regressed);
+        let ln2 = std::f64::consts::LN_2;
+        // ln C(n, i) built incrementally; tail = sum_{i<=k} C(n,i) / 2^n.
+        let mut ln_terms: Vec<f64> = Vec::with_capacity(k as usize + 1);
+        let mut ln_c = 0.0_f64; // ln C(n, 0)
+        for i in 0..=k {
+            ln_terms.push(ln_c - f64::from(n) * ln2);
+            ln_c += (f64::from(n - i)).ln() - (f64::from(i + 1)).ln();
+        }
+        let max = ln_terms.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let tail: f64 = ln_terms.iter().map(|t| (t - max).exp()).sum::<f64>() * max.exp();
+        (2.0 * tail).min(1.0)
+    };
+    SignTest {
+        improved,
+        regressed,
+        p_value,
+    }
+}
+
 /// Pass↔Fail flip diff between two adapter runs of the same suite.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FlipDiff {
@@ -667,6 +716,13 @@ pub struct FlipDiff {
     pub both_pass: u32,
     /// Examples that failed under both runs.
     pub both_fail: u32,
+}
+
+impl FlipDiff {
+    /// Sign test over this diff's discordant examples.
+    pub fn significance(&self) -> SignTest {
+        sign_test(self.improved.len() as u32, self.regressed.len() as u32)
+    }
 }
 
 #[cfg(test)]
@@ -710,6 +766,27 @@ mod tests {
             finished_at: "2026-05-14T00:00:01Z".into(),
             suite_hash: "deadbeef".into(),
         }
+    }
+
+    #[test]
+    fn sign_test_matches_known_exact_values() {
+        // b=9, c=2: n=11, k=2 -> 2 * (1+11+55)/2^11 = 134/2048.
+        let t = sign_test(9, 2);
+        assert!((t.p_value - 134.0 / 2048.0).abs() < 1e-12, "{}", t.p_value);
+        assert!(!t.significant());
+        // b=15, c=3: n=18, k=3 -> 2 * (1+18+153+816)/2^18.
+        let t = sign_test(15, 3);
+        assert!((t.p_value - 2.0 * 988.0 / 262144.0).abs() < 1e-12, "{}", t.p_value);
+        assert!(t.significant());
+        // No discordant pairs: no evidence.
+        assert_eq!(sign_test(0, 0).p_value, 1.0);
+        // Symmetric in b/c.
+        assert_eq!(sign_test(9, 2).p_value, sign_test(2, 9).p_value);
+        // Even split: p clamps to 1.0.
+        assert_eq!(sign_test(5, 5).p_value, 1.0);
+        // Large n must not underflow to 0-vs-NaN.
+        let t = sign_test(900, 700);
+        assert!(t.p_value > 0.0 && t.p_value <= 1.0, "{}", t.p_value);
     }
 
     #[test]

--- a/crates/kiln-server/src/bin/kiln_eval_cli.rs
+++ b/crates/kiln-server/src/bin/kiln_eval_cli.rs
@@ -1447,6 +1447,18 @@ fn print_compare(result: &EvalResultPayload) {
                 diff.regressed.join(", ")
             );
         }
+        let test = diff.significance();
+        println!(
+            "  sign test: improved {} / regressed {} -> p={:.4} (two-sided exact)",
+            test.improved, test.regressed, test.p_value
+        );
+        if test.improved + test.regressed == 0 {
+            println!("  verdict: no discordant examples — the adapters are indistinguishable on this suite");
+        } else if test.significant() {
+            println!("  verdict: significant at p<0.05");
+        } else {
+            println!("  verdict: NOT significant at p<0.05 — the delta could be noise; add examples or rerun");
+        }
     }
 }
 

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -11761,6 +11761,42 @@ function adapterEvalChip(name) {
 // The strongest signal for "is the loaded adapter actually better than base?":
 // the newest completed COMPARE eval (base run + this adapter's run). Returns
 // { delta, suite } in accuracy points, or null. Powers the active-card verdict.
+// Two-sided exact binomial sign test over discordant flips — mirrors
+// kiln-eval's SignTest so the dashboard verdicts use the same math as
+// the CLI. p=1 when there are no discordant examples.
+function signTestP(improved, regressed) {
+  const n = improved + regressed;
+  if (n === 0) return 1.0;
+  const k = Math.min(improved, regressed);
+  let lnC = 0;            // ln C(n, 0)
+  let lnTerms = [];
+  for (let i = 0; i <= k; i++) {
+    lnTerms.push(lnC - n * Math.LN2);
+    lnC += Math.log(n - i) - Math.log(i + 1);
+  }
+  const max = Math.max(...lnTerms);
+  const tail = lnTerms.reduce((acc, t) => acc + Math.exp(t - max), 0) * Math.exp(max);
+  return Math.min(2 * tail, 1.0);
+}
+// First-completion pass/fail flips between a base run and an adapter run.
+function compareFlips(baseRun, adapterRun) {
+  const verdictOf = (run) => {
+    const m = new Map();
+    for (const o of run.outcomes || []) {
+      if ((o.completion_index || 0) === 0) m.set(o.example_id, o.kind === 'pass');
+    }
+    return m;
+  };
+  const b = verdictOf(baseRun), a = verdictOf(adapterRun);
+  let improved = 0, regressed = 0;
+  for (const [id, basePass] of b) {
+    if (!a.has(id)) continue;
+    const adapterPass = a.get(id);
+    if (!basePass && adapterPass) improved++;
+    else if (basePass && !adapterPass) regressed++;
+  }
+  return { improved, regressed };
+}
 function adapterCompareVerdict(name) {
   const jobs = ((typeof evalJobsCache !== 'undefined' ? evalJobsCache : []) || [])
     .filter(j => (j.state || '').toLowerCase() === 'completed' && Array.isArray(j.finished_runs)
@@ -11770,16 +11806,33 @@ function adapterCompareVerdict(name) {
     const base = j.finished_runs.find(r => r.adapter == null || r.adapter === 'base');
     const run = j.finished_runs.find(r => r.adapter === name);
     if (base && run && typeof base.metrics?.accuracy === 'number' && typeof run.metrics?.accuracy === 'number') {
-      return { delta: Math.round((run.metrics.accuracy - base.metrics.accuracy) * 1000) / 10, suite: j.suite_name };
+      const flips = compareFlips(base, run);
+      const p = signTestP(flips.improved, flips.regressed);
+      return {
+        delta: Math.round((run.metrics.accuracy - base.metrics.accuracy) * 1000) / 10,
+        suite: j.suite_name,
+        improved: flips.improved,
+        regressed: flips.regressed,
+        p,
+      };
     }
   }
   return null;
 }
 function verdictDeltaHtml(v) {
   if (!v) return '';
+  // A green/red verdict is a claim — gate it on the paired sign test so
+  // a 2-example wobble doesn't render as "beats base".
+  const significant = typeof v.p === 'number' ? v.p < 0.05 : true;
+  const detail = typeof v.p === 'number'
+    ? ` — sign test improved ${v.improved} / regressed ${v.regressed}, p=${v.p.toFixed(3)}`
+    : '';
+  if (!significant && Math.abs(v.delta) > 0.5) {
+    return `<span class="delta-badge delta-flat" title="vs base on ${escapeHtml(v.suite || 'eval')}${detail}">${v.delta > 0 ? '+' : ''}${v.delta.toFixed(1)} pts — not enough evidence</span>`;
+  }
   const cls = v.delta > 0.5 ? 'delta-up' : (v.delta < -0.5 ? 'delta-down' : 'delta-flat');
   const label = cls === 'delta-flat' ? 'matches base' : `${v.delta > 0 ? '+' : ''}${v.delta.toFixed(1)} pts vs base`;
-  return `<span class="delta-badge ${cls}" title="vs base on ${escapeHtml(v.suite || 'eval')}">${label}</span>`;
+  return `<span class="delta-badge ${cls}" title="vs base on ${escapeHtml(v.suite || 'eval')}${detail}">${label}</span>`;
 }
 
 function renderAdaptersAsCards(data) {


### PR DESCRIPTION
## Problem

The compare verdict — the flywheel's *"did training actually help?"* answer, shown as green/red badges on adapter cards, the flywheel ribbon, and `kiln-eval` CLI compare — was a raw accuracy delta. On a 30-example suite, two lucky flips render as a confident **+6.7 pts vs base** green badge. The product's central claim was statistically unsupported.

## Changes

- **kiln-eval**: `SignTest` + `sign_test(improved, regressed)` — two-sided exact binomial over the discordant first-completion flips (concordant pass/pass + fail/fail pairs carry no information about which adapter is better). Log-space accumulation, so 1000-example suites don't underflow. `FlipDiff::significance()`.
- **CLI compare**: after the flip block prints `sign test: improved 9 / regressed 2 -> p=0.0654 (two-sided exact)` and a plain-language verdict (`significant at p<0.05` / `NOT significant — the delta could be noise`).
- **Dashboard**: `adapterCompareVerdict` computes the identical test client-side from the compare job's outcomes; non-significant deltas render as a neutral **"+N pts — not enough evidence"** badge instead of green/red, with the test detail in the tooltip. Significant verdicts unchanged.

## Validation

- Sign test pinned against hand-computed exact values: (9,2) → 134/2048 ≈ 0.0654 not significant; (15,3) → 0.0075 significant; (0,0) → 1.0; b/c symmetry; even-split clamps to 1.0; (900,700) no underflow
- `cargo test -p kiln-eval` 231/231; `cargo test -p kiln-server --lib` 511/511; UI smoke all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)