### PR TITLE
Un-sever the pi-session-to-training bridge: agent_traces resolver + real judge/CRISP corpora

### DIFF
--- a/crates/kiln-server/src/api/agent_traces.rs
+++ b/crates/kiln-server/src/api/agent_traces.rs
@@ -60,7 +60,14 @@ pub struct AgentTrace {
     /// pi tool manifest fingerprint at the time the session ran
     /// (§10.11 tool-schema versioning).
     pub tool_manifest_sha: Option<String>,
-    /// Canonical action/observation trajectory parsed from Pi message events.
+    /// Leading system/user context the session started from — the task
+    /// scaffold the training bridge re-rolls (`agent_traces:` selectors).
+    /// Empty on indices written before prompt capture; re-run discover.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prompt_messages: Vec<kiln_train::ChatMessage>,
+    /// Canonical trajectory parsed from Pi message events: Action and
+    /// Observation segments, with any mid-session user/system turns
+    /// preserved as Context segments (the masking layer skips Context).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trajectory: Vec<TurnSegment>,
 }
@@ -227,7 +234,10 @@ async fn get_trace(
 fn parse_pi_session(path: &Path) -> Option<AgentTrace> {
     let bytes = std::fs::read(path).ok()?;
     let text = std::str::from_utf8(&bytes).ok()?;
-    let parsed_pi = parse_pi_session_str(text, false);
+    // include_context=true keeps user/system turns ordered within the
+    // trajectory; the leading Context run is split off below as the prompt
+    // scaffold so the training bridge can re-roll the session's task.
+    let parsed_pi = parse_pi_session_str(text, true);
     let mut id: Option<String> = None;
     let mut cwd: Option<String> = None;
     let mut parent_id: Option<String> = None;
@@ -328,6 +338,26 @@ fn parse_pi_session(path: &Path) -> Option<AgentTrace> {
             .map(|p| p.display().to_string())
             .unwrap_or_default()
     });
+    // Split the leading Context run (system/user turns before the first
+    // action) into the prompt scaffold; mid-session Context turns stay in
+    // the trajectory, ordered, where the masking layer skips them.
+    let (prompt_messages, trajectory) = if saw_pi_message_event {
+        let mut trajectory = parsed_pi.trajectory;
+        let leading = trajectory
+            .iter()
+            .take_while(|seg| seg.kind == kiln_train::trajectory::TurnKind::Context)
+            .count();
+        let prompt_messages = trajectory
+            .drain(..leading)
+            .map(|seg| kiln_train::ChatMessage {
+                role: seg.role,
+                content: seg.content,
+            })
+            .collect();
+        (prompt_messages, trajectory)
+    } else {
+        (Vec::new(), Vec::new())
+    };
     Some(AgentTrace {
         id,
         working_dir,
@@ -343,11 +373,8 @@ fn parse_pi_session(path: &Path) -> Option<AgentTrace> {
         forked,
         parent_id,
         tool_manifest_sha,
-        trajectory: if saw_pi_message_event {
-            parsed_pi.trajectory
-        } else {
-            Vec::new()
-        },
+        prompt_messages,
+        trajectory,
     })
 }
 
@@ -416,6 +443,11 @@ mod tests {
         assert_eq!(trace.id, "pi0751");
         assert_eq!(trace.num_turns, 3);
         assert_eq!(trace.num_tool_calls, 1);
+        // The leading user turn is the task scaffold, not a trajectory
+        // segment — the training bridge re-rolls from it.
+        assert_eq!(trace.prompt_messages.len(), 1);
+        assert_eq!(trace.prompt_messages[0].role, "user");
+        assert_eq!(trace.prompt_messages[0].content, "Print 42");
         assert_eq!(trace.trajectory.len(), 3);
         assert_eq!(trace.trajectory[0].role, "assistant");
         assert_eq!(trace.trajectory[0].kind, kiln_train::trajectory::TurnKind::Action);
@@ -429,6 +461,39 @@ mod tests {
         assert_eq!(trace.trajectory[1].tool_call_id.as_deref(), Some("c1"));
         assert_eq!(trace.trajectory[1].content, "42\n");
         assert_eq!(trace.trajectory[2].content, "Done");
+    }
+
+    #[test]
+    fn parse_keeps_mid_session_user_turns_as_context_segments() {
+        let dir = tempdir().unwrap();
+        let session_path = dir.path().join("midctx.jsonl");
+        write_jsonl(
+            &session_path,
+            &[
+                json!({"type":"message","message":{"role":"system","content":[{"type":"text","text":"You are pi."}]}}),
+                json!({"type":"message","message":{"role":"user","content":[{"type":"text","text":"Run the tests"}]}}),
+                json!({"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"Running."}]}}),
+                json!({"type":"message","message":{"role":"user","content":[{"type":"text","text":"Now fix the failure"}]}}),
+                json!({"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"Fixed."}]}}),
+            ],
+        );
+
+        let trace = parse_pi_session(&session_path).unwrap();
+
+        // Leading system+user run = scaffold.
+        assert_eq!(trace.prompt_messages.len(), 2);
+        assert_eq!(trace.prompt_messages[0].role, "system");
+        assert_eq!(trace.prompt_messages[1].content, "Run the tests");
+        // Mid-session user turn stays ordered inside the trajectory as
+        // Context, between the two actions.
+        assert_eq!(trace.trajectory.len(), 3);
+        assert_eq!(trace.trajectory[0].content, "Running.");
+        assert_eq!(
+            trace.trajectory[1].kind,
+            kiln_train::trajectory::TurnKind::Context
+        );
+        assert_eq!(trace.trajectory[1].content, "Now fix the failure");
+        assert_eq!(trace.trajectory[2].content, "Fixed.");
     }
 
     #[test]
@@ -594,6 +659,7 @@ mod tests {
                 forked: false,
                 parent_id: None,
                 tool_manifest_sha: Some("sha256:abc".into()),
+                prompt_messages: Vec::new(),
                 trajectory: Vec::new(),
             },
         );

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -6,7 +6,7 @@ use tracing::Span;
 use crate::state::AppState;
 
 mod adapters;
-pub(crate) mod agent_traces;
+pub mod agent_traces;
 pub(crate) mod cache;
 pub(crate) mod completions;
 mod config;

--- a/crates/kiln-server/src/api/recipes.rs
+++ b/crates/kiln-server/src/api/recipes.rs
@@ -306,7 +306,8 @@ async fn run_recipe(
             continue;
         }
         let job_id = uuid::Uuid::new_v4().to_string();
-        let (adapter_name, queued) = step_to_queued_job(step, previous_adapter.as_deref(), &job_id)?;
+        let (adapter_name, queued) =
+            step_to_queued_job(&state, step, previous_adapter.as_deref(), &job_id)?;
         previous_adapter = Some(adapter_name.clone());
         prepared.push((job_id, adapter_name, queued));
     }
@@ -338,6 +339,7 @@ async fn run_recipe(
 /// the §3.7 recipe contract is "each step's output is the next
 /// step's input by default."
 fn step_to_queued_job(
+    state: &AppState,
     step: &RecipeStep,
     previous_adapter: Option<&str>,
     _job_id: &str,
@@ -366,10 +368,15 @@ fn step_to_queued_job(
             let examples = match examples_from {
                 ExamplesSource::Inline { examples } => examples.clone(),
                 ExamplesSource::Dataset { dataset } => {
-                    return Err(ApiError::training_invalid_request(format!(
-                        "SFT step with `dataset: {dataset}` requires server-side dataset \
-                         resolution (eval-dataset registry follow-up)"
-                    )));
+                    crate::dataset_resolve::resolve_registry_sft_examples(
+                        state.dataset_registry.as_deref(),
+                        dataset,
+                    )
+                    .map_err(|e| {
+                        ApiError::training_invalid_request(format!(
+                            "SFT step `dataset: {dataset}`: {e}"
+                        ))
+                    })?
                 }
             };
             let mut sft_config = config.clone();
@@ -398,10 +405,21 @@ fn step_to_queued_job(
             let prompts = match prompts_from {
                 PromptsSource::Inline { prompts } => prompts.clone(),
                 PromptsSource::Dataset { dataset } => {
-                    return Err(ApiError::training_invalid_request(format!(
-                        "OPD step with `dataset: {dataset}` requires server-side dataset \
-                         resolution (eval-dataset registry follow-up)"
-                    )));
+                    // `agent_traces:` selectors (e.g. the day-one
+                    // learn-from-my-pi-history recipe) resolve against the
+                    // §10.3 trace index; bare names against the uploaded
+                    // dataset registry.
+                    crate::dataset_resolve::resolve_opd_dataset_selector(
+                        dataset,
+                        &state.adapter_dir,
+                        state.dataset_registry.as_deref(),
+                        crate::recent_requests::now_unix_ms() as i64,
+                    )
+                    .map_err(|e| {
+                        ApiError::training_invalid_request(format!(
+                            "OPD step `dataset: {dataset}`: {e}"
+                        ))
+                    })?
                 }
             };
             let mut opd_config = config.clone();

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -98,23 +98,14 @@ async fn judge_distill(
             req.teacher
         ),
     )?;
+    // §10.6.1: the judge corpus is (turn, context) pairs from the user's
+    // OWN indexed pi sessions — resolved here, at submission (and before
+    // the queue/mock gates, so data problems surface with their
+    // remediation first). Before this, the corpus silently fell through
+    // to generic seed prompts and reported success.
+    let (pump_req, num_pairs) =
+        build_judge_pump_request(&state.adapter_dir, &req)?;
     super::training::enforce_queue_caps(&state)?;
-
-    // §10.6.1 internally is a `distill_pump` against the judge_traces
-    // canonical corpus. We construct the pump request server-side so
-    // the agentic surface stays minimal.
-    let pump_req = DistillPumpRequest {
-        name: req.name.clone(),
-        teacher: req.teacher.clone(),
-        mode: DistillPumpMode::Domain {
-            domain: "judge_traces".to_string(),
-        },
-        rank: Some(req.config.lora_rank),
-        rollout_budget: 50_000,
-        use_cache: true,
-        config: req.config.clone(),
-        post_eval: None,
-    };
 
     let job_id = uuid::Uuid::new_v4().to_string();
     register_agent_job(&state, &job_id, &req.name, QueuedJob::DistillPump(pump_req));
@@ -122,7 +113,8 @@ async fn judge_distill(
         job_id,
         state: TrainingState::Queued,
         message: format!(
-            "Queued judge distillation for '{}'. Per §10.6.1 this is the one-time \
+            "Queued judge distillation for '{}' on {num_pairs} (turn, context) pairs \
+             from your indexed pi sessions. Per §10.6.1 this is the one-time \
              investment — pay once, judge approximates 27B at <1% inference cost.",
             req.name
         ),
@@ -188,6 +180,14 @@ async fn self_improve(
             req.judge
         ),
     )?;
+    // Resolve the week's tasks from the §10.3 trace index NOW — an empty
+    // or stale index fails here with the remediation, not at worker
+    // dequeue hours later, and before the queue/mock gates so data
+    // problems surface first. (The worker re-resolves the same selector
+    // at run time so sessions captured between submission and dequeue
+    // are included.)
+    let (opd_phase, crisp_pump, num_tasks) =
+        build_self_improve_jobs(&state.adapter_dir, &req)?;
     super::training::enforce_queue_caps(&state)?;
 
     // §10.6.2: score with judge → GRPO → CRISP pass. Each phase
@@ -195,16 +195,6 @@ async fn self_improve(
     // judge-scored advantages into the GRPO step.
     let mut job_ids = Vec::new();
 
-    // Phase 1: agent GRPO step (queued as OPD with the judge as the
-    // teacher — the loss kernel scores per-token KL against the
-    // judge's distribution).
-    let opd_phase = OpdRequest {
-        prompts: Vec::new(),
-        dataset_path: Some("agent_traces:weekly".to_string()),
-        teacher: req.judge.clone(),
-        config: req.config.clone(),
-        post_eval: None,
-    };
     let opd_job = uuid::Uuid::new_v4().to_string();
     register_agent_job(
         &state,
@@ -214,23 +204,8 @@ async fn self_improve(
     );
     job_ids.push(opd_job);
 
-    // Phase 2: optional CRISP terseness pass.
-    if req.crisp {
-        let mut crisp_config = req.config.clone();
-        crisp_config.output_name = Some(format!("{}-crisp", req.agent));
+    if let Some(crisp_pump) = crisp_pump {
         let crisp_job = uuid::Uuid::new_v4().to_string();
-        let crisp_pump = DistillPumpRequest {
-            name: format!("{}-crisp", req.agent),
-            teacher: req.judge.clone(),
-            mode: DistillPumpMode::Domain {
-                domain: "crisp_terseness".to_string(),
-            },
-            rank: None,
-            rollout_budget: 10_000,
-            use_cache: true,
-            config: crisp_config,
-            post_eval: None,
-        };
         register_agent_job(
             &state,
             &crisp_job,
@@ -244,8 +219,9 @@ async fn self_improve(
         job_ids,
         state: TrainingState::Queued,
         message: format!(
-            "§10.6.2 self_improve queued: agent={}, judge={}, crisp={}. \
-             Phase 1 = judge-scored GRPO; Phase 2 = CRISP terseness pass.",
+            "§10.6.2 self_improve queued on {num_tasks} task(s) from this week's pi \
+             sessions: agent={}, judge={}, crisp={}. Phase 1 = judge-scored GRPO; \
+             Phase 2 = CRISP terseness pass.",
             req.agent, req.judge, req.crisp
         ),
     }))
@@ -313,6 +289,96 @@ async fn judge_drift_check(
         )));
     }
     Err(ApiError::drift_check_not_implemented())
+}
+
+/// §10.6.1 corpus + pump construction, factored out of the handler so the
+/// wiring is unit-testable without a real (non-mock) backend. Returns the
+/// pump request and the corpus size.
+fn build_judge_pump_request(
+    adapter_dir: &std::path::Path,
+    req: &JudgeDistillRequest,
+) -> Result<(DistillPumpRequest, usize), ApiError> {
+    let judge_prompts = crate::dataset_resolve::resolve_agent_trace_prompts(
+        adapter_dir,
+        "agent_traces:judge_turns",
+        crate::recent_requests::now_unix_ms() as i64,
+    )
+    .map_err(|e| ApiError::training_invalid_request(format!("judge_distill: {e}")))?;
+    let num_pairs = judge_prompts.len();
+    let pump_req = DistillPumpRequest {
+        name: req.name.clone(),
+        teacher: req.teacher.clone(),
+        mode: DistillPumpMode::Examples {
+            examples: judge_prompts,
+        },
+        rank: Some(req.config.lora_rank),
+        rollout_budget: 50_000,
+        use_cache: true,
+        config: req.config.clone(),
+        post_eval: None,
+    };
+    Ok((pump_req, num_pairs))
+}
+
+/// §10.6.2 phase construction: the weekly on-policy OPD phase (validated
+/// here, re-resolved by the worker at dequeue) and the optional §10.6.4
+/// CRISP pump on resolved conciseness prompts. Returns the task count for
+/// the response message.
+#[allow(clippy::type_complexity)]
+fn build_self_improve_jobs(
+    adapter_dir: &std::path::Path,
+    req: &SelfImproveRequest,
+) -> Result<(OpdRequest, Option<DistillPumpRequest>, usize), ApiError> {
+    let now_ms = crate::recent_requests::now_unix_ms() as i64;
+    let weekly = crate::dataset_resolve::resolve_agent_trace_prompts(
+        adapter_dir,
+        "agent_traces:weekly",
+        now_ms,
+    )
+    .map_err(|e| ApiError::training_invalid_request(format!("self_improve: {e}")))?;
+    let num_tasks = weekly.len();
+
+    // Phase 1: the student re-rolls the week's pi tasks on-policy with
+    // the judge as the scoring teacher. The selector resolves in the
+    // worker via the same path that just validated it above.
+    let opd_phase = OpdRequest {
+        prompts: Vec::new(),
+        dataset_path: Some("agent_traces:weekly".to_string()),
+        teacher: req.judge.clone(),
+        config: req.config.clone(),
+        post_eval: None,
+    };
+
+    // Phase 2: the same successful sessions re-prompted under
+    // conciseness pressure (§10.6.4).
+    let crisp_pump = if req.crisp {
+        let crisp_prompts = crate::dataset_resolve::resolve_agent_trace_prompts(
+            adapter_dir,
+            "agent_traces:crisp",
+            now_ms,
+        )
+        .map_err(|e| {
+            ApiError::training_invalid_request(format!("self_improve (crisp phase): {e}"))
+        })?;
+        let mut crisp_config = req.config.clone();
+        crisp_config.output_name = Some(format!("{}-crisp", req.agent));
+        Some(DistillPumpRequest {
+            name: format!("{}-crisp", req.agent),
+            teacher: req.judge.clone(),
+            mode: DistillPumpMode::Examples {
+                examples: crisp_prompts,
+            },
+            rank: None,
+            rollout_budget: 10_000,
+            use_cache: true,
+            config: crisp_config,
+            post_eval: None,
+        })
+    } else {
+        None
+    };
+
+    Ok((opd_phase, crisp_pump, num_tasks))
 }
 
 /// Resolve a teacher alias against the registry, failing with the
@@ -418,5 +484,128 @@ mod tests {
         assert_eq!(req.teacher, "qwen3.6-27b@local");
         assert_eq!(req.sample_size, 50);
         assert!((req.agreement_threshold - 0.80).abs() < 1e-9);
+    }
+
+    use kiln_train::ChatMessage;
+    use kiln_train::trajectory::{TurnKind, TurnSegment};
+
+    fn seeded_trace_index(dir: &std::path::Path) {
+        let now = chrono::Utc::now().to_rfc3339();
+        let trace = crate::api::agent_traces::AgentTrace {
+            id: "session-a".into(),
+            working_dir: "/home/user/proj".into(),
+            num_turns: 4,
+            num_tool_calls: 1,
+            outcome: crate::api::agent_traces::TraceOutcome {
+                ended_with_exit_0: Some(true),
+                user_edited_agent_files: Vec::new(),
+                has_followup_attempt: Some(false),
+            },
+            first_event_at: Some(now.clone()),
+            last_event_at: Some(now),
+            forked: false,
+            parent_id: None,
+            tool_manifest_sha: None,
+            prompt_messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: "You are pi.".into(),
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: "Fix the flaky test".into(),
+                },
+            ],
+            trajectory: vec![
+                TurnSegment {
+                    role: "assistant".into(),
+                    content: "Reading the test.".into(),
+                    kind: TurnKind::Action,
+                    tool_call_id: None,
+                    warning_prefix_len: None,
+                },
+                TurnSegment {
+                    role: "tool".into(),
+                    content: "FAILED tests/flaky.rs".into(),
+                    kind: TurnKind::Observation,
+                    tool_call_id: None,
+                    warning_prefix_len: None,
+                },
+                TurnSegment {
+                    role: "assistant".into(),
+                    content: "Pinning the seed.".into(),
+                    kind: TurnKind::Action,
+                    tool_call_id: None,
+                    warning_prefix_len: None,
+                },
+            ],
+        };
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(trace.id.clone(), trace);
+        std::fs::write(
+            dir.join("agent_traces.json"),
+            serde_json::to_vec_pretty(&map).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn judge_pump_carries_turn_context_pairs_from_the_index() {
+        let dir = tempfile::tempdir().unwrap();
+        seeded_trace_index(dir.path());
+        let req: JudgeDistillRequest = serde_json::from_str("{}").unwrap();
+
+        let (pump, num_pairs) = build_judge_pump_request(dir.path(), &req).unwrap();
+
+        assert_eq!(num_pairs, 2, "one judge prompt per assistant action");
+        let DistillPumpMode::Examples { examples } = &pump.mode else {
+            panic!("judge pump must carry resolved Examples");
+        };
+        assert!(examples[0].messages[0].content.contains("tool_correctness"));
+        assert!(
+            examples[1].messages[1].content.contains("FAILED tests/flaky.rs"),
+            "later turns see the observations that preceded them"
+        );
+    }
+
+    #[test]
+    fn judge_pump_without_index_carries_discover_remediation() {
+        let dir = tempfile::tempdir().unwrap();
+        let req: JudgeDistillRequest = serde_json::from_str("{}").unwrap();
+        let err = build_judge_pump_request(dir.path(), &req).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("/v1/agent/traces/discover"), "{msg}");
+    }
+
+    #[test]
+    fn self_improve_jobs_resolve_weekly_tasks_and_crisp_examples() {
+        let dir = tempfile::tempdir().unwrap();
+        seeded_trace_index(dir.path());
+        let req: SelfImproveRequest = serde_json::from_str("{}").unwrap();
+
+        let (opd, crisp, num_tasks) = build_self_improve_jobs(dir.path(), &req).unwrap();
+
+        assert_eq!(num_tasks, 1);
+        assert_eq!(opd.dataset_path.as_deref(), Some("agent_traces:weekly"));
+        assert_eq!(opd.teacher, "judge-pi-v1");
+        let crisp = crisp.expect("crisp defaults on");
+        let DistillPumpMode::Examples { examples } = &crisp.mode else {
+            panic!("crisp pump must carry resolved Examples");
+        };
+        assert_eq!(examples.len(), 1);
+        assert!(
+            examples[0].messages[0].content.contains("maximally concise"),
+            "conciseness pressure folded into the system turn"
+        );
+        assert!(examples[0].messages[1].content.contains("Fix the flaky test"));
+    }
+
+    #[test]
+    fn self_improve_jobs_skip_crisp_when_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        seeded_trace_index(dir.path());
+        let req: SelfImproveRequest = serde_json::from_str(r#"{"crisp": false}"#).unwrap();
+        let (_, crisp, _) = build_self_improve_jobs(dir.path(), &req).unwrap();
+        assert!(crisp.is_none());
     }
 }

--- a/crates/kiln-server/src/dataset_resolve.rs
+++ b/crates/kiln-server/src/dataset_resolve.rs
@@ -1,0 +1,639 @@
+//! Symbolic dataset selectors → concrete training prompts.
+//!
+//! The §10 agentic loop ("use pi all week, train on it Saturday") needs a
+//! bridge between the §10.3 Agent Trace Layer index and the training
+//! pipeline. This module is that bridge: it resolves the
+//! `agent_traces:<filter>` selectors used by `/v1/agent/self_improve`,
+//! `/v1/agent/judge_distill`, recipe `dataset:` sources, and OPD
+//! `dataset_path` into `OpdPrompt`s built from the user's actual pi
+//! sessions, and resolves bare names against the uploaded eval dataset
+//! registry.
+//!
+//! Every resolution failure is actionable: it says which index/registry was
+//! consulted, why zero prompts qualified, and what to run next — never a
+//! placeholder corpus. (Before this module existed, an unresolvable
+//! selector either failed at worker dequeue or silently fell through to a
+//! three-generic-prompt seed bank, producing "judge" adapters trained on
+//! "describe an interesting fact about this topic".)
+
+use std::path::Path;
+
+use kiln_train::ChatMessage;
+use kiln_train::opd::OpdPrompt;
+use kiln_train::trajectory::{TurnKind, TurnSegment};
+
+use crate::api::agent_traces::{AgentTrace, AgentTraceIndex};
+
+/// Selector scheme prefix for the agent-trace index.
+pub const AGENT_TRACES_PREFIX: &str = "agent_traces:";
+
+/// How far back `agent_traces:weekly` reaches.
+const WEEKLY_WINDOW_MS: i64 = 7 * 24 * 3600 * 1000;
+/// Judge-corpus caps: most-recent actions per trace, total prompts, and
+/// character budgets so a single huge session can't produce a 100 MB
+/// request body (the corpus is embedded into the queued pump request).
+const MAX_JUDGE_TURNS_PER_TRACE: usize = 8;
+const MAX_JUDGE_PROMPTS: usize = 256;
+const JUDGE_CONTEXT_CHAR_BUDGET: usize = 3000;
+const JUDGE_SEGMENT_CHAR_CAP: usize = 600;
+const JUDGE_TURN_CHAR_CAP: usize = 2000;
+
+/// Filters over the persisted agent-trace index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentTraceFilter {
+    /// Every indexed trace with a usable prompt scaffold.
+    All,
+    /// Sessions that look like they went well: ended exit-0 (or unknown),
+    /// not forked, no follow-up re-attempt.
+    Successful,
+    /// `Successful` restricted to the last 7 days — the
+    /// `kiln self-improve` Saturday default.
+    Weekly,
+    /// (turn, context) judge-scoring prompts from *all* traces — failures
+    /// and forks are exactly the discrimination signal a judge needs.
+    JudgeTurns,
+    /// `Successful` scaffolds re-prompted under conciseness pressure
+    /// (§10.6.4 CRISP).
+    Crisp,
+}
+
+pub fn is_agent_traces_selector(selector: &str) -> bool {
+    selector.starts_with(AGENT_TRACES_PREFIX)
+}
+
+pub fn parse_agent_trace_filter(selector: &str) -> Result<AgentTraceFilter, String> {
+    let suffix = selector.strip_prefix(AGENT_TRACES_PREFIX).ok_or_else(|| {
+        format!("selector {selector:?} does not start with {AGENT_TRACES_PREFIX:?}")
+    })?;
+    match suffix {
+        "all" => Ok(AgentTraceFilter::All),
+        // `user-pi` is the spelling the day-one `learn-from-my-pi-history`
+        // recipe shipped with — keep it working.
+        "successful" | "user-pi" => Ok(AgentTraceFilter::Successful),
+        "weekly" => Ok(AgentTraceFilter::Weekly),
+        "judge_turns" => Ok(AgentTraceFilter::JudgeTurns),
+        "crisp" => Ok(AgentTraceFilter::Crisp),
+        other => Err(format!(
+            "unknown agent_traces filter {other:?} — valid filters: all, successful, \
+             user-pi, weekly, judge_turns, crisp"
+        )),
+    }
+}
+
+/// Resolve an `agent_traces:<filter>` selector against the index persisted
+/// at `<adapter_dir>/agent_traces.json`. Errors are user-facing and carry
+/// the remediation.
+pub fn resolve_agent_trace_prompts(
+    adapter_dir: &Path,
+    selector: &str,
+    now_unix_ms: i64,
+) -> Result<Vec<OpdPrompt>, String> {
+    let filter = parse_agent_trace_filter(selector)?;
+    let index_path = adapter_dir.join("agent_traces.json");
+    if !index_path.is_file() {
+        return Err(format!(
+            "no agent-trace index at {} — run `POST /v1/agent/traces/discover` (or open \
+             the dashboard's Agent Traces panel) to index your pi sessions first",
+            index_path.display()
+        ));
+    }
+    let index = AgentTraceIndex::load_from_path(&index_path);
+    if index.traces.is_empty() {
+        return Err(format!(
+            "agent-trace index at {} is empty — use pi pointed at this Kiln (try `kiln \
+             pi-setup` or the dashboard's pi terminal), then re-run `POST \
+             /v1/agent/traces/discover`",
+            index_path.display()
+        ));
+    }
+    let total = index.traces.len();
+
+    // Most-recent-first so prompt caps keep the freshest sessions.
+    let mut traces: Vec<&AgentTrace> = index.traces.values().collect();
+    traces.sort_by(|a, b| b.last_event_at.cmp(&a.last_event_at));
+
+    let prompts = match filter {
+        AgentTraceFilter::All => scaffold_prompts(traces.iter().copied()),
+        AgentTraceFilter::Successful => {
+            scaffold_prompts(traces.iter().copied().filter(|t| trace_is_successful(t)))
+        }
+        AgentTraceFilter::Weekly => scaffold_prompts(
+            traces
+                .iter()
+                .copied()
+                .filter(|t| trace_is_successful(t) && trace_within_ms(t, now_unix_ms, WEEKLY_WINDOW_MS)),
+        ),
+        AgentTraceFilter::JudgeTurns => judge_turn_prompts(&traces),
+        AgentTraceFilter::Crisp => {
+            scaffold_prompts(traces.iter().copied().filter(|t| trace_is_successful(t)))
+                .into_iter()
+                .map(with_conciseness_pressure)
+                .collect()
+        }
+    };
+
+    if prompts.is_empty() {
+        let scaffoldless = index
+            .traces
+            .values()
+            .filter(|t| t.prompt_messages.is_empty())
+            .count();
+        if scaffoldless == total {
+            return Err(format!(
+                "agent-trace index has {total} trace(s) but none carry a prompt scaffold — \
+                 the index predates prompt capture. Re-run `POST /v1/agent/traces/discover` \
+                 to refresh it"
+            ));
+        }
+        return Err(format!(
+            "agent-trace index has {total} trace(s) but none qualify under \
+             {selector:?} (successful = ended exit-0, not forked, no follow-up attempt; \
+             weekly additionally = within the last 7 days) — try `agent_traces:all`, or \
+             re-run `POST /v1/agent/traces/discover` to pick up newer sessions"
+        ));
+    }
+    Ok(prompts)
+}
+
+/// Resolve a bare dataset name against the uploaded eval dataset registry
+/// into OPD prompt scaffolds (one prompt per SFT conversation).
+pub fn resolve_registry_opd_prompts(
+    registry: Option<&crate::eval::DatasetRegistry>,
+    name: &str,
+) -> Result<Vec<OpdPrompt>, String> {
+    let registry = registry.ok_or_else(|| {
+        "dataset registry unavailable (server started without an eval root)".to_string()
+    })?;
+    // `iter_sft` surfaces a missing dataset as a bare IO error — probe the
+    // data file first so absence gets the actionable message.
+    let not_found = || {
+        format!(
+            "dataset {name:?} not found in the eval dataset registry — upload it via \
+             `POST /v1/eval/datasets` or use an `agent_traces:` selector"
+        )
+    };
+    let dir = registry
+        .dataset_dir(name)
+        .map_err(|e| format!("dataset {name:?}: {e}"))?;
+    if !dir.join("data.jsonl").is_file() {
+        return Err(not_found());
+    }
+    let iter = registry.iter_sft(name).map_err(|e| match e {
+        crate::eval::DatasetError::NotFound(_) => not_found(),
+        other => format!("dataset {name:?}: {other}"),
+    })?;
+    let prompts: Vec<OpdPrompt> = iter
+        .map(|conv| OpdPrompt {
+            messages: conv
+                .messages
+                .into_iter()
+                .map(|m| ChatMessage {
+                    role: m.role,
+                    content: m.content,
+                })
+                .collect(),
+            teacher_extra_messages: Vec::new(),
+            trajectory: Vec::new(),
+        })
+        .filter(|p| !p.messages.is_empty())
+        .collect();
+    if prompts.is_empty() {
+        return Err(format!(
+            "dataset {name:?} contains no usable conversations (every row was empty or \
+             malformed)"
+        ));
+    }
+    Ok(prompts)
+}
+
+/// Resolve a bare dataset name against the registry into SFT examples.
+/// Mirrors `submit_sft`'s train-by-dataset-name path for recipe steps,
+/// which enqueue directly without passing through `submit_sft`.
+pub fn resolve_registry_sft_examples(
+    registry: Option<&crate::eval::DatasetRegistry>,
+    name: &str,
+) -> Result<Vec<kiln_train::SftExample>, String> {
+    let prompts = resolve_registry_opd_prompts(registry, name)?;
+    Ok(prompts
+        .into_iter()
+        .map(|p| kiln_train::SftExample {
+            messages: p.messages,
+        })
+        .collect())
+}
+
+/// Unified entry: `agent_traces:<filter>` selectors hit the trace index;
+/// anything else is treated as an uploaded-dataset name.
+pub fn resolve_opd_dataset_selector(
+    selector: &str,
+    adapter_dir: &Path,
+    registry: Option<&crate::eval::DatasetRegistry>,
+    now_unix_ms: i64,
+) -> Result<Vec<OpdPrompt>, String> {
+    if is_agent_traces_selector(selector) {
+        resolve_agent_trace_prompts(adapter_dir, selector, now_unix_ms)
+    } else {
+        resolve_registry_opd_prompts(registry, selector)
+    }
+}
+
+fn trace_is_successful(trace: &AgentTrace) -> bool {
+    trace.outcome.ended_with_exit_0 != Some(false)
+        && trace.outcome.has_followup_attempt != Some(true)
+        && !trace.forked
+}
+
+fn trace_within_ms(trace: &AgentTrace, now_unix_ms: i64, window_ms: i64) -> bool {
+    let Some(ts) = trace.last_event_at.as_deref() else {
+        return false;
+    };
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(ts) else {
+        return false;
+    };
+    let age_ms = now_unix_ms.saturating_sub(parsed.timestamp_millis());
+    (0..=window_ms).contains(&age_ms)
+}
+
+/// Task scaffolds for re-rolling: one prompt per trace, carrying the
+/// leading system/user context the session started from. The student
+/// samples fresh rollouts from these; the (judge) teacher scores them —
+/// §10.6.2 step 1, "samples agent rollouts on the week's pi tasks".
+fn scaffold_prompts<'a>(traces: impl Iterator<Item = &'a AgentTrace>) -> Vec<OpdPrompt> {
+    traces
+        .filter(|t| !t.prompt_messages.is_empty())
+        .map(|t| OpdPrompt {
+            messages: t.prompt_messages.clone(),
+            teacher_extra_messages: Vec::new(),
+            trajectory: Vec::new(),
+        })
+        .collect()
+}
+
+/// §10.6.1 (turn, context) judge-scoring corpus: for each assistant action
+/// in each trace, a prompt asking the model to score that turn given the
+/// session context that preceded it.
+fn judge_turn_prompts(traces: &[&AgentTrace]) -> Vec<OpdPrompt> {
+    let mut prompts = Vec::new();
+    for trace in traces {
+        if prompts.len() >= MAX_JUDGE_PROMPTS {
+            break;
+        }
+        let action_count = trace
+            .trajectory
+            .iter()
+            .filter(|s| s.kind == TurnKind::Action)
+            .count();
+        if action_count == 0 {
+            continue;
+        }
+        // Keep the most recent N actions per trace.
+        let skip_actions = action_count.saturating_sub(MAX_JUDGE_TURNS_PER_TRACE);
+
+        let mut transcript: Vec<String> = trace
+            .prompt_messages
+            .iter()
+            .map(|m| render_transcript_line(&m.role, &m.content))
+            .collect();
+        let mut actions_seen = 0usize;
+        for seg in &trace.trajectory {
+            if seg.kind == TurnKind::Action {
+                actions_seen += 1;
+                if actions_seen > skip_actions && prompts.len() < MAX_JUDGE_PROMPTS {
+                    prompts.push(judge_prompt(&transcript, seg));
+                }
+            }
+            transcript.push(render_transcript_line(&seg.role, &seg.content));
+        }
+    }
+    prompts
+}
+
+fn render_transcript_line(role: &str, content: &str) -> String {
+    format!("[{role}] {}", truncate_middle(content, JUDGE_SEGMENT_CHAR_CAP))
+}
+
+fn judge_prompt(transcript: &[String], action: &TurnSegment) -> OpdPrompt {
+    // Tail of the transcript closest to the candidate turn, within budget.
+    let mut context_lines: Vec<&str> = Vec::new();
+    let mut budget = JUDGE_CONTEXT_CHAR_BUDGET;
+    for line in transcript.iter().rev() {
+        let cost = line.chars().count() + 1;
+        if cost > budget {
+            break;
+        }
+        budget -= cost;
+        context_lines.push(line.as_str());
+    }
+    context_lines.reverse();
+    let context = if context_lines.is_empty() {
+        "(session start)".to_string()
+    } else {
+        context_lines.join("\n")
+    };
+    OpdPrompt {
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a strict turn judge for terminal coding agents. Score \
+                          the candidate assistant turn on five axes — tool_correctness, \
+                          goal_progress, reasoning_quality, terseness, \
+                          instruction_following — each 0-10, and respond with only a \
+                          JSON object like {\"tool_correctness\": 7, \"goal_progress\": 5, \
+                          \"reasoning_quality\": 6, \"terseness\": 8, \
+                          \"instruction_following\": 9}. Judge only the candidate turn, \
+                          not the rest of the session."
+                    .to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: format!(
+                    "# Session context\n{context}\n\n# Candidate assistant turn\n{}\n\n\
+                     Score the candidate turn now.",
+                    truncate_middle(&action.content, JUDGE_TURN_CHAR_CAP)
+                ),
+            },
+        ],
+        teacher_extra_messages: Vec::new(),
+        trajectory: Vec::new(),
+    }
+}
+
+/// §10.6.4 CRISP: same task, explicit conciseness pressure. Folded into an
+/// existing system message when present so the chat template still sees a
+/// single system turn.
+fn with_conciseness_pressure(mut prompt: OpdPrompt) -> OpdPrompt {
+    const PRESSURE: &str = "Be maximally concise: shortest correct tool calls, no filler \
+                            prose, the minimum tokens that still solve the task correctly.";
+    match prompt.messages.first_mut() {
+        Some(first) if first.role == "system" => {
+            first.content = format!("{}\n\n{PRESSURE}", first.content);
+        }
+        _ => prompt.messages.insert(
+            0,
+            ChatMessage {
+                role: "system".to_string(),
+                content: PRESSURE.to_string(),
+            },
+        ),
+    }
+    prompt
+}
+
+fn truncate_middle(text: &str, max_chars: usize) -> String {
+    let count = text.chars().count();
+    if count <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(16) / 2;
+    let head: String = text.chars().take(keep).collect();
+    let tail: String = text.chars().skip(count - keep).collect();
+    format!("{head}\n[… {} chars …]\n{tail}", count - 2 * keep)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::agent_traces::TraceOutcome;
+    use std::collections::BTreeMap;
+
+    fn msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    fn seg(role: &str, kind: TurnKind, content: &str) -> TurnSegment {
+        TurnSegment {
+            role: role.to_string(),
+            content: content.to_string(),
+            kind,
+            tool_call_id: None,
+            warning_prefix_len: None,
+        }
+    }
+
+    fn trace(id: &str, last_event_at: &str, success: bool) -> AgentTrace {
+        AgentTrace {
+            id: id.to_string(),
+            working_dir: "/tmp/proj".to_string(),
+            num_turns: 4,
+            num_tool_calls: 1,
+            outcome: TraceOutcome {
+                ended_with_exit_0: Some(success),
+                user_edited_agent_files: Vec::new(),
+                has_followup_attempt: Some(false),
+            },
+            first_event_at: Some(last_event_at.to_string()),
+            last_event_at: Some(last_event_at.to_string()),
+            forked: false,
+            parent_id: None,
+            tool_manifest_sha: None,
+            prompt_messages: vec![
+                msg("system", "You are pi."),
+                msg("user", &format!("Fix the failing test in {id}")),
+            ],
+            trajectory: vec![
+                seg("assistant", TurnKind::Action, "Looking at the test."),
+                seg("tool", TurnKind::Observation, "FAILED tests/x.rs"),
+                seg("assistant", TurnKind::Action, "Patching."),
+            ],
+        }
+    }
+
+    fn write_index(dir: &Path, traces: &[AgentTrace]) {
+        let map: BTreeMap<String, AgentTrace> =
+            traces.iter().map(|t| (t.id.clone(), t.clone())).collect();
+        std::fs::write(
+            dir.join("agent_traces.json"),
+            serde_json::to_vec_pretty(&map).unwrap(),
+        )
+        .unwrap();
+    }
+
+    const NOW_MS: i64 = 1_780_000_000_000; // 2026-06-08-ish
+
+    fn rfc3339_ms_ago(ms: i64) -> String {
+        chrono::DateTime::from_timestamp_millis(NOW_MS - ms)
+            .unwrap()
+            .to_rfc3339()
+    }
+
+    #[test]
+    fn filter_parsing_accepts_known_filters_and_aliases() {
+        assert_eq!(
+            parse_agent_trace_filter("agent_traces:weekly").unwrap(),
+            AgentTraceFilter::Weekly
+        );
+        assert_eq!(
+            parse_agent_trace_filter("agent_traces:user-pi").unwrap(),
+            AgentTraceFilter::Successful
+        );
+        let err = parse_agent_trace_filter("agent_traces:bogus").unwrap_err();
+        assert!(err.contains("weekly"), "lists valid filters: {err}");
+    }
+
+    #[test]
+    fn missing_index_error_names_discover_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:weekly", NOW_MS).unwrap_err();
+        assert!(err.contains("/v1/agent/traces/discover"), "{err}");
+    }
+
+    #[test]
+    fn weekly_filters_by_success_and_recency() {
+        let dir = tempfile::tempdir().unwrap();
+        let recent_ok = trace("recent-ok", &rfc3339_ms_ago(3_600_000), true);
+        let recent_fail = trace("recent-fail", &rfc3339_ms_ago(3_600_000), false);
+        let old_ok = trace("old-ok", &rfc3339_ms_ago(30 * 24 * 3_600_000), true);
+        write_index(dir.path(), &[recent_ok, recent_fail, old_ok]);
+
+        let prompts =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:weekly", NOW_MS).unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].messages[1].content.contains("recent-ok"));
+        // Re-roll scaffolds carry no replay trajectory.
+        assert!(prompts[0].trajectory.is_empty());
+
+        let all = resolve_agent_trace_prompts(dir.path(), "agent_traces:all", NOW_MS).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let successful =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:successful", NOW_MS).unwrap();
+        assert_eq!(successful.len(), 2, "old-ok still qualifies as successful");
+    }
+
+    #[test]
+    fn forked_and_followed_up_traces_are_not_successful() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut forked = trace("forked", &rfc3339_ms_ago(1000), true);
+        forked.forked = true;
+        let mut followup = trace("followup", &rfc3339_ms_ago(1000), true);
+        followup.outcome.has_followup_attempt = Some(true);
+        write_index(dir.path(), &[forked, followup]);
+        let err = resolve_agent_trace_prompts(dir.path(), "agent_traces:weekly", NOW_MS)
+            .unwrap_err();
+        assert!(err.contains("none qualify"), "{err}");
+        assert!(err.contains("agent_traces:all"), "offers remediation: {err}");
+    }
+
+    #[test]
+    fn scaffoldless_index_says_rerun_discover() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut t = trace("old-format", &rfc3339_ms_ago(1000), true);
+        t.prompt_messages.clear();
+        write_index(dir.path(), &[t]);
+        let err =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:all", NOW_MS).unwrap_err();
+        assert!(err.contains("predates prompt capture"), "{err}");
+    }
+
+    #[test]
+    fn judge_turns_builds_turn_context_pairs_from_all_traces() {
+        let dir = tempfile::tempdir().unwrap();
+        let ok = trace("ok", &rfc3339_ms_ago(1000), true);
+        let failed = trace("failed", &rfc3339_ms_ago(2000), false);
+        write_index(dir.path(), &[ok, failed]);
+
+        let prompts =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:judge_turns", NOW_MS).unwrap();
+        // 2 actions per trace × 2 traces (failures included — they're the
+        // discrimination signal).
+        assert_eq!(prompts.len(), 4);
+        for p in &prompts {
+            assert_eq!(p.messages[0].role, "system");
+            assert!(p.messages[0].content.contains("tool_correctness"));
+            assert!(p.messages[1].content.contains("# Candidate assistant turn"));
+        }
+        // The second action's context includes the first action and the
+        // tool observation that followed it.
+        let second = &prompts[1].messages[1].content;
+        assert!(second.contains("Looking at the test."), "{second}");
+        assert!(second.contains("FAILED tests/x.rs"), "{second}");
+        assert!(second.contains("Patching."), "{second}");
+    }
+
+    #[test]
+    fn crisp_prompts_fold_pressure_into_existing_system_message() {
+        let dir = tempfile::tempdir().unwrap();
+        write_index(dir.path(), &[trace("t", &rfc3339_ms_ago(1000), true)]);
+        let prompts =
+            resolve_agent_trace_prompts(dir.path(), "agent_traces:crisp", NOW_MS).unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].messages[0].role, "system");
+        assert!(prompts[0].messages[0].content.starts_with("You are pi."));
+        assert!(prompts[0].messages[0].content.contains("maximally concise"));
+        // No double system message.
+        assert_eq!(
+            prompts[0]
+                .messages
+                .iter()
+                .filter(|m| m.role == "system")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn registry_resolution_reads_sft_datasets() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = crate::eval::DatasetRegistry::new(dir.path().join("datasets"));
+        registry
+            .create(
+                "my-data",
+                crate::eval::DatasetFormat::SftChat,
+                None,
+                b"{\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}\n",
+            )
+            .unwrap();
+        let prompts = resolve_registry_opd_prompts(Some(&registry), "my-data").unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].messages[0].content, "hello");
+
+        let err = resolve_registry_opd_prompts(Some(&registry), "nope").unwrap_err();
+        assert!(err.contains("/v1/eval/datasets"), "{err}");
+
+        let err = resolve_registry_opd_prompts(None, "my-data").unwrap_err();
+        assert!(err.contains("registry unavailable"), "{err}");
+    }
+
+    #[test]
+    fn unified_selector_routes_by_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        write_index(dir.path(), &[trace("t", &rfc3339_ms_ago(1000), true)]);
+        let registry = crate::eval::DatasetRegistry::new(dir.path().join(".eval/datasets"));
+        registry
+            .create(
+                "uploaded",
+                crate::eval::DatasetFormat::SftChat,
+                None,
+                b"{\"messages\":[{\"role\":\"user\",\"content\":\"from registry\"}]}\n",
+            )
+            .unwrap();
+
+        let from_traces = resolve_opd_dataset_selector(
+            "agent_traces:all",
+            dir.path(),
+            Some(&registry),
+            NOW_MS,
+        )
+        .unwrap();
+        assert!(from_traces[0].messages[1].content.contains("Fix the failing test"));
+
+        let from_registry =
+            resolve_opd_dataset_selector("uploaded", dir.path(), Some(&registry), NOW_MS)
+                .unwrap();
+        assert_eq!(from_registry[0].messages[0].content, "from registry");
+    }
+
+    #[test]
+    fn truncate_middle_keeps_head_and_tail() {
+        let long = "a".repeat(100) + &"b".repeat(100);
+        let cut = truncate_middle(&long, 50);
+        assert!(cut.starts_with("aaa"));
+        assert!(cut.ends_with("bbb"));
+        assert!(cut.contains("chars …"));
+        assert!(truncate_middle("short", 50) == "short");
+    }
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod adapter_verify;
 pub mod batching_engine;
 pub mod cli;
 pub mod config;
+pub mod dataset_resolve;
 pub mod decode_stats;
 pub mod device;
 pub(crate) mod device_memory;

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -556,40 +556,62 @@ fn run_opd(
     let mut dataset_summary: Option<kiln_train::OffPolicyDistillationSummary> = None;
     let mut owned_prompts: Option<Vec<kiln_train::opd::OpdPrompt>> = None;
     if let Some(path) = req.dataset_path.as_deref() {
-        if !matches!(
-            req.config.training_mode,
-            kiln_train::opd::OpdTrainingMode::OffPolicy
-        ) {
-            return Err(
-                "OPD dataset_path is only supported with config.training_mode = \"off_policy\""
+        // `agent_traces:<filter>` selectors resolve to live prompt
+        // scaffolds from the §10.3 trace index — the student re-rolls
+        // them on-policy against the registered teacher (this is the
+        // `/v1/agent/self_improve` data path). Plain file paths remain
+        // pre-scored off-policy teacher JSONL.
+        if crate::dataset_resolve::is_agent_traces_selector(path) {
+            let resolved = crate::dataset_resolve::resolve_agent_trace_prompts(
+                adapter_dir,
+                path,
+                crate::recent_requests::now_unix_ms() as i64,
+            )
+            .map_err(|e| format!("resolve OPD dataset_path {path:?}: {e}"))?;
+            tracing::info!(
+                job_id = %job_id,
+                dataset_path = %path,
+                prompts = resolved.len(),
+                "resolved agent-trace selector into OPD prompts"
+            );
+            owned_prompts = Some(resolved);
+        } else {
+            if !matches!(
+                req.config.training_mode,
+                kiln_train::opd::OpdTrainingMode::OffPolicy
+            ) {
+                return Err(
+                "OPD dataset_path is only supported with config.training_mode = \"off_policy\" \
+                 (or use an `agent_traces:` selector for on-policy training on pi sessions)"
                     .into(),
             );
+            }
+            let examples = kiln_train::load_off_policy_distillation_jsonl(path)
+                .map_err(|e| format!("load off-policy OPD dataset_path {path:?}: {e:#}"))?;
+            let prepared = kiln_train::prepare_off_policy_distillation_dataset(
+                &examples,
+                tokenizer,
+                req.teacher.clone(),
+                model_config.vocab_size,
+                req.config.top_k,
+                req.config.objective,
+                req.config.echo.as_ref(),
+            )
+            .map_err(|e| format!("prepare off-policy OPD dataset_path {path:?}: {e:#}"))?;
+            tracing::info!(
+                job_id = %job_id,
+                dataset_path = %path,
+                examples = prepared.summary.examples,
+                action_tokens = prepared.summary.action_tokens,
+                env_tokens = prepared.summary.env_tokens,
+                objective = ?prepared.summary.objective,
+                echo_combined = prepared.summary.echo_combined,
+                "loaded off-policy OPD teacher JSONL dataset"
+            );
+            dataset_teacher = Some(std::sync::Arc::new(prepared.teacher));
+            dataset_summary = Some(prepared.summary);
+            owned_prompts = Some(prepared.prompts);
         }
-        let examples = kiln_train::load_off_policy_distillation_jsonl(path)
-            .map_err(|e| format!("load off-policy OPD dataset_path {path:?}: {e:#}"))?;
-        let prepared = kiln_train::prepare_off_policy_distillation_dataset(
-            &examples,
-            tokenizer,
-            req.teacher.clone(),
-            model_config.vocab_size,
-            req.config.top_k,
-            req.config.objective,
-            req.config.echo.as_ref(),
-        )
-        .map_err(|e| format!("prepare off-policy OPD dataset_path {path:?}: {e:#}"))?;
-        tracing::info!(
-            job_id = %job_id,
-            dataset_path = %path,
-            examples = prepared.summary.examples,
-            action_tokens = prepared.summary.action_tokens,
-            env_tokens = prepared.summary.env_tokens,
-            objective = ?prepared.summary.objective,
-            echo_combined = prepared.summary.echo_combined,
-            "loaded off-policy OPD teacher JSONL dataset"
-        );
-        dataset_teacher = Some(std::sync::Arc::new(prepared.teacher));
-        dataset_summary = Some(prepared.summary);
-        owned_prompts = Some(prepared.prompts);
     }
     let prompts: &[kiln_train::opd::OpdPrompt] =
         owned_prompts.as_deref().unwrap_or(req.prompts.as_slice());
@@ -1170,6 +1192,7 @@ fn guess_remote_provider(url: &str) -> kiln_train::RemoteProvider {
 /// alongside the §3.1 trainer body (task #31), since the OPD step is
 /// what the refresh orchestrates.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn run_distill_refresh(
     req: &DistillRefreshRequest,
     model_config: &kiln_core::config::ModelConfig,
@@ -1179,6 +1202,7 @@ fn run_distill_refresh(
     adapter_name: &str,
     progress_cb: trainer::ProgressCallback,
     teacher_registry: &crate::api::teachers::TeacherRegistry,
+    dataset_registry: Option<&crate::eval::DatasetRegistry>,
     job_id: &str,
 ) -> std::result::Result<PathBuf, String> {
     if req.name.trim().is_empty() {
@@ -1189,14 +1213,19 @@ fn run_distill_refresh(
     }
 
     // Resolve the new-knowledge source to an inline list of prompts.
-    // Dataset-path resolution (server-side eval-datasets registry) is
-    // a follow-up — Inline is the path the §3.6 recipe uses today.
+    // Dataset sources go through the shared resolver: `agent_traces:`
+    // selectors hit the §10.3 trace index, bare names the uploaded
+    // dataset registry.
     let prompts: Vec<kiln_train::opd::OpdPrompt> = match &req.new_data {
         kiln_train::NewKnowledgeSource::Inline { examples } => examples.clone(),
         kiln_train::NewKnowledgeSource::Dataset { dataset } => {
-            return Err(format!(
-                "DistillRefresh: Dataset source {dataset:?} not yet resolved by the runtime — supply `examples` inline for now"
-            ));
+            crate::dataset_resolve::resolve_opd_dataset_selector(
+                dataset,
+                adapter_dir,
+                dataset_registry,
+                crate::recent_requests::now_unix_ms() as i64,
+            )
+            .map_err(|e| format!("DistillRefresh: resolve new_data dataset {dataset:?}: {e}"))?
         }
     };
     if prompts.is_empty() {
@@ -1609,7 +1638,9 @@ fn run_distill_pump(
     // end-to-end without depending on the corpus deliverable.
     let prompts: Vec<kiln_train::opd::OpdPrompt> = match &req.mode {
         kiln_train::DistillPumpMode::Examples { examples } => examples.clone(),
-        kiln_train::DistillPumpMode::Domain { domain } => canonical_domain_seed_prompts(domain),
+        kiln_train::DistillPumpMode::Domain { domain } => {
+            canonical_domain_seed_prompts(domain).map_err(|e| format!("distill_pump: {e}"))?
+        }
         kiln_train::DistillPumpMode::Wide { wide: _ } => wide_seed_prompts(),
     };
     if prompts.is_empty() {
@@ -1716,43 +1747,109 @@ fn run_distill_pump(
     Ok(output_dir)
 }
 
+/// Canonical pump domains, aligned with the §8.4 compatibility table in
+/// `api/pit_of_success.rs` and the shipped recipes. Unknown domains are a
+/// hard error — before this, anything (including typos and the agentic
+/// `judge_traces` corpus) silently fell through to three generic filler
+/// prompts and reported SUCCESS, producing meaningless adapters.
+const CANONICAL_PUMP_DOMAINS: &[&str] = &[
+    "math",
+    "math_reasoning",
+    "code",
+    "coding",
+    "python_codegen",
+    "rust_codegen",
+    "writing",
+    "chinese_writing",
+    "scientific_writing",
+    "legal_drafting",
+    "clinical_notes",
+    "instruction",
+    "if",
+    "instruction_following",
+    "tool_calling",
+    "long_context_summarization",
+];
+
 /// Tiny seed-prompt bank for the §3.5.1 targeted-domain pump. Maps a
 /// canonical-domain name to a handful of representative prompts. The
 /// full corpus lives on disk and ships in a separate Phase 3 artefact;
 /// these seeds let the runtime path exercise end-to-end against any
 /// registered teacher without depending on the corpus deliverable.
-fn canonical_domain_seed_prompts(domain: &str) -> Vec<kiln_train::opd::OpdPrompt> {
+fn canonical_domain_seed_prompts(
+    domain: &str,
+) -> std::result::Result<Vec<kiln_train::opd::OpdPrompt>, String> {
     use kiln_train::ChatMessage;
     let prompts: &[&str] = match domain.to_ascii_lowercase().as_str() {
-        "math" => &[
+        "math" | "math_reasoning" => &[
             "Solve for x: 2x^2 - 5x + 3 = 0.",
             "What is the derivative of sin(x^2)?",
             "Prove that the sum of the angles in a triangle is 180 degrees.",
             "Compute the integral of 1/(x^2 + 1) from -infinity to infinity.",
         ],
-        "code" | "coding" => &[
+        "code" | "coding" | "python_codegen" => &[
             "Write a Python function that reverses a linked list in place.",
             "Implement quicksort in Rust without using the standard sort.",
             "Explain the difference between a deadlock and a livelock with an example.",
             "Refactor this nested-for loop to a single map+filter call: nums = [1,2,3,4]; out = []; for n in nums: if n%2==0: out.append(n*n)",
+        ],
+        "rust_codegen" => &[
+            "Implement a thread-safe LRU cache in Rust with a fixed capacity.",
+            "Write a Rust iterator adapter that yields overlapping windows of size N over a slice.",
+            "Explain why this borrow fails and fix it: fn longest<'a>(a: &str, b: &'a str) -> &'a str { if a.len() > b.len() { a } else { b } }",
+            "Convert this blocking std::net TCP echo server sketch to tokio.",
         ],
         "writing" => &[
             "Write the opening paragraph of a short story set in a lighthouse.",
             "Compose a polite but firm email declining a vendor's price increase.",
             "Rewrite this sentence in active voice: 'The decision was made by the committee.'",
         ],
-        "instruction" | "if" => &[
+        "chinese_writing" => &[
+            "用三句话向新同事介绍团队的代码评审流程。",
+            "把这句话改写得更正式：\"这个方案不行，得重做。\"",
+            "为一款本地运行的笔记应用写一段 50 字以内的产品简介。",
+        ],
+        "scientific_writing" => &[
+            "Rewrite this sentence for a journal abstract: 'We tried a bunch of learning rates and picked the one that worked best.'",
+            "Summarize the difference between ablation and sensitivity analysis in two sentences.",
+            "Draft a one-sentence limitations statement for a study with n=12 participants.",
+        ],
+        "legal_drafting" => &[
+            "Draft a one-paragraph mutual confidentiality clause for a consulting agreement.",
+            "Rewrite this clause in plain English: 'Notwithstanding anything to the contrary herein, Licensor shall not be liable for indirect damages.'",
+            "List the essential elements of a valid termination-for-convenience clause.",
+        ],
+        "clinical_notes" => &[
+            "Convert to a SOAP note: 54yo male, 2 days of chest tightness on exertion, resolves with rest, no radiation, vitals stable.",
+            "Summarize this discharge plan for the patient in plain language: metoprolol 25mg BID, follow-up echo in 6 weeks, low-sodium diet.",
+            "List three red-flag symptoms that should trigger immediate escalation for a post-operative knee replacement patient.",
+        ],
+        "instruction" | "if" | "instruction_following" => &[
             "List exactly five reasons to ride a bicycle instead of driving, each in one sentence.",
             "Translate 'good morning' to Spanish, French, German, and Japanese in that order.",
             "Summarize the plot of Pride and Prejudice in fewer than 50 words.",
         ],
-        _ => &[
-            "Describe an interesting fact about this topic in two sentences.",
-            "Give a beginner-friendly explanation of a core concept in this domain.",
-            "List three open problems experts care about right now.",
+        "tool_calling" => &[
+            "You have tools read_file(path), write_file(path, content), and bash(cmd). Find every TODO comment under src/ and list the files that contain one.",
+            "You have tools grep(pattern, glob) and read_file(path). Determine which test file covers the RateLimiter struct.",
+            "You have a bash(cmd) tool. Check whether port 8420 is already in use and report the owning process.",
+            "You have tools ls(path) and read_file(path). Summarize what this repository does from its top-level files.",
         ],
+        "long_context_summarization" => &[
+            "Summarize the key decisions from this meeting transcript in five bullets, citing the speaker for each.",
+            "Given a long changelog, produce a one-paragraph 'what changed for users' summary, ignoring internal refactors.",
+            "Condense this multi-chapter design document into a half-page executive brief preserving every numbered requirement.",
+        ],
+        _ => {
+            return Err(format!(
+                "unknown pump domain {domain:?} — valid domains: {}. For agentic corpora \
+                 use the /v1/agent endpoints (they build prompts from your indexed pi \
+                 sessions instead of a seed bank)",
+                CANONICAL_PUMP_DOMAINS.join(", ")
+            ));
+        }
     };
-    prompts
+    Ok(prompts
         .iter()
         .map(|p| kiln_train::opd::OpdPrompt {
             messages: vec![ChatMessage {
@@ -1762,7 +1859,7 @@ fn canonical_domain_seed_prompts(domain: &str) -> Vec<kiln_train::opd::OpdPrompt
             teacher_extra_messages: vec![],
             trajectory: vec![],
         })
-        .collect()
+        .collect())
 }
 
 /// Tiny seed-prompt bank for the §3.5.2 wide-coverage pump. Covers
@@ -1771,7 +1868,10 @@ fn canonical_domain_seed_prompts(domain: &str) -> Vec<kiln_train::opd::OpdPrompt
 fn wide_seed_prompts() -> Vec<kiln_train::opd::OpdPrompt> {
     let mut all = Vec::new();
     for domain in ["math", "code", "writing", "instruction"] {
-        all.extend(canonical_domain_seed_prompts(domain));
+        all.extend(
+            canonical_domain_seed_prompts(domain)
+                .expect("wide pump iterates known-canonical domains"),
+        );
     }
     all
 }
@@ -2124,6 +2224,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 &adapter_name,
                 progress_cb,
                 &state.teacher_registry,
+                state.dataset_registry.as_deref(),
                 &job_id,
             )
         }

--- a/crates/kiln-server/tests/agent_teacher_validation.rs
+++ b/crates/kiln-server/tests/agent_teacher_validation.rs
@@ -167,8 +167,12 @@ async fn judge_distill_registered_teacher_proceeds_past_resolution() {
         response["error"]["code"], "teacher_not_registered",
         "registered teacher must pass resolution: {response}"
     );
-    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{response}");
-    assert_eq!(response["error"]["code"], "mock_mode", "{response}");
+    // Past the teacher gate, the next stop is §10.6.1 corpus resolution —
+    // with no trace index on this fresh state that's the actionable 400.
+    // (agent_traces_bridge.rs covers the populated-index path.)
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(message.contains("agent-trace index"), "{message}");
 }
 
 #[tokio::test]
@@ -207,8 +211,12 @@ async fn self_improve_registered_judge_proceeds_past_resolution() {
         response["error"]["code"], "teacher_not_registered",
         "registered judge must pass resolution: {response}"
     );
-    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{response}");
-    assert_eq!(response["error"]["code"], "mock_mode", "{response}");
+    // Past the judge gate, the next stop is §10.6.2 task resolution —
+    // with no trace index on this fresh state that's the actionable 400.
+    // (agent_traces_bridge.rs covers the populated-index path.)
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(message.contains("agent-trace index"), "{message}");
 }
 
 // ── judge_drift_check honesty ────────────────────────────────────────

--- a/crates/kiln-server/tests/agent_traces_bridge.rs
+++ b/crates/kiln-server/tests/agent_traces_bridge.rs
@@ -1,0 +1,253 @@
+//! Integration tests: the §10 pi-session→training bridge.
+//!
+//! `/v1/agent/self_improve` and `/v1/agent/judge_distill` resolve their
+//! corpora from the §10.3 agent-trace index at submission time — a missing
+//! or empty index is an immediate actionable 400 (naming the discover
+//! endpoint), and a populated index produces queued jobs that carry REAL
+//! prompts from the user's pi sessions instead of placeholder seed text.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::api::agent_traces::{AgentTrace, TraceOutcome};
+use kiln_server::state::AppState;
+use kiln_train::ChatMessage;
+use kiln_train::trajectory::{TurnKind, TurnSegment};
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state() -> (AppState, tempfile::TempDir) {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "Qwen3.5-4B".to_string(),
+    );
+    let dir = tempfile::tempdir().unwrap();
+    state.adapter_dir = dir.path().to_path_buf();
+    (state, dir)
+}
+
+async fn post(app: &axum::Router, path: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+async fn register_fixture_teacher(app: &axum::Router, alias: &str) {
+    let (status, response) = post(
+        app,
+        "/v1/teachers",
+        json!({"alias": alias, "kind": "fixture", "model_id": "test-model"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "teacher registration: {response}");
+}
+
+/// A fresh, successful trace with a real prompt scaffold and two actions.
+fn recent_successful_trace(id: &str) -> AgentTrace {
+    let now = chrono::Utc::now();
+    AgentTrace {
+        id: id.to_string(),
+        working_dir: "/home/user/proj".to_string(),
+        num_turns: 4,
+        num_tool_calls: 1,
+        outcome: TraceOutcome {
+            ended_with_exit_0: Some(true),
+            user_edited_agent_files: Vec::new(),
+            has_followup_attempt: Some(false),
+        },
+        first_event_at: Some(now.to_rfc3339()),
+        last_event_at: Some(now.to_rfc3339()),
+        forked: false,
+        parent_id: None,
+        tool_manifest_sha: None,
+        prompt_messages: vec![
+            ChatMessage {
+                role: "system".into(),
+                content: "You are pi.".into(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: format!("Fix the flaky test in {id}"),
+            },
+        ],
+        trajectory: vec![
+            TurnSegment {
+                role: "assistant".into(),
+                content: "Reading the test.".into(),
+                kind: TurnKind::Action,
+                tool_call_id: None,
+                warning_prefix_len: None,
+            },
+            TurnSegment {
+                role: "tool".into(),
+                content: "FAILED tests/flaky.rs".into(),
+                kind: TurnKind::Observation,
+                tool_call_id: None,
+                warning_prefix_len: None,
+            },
+            TurnSegment {
+                role: "assistant".into(),
+                content: "Pinning the seed.".into(),
+                kind: TurnKind::Action,
+                tool_call_id: None,
+                warning_prefix_len: None,
+            },
+        ],
+    }
+}
+
+fn write_trace_index(state: &AppState, traces: &[AgentTrace]) {
+    let map: BTreeMap<String, AgentTrace> =
+        traces.iter().map(|t| (t.id.clone(), t.clone())).collect();
+    std::fs::write(
+        state.adapter_dir.join("agent_traces.json"),
+        serde_json::to_vec_pretty(&map).unwrap(),
+    )
+    .unwrap();
+}
+
+fn assert_no_jobs(state: &AppState, context: &str) {
+    assert_eq!(
+        state.training_queue.lock().unwrap().len(),
+        0,
+        "{context}: queue must stay empty"
+    );
+}
+
+// ── self_improve ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn self_improve_without_trace_index_fails_fast_with_remediation() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_fixture_teacher(&app, "judge-pi-v1").await;
+
+    let (status, response) = post(&app, "/v1/agent/self_improve", json!({})).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("/v1/agent/traces/discover"),
+        "must name the discover endpoint: {message}"
+    );
+    assert_no_jobs(&state, "self_improve without index");
+}
+
+#[tokio::test]
+async fn self_improve_with_traces_passes_data_resolution() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_fixture_teacher(&app, "judge-pi-v1").await;
+    write_trace_index(
+        &state,
+        &[
+            recent_successful_trace("session-a"),
+            recent_successful_trace("session-b"),
+        ],
+    );
+
+    let (status, response) = post(&app, "/v1/agent/self_improve", json!({})).await;
+
+    // With a populated index, data resolution succeeds and the request
+    // proceeds to the backend gate — in this mock-mode test that's the
+    // honest 503, NOT a corpus error. (The queued-job contents are pinned
+    // by the build_self_improve_jobs unit tests in api/self_improve.rs.)
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{response}");
+    assert_eq!(response["error"]["code"], "mock_mode", "{response}");
+    assert_no_jobs(&state, "self_improve in mock mode");
+}
+
+// ── judge_distill ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn judge_distill_without_trace_index_fails_fast() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_fixture_teacher(&app, "qwen3.6-27b@local").await;
+
+    let (status, response) = post(&app, "/v1/agent/judge_distill", json!({})).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("/v1/agent/traces/discover"),
+        "must name the discover endpoint: {message}"
+    );
+    assert_no_jobs(&state, "judge_distill without index");
+}
+
+#[tokio::test]
+async fn judge_distill_with_traces_passes_data_resolution() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_fixture_teacher(&app, "qwen3.6-27b@local").await;
+    write_trace_index(&state, &[recent_successful_trace("session-a")]);
+
+    let (status, response) = post(&app, "/v1/agent/judge_distill", json!({})).await;
+
+    // Corpus resolution succeeded (otherwise this would be the 400 with
+    // the discover remediation); the mock backend gate is what stops it.
+    // The (turn, context) corpus contents are pinned by the
+    // build_judge_pump_request unit tests in api/self_improve.rs.
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{response}");
+    assert_eq!(response["error"]["code"], "mock_mode", "{response}");
+    assert_no_jobs(&state, "judge_distill in mock mode");
+}

--- a/crates/kiln-server/tests/training_output_name_validation.rs
+++ b/crates/kiln-server/tests/training_output_name_validation.rs
@@ -73,6 +73,47 @@ fn make_state_with_dir() -> (AppState, tempfile::TempDir) {
     (state, dir)
 }
 
+/// Seed a minimal agent-trace index so the §10.6 agent endpoints get past
+/// corpus resolution and exercise the gate under test (queue cap / mock
+/// mode) instead of the missing-index 400.
+fn seed_trace_index(state: &AppState) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let trace = kiln_server::api::agent_traces::AgentTrace {
+        id: "session-a".into(),
+        working_dir: "/home/user/proj".into(),
+        num_turns: 2,
+        num_tool_calls: 0,
+        outcome: kiln_server::api::agent_traces::TraceOutcome {
+            ended_with_exit_0: Some(true),
+            user_edited_agent_files: Vec::new(),
+            has_followup_attempt: Some(false),
+        },
+        first_event_at: Some(now.clone()),
+        last_event_at: Some(now),
+        forked: false,
+        parent_id: None,
+        tool_manifest_sha: None,
+        prompt_messages: vec![kiln_train::ChatMessage {
+            role: "user".into(),
+            content: "Fix the failing test".into(),
+        }],
+        trajectory: vec![kiln_train::trajectory::TurnSegment {
+            role: "assistant".into(),
+            content: "On it.".into(),
+            kind: kiln_train::trajectory::TurnKind::Action,
+            tool_call_id: None,
+            warning_prefix_len: None,
+        }],
+    };
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(trace.id.clone(), trace);
+    std::fs::write(
+        state.adapter_dir.join("agent_traces.json"),
+        serde_json::to_vec_pretty(&map).unwrap(),
+    )
+    .unwrap();
+}
+
 /// Register a fixture teacher alias through the API so endpoints with
 /// teacher-resolvability validation get past that gate.
 async fn register_teacher(app: &axum::Router, alias: &str) {
@@ -320,6 +361,7 @@ async fn missed_endpoints_enforce_queue_cap() {
     state.max_queued_training_jobs = 0; // queue is "at cap" immediately
     let app = api::router(state.clone());
     register_teacher(&app, "fixture@t").await;
+    seed_trace_index(&state);
 
     let full = StatusCode::SERVICE_UNAVAILABLE;
     let fd_sft = front_door_bodies("ok-name").remove(0).1;
@@ -356,6 +398,7 @@ async fn missed_endpoints_reject_mock_mode() {
     let (state, _dir) = make_state_with_dir();
     let app = api::router(state.clone());
     register_teacher(&app, "fixture@t").await;
+    seed_trace_index(&state);
 
     let unavailable = StatusCode::SERVICE_UNAVAILABLE;
     for (variant, body) in front_door_bodies("ok-name") {


### PR DESCRIPTION
## Summary

The product tagline made literal — "use pi for a week, train on it Saturday" — was severed at one data-plumbing joint, in three ways:

1. **`POST /v1/agent/self_improve`** queued `OpdRequest{dataset_path: "agent_traces:weekly"}`, which the worker rejected for any non-`off_policy` `dataset_path` → **every self-improve job was guaranteed to fail at dequeue**, hours later.
2. **`POST /v1/agent/judge_distill`** resolved its `judge_traces` domain through the seed bank's wildcard arm → a "judge" LoRA trained on *"Describe an interesting fact about this topic"*, reported as **SUCCESS**.
3. The day-one recipes (`learn-from-my-pi-history` with `dataset: agent_traces:user-pi`) **4xx'd on every Dataset source**.

All the ingredients already existed (trace ingestion, the pi-session parser, the dataset registry) — they were never connected. This PR connects them.

## What's wired

**New `dataset_resolve.rs`** — one shared resolver:
- `agent_traces:<filter>` → real OPD prompts from the persisted §10.3 trace index. Filters: `all`, `successful` (alias `user-pi`), `weekly` (successful + last 7 days), `judge_turns` ((turn, context) scoring pairs from **all** traces — failures are exactly the discrimination signal a judge needs), `crisp` (successful scaffolds under §10.6.4 conciseness pressure).
- Bare names → the uploaded eval-dataset registry.
- Every failure is actionable: which index, why zero qualified, what to run next. Never a placeholder corpus.

**Trace index upgrade** — `AgentTrace` now captures the session's leading system/user context as `prompt_messages` (the re-rollable task scaffold); mid-session user turns stay ordered in the trajectory as `Context` segments (the masking layer already skips those).

**Wire-in points**
- `run_opd`: `agent_traces:` selectors resolve for on-policy training (registered teacher scores student re-rolls); plain file paths remain off-policy teacher JSONL.
- `self_improve` / `judge_distill`: corpora resolve **at submission** — missing/empty index is an immediate 400 naming `POST /v1/agent/traces/discover`; queued judge + CRISP pumps carry resolved `Examples` from real sessions.
- Recipes: `Dataset` sources resolve server-side (`learn-from-my-pi-history` works); `distill_refresh` `Dataset` sources resolve in the worker.
- The pump seed bank hard-errors on unknown domains (listing valid ones) and gains real seeds for the §8.4 canonical domains the compatibility table + `frontier-pump` recipe reference (`math_reasoning`, `python_codegen`, `rust_codegen`, `tool_calling`, …) — previously **all ten** fell into the generic wildcard.

## Verification

- `cargo test -p kiln-server --no-default-features` — 526 lib tests + all integration suites green.
- New: 11 resolver unit tests (filters, weekly windowing, judge/CRISP corpus shapes, registry resolution, actionable errors), 4 bridge integration tests (fail-fast without index incl. remediation text; data resolution passes with index), in-module pump-construction tests, mid-session-context parse test.
- Two pre-existing gate-order tests updated: registered-teacher now proceeds to **corpus resolution** (the new pipeline stage) rather than straight to the mock gate; the queue-cap/mock invariant tests seed a trace index so they still exercise their gates.

No GPU needed for any of it. The first attended OPD smoke (a few steps on the CUDA rig) is the natural follow-up validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)