### PR TITLE
Adapter hot-swap correctness: barrier swaps + per-adapter cache coherence

### DIFF
--- a/crates/kiln-server/src/adapter_swap.rs
+++ b/crates/kiln-server/src/adapter_swap.rs
@@ -1,0 +1,231 @@
+//! Single entry point for activating LoRA weights on the live runner.
+//!
+//! Correctness contract: **adapter weights must never change under an
+//! in-flight request.** KV computed under the old weights followed by
+//! decode steps under the new weights produces silently wrong text. The
+//! historical swap sites (`ensure_runtime_adapter`, the training queue's
+//! auto-load, the eval generator) each mutated the shared `ModelRunner`
+//! behind a `write()` lock — which only waits for the *current decode
+//! step* to finish, not the current request, so a streaming pi request
+//! would continue mid-generation on different weights whenever training
+//! auto-loaded or an eval swapped adapters.
+//!
+//! With the batching engine running (the default), the swap closure now
+//! executes at the engine's between-requests barrier (the `ResizeKv`
+//! pattern): admission pauses, active requests finish, then the weights
+//! flip and queued requests resume. The engine-less fallback path keeps
+//! the historical between-steps behavior — it serves one request at a
+//! time, so the window is far smaller there.
+//!
+//! Cache coherence rides along: when the target adapter's directory
+//! content changed (retrain auto-load, upload), its name-keyed cache
+//! entries are purged inside the same barrier, after every request that
+//! could have been computed under the old weights has finished.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use kiln_model::ModelRunner;
+use kiln_model::lora_loader::LoraWeights;
+
+use crate::state::{AppState, ModelBackend};
+
+/// What to activate.
+#[derive(Debug, Clone)]
+pub enum SwapTarget {
+    /// Revert to the base model (no LoRA).
+    Base,
+    /// Adapter directory `<adapter_dir>/<name>`.
+    Named(String),
+    /// Pre-resolved directory with an explicit cache identity — composed
+    /// adapters (`__composed:<hash>`) live outside `adapter_dir`.
+    Resolved { active_name: String, dir: PathBuf },
+}
+
+impl SwapTarget {
+    fn cache_name(&self) -> Option<String> {
+        match self {
+            SwapTarget::Base => None,
+            SwapTarget::Named(name) => Some(name.clone()),
+            SwapTarget::Resolved { active_name, .. } => Some(active_name.clone()),
+        }
+    }
+}
+
+/// One adapter activation request.
+pub struct SwapRequest {
+    pub target: SwapTarget,
+    /// The target's on-disk content changed (retrain/import): force the
+    /// reload even when the name is already active, and purge the name's
+    /// cache entries at the barrier.
+    pub content_changed: bool,
+    /// For the transition log line.
+    pub reason: &'static str,
+}
+
+/// Activate `req.target` on the live runner. Serialized via
+/// `state.adapter_swap_lock`; no-ops when the target is already loaded
+/// (unless `content_changed`). Returns the previously-loaded adapter name.
+pub async fn swap_runtime_adapter(
+    state: &AppState,
+    req: SwapRequest,
+) -> Result<Option<String>, String> {
+    let _serial = state.adapter_swap_lock.lock().await;
+
+    let target_name = req.target.cache_name();
+    let current = state.loaded_adapter_name.read().unwrap().clone();
+    if current == target_name && !req.content_changed {
+        return Ok(current);
+    }
+
+    let (runner, engine) = real_backend_handles(state)?;
+    let lora = match resolve_dir(state, &req.target)? {
+        Some(dir) => {
+            let (device, num_layers) = {
+                let guard = runner.read().unwrap();
+                (
+                    guard.weights.embed_tokens.device().clone(),
+                    guard.config.num_layers,
+                )
+            };
+            // Load weights OUTSIDE the barrier (disk + H2D copy take real
+            // time; the engine keeps serving meanwhile). Only the cheap
+            // pointer flip happens at the barrier.
+            let dir_clone = dir.clone();
+            Some(
+                tokio::task::spawn_blocking(move || {
+                    LoraWeights::load(&dir_clone, num_layers, device).map_err(|e| format!("{e}"))
+                })
+                .await
+                .map_err(|e| format!("join error: {e}"))??,
+            )
+        }
+        None => None,
+    };
+
+    let closure = swap_closure(state, runner, lora, target_name.clone(), req.content_changed);
+    match engine {
+        Some(engine) => engine
+            .swap_adapter(closure)
+            .await
+            .map_err(|e| format!("{e:#}"))?,
+        None => {
+            tokio::task::spawn_blocking(closure)
+                .await
+                .map_err(|e| format!("join error: {e}"))??;
+        }
+    }
+
+    log_transition(&current, &target_name, req.reason);
+    Ok(current)
+}
+
+/// Blocking variant for the training worker's job thread.
+pub fn swap_runtime_adapter_blocking(
+    state: &AppState,
+    req: SwapRequest,
+) -> Result<Option<String>, String> {
+    let _serial = state.adapter_swap_lock.blocking_lock();
+
+    let target_name = req.target.cache_name();
+    let current = state.loaded_adapter_name.read().unwrap().clone();
+    if current == target_name && !req.content_changed {
+        return Ok(current);
+    }
+
+    let (runner, engine) = real_backend_handles(state)?;
+    let lora = match resolve_dir(state, &req.target)? {
+        Some(dir) => {
+            let (device, num_layers) = {
+                let guard = runner.read().unwrap();
+                (
+                    guard.weights.embed_tokens.device().clone(),
+                    guard.config.num_layers,
+                )
+            };
+            Some(LoraWeights::load(&dir, num_layers, device).map_err(|e| format!("{e}"))?)
+        }
+        None => None,
+    };
+
+    let closure = swap_closure(state, runner, lora, target_name.clone(), req.content_changed);
+    match engine {
+        Some(engine) => engine
+            .swap_adapter_blocking(closure)
+            .map_err(|e| format!("{e:#}"))?,
+        None => closure()?,
+    }
+
+    log_transition(&current, &target_name, req.reason);
+    Ok(current)
+}
+
+fn real_backend_handles(
+    state: &AppState,
+) -> Result<
+    (
+        Arc<std::sync::RwLock<ModelRunner>>,
+        Option<crate::batching_engine::BatchingEngineHandle>,
+    ),
+    String,
+> {
+    match state.backend.as_ref() {
+        ModelBackend::Real {
+            runner,
+            batching_engine,
+            ..
+        } => Ok((runner.clone(), batching_engine.clone())),
+        ModelBackend::Mock { .. } => {
+            Err("adapter swap requires the real model backend".to_string())
+        }
+    }
+}
+
+fn resolve_dir(state: &AppState, target: &SwapTarget) -> Result<Option<PathBuf>, String> {
+    match target {
+        SwapTarget::Base => Ok(None),
+        SwapTarget::Named(name) => {
+            let dir = state.adapter_dir.join(name);
+            if !dir.exists() {
+                return Err(format!("adapter `{name}` not found at {}", dir.display()));
+            }
+            Ok(Some(dir))
+        }
+        SwapTarget::Resolved { dir, .. } => Ok(Some(dir.clone())),
+    }
+}
+
+/// The work that runs at the engine barrier (or inline on the fallback
+/// path): flip the weights, update the physical-truth name, and purge the
+/// target's stale cache entries when its content changed — after every
+/// request that could have used the old weights has finished, so none can
+/// re-register stale entries behind the purge.
+fn swap_closure(
+    state: &AppState,
+    runner: Arc<std::sync::RwLock<ModelRunner>>,
+    lora: Option<LoraWeights>,
+    target_name: Option<String>,
+    content_changed: bool,
+) -> crate::batching_engine::AdapterSwapClosure {
+    let state = state.clone();
+    Box::new(move || {
+        {
+            let mut guard = runner.write().unwrap();
+            guard.swap_lora(lora);
+        }
+        *state.loaded_adapter_name.write().unwrap() = target_name.clone();
+        if content_changed {
+            state.purge_adapter_caches(&target_name);
+        }
+        Ok(())
+    })
+}
+
+fn log_transition(old: &Option<String>, new: &Option<String>, reason: &str) {
+    tracing::info!(
+        old_adapter = ?old,
+        new_adapter = ?new,
+        reason = reason,
+        "adapter transition (barrier swap)"
+    );
+}

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -17,7 +17,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use kiln_model::adapter_merge::{PeftLora, merge_concat, merge_linear, merge_ties};
-use kiln_model::lora_loader::LoraWeights;
 
 use crate::error::ApiError;
 use crate::state::{AppState, ModelBackend};
@@ -228,31 +227,24 @@ async fn load_adapter(
         }
     };
 
-    // Two-phase load: read device/num_layers under a brief read lock, then load
-    // weights outside any lock so inference is not blocked during I/O.
-    let (device, num_layers) = {
-        let guard = runner.read().unwrap();
-        (
-            guard.weights.embed_tokens.device().clone(),
-            guard.config.num_layers,
-        )
-    };
-
-    let runner = runner.clone();
-    let path = resolved_adapter_path.clone();
+    let _ = runner; // barrier swap reaches the runner through the state
     let name = req.name.clone();
 
-    let load_result = tokio::task::spawn_blocking(move || {
-        // Load weights outside any lock (I/O + tensor allocation).
-        // #1082: LoraWeights::load is kt-native — pass the kt device directly.
-        let lora = LoraWeights::load(&path, num_layers, device).map_err(|e| format!("{e}"))?;
-        // Brief write lock to swap the adapter in.
-        let mut guard = runner.write().unwrap();
-        guard.swap_lora(Some(lora));
-        Ok::<(), String>(())
-    })
+    // Barrier swap (see `adapter_swap`): the weight flip waits for
+    // in-flight requests to finish instead of landing mid-generation.
+    let load_result = crate::adapter_swap::swap_runtime_adapter(
+        &state,
+        crate::adapter_swap::SwapRequest {
+            target: crate::adapter_swap::SwapTarget::Resolved {
+                active_name: req.name.clone(),
+                dir: resolved_adapter_path.clone(),
+            },
+            content_changed: false,
+            reason: "adapter_load_endpoint",
+        },
+    )
     .await
-    .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
+    .map(|_| ());
     if let Err(err) = load_result {
         state
             .adapter_load_errors
@@ -282,7 +274,6 @@ fn record_adapter_loaded(state: &AppState, name: &str, path: &Path) {
     *state.active_adapter_name.write().unwrap() = Some(name.to_string());
     *state.loaded_adapter_name.write().unwrap() = Some(name.to_string());
     state.adapter_load_errors.write().unwrap().remove(name);
-    state.clear_real_prefix_cache();
 
     tracing::info!(
         request_id = %Uuid::new_v4(),
@@ -372,13 +363,17 @@ async fn unload_adapter(
         }
     };
 
-    let runner = runner.clone();
-    tokio::task::spawn_blocking(move || {
-        let mut guard = runner.write().unwrap();
-        guard.unload_adapter();
-    })
+    let _ = runner; // barrier swap reaches the runner through the state
+    crate::adapter_swap::swap_runtime_adapter(
+        &state,
+        crate::adapter_swap::SwapRequest {
+            target: crate::adapter_swap::SwapTarget::Base,
+            content_changed: false,
+            reason: "adapter_unload_endpoint",
+        },
+    )
     .await
-    .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
+    .map_err(ApiError::adapter_load_failed)?;
 
     record_adapter_unloaded(&state);
 
@@ -389,7 +384,6 @@ fn record_adapter_unloaded(state: &AppState) {
     let old = state.active_adapter_name.read().unwrap().clone();
     *state.active_adapter_name.write().unwrap() = None;
     *state.loaded_adapter_name.write().unwrap() = None;
-    state.clear_real_prefix_cache();
 
     tracing::info!(
         request_id = %Uuid::new_v4(),
@@ -437,6 +431,10 @@ async fn delete_adapter(
     }
 
     tracing::info!(adapter = %name, operation = "delete", "deleted adapter from disk");
+
+    // The name no longer refers to these weights — drop its cache entries
+    // so a future adapter recreated under the same name can't replay them.
+    state.purge_adapter_caches(&Some(name.clone()));
 
     Ok(Json(DeleteAdapterResponse {
         status: "deleted",
@@ -1500,6 +1498,11 @@ async fn upload_adapter(
         operation = "upload",
         "imported adapter from upload"
     );
+
+    // The directory content under this name just changed — stale
+    // name-keyed cache entries (prefix KV, deterministic completions)
+    // would replay whatever weights the name used to mean.
+    state.purge_adapter_caches(&Some(name.clone()));
 
     Ok(Json(UploadAdapterResponse {
         name,

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -17,7 +17,6 @@ use kiln_core::token::TokenId;
 use kiln_core::tokenizer::{ChatMessage, ChatTemplateOptions};
 use kiln_eval::qwen3::ParsedToolCall;
 use kiln_model::adapter_merge::{PeftLora, merge_concat};
-use kiln_model::lora_loader::LoraWeights;
 use kiln_model::{
     CancelHandle, GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeConfig,
     SpeculativeDecodePolicy, StreamEvent,
@@ -4499,7 +4498,7 @@ async fn ensure_batch_adapter(
 
 async fn ensure_runtime_adapter(
     state: &AppState,
-    runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
+    _runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
     target_adapter: Option<String>,
     request_id: &str,
     reason: &str,
@@ -4509,57 +4508,30 @@ async fn ensure_runtime_adapter(
         return Ok(());
     }
 
-    match target_adapter.clone() {
+    let target = match target_adapter.clone() {
         Some(name) => {
             validate_compose_name(&name)?;
-            // Resolve adapter path
-            let adapter_path = state.adapter_dir.join(&name);
-            if !adapter_path.exists() {
+            if !state.adapter_dir.join(&name).exists() {
                 return Err(ApiError::adapter_not_found(&name));
             }
-
-            // Two-phase load: read device/num_layers, load weights, then swap.
-            let (device, num_layers) = {
-                let guard = runner.read().unwrap();
-                (
-                    guard.weights.embed_tokens.device().clone(),
-                    guard.config.num_layers,
-                )
-            };
-
-            let runner = runner.clone();
-            let adapter_name = name.clone();
-            let loaded_name = state.loaded_adapter_name.clone();
-
-            tokio::task::spawn_blocking(move || {
-                // #1082: LoraWeights::load is kt-native — pass the kt device directly.
-                let lora = LoraWeights::load(&adapter_path, num_layers, device)
-                    .map_err(|e| format!("{e}"))?;
-                let mut guard = runner.write().unwrap();
-                guard.swap_lora(Some(lora));
-                *loaded_name.write().unwrap() = Some(adapter_name);
-                Ok::<(), String>(())
-            })
-            .await
-            .map_err(|e| ApiError::internal(format!("join error: {e}")))?
-            .map_err(ApiError::adapter_load_failed)?;
-            state.clear_real_prefix_cache();
+            crate::adapter_swap::SwapTarget::Named(name)
         }
-        None => {
-            // Revert to base model.
-            let runner = runner.clone();
-            let loaded_name = state.loaded_adapter_name.clone();
+        None => crate::adapter_swap::SwapTarget::Base,
+    };
 
-            tokio::task::spawn_blocking(move || {
-                let mut guard = runner.write().unwrap();
-                guard.swap_lora(None);
-                *loaded_name.write().unwrap() = None;
-            })
-            .await
-            .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
-            state.clear_real_prefix_cache();
-        }
-    }
+    // The actual weight flip happens at the batching engine's
+    // between-requests barrier (see `adapter_swap`), so a streaming
+    // request can never continue mid-generation on different weights.
+    crate::adapter_swap::swap_runtime_adapter(
+        state,
+        crate::adapter_swap::SwapRequest {
+            target,
+            content_changed: false,
+            reason: "per_request_adapter",
+        },
+    )
+    .await
+    .map_err(ApiError::adapter_load_failed)?;
 
     tracing::info!(
         request_id = %request_id,
@@ -4842,12 +4814,12 @@ fn composed_entry_size_bytes(root: &Path) -> u64 {
 
 /// Hot-swap the runner onto a synthesized composed adapter.
 ///
-/// Mirrors `ensure_adapter`'s two-phase RwLock pattern (read device + num
-/// layers, load weights outside any lock, then write-lock to swap). No-op if
-/// the composed adapter is already active.
+/// Same barrier semantics as `ensure_runtime_adapter` — composed names are
+/// content-hashed (`__composed:<hash>`), so they never alias stale cache
+/// entries and `content_changed` stays false. No-op if already active.
 async fn ensure_composed_adapter_swap(
     state: &AppState,
-    runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
+    _runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
     target: &ComposedTarget,
 ) -> Result<(), ApiError> {
     {
@@ -4857,31 +4829,19 @@ async fn ensure_composed_adapter_swap(
         }
     }
 
-    let (device, num_layers) = {
-        let guard = runner.read().unwrap();
-        (
-            guard.weights.embed_tokens.device().clone(),
-            guard.config.num_layers,
-        )
-    };
-
-    let runner = runner.clone();
-    let active_name = state.loaded_adapter_name.clone();
-    let cache_dir = target.cache_dir.clone();
-    let composed_active = target.active_name.clone();
-
-    tokio::task::spawn_blocking(move || {
-        // #1082: LoraWeights::load is kt-native — pass the kt device directly.
-        let lora = LoraWeights::load(&cache_dir, num_layers, device).map_err(|e| format!("{e}"))?;
-        let mut guard = runner.write().unwrap();
-        guard.swap_lora(Some(lora));
-        *active_name.write().unwrap() = Some(composed_active);
-        Ok::<(), String>(())
-    })
+    crate::adapter_swap::swap_runtime_adapter(
+        state,
+        crate::adapter_swap::SwapRequest {
+            target: crate::adapter_swap::SwapTarget::Resolved {
+                active_name: target.active_name.clone(),
+                dir: target.cache_dir.clone(),
+            },
+            content_changed: false,
+            reason: "composed_adapter",
+        },
+    )
     .await
-    .map_err(|e| ApiError::internal(format!("join error: {e}")))?
     .map_err(ApiError::adapter_load_failed)?;
-    state.clear_real_prefix_cache();
     if state.eval_mode {
         tracing::warn!(
             adapter = %target.active_name,

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -864,7 +864,41 @@ impl BatchingEngineHandle {
             .map_err(|_| anyhow::anyhow!("batching engine stopped before resize ack"))?
             .map_err(|e| anyhow::anyhow!(e))
     }
+
+    /// Run `swap` at the engine's between-requests barrier: admission pauses
+    /// and the closure executes only once every in-flight request has
+    /// finished, so generation never continues across a weight change (KV
+    /// computed under the old weights + decode steps under the new weights
+    /// is silent garbage). Queued requests resume right after.
+    pub async fn swap_adapter(&self, swap: AdapterSwapClosure) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(EngineCommand::SwapAdapter { swap, reply })
+            .await
+            .map_err(|_| anyhow::anyhow!("batching engine stopped"))?;
+        rx.await
+            .map_err(|_| anyhow::anyhow!("batching engine stopped before swap ack"))?
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    /// Blocking variant of [`Self::swap_adapter`] for the training worker's
+    /// (non-async) job thread.
+    pub fn swap_adapter_blocking(&self, swap: AdapterSwapClosure) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .blocking_send(EngineCommand::SwapAdapter { swap, reply })
+            .map_err(|_| anyhow::anyhow!("batching engine stopped"))?;
+        rx.blocking_recv()
+            .map_err(|_| anyhow::anyhow!("batching engine stopped before swap ack"))?
+            .map_err(|e| anyhow::anyhow!(e))
+    }
 }
+
+/// Deferred adapter-swap work executed on the engine thread at the
+/// between-requests barrier. The closure owns everything it needs (runner
+/// handle, pre-loaded LoRA weights, cache handles) so the engine stays
+/// ignorant of LoRA specifics.
+pub type AdapterSwapClosure = Box<dyn FnOnce() -> std::result::Result<(), String> + Send>;
 
 enum EngineCommand {
     Enqueue {
@@ -889,6 +923,19 @@ enum EngineCommand {
         target_blocks: usize,
         reply: oneshot::Sender<std::result::Result<usize, String>>,
     },
+    /// Swap adapter weights at the between-REQUESTS barrier: queued until
+    /// every active request has finished (admission pauses meanwhile), then
+    /// executed on the engine thread with no forward in flight anywhere.
+    SwapAdapter {
+        swap: AdapterSwapClosure,
+        reply: oneshot::Sender<std::result::Result<(), String>>,
+    },
+}
+
+/// A queued adapter swap waiting for the active batch to drain.
+struct PendingAdapterSwap {
+    swap: AdapterSwapClosure,
+    reply: oneshot::Sender<std::result::Result<(), String>>,
 }
 
 struct QueuedRequest {
@@ -922,6 +969,10 @@ struct BatchingEngineActor {
     // anti-scaling (n=32 slower than n=8). Set only for CUDA; Vulkan/Metal keep
     // their tuned yield behavior.
     burst_refill: bool,
+    /// Adapter swaps waiting for the active batch to drain. While any swap
+    /// is pending, admission pauses (waiting requests stay queued) so the
+    /// barrier is reached promptly; swaps then run FIFO on this thread.
+    pending_swaps: VecDeque<PendingAdapterSwap>,
     snapshot: BatchingEngineSnapshot,
 }
 
@@ -947,6 +998,7 @@ impl BatchingEngineActor {
             prefix_aware_admission,
             max_prefill_admissions_per_cycle,
             burst_refill,
+            pending_swaps: VecDeque::new(),
             snapshot: BatchingEngineSnapshot {
                 accepting: true,
                 max_prefill_admission_quantum: max_prefill_admissions_per_cycle,
@@ -957,11 +1009,20 @@ impl BatchingEngineActor {
 
     fn run(mut self) {
         while !self.stopped {
-            if self.active.is_empty() && self.waiting.is_empty() {
+            // Between-requests barrier: with no decode step in flight and
+            // the active batch drained, queued adapter swaps execute now —
+            // before blocking on the channel, so a swap queued behind a
+            // just-finished batch doesn't wait for the next command.
+            self.run_pending_swaps_at_barrier();
+
+            if self.active.is_empty() && self.waiting.is_empty() && self.pending_swaps.is_empty()
+            {
                 match self.rx.blocking_recv() {
                     Some(cmd) => self.handle_command(cmd),
                     None => break,
                 }
+                // A swap that arrived while idle executes immediately.
+                self.run_pending_swaps_at_barrier();
             }
 
             // Only sleep when we have nothing to do. Sleeping unconditionally
@@ -1045,6 +1106,26 @@ impl BatchingEngineActor {
                     .map_err(|e| format!("{e:#}"));
                 let _ = reply.send(result);
             }
+            EngineCommand::SwapAdapter { swap, reply } => {
+                // Unlike ResizeKv, a weight swap must also wait for the
+                // active batch to DRAIN (KV computed under the old weights
+                // can't continue under new ones), so it queues here and the
+                // run loop executes it at the between-requests barrier.
+                self.pending_swaps.push_back(PendingAdapterSwap { swap, reply });
+            }
+        }
+    }
+
+    /// Execute queued adapter swaps when the active batch has drained. The
+    /// run loop calls this between decode steps; while swaps are pending,
+    /// `admit_waiting` pauses admission so the barrier is reached promptly.
+    fn run_pending_swaps_at_barrier(&mut self) {
+        if self.pending_swaps.is_empty() || !self.active.is_empty() {
+            return;
+        }
+        while let Some(pending) = self.pending_swaps.pop_front() {
+            let result = (pending.swap)();
+            let _ = pending.reply.send(result);
         }
     }
 
@@ -1076,6 +1157,13 @@ impl BatchingEngineActor {
     }
 
     fn admit_waiting(&mut self) {
+        // A pending adapter swap needs the active batch to drain — admitting
+        // new requests now would (a) delay the swap arbitrarily and (b) run
+        // them under weights the caller is replacing. They stay queued and
+        // resume right after the swap executes.
+        if !self.pending_swaps.is_empty() {
+            return;
+        }
         let mut admitted = 0usize;
         // #1082 CUDA concurrency regression fix: CUDA (burst_refill) refills the
         // batch toward max_decode_batch every cycle — the LKG 2d9d4fc4 burst-fill
@@ -1364,6 +1452,9 @@ impl BatchingEngineActor {
                 .response_tx
                 .blocking_send(EngineEvent::Error(error.to_string()));
         }
+        while let Some(pending) = self.pending_swaps.pop_front() {
+            let _ = pending.reply.send(Err(error.to_string()));
+        }
     }
 
     fn refresh_snapshot(&mut self) {
@@ -1579,6 +1670,197 @@ mod tests {
             adapter: None,
             first_token_pending,
         }
+    }
+
+    /// Test double whose `forward_decode` blocks until the test releases a
+    /// step, and which records prepare/decode events into a shared log —
+    /// the deterministic harness for asserting barrier ordering.
+    struct GatedForward {
+        gate: StdMutex<std::sync::mpsc::Receiver<()>>,
+        events: Arc<StdMutex<Vec<String>>>,
+    }
+
+    impl GatedForward {
+        fn new(events: Arc<StdMutex<Vec<String>>>) -> (Self, std::sync::mpsc::Sender<()>) {
+            let (tx, rx) = std::sync::mpsc::channel();
+            (
+                Self {
+                    gate: StdMutex::new(rx),
+                    events,
+                },
+                tx,
+            )
+        }
+    }
+
+    impl DecodeForward for GatedForward {
+        fn prepare_request(&self, req: &EngineRequest) -> Result<DecodeSlot> {
+            self.events.lock().unwrap().push(format!(
+                "prepare:{}",
+                req.prompt_tokens.last().copied().unwrap_or_default()
+            ));
+            Ok(DecodeSlot::Mock {
+                next_token: req.prompt_tokens.last().copied().unwrap_or_default(),
+                generated_tokens: Vec::new(),
+            })
+        }
+
+        fn forward_decode(
+            &self,
+            slots: &mut [&mut DecodeSlot],
+            _sampling: &[SamplingParams],
+        ) -> Result<Vec<TokenId>> {
+            // Hold the decode step until the test releases it.
+            self.gate.lock().unwrap().recv().ok();
+            self.events.lock().unwrap().push("decode".to_string());
+            Ok(slots
+                .iter()
+                .map(|slot| match slot {
+                    DecodeSlot::Mock { next_token, .. } => *next_token + 10,
+                    DecodeSlot::Real { .. } => unreachable!(),
+                })
+                .collect())
+        }
+
+        fn accept_token(&self, slot: &mut DecodeSlot, token: TokenId) -> Result<usize> {
+            let DecodeSlot::Mock {
+                next_token,
+                generated_tokens,
+            } = slot
+            else {
+                unreachable!();
+            };
+            generated_tokens.push(token);
+            *next_token = token;
+            Ok(generated_tokens.len())
+        }
+
+        fn finish_request(
+            &self,
+            slot: DecodeSlot,
+            finish_reason: FinishReason,
+        ) -> Result<DecodeForwardOutput> {
+            let DecodeSlot::Mock {
+                generated_tokens, ..
+            } = slot
+            else {
+                unreachable!();
+            };
+            Ok(DecodeForwardOutput {
+                output: GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason,
+                },
+                prefill_duration: Duration::ZERO,
+                decode_duration: Duration::ZERO,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_swap_waits_for_active_request_and_pauses_admission() {
+        let events: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
+        let (forward, release) = GatedForward::new(events.clone());
+        let handle = BatchingEngineHandle::start_with_options(Arc::new(forward), 8);
+
+        // Request A needs two decode steps; hold it mid-generation after
+        // the first release.
+        let mut rx_a = handle.enqueue(request(100, 2)).await.unwrap();
+        release.send(()).unwrap(); // A's first step runs; A stays active.
+        assert!(matches!(rx_a.recv().await, Some(EngineEvent::Token(_))));
+
+        // With A mid-generation: queue a swap, then request B behind it.
+        let swap_events = events.clone();
+        let swap_task = {
+            let handle = handle.clone();
+            tokio::spawn(async move {
+                handle
+                    .swap_adapter(Box::new(move || {
+                        swap_events.lock().unwrap().push("swap".to_string());
+                        Ok(())
+                    }))
+                    .await
+            })
+        };
+        // Give the swap command time to land in the actor's pending queue
+        // while A is still blocked on the gate.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let mut rx_b = handle.enqueue(request(200, 1)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Release everything: A's second step, then B's step after the swap.
+        release.send(()).unwrap();
+        release.send(()).unwrap();
+
+        swap_task.await.unwrap().unwrap();
+        loop {
+            match rx_a.recv().await {
+                Some(EngineEvent::Done { .. }) => break,
+                Some(_) => {}
+                None => panic!("request A channel closed before Done"),
+            }
+        }
+        loop {
+            match rx_b.recv().await {
+                Some(EngineEvent::Done { .. }) => break,
+                Some(_) => {}
+                None => panic!("request B channel closed before Done"),
+            }
+        }
+
+        let log = events.lock().unwrap().clone();
+        let swap_idx = log.iter().position(|e| e == "swap").expect("swap ran");
+        let prepare_b_idx = log
+            .iter()
+            .position(|e| e == "prepare:200")
+            .expect("B admitted");
+        // The swap executed only after A's final decode step (both steps
+        // precede it), and B was admitted only after the swap — so no
+        // request ever spans a weight change.
+        assert!(
+            swap_idx < prepare_b_idx,
+            "B must be admitted after the swap: {log:?}"
+        );
+        let decodes_before_swap = log[..swap_idx].iter().filter(|e| *e == "decode").count();
+        assert_eq!(
+            decodes_before_swap, 2,
+            "both of A's decode steps precede the swap: {log:?}"
+        );
+
+        handle.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn adapter_swap_executes_immediately_when_idle() {
+        let forward = Arc::new(MockForward::default());
+        let handle = BatchingEngineHandle::start_with_options(forward, 8);
+        let fired = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = fired.clone();
+        handle
+            .swap_adapter(Box::new(move || {
+                flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            }))
+            .await
+            .unwrap();
+        assert!(fired.load(std::sync::atomic::Ordering::SeqCst));
+        handle.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn adapter_swap_error_propagates_to_caller() {
+        let forward = Arc::new(MockForward::default());
+        let handle = BatchingEngineHandle::start_with_options(forward, 8);
+        let err = handle
+            .swap_adapter(Box::new(|| Err("load exploded".to_string())))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("load exploded"));
+        // The engine keeps serving after a failed swap.
+        let mut rx = handle.enqueue(request(7, 1)).await.unwrap();
+        assert!(matches!(rx.recv().await, Some(EngineEvent::Token(_))));
+        handle.stop().await.unwrap();
     }
 
     #[test]

--- a/crates/kiln-server/src/eval/generator.rs
+++ b/crates/kiln-server/src/eval/generator.rs
@@ -156,44 +156,28 @@ impl EvalGenerator for LiveEvalGenerator {
             if want == previous {
                 return Ok(previous);
             }
-            // RwLock acquires + LoraWeights::load are blocking — punt to
-            // a dedicated thread so we don't stall the runtime.
-            tokio::task::spawn_blocking(move || -> Result<Option<String>, String> {
-                let ModelBackend::Real { runner, .. } = state.backend.as_ref() else {
-                    return Err("eval requires a real model backend".into());
-                };
-                let (device, num_layers) = {
-                    let guard = runner.read().unwrap();
-                    (
-                        guard.weights.embed_tokens.device().clone(),
-                        guard.config.num_layers,
-                    )
-                };
-                match want.as_ref() {
-                    Some(name) => {
-                        let path = state.adapter_dir.join(name);
-                        if !path.exists() {
-                            return Err(format!(
-                                "adapter `{name}` not found at {}",
-                                path.display()
-                            ));
-                        }
-                        // #1082: LoraWeights::load is kt-native — pass the kt device directly.
-                        let lora =
-                            kiln_model::lora_loader::LoraWeights::load(&path, num_layers, device)
-                                .map_err(|e| format!("loading adapter `{name}`: {e}"))?;
-                        runner.write().unwrap().swap_lora(Some(lora));
-                    }
-                    None => {
-                        runner.write().unwrap().unload_adapter();
-                    }
-                }
-                *state.active_adapter_name.write().unwrap() = want;
-                state.clear_real_prefix_cache();
-                Ok(previous)
-            })
-            .await
-            .map_err(|e| format!("join error: {e}"))?
+            // Barrier swap (see `adapter_swap`): a streaming request that's
+            // mid-generation when an eval starts finishes on its own
+            // weights first. This also keeps `loaded_adapter_name`
+            // truthful — the old direct swap left it stale, so the next
+            // chat request could no-op its adapter check and silently
+            // serve on the eval's weights. Per-adapter cache keying means
+            // the serving agent's prefix cache survives the round-trip.
+            let target = match want.as_ref() {
+                Some(name) => crate::adapter_swap::SwapTarget::Named(name.clone()),
+                None => crate::adapter_swap::SwapTarget::Base,
+            };
+            crate::adapter_swap::swap_runtime_adapter(
+                &state,
+                crate::adapter_swap::SwapRequest {
+                    target,
+                    content_changed: false,
+                    reason: "eval_set_adapter",
+                },
+            )
+            .await?;
+            *state.active_adapter_name.write().unwrap() = want;
+            Ok(previous)
         })
     }
 

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,6 +1,7 @@
 //! Kiln HTTP server — library interface for integration testing.
 
 pub mod api;
+pub mod adapter_swap;
 pub mod adapter_verify;
 pub mod batching_engine;
 pub mod cli;

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -883,6 +883,26 @@ impl DeterministicCompletionCache {
         self.lru.clear();
     }
 
+    /// Drop every entry keyed to `adapter` (completed and in-flight),
+    /// leaving other adapters' entries intact. In-flight waiters get
+    /// `Ready(None)` — the recompute path — since the value they're
+    /// waiting on was produced under weights that no longer exist.
+    pub fn purge_adapter(&mut self, adapter: &Option<String>) {
+        self.entries.retain(|key, _| &key.adapter != adapter);
+        self.lru.retain(|key| &key.adapter != adapter);
+        let stale: Vec<DeterministicCompletionCacheKey> = self
+            .in_flight
+            .keys()
+            .filter(|key| &key.adapter == adapter)
+            .cloned()
+            .collect();
+        for key in stale {
+            if let Some(sender) = self.in_flight.remove(&key) {
+                let _ = sender.send(DeterministicCompletionInFlightState::Ready(None));
+            }
+        }
+    }
+
     pub fn stats(&self) -> usize {
         self.entries.len()
     }
@@ -1106,6 +1126,28 @@ impl RealPrefixCache {
         blocks
     }
 
+    /// Remove every entry cached for `adapter`, releasing its blocks.
+    /// Returns the block ids whose refcount dropped to zero (the caller
+    /// frees those in the BlockManager). Used when an adapter's directory
+    /// content changes (retrain/import): name-keyed entries would
+    /// otherwise replay KV computed under the OLD weights. Entries for
+    /// other adapters are untouched — that's the point (a background eval
+    /// swap must not destroy the serving agent's accumulated prefix
+    /// cache).
+    pub fn purge_adapter(&mut self, adapter: &Option<String>) -> Vec<u32> {
+        let mut freed = Vec::new();
+        let mut idx = 0;
+        while idx < self.entries.len() {
+            if &self.entries[idx].adapter == adapter {
+                let entry = self.entries.remove(idx);
+                freed.extend(self.release_entry_blocks(&entry.block_ids));
+            } else {
+                idx += 1;
+            }
+        }
+        freed
+    }
+
     fn oldest_evictable_entry_idx(&self) -> Option<usize> {
         self.entries
             .iter()
@@ -1300,6 +1342,10 @@ pub struct AppState {
     /// Last adapter load failure by adapter name. Used by the registry so
     /// automation can distinguish "not loaded" from "failed to load".
     pub adapter_load_errors: Arc<std::sync::RwLock<HashMap<String, String>>>,
+    /// Serializes adapter swap check-then-act sequences (see
+    /// `adapter_swap`): two concurrent requests for the same not-yet-loaded
+    /// adapter must produce one load, not two racing ones.
+    pub adapter_swap_lock: Arc<tokio::sync::Mutex<()>>,
     /// Tracked training jobs (job_id → info).
     pub training_jobs: TrainingJobs,
     /// GPU memory budget for coordinating inference and training.
@@ -1493,6 +1539,36 @@ impl AppState {
         }
     }
 
+    /// Invalidate everything cached under `adapter` — prefix KV entries
+    /// (freeing their blocks) plus the deterministic completion caches.
+    /// Call this whenever the adapter's on-disk content changes (retrain
+    /// auto-load, upload/import, delete): the name now refers to different
+    /// weights, so name-keyed cache entries would replay the old model.
+    /// Entries for OTHER adapters are deliberately left intact — prefix
+    /// lookups are adapter-filtered, so they're still correct, and
+    /// clearing them is what used to force minutes of re-prefill on the
+    /// serving agent every time a background eval or training job swapped.
+    ///
+    /// The string-keyed chat/batch caches embed the adapter in an opaque
+    /// hash, so they can't be purged selectively — they're cleared whole.
+    pub fn purge_adapter_caches(&self, adapter: &Option<String>) {
+        self.completion_cache.lock().unwrap().purge_adapter(adapter);
+        self.chat_request_cache.lock().unwrap().clear_completed();
+        self.chat_choices_cache.lock().unwrap().clear_completed();
+        self.batch_cache.lock().unwrap().clear_completed();
+        if let ModelBackend::Real {
+            block_manager,
+            prefix_cache,
+            ..
+        } = self.backend.as_ref()
+        {
+            let blocks = prefix_cache.lock().unwrap().purge_adapter(adapter);
+            if !blocks.is_empty() {
+                block_manager.lock().unwrap().free_all(&blocks);
+            }
+        }
+    }
+
     pub fn clear_eval_mode_transient_state(&self) {
         self.completion_cache.lock().unwrap().clear_completed();
         self.chat_request_cache.lock().unwrap().clear_completed();
@@ -1524,6 +1600,7 @@ impl AppState {
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
             memory_budget: Arc::new(GpuMemoryBudget::compute(0, 0, 0, 0, 0, 1.0, None)),
             gpu_lock: Arc::new(std::sync::RwLock::new(())),
@@ -2172,6 +2249,7 @@ impl AppState {
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
             memory_budget: Arc::new(memory_budget),
             gpu_lock,
@@ -3293,6 +3371,111 @@ mod tests {
                 .is_some()
         );
         Ok(())
+    }
+
+    #[test]
+    fn prefix_cache_purge_adapter_is_selective_and_frees_blocks() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = cpu_device!();
+        let mut cache = RealPrefixCache::new(true, 4, 16, 1024, 49);
+        cache.register(
+            Some("retrained".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4],
+                block_ids: vec![10],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+                next_token: None,
+            },
+        );
+        cache.register(
+            Some("retrained".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                // Shares block 10 with the first entry, plus its own 11.
+                block_ids: vec![10, 11],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+                next_token: None,
+            },
+        );
+        cache.register(
+            Some("untouched".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![9, 9, 9, 9],
+                block_ids: vec![20],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+                next_token: None,
+            },
+        );
+
+        let mut freed = cache.purge_adapter(&Some("retrained".to_string()));
+        freed.sort_unstable();
+        // Both of the retrained adapter's blocks come back exactly once,
+        // shared refcounts unwound correctly; the other adapter's block 20
+        // stays held.
+        assert_eq!(freed, vec![10, 11]);
+
+        assert!(
+            cache
+                .lookup(&Some("retrained".to_string()), &[1, 2, 3, 4, 5])?
+                .is_none(),
+            "retrained adapter's entries are gone"
+        );
+        assert!(
+            cache
+                .lookup(&Some("untouched".to_string()), &[9, 9, 9, 9, 1])?
+                .is_some(),
+            "other adapters' entries survive — a background eval/training \
+             swap must not cost the serving agent its prefix cache"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn completion_cache_purge_adapter_is_selective() {
+        let mut cache = DeterministicCompletionCache::new(8);
+        let key = |adapter: Option<&str>| DeterministicCompletionCacheKey {
+            adapter: adapter.map(str::to_string),
+            prompt_tokens: vec![1, 2, 3],
+            temperature_bits: 0,
+            max_tokens: 16,
+            stop: Vec::new(),
+            top_p_bits: 0,
+            top_k: 0,
+            min_p_bits: 0,
+            presence_penalty_bits: 0,
+            frequency_penalty_bits: 0,
+            repetition_penalty_bits: 0,
+            seed: Some(7),
+            fold_reasoning_into_content: false,
+        };
+        let value = DeterministicCompletionCacheValue {
+            text: "old-weights answer".to_string(),
+            reasoning_content: None,
+            tool_calls: None,
+            finish_reason: "stop".to_string(),
+            completion_tokens: 3,
+        };
+        cache.insert_complete_value(key(Some("retrained")), value.clone());
+        cache.insert_complete_value(key(Some("other")), value.clone());
+        cache.insert_complete_value(key(None), value);
+
+        cache.purge_adapter(&Some("retrained".to_string()));
+
+        assert!(
+            matches!(
+                cache.probe(&key(Some("retrained"))),
+                DeterministicCompletionCacheProbe::Miss
+            ),
+            "retrained adapter must recompute"
+        );
+        assert!(matches!(
+            cache.probe(&key(Some("other"))),
+            DeterministicCompletionCacheProbe::Hit(_)
+        ));
+        assert!(matches!(
+            cache.probe(&key(None)),
+            DeterministicCompletionCacheProbe::Hit(_)
+        ));
     }
 
     // Regression tests for #673: prefix-cache eviction must never return block

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use kiln_model::lora_loader::LoraWeights;
 use kiln_train::trainer;
 use kiln_train::{
     self, DistillMergeRequest, DistillPumpRequest, DistillRefreshRequest, DistillSelfRequest,
@@ -2034,11 +2033,6 @@ fn execute_job(state: AppState, entry: QueueEntry) {
         }
     };
 
-    let (weights_ref, num_layers) = {
-        let guard = runner_arc.read().unwrap();
-        (runner_arc.clone(), guard.config.num_layers)
-    };
-
     // Get auto_load, adapter_name, and job_type from the job info
     let (auto_load, adapter_name, job_type) = {
         let jobs = state.training_jobs.read().unwrap();
@@ -2304,18 +2298,19 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             }
 
             if auto_load && adapter_canary_allows_auto_load(&adapter_path, &adapter_name, &job_id) {
-                if let Err(e) = auto_load_adapter(
-                    &weights_ref,
-                    &state.active_adapter_name,
-                    &state.loaded_adapter_name,
-                    &adapter_path,
-                    &adapter_name,
-                    num_layers,
-                ) {
+                if let Err(e) = auto_load_adapter(&state, &adapter_path, &adapter_name) {
                     tracing::error!(job_id = %job_id, "auto-load failed: {e}");
                 } else {
                     tracing::info!(job_id = %job_id, "auto-loaded trained adapter");
                 }
+            } else {
+                // Not promoting the fresh weights into serving — but the
+                // adapter directory CONTENT changed, so any cache entries
+                // keyed to this name (prefix KV, deterministic completions)
+                // now describe weights that no longer exist. Without this,
+                // retraining an idle adapter and swapping back to it later
+                // replays the old model's answers.
+                state.purge_adapter_caches(&Some(adapter_name.clone()));
             }
 
             // Post-training auto-eval: enqueue an eval job against the
@@ -2483,29 +2478,26 @@ fn adapter_canary_allows_auto_load(
 
 /// Load a LoRA adapter using the two-phase RwLock pattern.
 fn auto_load_adapter(
-    runner: &Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
-    active_adapter_name: &Arc<std::sync::RwLock<Option<String>>>,
-    loaded_adapter_name: &Arc<std::sync::RwLock<Option<String>>>,
+    state: &AppState,
     adapter_path: &std::path::Path,
     adapter_name: &str,
-    num_layers: usize,
 ) -> Result<(), String> {
-    let device = {
-        let guard = runner.read().unwrap();
-        guard.weights.embed_tokens.device().clone()
-    };
-
-    // #1082: LoraWeights::load is kt-native — pass the kt device directly.
-    let lora = LoraWeights::load(adapter_path, num_layers, device)
-        .map_err(|e| format!("failed to load adapter: {e}"))?;
-
-    {
-        let mut guard = runner.write().unwrap();
-        guard.swap_lora(Some(lora));
-    }
-    *active_adapter_name.write().unwrap() = Some(adapter_name.to_string());
-    *loaded_adapter_name.write().unwrap() = Some(adapter_name.to_string());
-
+    // Barrier swap (see `adapter_swap`): in-flight requests finish on the
+    // weights they started with, THEN the fresh adapter activates and its
+    // stale name-keyed cache entries purge — `content_changed` because the
+    // directory was just rewritten by training.
+    crate::adapter_swap::swap_runtime_adapter_blocking(
+        state,
+        crate::adapter_swap::SwapRequest {
+            target: crate::adapter_swap::SwapTarget::Resolved {
+                active_name: adapter_name.to_string(),
+                dir: adapter_path.to_path_buf(),
+            },
+            content_changed: true,
+            reason: "training_auto_load",
+        },
+    )?;
+    *state.active_adapter_name.write().unwrap() = Some(adapter_name.to_string());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Two corroborated bug classes at the exact heart of "serve + train + eval in one process":

### Correctness: weights must never change under an in-flight request

Every swap site — per-request `ensure_runtime_adapter`, training auto-load, eval `set_adapter`, the load/unload endpoints — mutated the shared `ModelRunner` behind a `write()` lock, which only waits for the current **decode step**, not the current **request**. A streaming pi request would silently continue mid-generation on different weights (KV from the old weights + decode under the new) whenever training auto-loaded or a background eval swapped adapters. Bonus bug: the eval path updated `active_adapter_name` but not `loaded_adapter_name`, so a subsequent chat request could no-op its adapter check and serve on the eval's weights.

**Fix:** all swap sites route through one entry point (`adapter_swap.rs`) that executes the flip at the batching engine's **between-requests barrier** (the `ResizeKv` pattern, extended to wait for the active batch to drain): admission pauses, in-flight requests finish on the weights they started with, the flip + cache purge run on the engine thread, queued requests resume. Weight *loading* stays outside the barrier (engine keeps serving during disk/H2D); a `tokio::Mutex` serializes check-then-act so concurrent requests for the same adapter produce one load; `loaded_adapter_name` updates inside the barrier closure.

### Coherence: name-keyed caches vs. retrained weights

- Training auto-load never invalidated the prefix/completion caches → after retraining `my-coder`, the same prompt could **replay the old adapter's cached answer** — directly falsifying the headline "submit a correction, the model learns it" demo.
- Conversely, every site that *did* invalidate cleared **all** adapters' prefix entries → a background eval between pi turns destroyed the serving agent's accumulated prefix cache (minutes of re-prefill on slow hardware).

**Fix:** per-adapter purge (`RealPrefixCache::purge_adapter` frees only that adapter's blocks with shared-refcount accounting; `DeterministicCompletionCache::purge_adapter` drops its typed keys; the string-keyed chat/batch caches clear whole since their keys are opaque hashes) and only on **content change** (retrain auto-load, the no-auto-load training completion path, upload, delete). Plain A→B swaps clear nothing — prefix lookups were already adapter-filtered, so other adapters' entries stay valid and warm across eval/training round-trips.

## Verification

- New deterministic engine tests using a gated `DecodeForward` (decode steps block until released): the swap executes only after the active request's final decode step; a request queued behind the swap is admitted only after it; failed swap closures propagate to the caller without killing the engine; idle swaps run immediately.
- Selective-purge tests for both caches (shared-block refcounts unwound exactly once; other adapters' entries survive).
- Full `kiln-server` suite: 534 lib tests + all integration suites green. No GPU required.

The natural attended follow-up: a short live session — stream a long completion, trigger a training auto-load mid-stream, confirm the stream finishes coherently and the next request uses the new adapter with the correction applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)