### PR TITLE
Enforce the §8.7 post-eval promotion gate: never auto-deploy an unmeasured or failing adapter

### DIFF
--- a/crates/kiln-server/src/api/pit_of_success.rs
+++ b/crates/kiln-server/src/api/pit_of_success.rs
@@ -168,6 +168,7 @@ async fn submit_front_door(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state

--- a/crates/kiln-server/src/api/recipes.rs
+++ b/crates/kiln-server/src/api/recipes.rs
@@ -572,6 +572,7 @@ fn register_step_job(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -422,6 +422,7 @@ fn register_agent_job(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -338,6 +338,7 @@ async fn submit_sft(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state
@@ -499,6 +500,7 @@ async fn submit_grpo(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state
@@ -669,6 +671,7 @@ async fn submit_opd(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state
@@ -773,6 +776,7 @@ async fn submit_distill_refresh(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state
@@ -943,6 +947,7 @@ fn register_and_enqueue_distill(
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state
@@ -1194,6 +1199,9 @@ struct TrainingJobDetail {
     /// Eval job IDs queued by `post_eval`. `None` when no post-eval was
     /// requested; otherwise newest-first.
     linked_eval_job_ids: Vec<String>,
+    /// §8.7 gate verdict (promoted / demoted to `.failed` / not measured)
+    /// once the post-training eval reaches a terminal state.
+    post_eval_verdict: Option<String>,
     /// Time-series of progress samples. Empty until the trainer emits
     /// its first callback.
     loss_history: Vec<crate::state::TrainingLossSample>,
@@ -1221,6 +1229,7 @@ async fn job_detail(
             adapter_path: job.adapter_path.clone(),
             auto_load: job.auto_load,
             linked_eval_job_ids: job.linked_eval_job_ids.clone(),
+            post_eval_verdict: job.post_eval_verdict.clone(),
             loss_history: job.loss_history.clone(),
         }
     };

--- a/crates/kiln-server/src/eval/queue.rs
+++ b/crates/kiln-server/src/eval/queue.rs
@@ -68,6 +68,26 @@ fn now_instant_default() -> std::time::Instant {
     std::time::Instant::now()
 }
 
+/// §8.7 promotion gate carried by a post-training eval job. When the run
+/// completes, the eval worker applies the verdict: accuracy >= threshold
+/// promotes (auto-loads) the adapter when training asked for that;
+/// accuracy below it renames the adapter dir to `<name>.failed` and the
+/// adapter is never promoted — "kiln must not make the model worse and
+/// silently keep serving it."
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostEvalGate {
+    /// Aggregate-accuracy floor from `PostEvalConfig::min_accuracy`.
+    pub min_accuracy: f32,
+    /// The adapter under judgment (the training job's output).
+    pub adapter_name: String,
+    /// Training job to stamp the verdict on.
+    pub training_job_id: String,
+    /// Training requested auto-load, which was DEFERRED until this gate
+    /// passes (§8.7: while the verdict is pending, the prior adapter
+    /// stays active).
+    pub auto_load_on_pass: bool,
+}
+
 /// Tracked eval job — mirrors `TrainingJobInfo` so the UI can render both
 /// with one code path. Stored under `state.eval_jobs`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -101,6 +121,11 @@ pub struct EvalJobInfo {
     /// job starts. Skipped from serde (runtime-only).
     #[serde(skip, default)]
     pub cancel_flag: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// §8.7 promotion gate — set by `enqueue_post_training_eval` on the
+    /// adapter's run (never the baseline run) when the training request
+    /// carried `post_eval.min_accuracy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_eval_gate: Option<PostEvalGate>,
 }
 
 impl EvalJobInfo {
@@ -131,6 +156,7 @@ impl EvalJobInfo {
             submitted_at: std::time::Instant::now(),
             finished_at: None,
             cancel_flag: None,
+            post_eval_gate: None,
         }
     }
 

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -178,6 +178,10 @@ async fn run_one_job_with_generator(
             &state.adapter_dir,
             crate::eval_history::MAX_ARCHIVED_JOBS,
         );
+        // §8.7: this job may carry a promotion gate (post-training eval
+        // with min_accuracy). Apply the verdict now that the run is
+        // terminal.
+        apply_post_eval_gate(&state, &snapshot).await;
     }
 
     // Back-linking from eval-completion → training-job is intentionally
@@ -186,6 +190,140 @@ async fn run_one_job_with_generator(
     // training-side dashboard can link to the eval the moment it lands
     // in the queue (not after it finishes). Pushing again here would
     // duplicate every ID.
+}
+
+/// Apply the §8.7 promotion gate carried by a post-training eval job.
+///
+/// - **Pass** (`accuracy >= min_accuracy`): promote the adapter into
+///   serving when training deferred its auto-load to this verdict.
+/// - **Fail**: rename the adapter dir to `<name>.failed` (the documented
+///   `PostEvalConfig::min_accuracy` contract), purge its cache entries,
+///   and never promote. The previously-active adapter simply stays
+///   active — it was never displaced, because training defers auto-load
+///   while a gate is pending.
+/// - **Eval errored/cancelled**: leave the adapter on disk but do NOT
+///   promote — an unmeasured adapter must not start serving. The verdict
+///   on the training job says exactly that.
+async fn apply_post_eval_gate(state: &AppState, snapshot: &crate::eval::queue::EvalJobInfo) {
+    let Some(gate) = snapshot.post_eval_gate.clone() else {
+        return;
+    };
+    let job_id = snapshot.job_id.clone();
+
+    let stamp_verdict = |verdict: String| {
+        tracing::info!(
+            eval_job = %job_id,
+            training_job = %gate.training_job_id,
+            adapter = %gate.adapter_name,
+            verdict = %verdict,
+            "post-eval gate verdict"
+        );
+        let mut jobs = state.training_jobs.write().unwrap();
+        if let Some(job) = jobs.get_mut(&gate.training_job_id) {
+            job.post_eval_verdict = Some(verdict);
+        }
+    };
+
+    if snapshot.state != EvalJobState::Completed {
+        stamp_verdict(format!(
+            "post-eval did not complete (state: {:?}) — adapter `{}` left on disk, NOT promoted",
+            snapshot.state, gate.adapter_name
+        ));
+        return;
+    }
+
+    let accuracy = snapshot
+        .finished_runs
+        .iter()
+        .find(|run| run.adapter.as_deref() == Some(gate.adapter_name.as_str()))
+        .map(|run| run.metrics.accuracy)
+        .or(snapshot.headline_accuracy);
+    let Some(accuracy) = accuracy else {
+        stamp_verdict(format!(
+            "post-eval produced no run for adapter `{}` — NOT promoted",
+            gate.adapter_name
+        ));
+        return;
+    };
+
+    if accuracy >= gate.min_accuracy {
+        if gate.auto_load_on_pass {
+            let adapter_dir = state.adapter_dir.join(&gate.adapter_name);
+            match crate::adapter_swap::swap_runtime_adapter(
+                state,
+                crate::adapter_swap::SwapRequest {
+                    target: crate::adapter_swap::SwapTarget::Resolved {
+                        active_name: gate.adapter_name.clone(),
+                        dir: adapter_dir,
+                    },
+                    content_changed: false,
+                    reason: "post_eval_gate_promotion",
+                },
+            )
+            .await
+            {
+                Ok(_) => {
+                    *state.active_adapter_name.write().unwrap() =
+                        Some(gate.adapter_name.clone());
+                    stamp_verdict(format!(
+                        "PASSED: accuracy {accuracy:.3} >= {:.3}; adapter `{}` promoted to active",
+                        gate.min_accuracy, gate.adapter_name
+                    ));
+                }
+                Err(e) => stamp_verdict(format!(
+                    "PASSED: accuracy {accuracy:.3} >= {:.3}, but promotion failed: {e}",
+                    gate.min_accuracy
+                )),
+            }
+        } else {
+            stamp_verdict(format!(
+                "PASSED: accuracy {accuracy:.3} >= {:.3}; adapter `{}` kept (auto_load not requested)",
+                gate.min_accuracy, gate.adapter_name
+            ));
+        }
+        return;
+    }
+
+    // FAILED the gate. If someone manually loaded the adapter while the
+    // eval ran, get it out of serving first.
+    let currently_loaded = state.loaded_adapter_name.read().unwrap().clone();
+    if currently_loaded.as_deref() == Some(gate.adapter_name.as_str()) {
+        if let Err(e) = crate::adapter_swap::swap_runtime_adapter(
+            state,
+            crate::adapter_swap::SwapRequest {
+                target: crate::adapter_swap::SwapTarget::Base,
+                content_changed: false,
+                reason: "post_eval_gate_demotion",
+            },
+        )
+        .await
+        {
+            tracing::warn!(error = %e, adapter = %gate.adapter_name, "failed to unload gated adapter");
+        }
+        let mut active = state.active_adapter_name.write().unwrap();
+        if active.as_deref() == Some(gate.adapter_name.as_str()) {
+            *active = None;
+        }
+    }
+
+    let src = state.adapter_dir.join(&gate.adapter_name);
+    let mut dst = state.adapter_dir.join(format!("{}.failed", gate.adapter_name));
+    if dst.exists() {
+        dst = state.adapter_dir.join(format!(
+            "{}.failed-{}",
+            gate.adapter_name,
+            crate::recent_requests::now_unix_ms()
+        ));
+    }
+    let rename_note = match std::fs::rename(&src, &dst) {
+        Ok(()) => format!("renamed to `{}`", dst.file_name().unwrap_or_default().to_string_lossy()),
+        Err(e) => format!("rename to .failed failed: {e}"),
+    };
+    state.purge_adapter_caches(&Some(gate.adapter_name.clone()));
+    stamp_verdict(format!(
+        "FAILED: accuracy {accuracy:.3} < {:.3}; adapter `{}` NOT promoted, {rename_note}",
+        gate.min_accuracy, gate.adapter_name
+    ));
 }
 
 async fn run_job(
@@ -380,6 +518,232 @@ mod tests {
                 fut.await
             })
         }
+    }
+
+    fn gate_test_state() -> (crate::state::AppState, tempfile::TempDir) {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let config = kiln_core::config::ModelConfig::qwen3_5_4b();
+        let scheduler = kiln_scheduler::Scheduler::new(
+            kiln_scheduler::SchedulerConfig {
+                max_batch_tokens: 8192,
+                max_batch_size: 64,
+                block_size: 16,
+                prefix_cache_enabled: false,
+                ..Default::default()
+            },
+            256,
+        );
+        let engine = kiln_model::engine::MockEngine::new(config.clone());
+        let mut state = crate::state::AppState::new_mock(
+            config,
+            scheduler,
+            Arc::new(engine),
+            crate::api::test_tokenizer(),
+            300,
+            "kiln-test".to_string(),
+        );
+        state.adapter_dir = adapter_dir.path().to_path_buf();
+        (state, adapter_dir)
+    }
+
+    fn seed_training_job(state: &crate::state::AppState, job_id: &str, adapter: &str) {
+        state.training_jobs.write().unwrap().insert(
+            job_id.to_string(),
+            crate::state::TrainingJobInfo {
+                job_id: job_id.to_string(),
+                adapter_name: adapter.to_string(),
+                job_type: crate::state::TrainingJobType::Sft,
+                state: kiln_train::TrainingState::Completed,
+                progress: 1.0,
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                submitted_unix_ms: crate::recent_requests::now_unix_ms(),
+                auto_load: true,
+                finished_at: None,
+                finished_unix_ms: None,
+                error: None,
+                linked_eval_job_ids: Vec::new(),
+                post_eval_verdict: None,
+                loss_history: Vec::new(),
+            },
+        );
+    }
+
+    /// One-example suite whose scorer passes iff the mock generator's
+    /// reply contains `phrase`.
+    fn gate_suite(phrase: &str) -> EvalSuite {
+        EvalSuite {
+            name: "gate-suite".into(),
+            description: None,
+            default_scorer: Scorer::Contains {
+                phrases: vec![phrase.into()],
+                mode: Default::default(),
+                case_sensitive: false,
+            },
+            generation: EvalGenerationParams::default(),
+            system_prompt: None,
+            examples: vec![EvalExample {
+                id: Some("e0".into()),
+                messages: vec![EvalChatMessage::new("user", "ping")],
+                target: None,
+                ..Default::default()
+            }],
+            schema_version: 1,
+            tools: None,
+        }
+    }
+
+    async fn run_gated_job(
+        state: &crate::state::AppState,
+        suite: EvalSuite,
+        gate: crate::eval::queue::PostEvalGate,
+        reply: &str,
+    ) {
+        let job_id = format!("eval-{}", gate.adapter_name);
+        let mut info = EvalJobInfo::queued(
+            job_id.clone(),
+            suite.name.clone(),
+            vec![Some(gate.adapter_name.clone())],
+            EvalSubmissionKind::PostTraining,
+            Some(gate.training_job_id.clone()),
+        );
+        info.post_eval_gate = Some(gate.clone());
+        state.eval_jobs.write().unwrap().insert(job_id.clone(), info);
+        let entry = EvalQueueEntry {
+            job_id,
+            job: QueuedEvalJob::Inline {
+                suite: Box::new(suite),
+                adapter: Some(gate.adapter_name.clone()),
+                generation_override: None,
+            },
+        };
+        let generator = Arc::new(
+            crate::eval::MockEvalGenerator::new().with_force_reply(reply.to_string()),
+        ) as Arc<dyn crate::eval::generator::EvalGenerator>;
+        run_one_job_with_generator(state.clone(), entry, generator).await;
+    }
+
+    fn verdict_of(state: &crate::state::AppState, training_job: &str) -> String {
+        state
+            .training_jobs
+            .read()
+            .unwrap()
+            .get(training_job)
+            .and_then(|j| j.post_eval_verdict.clone())
+            .expect("verdict stamped")
+    }
+
+    /// Gate FAIL: the adapter directory is renamed `<name>.failed` (the
+    /// documented PostEvalConfig::min_accuracy contract) and the verdict
+    /// lands on the training job. Before this, min_accuracy was parsed,
+    /// documented — and read by no code at all.
+    #[tokio::test]
+    async fn gate_failure_renames_adapter_and_stamps_verdict() {
+        let (state, _dir) = gate_test_state();
+        seed_training_job(&state, "train-1", "gated");
+        std::fs::create_dir(state.adapter_dir.join("gated")).unwrap();
+
+        run_gated_job(
+            &state,
+            gate_suite("phrase-the-reply-never-contains"),
+            crate::eval::queue::PostEvalGate {
+                min_accuracy: 0.9,
+                adapter_name: "gated".into(),
+                training_job_id: "train-1".into(),
+                auto_load_on_pass: false,
+            },
+            "mock reply",
+        )
+        .await;
+
+        assert!(
+            !state.adapter_dir.join("gated").exists(),
+            "failed adapter must not stay under its serving name"
+        );
+        assert!(
+            state.adapter_dir.join("gated.failed").exists(),
+            "failed adapter renamed per the documented contract"
+        );
+        let verdict = verdict_of(&state, "train-1");
+        assert!(verdict.contains("FAILED"), "{verdict}");
+        assert!(verdict.contains("gated.failed"), "{verdict}");
+    }
+
+    /// Gate PASS without a deferred auto-load: adapter stays under its
+    /// name, verdict records the pass.
+    #[tokio::test]
+    async fn gate_pass_keeps_adapter_and_stamps_verdict() {
+        let (state, _dir) = gate_test_state();
+        seed_training_job(&state, "train-2", "good");
+        std::fs::create_dir(state.adapter_dir.join("good")).unwrap();
+
+        run_gated_job(
+            &state,
+            gate_suite("mock"),
+            crate::eval::queue::PostEvalGate {
+                min_accuracy: 0.9,
+                adapter_name: "good".into(),
+                training_job_id: "train-2".into(),
+                auto_load_on_pass: false,
+            },
+            "a mock reply that matches",
+        )
+        .await;
+
+        assert!(state.adapter_dir.join("good").exists());
+        assert!(!state.adapter_dir.join("good.failed").exists());
+        let verdict = verdict_of(&state, "train-2");
+        assert!(verdict.contains("PASSED"), "{verdict}");
+    }
+
+    /// An errored eval must leave the adapter on disk and NOT promote it —
+    /// an unmeasured adapter never starts serving.
+    #[tokio::test]
+    async fn gate_on_errored_eval_does_not_promote_or_rename() {
+        let (state, _dir) = gate_test_state();
+        seed_training_job(&state, "train-3", "unmeasured");
+        std::fs::create_dir(state.adapter_dir.join("unmeasured")).unwrap();
+
+        // Registered suite with no registry configured → run_job errors →
+        // terminal state Failed.
+        let job_id = "eval-unmeasured".to_string();
+        let mut info = EvalJobInfo::queued(
+            job_id.clone(),
+            "missing-suite".into(),
+            vec![Some("unmeasured".into())],
+            EvalSubmissionKind::PostTraining,
+            Some("train-3".into()),
+        );
+        info.post_eval_gate = Some(crate::eval::queue::PostEvalGate {
+            min_accuracy: 0.5,
+            adapter_name: "unmeasured".into(),
+            training_job_id: "train-3".into(),
+            auto_load_on_pass: true,
+        });
+        state.eval_jobs.write().unwrap().insert(job_id.clone(), info);
+        let entry = EvalQueueEntry {
+            job_id,
+            job: QueuedEvalJob::Registered {
+                suite_name: "missing-suite".into(),
+                adapter: Some("unmeasured".into()),
+                generation_override: None,
+            },
+        };
+        let generator = Arc::new(crate::eval::MockEvalGenerator::new())
+            as Arc<dyn crate::eval::generator::EvalGenerator>;
+        run_one_job_with_generator(state.clone(), entry, generator).await;
+
+        assert!(state.adapter_dir.join("unmeasured").exists());
+        assert!(!state.adapter_dir.join("unmeasured.failed").exists());
+        assert!(
+            state.active_adapter_name.read().unwrap().is_none(),
+            "unmeasured adapter must not be promoted"
+        );
+        let verdict = verdict_of(&state, "train-3");
+        assert!(verdict.contains("did not complete"), "{verdict}");
+        assert!(verdict.contains("NOT promoted"), "{verdict}");
     }
 
     /// DELETE /v1/eval/jobs/{id} mid-run must stop the executor at the next

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -276,6 +276,12 @@ pub struct TrainingJobInfo {
     /// finishes). Empty when no post-training eval was requested.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub linked_eval_job_ids: Vec<String>,
+    /// §8.7 gate verdict stamped by the eval worker when the request
+    /// carried `post_eval.min_accuracy`: what the measured accuracy was,
+    /// whether the adapter was promoted, demoted to `<name>.failed`, or
+    /// left unpromoted because the eval itself errored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_eval_verdict: Option<String>,
     /// Loss history for live charts. Each sample is
     /// `{epoch, progress, loss, elapsed_secs}`. Capped at
     /// `TRAINING_LOSS_HISTORY_CAP` to bound memory; once full, every

--- a/crates/kiln-server/src/training_history.rs
+++ b/crates/kiln-server/src/training_history.rs
@@ -147,6 +147,7 @@ mod tests {
             finished_unix_ms: Some(2_000),
             error: None,
             linked_eval_job_ids: vec![],
+            post_eval_verdict: None,
             loss_history: vec![],
         }
     }

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -2297,19 +2297,38 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 fire_completion_webhook(url.clone(), event);
             }
 
-            if auto_load && adapter_canary_allows_auto_load(&adapter_path, &adapter_name, &job_id) {
+            // §8.7: when the request carries a promotion gate
+            // (post_eval.min_accuracy), auto-load is DEFERRED until the
+            // gate passes — the prior adapter stays active while the
+            // verdict is pending, so a worse model is never serving while
+            // the eval that would catch it is still in the queue. (The old
+            // order hot-swapped the fresh adapter BEFORE the eval was even
+            // enqueued.)
+            let promotion_gate_pending = post_eval
+                .as_ref()
+                .is_some_and(|cfg| cfg.min_accuracy.is_some());
+            let canary_ok =
+                adapter_canary_allows_auto_load(&adapter_path, &adapter_name, &job_id);
+            if auto_load && canary_ok && !promotion_gate_pending {
                 if let Err(e) = auto_load_adapter(&state, &adapter_path, &adapter_name) {
                     tracing::error!(job_id = %job_id, "auto-load failed: {e}");
                 } else {
                     tracing::info!(job_id = %job_id, "auto-loaded trained adapter");
                 }
             } else {
-                // Not promoting the fresh weights into serving — but the
-                // adapter directory CONTENT changed, so any cache entries
-                // keyed to this name (prefix KV, deterministic completions)
-                // now describe weights that no longer exist. Without this,
-                // retraining an idle adapter and swapping back to it later
-                // replays the old model's answers.
+                if promotion_gate_pending {
+                    tracing::info!(
+                        job_id = %job_id,
+                        adapter = %adapter_name,
+                        "auto-load deferred until the post-eval gate passes (§8.7)"
+                    );
+                }
+                // Not promoting the fresh weights into serving (yet) — but
+                // the adapter directory CONTENT changed, so any cache
+                // entries keyed to this name (prefix KV, deterministic
+                // completions) now describe weights that no longer exist.
+                // Without this, retraining an idle adapter and swapping
+                // back to it later replays the old model's answers.
                 state.purge_adapter_caches(&Some(adapter_name.clone()));
             }
 
@@ -2318,8 +2337,24 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             // result. Failures here are warnings — we still consider the
             // training itself successful.
             if let Some(cfg) = post_eval.as_ref() {
-                if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, cfg) {
+                if let Err(e) = enqueue_post_training_eval(
+                    &state,
+                    &job_id,
+                    &adapter_name,
+                    cfg,
+                    auto_load && canary_ok,
+                ) {
                     tracing::warn!(job_id = %job_id, error = %e, "post-training eval enqueue failed");
+                    // The gate could not be installed — an auto_load that
+                    // was deferred to it would otherwise be lost silently.
+                    if promotion_gate_pending {
+                        let mut jobs = state.training_jobs.write().unwrap();
+                        if let Some(job) = jobs.get_mut(&job_id) {
+                            job.post_eval_verdict = Some(format!(
+                                "post-eval gate could not be enqueued ({e}) — adapter `{adapter_name}` left on disk, NOT promoted"
+                            ));
+                        }
+                    }
                 }
             }
 
@@ -2344,7 +2379,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                         min_accuracy: None,
                         include_baseline: true,
                     };
-                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg)
+                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg, false)
                     {
                         tracing::warn!(job_id = %job_id, suite = %suite, error = %e, "distill_refresh IF-eval enqueue failed");
                     } else {
@@ -2358,7 +2393,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                         min_accuracy: None,
                         include_baseline: true,
                     };
-                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg)
+                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg, false)
                     {
                         tracing::warn!(job_id = %job_id, suite = %suite, error = %e, "distill_refresh QA-eval enqueue failed");
                     } else {
@@ -2407,6 +2442,7 @@ pub fn enqueue_post_training_eval(
     training_job_id: &str,
     adapter_name: &str,
     cfg: &kiln_eval::PostEvalConfig,
+    auto_load_on_pass: bool,
 ) -> Result<(), String> {
     if state.suite_registry.is_none() {
         return Err("server has no eval suite registry".to_string());
@@ -2436,7 +2472,25 @@ pub fn enqueue_post_training_eval(
     if cfg.include_baseline {
         linked_ids.push(push(None));
     }
-    linked_ids.push(push(Some(adapter_name.to_string())));
+    let adapter_eval_id = push(Some(adapter_name.to_string()));
+    linked_ids.push(adapter_eval_id.clone());
+
+    // §8.7 promotion gate: when the request set `min_accuracy`, the
+    // adapter's run (never the baseline's) carries the gate. The eval
+    // worker applies the verdict at terminal time — promote on pass,
+    // rename to `<name>.failed` on fail.
+    if let Some(min_accuracy) = cfg.min_accuracy {
+        let mut jobs = state.eval_jobs.write().unwrap();
+        if let Some(job) = jobs.get_mut(&adapter_eval_id) {
+            job.post_eval_gate = Some(crate::eval::queue::PostEvalGate {
+                min_accuracy,
+                adapter_name: adapter_name.to_string(),
+                training_job_id: training_job_id.to_string(),
+                auto_load_on_pass,
+            });
+        }
+    }
+
     // Back-link the eval job IDs onto the training job so dashboards can
     // find them quickly.
     {
@@ -2747,7 +2801,7 @@ mod tests {
             min_accuracy: None,
             include_baseline: false,
         };
-        enqueue_post_training_eval(&state, "train-job-1", "trained-adapter", &cfg).unwrap();
+        enqueue_post_training_eval(&state, "train-job-1", "trained-adapter", &cfg, false).unwrap();
         assert_eq!(state.eval_queue.lock().unwrap().len(), 1);
         assert_eq!(state.eval_jobs.read().unwrap().len(), 1);
     }
@@ -2761,9 +2815,48 @@ mod tests {
             min_accuracy: None,
             include_baseline: true,
         };
-        enqueue_post_training_eval(&state, "train-job-2", "trained-adapter", &cfg).unwrap();
+        enqueue_post_training_eval(&state, "train-job-2", "trained-adapter", &cfg, false).unwrap();
         assert_eq!(state.eval_queue.lock().unwrap().len(), 2);
         assert_eq!(state.eval_jobs.read().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn enqueue_post_training_eval_installs_gate_on_adapter_job_only() {
+        let state = mk_post_eval_state();
+        let cfg = kiln_eval::PostEvalConfig {
+            suite: "smoke".into(),
+            generation: None,
+            min_accuracy: Some(0.8),
+            include_baseline: true,
+        };
+        enqueue_post_training_eval(&state, "train-gated", "trained-adapter", &cfg, true).unwrap();
+
+        let jobs = state.eval_jobs.read().unwrap();
+        assert_eq!(jobs.len(), 2);
+        let mut gated = 0;
+        for job in jobs.values() {
+            match job.adapters.first() {
+                Some(Some(name)) => {
+                    assert_eq!(name, "trained-adapter");
+                    let gate = job
+                        .post_eval_gate
+                        .as_ref()
+                        .expect("adapter run carries the §8.7 gate");
+                    assert_eq!(gate.min_accuracy, 0.8);
+                    assert_eq!(gate.training_job_id, "train-gated");
+                    assert!(gate.auto_load_on_pass);
+                    gated += 1;
+                }
+                Some(None) => {
+                    assert!(
+                        job.post_eval_gate.is_none(),
+                        "baseline run must never carry the gate"
+                    );
+                }
+                None => panic!("job without adapters"),
+            }
+        }
+        assert_eq!(gated, 1);
     }
 
     #[test]
@@ -2776,7 +2869,7 @@ mod tests {
             min_accuracy: None,
             include_baseline: false,
         };
-        let err = enqueue_post_training_eval(&state, "j", "a", &cfg).unwrap_err();
+        let err = enqueue_post_training_eval(&state, "j", "a", &cfg, false).unwrap_err();
         assert!(err.contains("no eval suite registry"));
     }
 

--- a/crates/kiln-server/tests/eval_end_to_end.rs
+++ b/crates/kiln-server/tests/eval_end_to_end.rs
@@ -101,6 +101,7 @@ async fn worker_runs_inline_suite_with_mock_generator() {
             submitted_at: now_instant,
             finished_at: None,
             cancel_flag: None,
+            post_eval_gate: None,
         },
     );
 

--- a/crates/kiln-server/tests/training_failed_job_error.rs
+++ b/crates/kiln-server/tests/training_failed_job_error.rs
@@ -97,6 +97,7 @@ fn enqueue_sft_job(state: &AppState, job_id: &str) {
         finished_unix_ms: None,
         error: None,
         linked_eval_job_ids: Vec::new(),
+        post_eval_verdict: None,
         loss_history: Vec::new(),
     };
     state

--- a/crates/kiln-server/tests/training_tracked_cap.rs
+++ b/crates/kiln-server/tests/training_tracked_cap.rs
@@ -110,6 +110,7 @@ fn fill_tracked(
                 finished_unix_ms: None,
                 error: None,
                 linked_eval_job_ids: Vec::new(),
+                post_eval_verdict: None,
                 loss_history: Vec::new(),
             },
         );
@@ -268,6 +269,7 @@ fn gc_evicts_terminal_entries_past_ttl() {
                 finished_unix_ms: None,
                 error: None,
                 linked_eval_job_ids: Vec::new(),
+                post_eval_verdict: None,
                 loss_history: Vec::new(),
             },
         );
@@ -289,6 +291,7 @@ fn gc_evicts_terminal_entries_past_ttl() {
                 finished_unix_ms: None,
                 error: None,
                 linked_eval_job_ids: Vec::new(),
+                post_eval_verdict: None,
                 loss_history: Vec::new(),
             },
         );


### PR DESCRIPTION
## Summary

`PostEvalConfig.min_accuracy` documented a "promote-only-if-good" contract — *"the produced adapter is unloaded and renamed with a `.failed` suffix"* — but **no code read the field**, and training auto-loaded the fresh adapter into serving **before the post-eval was even enqueued**. Kiln could make the model worse and silently keep serving it; the grand plan calls auto-rollback "the single most important UX guarantee."

This PR makes the gate real, end to end:

- **Gate installation** — `enqueue_post_training_eval` installs a `PostEvalGate` (threshold, adapter, training job, deferred-auto-load flag) on the adapter's eval job, never the baseline's.
- **Deferred promotion (§8.7 "pending = prior stays active")** — when the request carries a gate, training defers auto-load; the prior adapter keeps serving while the verdict is pending. The fresh adapter's stale name-keyed cache entries still purge at training completion.
- **Verdict application** in the eval worker at terminal time:
  - **PASS** → promote via the barrier swap (#1500) when auto-load was deferred.
  - **FAIL** → rename to `<name>.failed` (collision-safe), purge its caches, and unload it if someone manually loaded it mid-eval.
  - **Eval errored/cancelled** → adapter stays on disk but is **not** promoted — an unmeasured adapter never starts serving.
- **Auditability** — the verdict (accuracy vs. threshold, what happened) is stamped on the training job (`post_eval_verdict`, exposed in `GET /v1/train/jobs/:id`).

## Verification

- New eval-worker tests: gate **fail** renames the dir + stamps the verdict; gate **pass** keeps the adapter; **errored** eval leaves it unpromoted with an honest verdict.
- New enqueue test: the gate lands on the adapter run only (baseline never carries it).
- Full `kiln-server` suite: 538 lib tests + all integration suites green. No GPU needed.

Builds on #1500 (barrier swaps) for the promotion/demotion swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)