### PR TITLE
ECHO fail-fast + honest receipts (resurrection PR1)

### DIFF
--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -179,6 +179,21 @@ fn validate_grpo_submission_source(req: &GrpoRequest) -> Result<(), ApiError> {
             "GRPO request needs either non-empty groups or dataset_path",
         ));
     }
+    // Fail fast on loss compositions the kt-tape trainer cannot train
+    // (ECHO env-CE with environment tokens, no_policy_loss, reserved OPD
+    // slot) — the worker would otherwise dequeue a job guaranteed to die,
+    // possibly hours later behind a long queue.
+    let has_env_tokens = req.groups.iter().any(|g| {
+        g.completions.iter().any(|c| {
+            c.trajectory
+                .iter()
+                .any(|seg| seg.kind == kiln_train::trajectory::TurnKind::Observation)
+        })
+    });
+    req.config
+        .loss
+        .validate_for_kt_tape(has_env_tokens)
+        .map_err(ApiError::training_invalid_request)?;
     Ok(())
 }
 
@@ -1324,6 +1339,51 @@ mod tests {
 
         let inline = grpo_req(None, vec![grpo_group()]);
         validate_grpo_submission_source(&inline).unwrap();
+    }
+
+    /// Post candle-drop (#1082) the kt-tape trainer cannot train ECHO
+    /// env-CE or no_policy_loss — submissions must fail HERE, not at
+    /// worker dequeue hours later behind a queue.
+    #[test]
+    fn grpo_submission_rejects_untrainable_loss_configs() {
+        // ECHO + a rollout carrying an Observation segment.
+        let mut group = grpo_group();
+        group.completions[0].trajectory = vec![
+            kiln_train::trajectory::TurnSegment {
+                role: "assistant".into(),
+                content: "running".into(),
+                kind: kiln_train::trajectory::TurnKind::Action,
+                tool_call_id: None,
+                warning_prefix_len: None,
+            },
+            kiln_train::trajectory::TurnSegment {
+                role: "tool".into(),
+                content: "exit 0".into(),
+                kind: kiln_train::trajectory::TurnKind::Observation,
+                tool_call_id: None,
+                warning_prefix_len: None,
+            },
+        ];
+        let mut req = grpo_req(None, vec![group.clone()]);
+        req.config.loss.echo = Some(kiln_train::EchoConfig::default());
+        let err = validate_grpo_submission_source(&req).unwrap_err();
+        assert!(err.message.contains("no gradient path"), "{}", err.message);
+
+        // Same data WITHOUT echo: fine — the policy loss trains the
+        // trajectory's action tokens.
+        let req = grpo_req(None, vec![group]);
+        validate_grpo_submission_source(&req).unwrap();
+
+        // ECHO on legacy single-turn rollouts: zero env term, harmless.
+        let mut req = grpo_req(None, vec![grpo_group()]);
+        req.config.loss.echo = Some(kiln_train::EchoConfig::default());
+        validate_grpo_submission_source(&req).unwrap();
+
+        // no_policy_loss: constant-zero loss.
+        let mut req = grpo_req(None, vec![grpo_group()]);
+        req.config.loss.no_policy_loss = true;
+        let err = validate_grpo_submission_source(&req).unwrap_err();
+        assert!(err.message.contains("no_policy_loss"), "{}", err.message);
     }
 
     #[test]

--- a/crates/kiln-train/src/grpo_tape_shim.rs
+++ b/crates/kiln-train/src/grpo_tape_shim.rs
@@ -68,16 +68,16 @@
 //!
 //! # Carve-outs (NOT covered by this tape root)
 //!
-//! * **ECHO env-CE.** The ECHO term (`λ · mean_envCE`) is added to the policy
-//!   loss only on agentic off-policy data. It is composed against the SAME
-//!   `policy_logits`, so it COULD be folded in here, but matching the OPD
-//!   carve-out we keep any step with an active ECHO contribution on the candle
-//!   gradient-checkpointing path (the dispatch in
-//!   `train_tokenized_grpo_group_with_grad_norms` gates the tape path off when
-//!   ECHO fires). Non-ECHO GRPO — the common verifier-based and verifier-free
-//!   on-policy case — is the tape-authoritative target.
-//! * **`no_policy_loss` with no ECHO.** That config is a constant-zero loss
-//!   (already rejected by the candle path); the dispatch keeps it on candle.
+//! * **ECHO env-CE.** The ECHO term (`λ · mean_envCE`) composes against the
+//!   SAME `policy_logits` and COULD be folded in here as extra
+//!   `(softmax − onehot)` rows at env positions — that is exactly the ECHO
+//!   resurrection plan's PR2. Until then there is NO fallback: the candle
+//!   gradient-checkpointing path that used to carry ECHO steps was deleted
+//!   in #1082, so ECHO-with-env-tokens configs are rejected at submission
+//!   and trainer entry (`LossConfig::validate_for_kt_tape`), never
+//!   dispatched.
+//! * **`no_policy_loss`.** With ECHO unavailable this is a constant-zero
+//!   loss; rejected at the same validation points.
 //! * **`KlEstimator` / `IsLevel`** are all SUPPORTED — the numeric-`coeff`
 //!   derivation handles every variant uniformly because it just re-runs
 //!   `grpo_loss`. CUDA/ROCm additionally use a device-resident fast path for

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -742,9 +742,9 @@ pub struct GrpoConfig {
     /// record the result in `train_receipt.json`.
     #[serde(default)]
     pub adapter_smoke_test: bool,
-    /// Composition of per-token training objectives. ECHO is on by default
-    /// (paper §3.3 λ=0.05); OPD's slot is reserved but empty until the OPD
-    /// branch rebases. See `LossConfig` for the full design.
+    /// Composition of per-token training objectives. ECHO is OFF by
+    /// default until its env-CE term regains a kt-tape gradient root
+    /// (#1082); OPD's slot is reserved but empty. See `LossConfig`.
     #[serde(default)]
     pub loss: LossConfig,
 }
@@ -776,14 +776,13 @@ fn default_reward_filter_min_groups() -> usize {
 //           + λ_echo · L_envCE(observations) [paper: Shrivastava 2026]
 //           + λ_opd  · L_revKL(actions)      [paper: Lu 2025; wired in OPD merge]
 //
-// `LossConfig::default()` enables ECHO at λ=0.05 (paper §3.3 default).
-// `opd` is a placeholder None until the OPD branch rebases on top; its
-// shape is reserved here so the composition stays orthogonal.
-//
-// For legacy single-string rollouts (`scored.has_trajectory() == false`)
-// the env_mask is empty and ECHO contributes exactly 0 — bit-identical
-// to the pre-ECHO loss. ECHO only fires when a rollout carries
-// observation segments. This is what makes "ECHO on by default" safe.
+// `LossConfig::default()` has ECHO OFF: the candle drop (#1082) deleted
+// the only env-CE gradient producer, so until the kt-tape root is
+// restored (ECHO resurrection plan) an enabled term either contributes
+// nothing (no env tokens) or hard-errors (env tokens present). Explicit
+// opt-in is validated up front via `LossConfig::validate_for_kt_tape`.
+// `opd` is a placeholder None; its shape is reserved so the composition
+// stays orthogonal.
 
 /// What positions in an observation segment contribute to the env_mask.
 ///
@@ -827,8 +826,14 @@ fn default_echo_lambda() -> f64 {
 fn default_warning_filter() -> bool {
     true
 }
+/// ECHO default. OFF until the env-CE term regains a gradient path: the
+/// candle drop (#1082) deleted the only producer that could backpropagate
+/// it, so a default-ON config made default-config agentic GRPO on real pi
+/// trajectories fail by design — after burning the rollout/reference
+/// forwards. Flip back to `Some(EchoConfig::default())` when the kt-tape
+/// env-CE root lands (ECHO resurrection plan, PR2).
 fn default_echo_some() -> Option<EchoConfig> {
-    Some(EchoConfig::default())
+    None
 }
 
 impl Default for EchoConfig {
@@ -866,10 +871,11 @@ pub struct LossConfig {
     /// trainer reads them from the surrounding GrpoConfig.
     ///
     /// Observation-token cross-entropy (paper: Shrivastava et al. 2026).
-    /// Default: `Some(EchoConfig::default())` with λ=0.05. Set to None to
-    /// opt out. Even when Some, ECHO contributes exactly 0 to the loss for
-    /// rollouts whose `env_mask` is empty (i.e. legacy single-turn) — so
-    /// "ECHO on by default" is safe for existing GRPO callers.
+    /// Default: `None` until the env-CE term regains a kt-tape gradient
+    /// root (deleted with the candle drop, #1082). Explicitly enabling it
+    /// fails fast at submission/trainer entry when the data carries
+    /// Observation segments — the term would otherwise silently train
+    /// nothing or hard-error mid-run after the rollout forwards.
     #[serde(default = "default_echo_some")]
     pub echo: Option<EchoConfig>,
     /// Action-token reverse-KL to a teacher (OPD; Lu 2025). Default: None.
@@ -898,6 +904,43 @@ impl Default for LossConfig {
 }
 
 impl LossConfig {
+    /// Validate this composition against the kt-tape training path BEFORE
+    /// any GPU work. Post-candle-drop (#1082) the ECHO env-CE term has no
+    /// tape gradient root and `no_policy_loss` therefore has no gradient
+    /// source at all; both previously failed mid-run, after the rollout
+    /// and reference forwards had already burned GPU time.
+    /// `has_env_tokens` = the training data carries trajectory
+    /// Observation/tool segments that the env mask would cover.
+    pub fn validate_for_kt_tape(&self, has_env_tokens: bool) -> Result<(), String> {
+        if self.no_policy_loss {
+            return Err(
+                "loss.no_policy_loss requires the ECHO env-CE gradient root, which was \
+                 removed in the candle drop (#1082) — there is currently nothing to train \
+                 on with the policy term masked out. Remove no_policy_loss (restoration \
+                 is tracked in the ECHO resurrection plan)."
+                    .to_string(),
+            );
+        }
+        if self.echo_enabled() && has_env_tokens {
+            return Err(
+                "loss.echo is enabled and the rollouts carry Observation/tool segments, \
+                 but the ECHO env-CE term has no gradient path post candle-drop (#1082) — \
+                 the step would fail after the rollout forwards. Set loss.echo to null \
+                 (or pass --no-echo); the action-token policy loss still trains on the \
+                 full trajectory. Restoration is tracked in the ECHO resurrection plan."
+                    .to_string(),
+            );
+        }
+        if self.opd.is_some() {
+            return Err(
+                "loss.opd composition on GRPO is reserved but not wired — use \
+                 POST /v1/train/opd for on-policy distillation instead."
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
     /// Lambda for the ECHO term, or 0.0 if ECHO is disabled.
     pub fn echo_lambda(&self) -> f64 {
         self.echo.as_ref().map(|c| c.lambda).unwrap_or(0.0)
@@ -1393,13 +1436,47 @@ mod tests {
     }
 
     #[test]
-    fn loss_config_default_has_echo_on_at_0_05() {
+    fn loss_config_default_has_echo_off_until_tape_root_restored() {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
         let cfg = LossConfig::default();
-        assert!(cfg.echo.is_some(), "ECHO should be on by default");
-        assert!((cfg.echo_lambda() - 0.05).abs() < 1e-12);
+        // The env-CE term lost its gradient path in the candle drop
+        // (#1082): default-ON made default-config agentic GRPO on real pi
+        // trajectories fail by design. Flip back to ON alongside the
+        // kt-tape env-CE root (ECHO resurrection plan PR2).
+        assert!(
+            cfg.echo.is_none(),
+            "ECHO must default OFF while the env-CE term has no gradient path"
+        );
         assert!(cfg.opd.is_none(), "OPD should be off by default");
+        assert!(cfg.validate_for_kt_tape(true).is_ok());
+    }
+
+    #[test]
+    fn loss_config_validation_rejects_untrainable_compositions() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_kiln_echo_env_vars();
+
+        // Explicit ECHO + env tokens: would fail mid-run after the rollout
+        // forwards — must be rejected up front, with the remediation.
+        let mut cfg = LossConfig::default();
+        cfg.echo = Some(EchoConfig::default());
+        assert!(cfg.validate_for_kt_tape(false).is_ok(), "no env tokens = zero term, harmless");
+        let err = cfg.validate_for_kt_tape(true).unwrap_err();
+        assert!(err.contains("no gradient path"), "{err}");
+        assert!(err.contains("--no-echo"), "{err}");
+
+        // no_policy_loss: constant-zero loss post candle-drop.
+        let mut cfg = LossConfig::default();
+        cfg.no_policy_loss = true;
+        let err = cfg.validate_for_kt_tape(false).unwrap_err();
+        assert!(err.contains("no_policy_loss"), "{err}");
+
+        // Reserved OPD slot: point at the real endpoint.
+        let mut cfg = LossConfig::default();
+        cfg.opd = Some(OpdAuxConfig { lambda: 1.0 });
+        let err = cfg.validate_for_kt_tape(false).unwrap_err();
+        assert!(err.contains("/v1/train/opd"), "{err}");
     }
 
     #[test]
@@ -1417,8 +1494,10 @@ mod tests {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
         unsafe { std::env::set_var("KILN_ECHO_ENABLED", "false") };
+        // Start from an explicitly-enabled config (the default is now OFF)
+        // so the env override has something to disable.
         let mut cfg = LossConfig::default();
-        assert!(cfg.echo.is_some());
+        cfg.echo = Some(EchoConfig::default());
         cfg.apply_kiln_echo_env_overrides();
         assert!(cfg.echo.is_none(), "KILN_ECHO_ENABLED=false should disable");
         clear_kiln_echo_env_vars();
@@ -1499,11 +1578,18 @@ mod tests {
     fn kiln_echo_no_env_vars_leaves_config_unchanged() {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
+        // Both the (now-OFF) default and an explicit opt-in survive a pass
+        // with no env vars set.
         let mut cfg = LossConfig::default();
+        cfg.apply_kiln_echo_env_overrides();
+        assert!(cfg.echo.is_none(), "default OFF stays OFF");
+
+        let mut cfg = LossConfig::default();
+        cfg.echo = Some(EchoConfig::default());
         let original_lambda = cfg.echo_lambda();
         cfg.apply_kiln_echo_env_overrides();
         assert!((cfg.echo_lambda() - original_lambda).abs() < 1e-12);
-        assert!(cfg.echo.is_some());
+        assert!(cfg.echo.is_some(), "explicit opt-in stays on");
     }
 
     #[test]

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -993,9 +993,13 @@ pub fn prepare_off_policy_distillation_dataset(
 
         let env_tokens = tokenized.env_mask.iter().filter(|&&active| active).count() as u64;
         summary.env_tokens = summary.env_tokens.saturating_add(env_tokens);
-        if echo.is_some() && env_tokens > 0 {
-            summary.echo_combined = true;
-        }
+        // HONESTY: env masks are *built* here, but the train step has no
+        // env-CE gradient root post candle-drop (#1082) — the term never
+        // combines into the loss. `echo_combined` stays false so the
+        // summary (and the receipt downstream) records what actually
+        // trains, not what the config requested. Flip back alongside the
+        // kt-tape env-CE root (ECHO resurrection plan PR2).
+        let _ = echo;
 
         prompts.push(prompt);
     }
@@ -3809,14 +3813,25 @@ fn write_opd_train_receipt_best_effort(
         samples_per_prompt: config.samples_per_prompt,
         action_tokens: token_counts.action_tokens,
         env_tokens: token_counts.env_tokens,
-        echo_combined: config.echo.is_some() && token_counts.env_tokens > 0,
+        // HONESTY: the env-CE term has no gradient path on the kt-only OPD
+        // step (the candle producer was deleted in #1082), so it never
+        // combines into the loss regardless of config. A receipt claiming
+        // `echo_combined: true` from config alone was asserting a loss
+        // term that never fired — audit-grade evidence must record what
+        // actually trained.
+        echo_combined: false,
         echo_lambda: config.echo.as_ref().map(|echo| echo.lambda),
         initial_opd_loss: None,
         final_opd_loss,
     });
     receipt.echo = match config.echo.as_ref() {
         Some(echo) => crate::train_receipt::EchoReceipt {
-            enabled: echo.lambda != 0.0,
+            // HONESTY: `enabled` records whether the term FIRED, not
+            // whether it was requested — and post candle-drop (#1082) the
+            // env-CE term has no gradient path on the kt OPD step. The
+            // request's lambda/knobs are still recorded for provenance,
+            // with the drop reason spelled out.
+            enabled: false,
             lambda: Some(echo.lambda),
             env_mask_mode: serde_json::to_value(echo.env_mask_mode)
                 .ok()
@@ -3824,6 +3839,11 @@ fn write_opd_train_receipt_best_effort(
             warning_filter: Some(echo.warning_filter),
             initial_env_ce: None,
             final_env_ce: None,
+            dropped_reason: Some(
+                "env-CE has no kt-tape gradient root post candle-drop (#1082); the \
+                 configured ECHO term did not contribute to this run's loss"
+                    .to_string(),
+            ),
         },
         None => crate::train_receipt::EchoReceipt::disabled(),
     };
@@ -4181,7 +4201,10 @@ mod tests {
             ce_prepared.summary.action_tokens
         );
         assert!(prepared.summary.env_tokens > 0);
-        assert!(prepared.summary.echo_combined);
+        // Env masks are built, but the env-CE term has no gradient path
+        // post candle-drop (#1082) — the summary must say it never
+        // combined, even when the config requested it.
+        assert!(!prepared.summary.echo_combined);
         Ok(())
     }
 

--- a/crates/kiln-train/src/train_receipt.rs
+++ b/crates/kiln-train/src/train_receipt.rs
@@ -57,6 +57,10 @@ pub enum TrainFailureReason {
     ZeroGroups,
     ZeroActionTokens,
     ZeroEnvTokens,
+    /// The loss composition asked for a term the kt-tape path cannot
+    /// train (ECHO env-CE with env tokens / no_policy_loss) — see
+    /// `LossConfig::validate_for_kt_tape`.
+    UnsupportedLossConfig,
     NanLoss,
     Oom,
     ShapeMismatch,
@@ -73,6 +77,7 @@ impl TrainFailureReason {
             Self::ZeroGroups => "zero_groups",
             Self::ZeroActionTokens => "zero_action_tokens",
             Self::ZeroEnvTokens => "zero_env_tokens",
+            Self::UnsupportedLossConfig => "unsupported_loss_config",
             Self::NanLoss => "nan_loss",
             Self::Oom => "oom",
             Self::ShapeMismatch => "shape_mismatch",
@@ -215,6 +220,9 @@ pub struct OpdReceipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EchoReceipt {
+    /// Whether the env-CE term actually FIRED during this run — not
+    /// whether it was requested. A requested-but-dropped term records
+    /// `enabled: false` plus `dropped_reason`.
     pub enabled: bool,
     pub lambda: Option<f64>,
     pub env_mask_mode: Option<String>,
@@ -223,6 +231,11 @@ pub struct EchoReceipt {
     pub initial_env_ce: Option<f64>,
     #[serde(default)]
     pub final_env_ce: Option<f64>,
+    /// Why a configured ECHO term did not contribute to the loss (e.g. no
+    /// kt-tape gradient root post candle-drop, #1082). `None` when the
+    /// term fired or was never requested.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dropped_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -756,6 +769,14 @@ pub fn classify_training_failure(message: &str) -> TrainFailureReason {
     {
         return TrainFailureReason::Oom;
     }
+    // Untrainable loss compositions (validate_for_kt_tape) — must match
+    // BEFORE the zero-env-tokens patterns since both mention env tokens.
+    if lower.contains("no gradient path")
+        || lower.contains("no_policy_loss requires")
+        || (lower.contains("echo") && lower.contains("post candle-drop"))
+    {
+        return TrainFailureReason::UnsupportedLossConfig;
+    }
     if lower.contains("echo is enabled")
         && (lower.contains("env_mask is empty")
             || lower.contains("no environment tokens")
@@ -876,6 +897,7 @@ impl EchoReceipt {
             warning_filter: None,
             initial_env_ce: None,
             final_env_ce: None,
+            dropped_reason: None,
         }
     }
 }
@@ -2138,6 +2160,7 @@ mod tests {
             warning_filter: Some(true),
             initial_env_ce: None,
             final_env_ce: None,
+            dropped_reason: None,
         };
         metrics.apply_to_echo_receipt(&mut receipt);
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1708,8 +1708,14 @@ fn grpo_hyperparameters(
 
 fn grpo_echo_receipt(config: &GrpoConfig) -> crate::train_receipt::EchoReceipt {
     match config.loss.echo.as_ref() {
-        Some(echo) if config.loss.echo_enabled() => crate::train_receipt::EchoReceipt {
-            enabled: true,
+        // A present config records its knobs for provenance (a λ=0 config
+        // still steers mask construction / warning-filter accounting), but
+        // `enabled` records whether the env-CE term FIRED — and post
+        // candle-drop (#1082) it has no gradient root: λ≠0 runs only reach
+        // training when the data carries no env tokens (entry validation
+        // rejects the rest), so the term contributed exactly zero.
+        Some(echo) => crate::train_receipt::EchoReceipt {
+            enabled: false,
             lambda: Some(echo.lambda),
             env_mask_mode: serde_json::to_value(echo.env_mask_mode)
                 .ok()
@@ -1717,8 +1723,14 @@ fn grpo_echo_receipt(config: &GrpoConfig) -> crate::train_receipt::EchoReceipt {
             warning_filter: Some(echo.warning_filter),
             initial_env_ce: None,
             final_env_ce: None,
+            dropped_reason: config.loss.echo_enabled().then(|| {
+                "env-CE has no kt-tape gradient root post candle-drop (#1082); runs \
+                 with environment tokens are rejected at entry and runs without them \
+                 have a zero env-CE term"
+                    .to_string()
+            }),
         },
-        _ => crate::train_receipt::EchoReceipt::disabled(),
+        None => crate::train_receipt::EchoReceipt::disabled(),
     }
 }
 
@@ -2956,6 +2968,21 @@ pub fn grpo_train(
     replay_ctx: Option<ReplayContext>,
 ) -> Result<PathBuf> {
     let run_started = Instant::now();
+    // Fail fast on loss compositions the kt-tape path cannot train —
+    // BEFORE any forward pass. The old order discovered this per-step,
+    // after the rollout + reference forwards had already burned GPU time.
+    let has_env_tokens = groups.iter().any(|g| {
+        g.completions.iter().any(|c| {
+            c.trajectory
+                .iter()
+                .any(|seg| seg.kind == crate::trajectory::TurnKind::Observation)
+        })
+    });
+    config
+        .loss
+        .validate_for_kt_tape(has_env_tokens)
+        .map_err(|e| anyhow::anyhow!("GRPO loss config: {e}"))?;
+
     let output_dir = adapter_dir.join(adapter_name);
     let training_data_sha256 = crate::train_receipt::sha256_json_serializable(&groups);
     let requested_base_adapter_dir = config
@@ -3718,10 +3745,18 @@ pub fn grpo_dry_run_jsonl(
                 token_counts.action_tokens > 0,
                 "GRPO dry run: dataset has no action tokens after mask construction"
             );
+            // The dry run pins the same constraint the real run enforces.
+            // (It used to demand the OPPOSITE — env tokens required when
+            // ECHO was on — so a dataset that passed the dry run was
+            // exactly one that failed the real run.)
             if config.loss.echo_enabled() {
                 anyhow::ensure!(
-                    token_counts.env_tokens > 0,
-                    "GRPO dry run: ECHO is enabled but env_mask is empty across all valid groups; pass --no-echo or provide trajectory Observation/tool segments"
+                    token_counts.env_tokens == 0,
+                    "GRPO dry run: ECHO is enabled and the dataset carries environment \
+                     tokens, but the env-CE term has no gradient path post candle-drop \
+                     (#1082) — the real run would fail after the rollout forwards. Pass \
+                     --no-echo (or set loss.echo to null); the action-token policy loss \
+                     still trains on the full trajectory."
                 );
             }
         }
@@ -3800,6 +3835,15 @@ pub fn grpo_train_jsonl(
     use std::io::{BufRead, BufReader};
 
     let run_started = Instant::now();
+    // Fail fast on compositions the kt-tape path cannot train. The
+    // streaming path can't cheaply pre-scan every group for Observation
+    // segments, so `no_policy_loss` / reserved-OPD reject here and the
+    // echo+env case rejects per-group at mask-construction time, before
+    // that group's forward (plus in the dry-run gate below).
+    config
+        .loss
+        .validate_for_kt_tape(false)
+        .map_err(|e| anyhow::anyhow!("GRPO loss config: {e}"))?;
     let output_dir = adapter_dir.join(adapter_name);
     let training_data = crate::train_receipt::TrainingDataReceipt {
         source: "jsonl_grpo_groups".to_string(),
@@ -5294,8 +5338,11 @@ fn train_tokenized_grpo_group_with_grad_norms(
             tape_auth_eligible,
             "GRPO requires the kt tape-authoritative path (backend tape support, \
              compatible base dtype, no ECHO env-CE, no no_policy_loss) post \
-             candle-drop. The candle `loss.backward()` / ECHO / candle-checkpointed \
-             GRPO producers were removed in #1082."
+             candle-drop (#1082). If this fired on ECHO: set loss.echo to null / pass \
+             --no-echo — the action-token policy loss still trains on the full \
+             trajectory. (Submission-time and trainer-entry validation should have \
+             rejected this config before any GPU work; reaching this point is a bug \
+             worth reporting.)"
         );
         let grads: GradSource = {
             #[cfg(any(
@@ -9714,9 +9761,9 @@ pub(crate) mod tests {
             seed: Some(42),
             ..GrpoConfig::default()
         };
-        if !echo {
-            config.loss.echo = None;
-        }
+        // The default is now OFF (#1082) — `echo: true` means an explicit
+        // opt-in here.
+        config.loss.echo = echo.then(crate::EchoConfig::default);
         config
     }
 
@@ -9829,46 +9876,80 @@ pub(crate) mod tests {
         assert!(err.to_string().contains("empty action_mask"));
     }
 
+    /// The dry run must pin the same constraint the real run enforces:
+    /// ECHO + env tokens has no gradient path post candle-drop (#1082), so
+    /// it REJECTS — while ECHO + legacy single-turn rollouts (zero env
+    /// tokens, zero contribution) passes. The pre-fix gate demanded the
+    /// exact opposite, so a dataset that passed the dry run was precisely
+    /// one that failed the real run.
     #[test]
-    fn grpo_dry_run_rejects_echo_without_env_tokens_and_writes_receipt() -> Result<()> {
+    fn grpo_dry_run_rejects_echo_with_env_tokens_and_writes_receipt() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         let tok = make_echo_smoke_tokenizer()?;
-        let group = dry_run_group(vec![
+
+        // Legacy rollouts (no observations): ECHO-enabled config passes.
+        let legacy_group = dry_run_group(vec![
             crate::ScoredRollout::legacy("a".to_string(), 0.0),
             crate::ScoredRollout::legacy("b".to_string(), 1.0),
         ]);
-        let data = dry_run_dataset(tmp.path(), "echo-empty-env.jsonl", &[group]);
+        let legacy_data = dry_run_dataset(tmp.path(), "echo-legacy.jsonl", &[legacy_group]);
         let output = tmp.path().join("out");
-
-        let err = grpo_dry_run_jsonl(
-            &data,
+        let report = grpo_dry_run_jsonl(
+            &legacy_data,
             &dry_run_config(true, false),
             &ModelConfig::qwen3_5_4b(),
             &tok,
             &output,
-            "echo-empty-env",
+            "echo-legacy",
+            false,
+        )?;
+        assert_eq!(report.token_counts.env_tokens, 0);
+
+        // Trajectory rollouts WITH observations: rejected up front.
+        let env_group = dry_run_group(vec![
+            crate::ScoredRollout::from_trajectory(
+                vec![
+                    crate::TurnSegment {
+                        role: "assistant".into(),
+                        content: "a".into(),
+                        kind: crate::trajectory::TurnKind::Action,
+                        tool_call_id: None,
+                        warning_prefix_len: None,
+                    },
+                    dry_run_observation("tool output"),
+                ],
+                0.0,
+            ),
+            crate::ScoredRollout::legacy("b".to_string(), 1.0),
+        ]);
+        let env_data = dry_run_dataset(tmp.path(), "echo-env.jsonl", &[env_group]);
+        let err = grpo_dry_run_jsonl(
+            &env_data,
+            &dry_run_config(true, false),
+            &ModelConfig::qwen3_5_4b(),
+            &tok,
+            &output,
+            "echo-env",
             false,
         )
         .unwrap_err();
 
-        assert!(err.to_string().contains("failure_reason=zero_env_tokens"));
-        assert!(err.to_string().contains("ECHO is enabled"));
-        let receipt = crate::train_receipt::TrainReceipt::read_from_adapter_dir(
-            &output.join("echo-empty-env"),
-        )?
-        .unwrap();
+        assert!(
+            err.to_string().contains("failure_reason=unsupported_loss_config"),
+            "{err}"
+        );
+        assert!(err.to_string().contains("--no-echo"), "{err}");
+        let receipt =
+            crate::train_receipt::TrainReceipt::read_from_adapter_dir(&output.join("echo-env"))?
+                .unwrap();
         assert_eq!(
             receipt.status,
             crate::train_receipt::TrainReceiptStatus::Failed
         );
-        assert_eq!(receipt.token_counts.env_tokens, 0);
-        assert_eq!(receipt.failure_reason.as_deref(), Some("zero_env_tokens"));
-        assert!(
-            receipt
-                .failure_message
-                .as_deref()
-                .unwrap()
-                .contains("ECHO is enabled")
+        assert!(receipt.token_counts.env_tokens > 0);
+        assert_eq!(
+            receipt.failure_reason.as_deref(),
+            Some("unsupported_loss_config")
         );
         Ok(())
     }
@@ -10026,9 +10107,12 @@ pub(crate) mod tests {
         let data = dry_run_dataset(tmp.path(), "ok.jsonl", &[group]);
         let output = tmp.path().join("out");
 
+        // ECHO off: trajectory rollouts with observations are the normal
+        // agentic case post candle-drop — the env-token ACCOUNTING still
+        // records, the env-CE term simply isn't part of the loss.
         let report = grpo_dry_run_jsonl(
             &data,
-            &dry_run_config(true, false),
+            &dry_run_config(false, false),
             &ModelConfig::qwen3_5_4b(),
             &tok,
             &output,
@@ -10052,7 +10136,7 @@ pub(crate) mod tests {
         assert_eq!(receipt.rewards.min, Some(0.0));
         assert_eq!(receipt.rewards.max, Some(1.0));
         assert_eq!(receipt.rewards.group_count, 1);
-        assert!(receipt.echo.enabled);
+        assert!(!receipt.echo.enabled, "no env-CE gradient path post #1082");
         assert!(
             receipt.phase_timings.tokenize_ms > 0.0,
             "dry-run receipt should record tokenization timing"
@@ -10092,9 +10176,15 @@ pub(crate) mod tests {
         let data = dry_run_dataset(tmp.path(), "warning-filter.jsonl", &[group]);
         let output = tmp.path().join("out");
 
+        // λ=0 keeps the EchoConfig as a pure mask-construction knob
+        // carrier: the warning-filter accounting runs, while the (gated,
+        // post-#1082) env-CE term stays out of the loss so the dry run
+        // passes on env-token data.
+        let mut filter_on = dry_run_config(true, false);
+        filter_on.loss.echo.as_mut().expect("ECHO config").lambda = 0.0;
         let report = grpo_dry_run_jsonl(
             &data,
-            &dry_run_config(true, false),
+            &filter_on,
             &ModelConfig::qwen3_5_4b(),
             &tok,
             &output,
@@ -10131,12 +10221,11 @@ pub(crate) mod tests {
         );
 
         let mut filter_off = dry_run_config(true, false);
-        filter_off
-            .loss
-            .echo
-            .as_mut()
-            .expect("ECHO enabled")
-            .warning_filter = false;
+        {
+            let echo = filter_off.loss.echo.as_mut().expect("ECHO config");
+            echo.lambda = 0.0;
+            echo.warning_filter = false;
+        }
         let off_report = grpo_dry_run_jsonl(
             &data,
             &filter_off,


### PR DESCRIPTION
## Summary

The founding ECHO doc's loss term has had **no gradient path since the candle drop (#1082)** deleted its only producer — yet:

- `LossConfig::default()` still shipped echo **ON** at λ=0.05, and the trainer hard-errored on exactly that config whenever pi trajectories carried Observation segments — **after** burning the rollout + reference forwards. Default-config agentic GRPO on real pi traces failed by design.
- The dry-run gate demanded the **opposite** (env tokens *required* when ECHO on), so a dataset that passed the dry run was precisely one that failed the real run.
- OPD receipts claimed `echo_combined: true` from config alone while the term (per the code's own comment) "drops out of OPD entirely" — audit-grade receipts asserting a loss that never fired.

This is **PR1 of the ECHO resurrection plan**: honesty and fail-fast now; PR2 restores env-CE as extra `(softmax − onehot)` rows on the existing GRPO tape root.

## Changes

- **Default OFF**: `LossConfig::default()` ships `echo: None`, documented against the PR2 flip-back. Agentic GRPO on pi traces now trains.
- **`LossConfig::validate_for_kt_tape`** rejects untrainable compositions (explicit ECHO + Observation segments, `no_policy_loss`, the reserved `loss.opd` slot → "use `/v1/train/opd`") at **both** HTTP submission (`submit_grpo`/`agentic`) and trainer entry — before any GPU work, with the remediation in the message. New `failure_reason: unsupported_loss_config` (distinct from `zero_env_tokens`).
- **Dry run pins the real constraint**: ECHO + env tokens rejects; ECHO + legacy single-turn rollouts passes (zero term, harmless).
- **Honest receipts**: `echo.enabled` records whether the term *fired* (plus `dropped_reason`); OPD `echo_combined` is `false`; a λ=0 `EchoConfig` still records its mask-construction knobs (warning-filter accounting) for provenance.
- **`grpo_tape_shim` carve-out docs** rewritten — no candle fallback exists; rejected-at-validation is the actual contract.

## Verification

- `kiln-train`: 267 tests green, including the rewritten dry-run contract tests and new `validate_for_kt_tape` unit tests.
- `kiln-server`: full suite green, including new submission-rejection tests at the HTTP layer.
- No GPU needed. The PR2 restoration (env-CE tape root + Appendix C acceptance tests + default flip-back) is the natural follow-up; the paired TBLite ECHO-vs-no-ECHO ablation stays attended work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)