### PR TITLE
Wire the live LLM judge: deferred batch scoring closes the flywheel's dead payoff step

### DIFF
--- a/crates/kiln-eval/src/scorers/mod.rs
+++ b/crates/kiln-eval/src/scorers/mod.rs
@@ -210,6 +210,20 @@ impl Scorer {
             _ => false,
         }
     }
+
+    /// First judge adapter named anywhere in this scorer tree. The executor
+    /// batches judge-scored examples per judge adapter so the model swaps
+    /// once per suite run, not once per judge call. `None` = judge with the
+    /// base model (or the scorer doesn't pin an adapter).
+    pub fn judge_adapter(&self) -> Option<&str> {
+        match self {
+            Scorer::LlmJudge { judge_adapter, .. } => judge_adapter.as_deref(),
+            Scorer::All { scorers } | Scorer::Any { scorers } => {
+                scorers.iter().find_map(|s| s.judge_adapter())
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Scorer-level errors. Most scorers degrade to `EvalOutcomeKind::Invalid`

--- a/crates/kiln-server/src/eval/executor.rs
+++ b/crates/kiln-server/src/eval/executor.rs
@@ -43,7 +43,8 @@ pub async fn run_suite_against_adapter(
     // Hoist the adapter swap out of the per-example loop. The previous
     // active adapter is restored at the end via the same call so a suite
     // run never leaves the model in an unexpected state, even when an
-    // example errors mid-loop.
+    // example errors mid-loop (including after the deferred judge pass
+    // swapped to a judge adapter).
     let previous_adapter = generator
         .set_adapter(adapter)
         .await
@@ -52,10 +53,10 @@ pub async fn run_suite_against_adapter(
         suite,
         adapter,
         generation_override,
-        generator.as_ref(),
+        generator.clone(),
         progress,
         cancelled,
-        judge_runner.as_ref(),
+        judge_runner,
     )
     .await;
     let _ = generator
@@ -67,14 +68,32 @@ pub async fn run_suite_against_adapter(
     result
 }
 
+/// A completion whose scoring needs the LLM judge. Pass 1 (generation)
+/// records it with a placeholder outcome; pass 2 swaps to the judge
+/// adapter ONCE per distinct judge and scores the batch on a blocking
+/// thread. Before this existed, every judge call would have swapped the
+/// model's adapter mid-suite (poisoning subsequent generations) — and in
+/// practice none of it ran at all, because the worker always installed the
+/// no-op judge.
+struct DeferredJudgeScore {
+    outcome_index: usize,
+    example_index: usize,
+    completion_idx: usize,
+    completion_text: String,
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    latency_ms: f64,
+    schema_note: Option<String>,
+}
+
 async fn run_suite_inner(
     suite: &EvalSuite,
     adapter: Option<&str>,
     generation_override: Option<&EvalGenerationParams>,
-    generator: &dyn EvalGenerator,
+    generator: Arc<dyn EvalGenerator>,
     progress: Option<ProgressCallback>,
     cancelled: Arc<std::sync::atomic::AtomicBool>,
-    judge_runner: &dyn JudgeRunner,
+    judge_runner: Arc<dyn JudgeRunner>,
 ) -> Result<SuiteResult, EvalExecutionError> {
     let started_at = chrono::Utc::now();
     let start_instant = Instant::now();
@@ -89,6 +108,7 @@ async fn run_suite_inner(
     let mut running_pass: u32 = 0;
     let mut running_score: f32 = 0.0;
     let mut completions_seen: u32 = 0;
+    let mut deferred_judge: Vec<DeferredJudgeScore> = Vec::new();
 
     let total_completions: u32 = suite
         .examples
@@ -102,7 +122,7 @@ async fn run_suite_inner(
         })
         .sum();
 
-    for example in &suite.examples {
+    for (outcomes_example_index, example) in suite.examples.iter().enumerate() {
         if cancelled.load(std::sync::atomic::Ordering::Relaxed) {
             break;
         }
@@ -210,54 +230,90 @@ async fn run_suite_inner(
                             }
                         }
                     }
-                    // A scorer error (missing target, bad regex, judge
-                    // unavailable) is a property of ONE example — record it
-                    // as that example's Error outcome instead of aborting
-                    // the run and discarding every completed outcome.
-                    let mut o = match score_completion(
-                        scorer,
-                        example,
-                        &completion.text,
-                        judge_runner,
-                    ) {
-                        Ok(o) => o,
-                        Err(e) => ExampleOutcome {
+                    let schema_note = pending_schema_detail.as_ref().and_then(|chk| {
+                        if chk.is_clean() {
+                            return None;
+                        }
+                        let mut parts = Vec::new();
+                        if !chk.missing_required.is_empty() {
+                            parts.push(format!("missing={}", chk.missing_required.join(",")));
+                        }
+                        if !chk.extra_unknown.is_empty() {
+                            parts.push(format!("extra={}", chk.extra_unknown.join(",")));
+                        }
+                        Some(format!(" || schema: {}", parts.join(" ")))
+                    });
+                    if scorer.requires_judge() {
+                        // Defer judge-backed scoring to pass 2: the judge
+                        // runs on a (possibly different) adapter, and
+                        // swapping mid-generation-loop would poison the
+                        // remaining generations. A placeholder Invalid
+                        // outcome holds the slot; pass 2 replaces it.
+                        deferred_judge.push(DeferredJudgeScore {
+                            outcome_index: outcomes.len(),
+                            example_index: outcomes_example_index,
+                            completion_idx,
+                            completion_text: completion.text.clone(),
+                            prompt_tokens: completion.prompt_tokens,
+                            completion_tokens: completion.completion_tokens,
+                            latency_ms: completion.latency_ms,
+                            schema_note: schema_note.clone(),
+                        });
+                        ExampleOutcome {
                             example_id: example_id.clone(),
                             completion_index: completion_idx,
                             completion_text: completion.text.clone(),
-                            kind: EvalOutcomeKind::Error,
+                            kind: EvalOutcomeKind::Invalid,
                             score: 0.0,
-                            detail: Some(format!("scorer error: {e}")),
-                            prompt_tokens: None,
-                            completion_tokens: None,
-                            latency_ms: None,
+                            detail: Some("awaiting judge pass".into()),
+                            prompt_tokens: Some(completion.prompt_tokens),
+                            completion_tokens: Some(completion.completion_tokens),
+                            latency_ms: Some(completion.latency_ms),
                             tags: example.tags.clone(),
                             metadata: example.metadata.clone(),
                             reasoning_text: None,
                             unclosed_thinking: false,
-                        },
-                    };
-                    o.completion_index = completion_idx;
-                    o.prompt_tokens = Some(completion.prompt_tokens);
-                    o.completion_tokens = Some(completion.completion_tokens);
-                    o.latency_ms = Some(completion.latency_ms);
-                    if let Some(chk) = pending_schema_detail.as_ref() {
-                        if !chk.is_clean() {
-                            let mut parts = Vec::new();
-                            if !chk.missing_required.is_empty() {
-                                parts.push(format!("missing={}", chk.missing_required.join(",")));
-                            }
-                            if !chk.extra_unknown.is_empty() {
-                                parts.push(format!("extra={}", chk.extra_unknown.join(",")));
-                            }
-                            let schema_note = format!(" || schema: {}", parts.join(" "));
-                            o.detail =
-                                Some(o.detail.map(|d| d + &schema_note).unwrap_or_else(|| {
-                                    schema_note.trim_start_matches(" || ").to_string()
-                                }));
                         }
+                    } else {
+                        // A scorer error (missing target, bad regex, judge
+                        // unavailable) is a property of ONE example — record
+                        // it as that example's Error outcome instead of
+                        // aborting the run and discarding every completed
+                        // outcome.
+                        let mut o = match score_completion(
+                            scorer,
+                            example,
+                            &completion.text,
+                            judge_runner.as_ref(),
+                        ) {
+                            Ok(o) => o,
+                            Err(e) => ExampleOutcome {
+                                example_id: example_id.clone(),
+                                completion_index: completion_idx,
+                                completion_text: completion.text.clone(),
+                                kind: EvalOutcomeKind::Error,
+                                score: 0.0,
+                                detail: Some(format!("scorer error: {e}")),
+                                prompt_tokens: None,
+                                completion_tokens: None,
+                                latency_ms: None,
+                                tags: example.tags.clone(),
+                                metadata: example.metadata.clone(),
+                                reasoning_text: None,
+                                unclosed_thinking: false,
+                            },
+                        };
+                        o.completion_index = completion_idx;
+                        o.prompt_tokens = Some(completion.prompt_tokens);
+                        o.completion_tokens = Some(completion.completion_tokens);
+                        o.latency_ms = Some(completion.latency_ms);
+                        if let Some(note) = schema_note.as_ref() {
+                            o.detail = Some(o.detail.map(|d| d + note).unwrap_or_else(|| {
+                                note.trim_start_matches(" || ").to_string()
+                            }));
+                        }
+                        o
                     }
-                    o
                 }
                 Err(err) => ExampleOutcome {
                     example_id: example_id.clone(),
@@ -298,6 +354,110 @@ async fn run_suite_inner(
                     },
                 };
                 cb(progress_snap);
+            }
+        }
+    }
+
+    // ── Pass 2: deferred judge scoring ──────────────────────────────
+    // Group by judge adapter, swap once per group (the barrier swap makes
+    // each swap wait out in-flight requests — once per suite, not once
+    // per call), then score the batch on a blocking thread: the live
+    // judge re-enters the generator via Handle::block_on, which panics on
+    // a runtime worker thread.
+    if !deferred_judge.is_empty() && !cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+        let mut groups: BTreeMap<Option<String>, Vec<DeferredJudgeScore>> = BTreeMap::new();
+        for item in deferred_judge.drain(..) {
+            let scorer = suite.examples[item.example_index]
+                .scorer
+                .as_ref()
+                .unwrap_or(&suite.default_scorer);
+            groups
+                .entry(scorer.judge_adapter().map(str::to_string))
+                .or_default()
+                .push(item);
+        }
+        for (judge_adapter, items) in groups {
+            if cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            if let Err(e) = generator.set_adapter(judge_adapter.as_deref()).await {
+                for item in items {
+                    outcomes[item.outcome_index].detail =
+                        Some(format!("judge adapter swap failed: {e}"));
+                }
+                continue;
+            }
+            let batch: Vec<(DeferredJudgeScore, kiln_eval::scorers::Scorer, kiln_eval::EvalExample)> =
+                items
+                    .into_iter()
+                    .map(|item| {
+                        let example = suite.examples[item.example_index].clone();
+                        let scorer = example
+                            .scorer
+                            .clone()
+                            .unwrap_or_else(|| suite.default_scorer.clone());
+                        (item, scorer, example)
+                    })
+                    .collect();
+            let judge = judge_runner.clone();
+            let cancel_flag = cancelled.clone();
+            let scored = tokio::task::spawn_blocking(move || {
+                batch
+                    .into_iter()
+                    .map(|(item, scorer, example)| {
+                        if cancel_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                            return (item, None);
+                        }
+                        let result =
+                            score_completion(&scorer, &example, &item.completion_text, judge.as_ref());
+                        (item, Some(result))
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .await
+            .map_err(|e| EvalExecutionError::Scorer(format!("judge scoring task: {e}")))?;
+
+            for (item, result) in scored {
+                let Some(result) = result else { continue };
+                let slot = &mut outcomes[item.outcome_index];
+                match result {
+                    Ok(mut o) => {
+                        o.completion_index = item.completion_idx;
+                        o.prompt_tokens = Some(item.prompt_tokens);
+                        o.completion_tokens = Some(item.completion_tokens);
+                        o.latency_ms = Some(item.latency_ms);
+                        if let Some(note) = item.schema_note.as_ref() {
+                            o.detail = Some(o.detail.map(|d| d + note).unwrap_or_else(|| {
+                                note.trim_start_matches(" || ").to_string()
+                            }));
+                        }
+                        if matches!(o.kind, EvalOutcomeKind::Pass) {
+                            running_pass += 1;
+                        }
+                        running_score += o.score;
+                        *slot = o;
+                    }
+                    Err(e) => {
+                        slot.kind = EvalOutcomeKind::Error;
+                        slot.detail = Some(format!("scorer error: {e}"));
+                    }
+                }
+            }
+            if let Some(cb) = progress.as_ref() {
+                cb(EvalProgress {
+                    examples_completed: completions_seen,
+                    examples_total: total_completions,
+                    running_accuracy: if completions_seen > 0 {
+                        running_pass as f32 / completions_seen as f32
+                    } else {
+                        0.0
+                    },
+                    running_mean_score: if completions_seen > 0 {
+                        running_score / completions_seen as f32
+                    } else {
+                        0.0
+                    },
+                });
             }
         }
     }
@@ -467,6 +627,123 @@ mod tests {
         // "2" matches), the original "5+5?" example fails on the wrong reply.
         assert_eq!(result.metrics.num_pass, 2);
         assert_eq!(result.metrics.num_fail, 1);
+    }
+
+    /// Judge runner test double: replies with a fixed judge verdict and
+    /// records the thread context plus every (adapter, prompt) it saw.
+    struct ScriptedJudge {
+        reply: &'static str,
+        calls: std::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    impl kiln_eval::scorers::JudgeRunner for ScriptedJudge {
+        fn judge(&self, adapter: Option<&str>, _prompt: &str) -> Option<String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(adapter.map(str::to_string));
+            Some(self.reply.to_string())
+        }
+    }
+
+    fn judge_suite() -> EvalSuite {
+        let mk = |id: &str| EvalExample {
+            id: Some(id.into()),
+            messages: vec![EvalChatMessage::new("user", "rate me")],
+            target: Some("anything".into()),
+            ..Default::default()
+        };
+        EvalSuite {
+            name: "judged".into(),
+            description: None,
+            default_scorer: Scorer::LlmJudge {
+                judge_adapter: Some("judge-x".into()),
+                template: kiln_eval::scorers::llm_judge::default_judge_template(),
+                score_regex: kiln_eval::scorers::llm_judge::default_judge_regex(),
+            },
+            generation: EvalGenerationParams::default(),
+            system_prompt: None,
+            examples: vec![mk("j1"), mk("j2")],
+            schema_version: 1,
+            tools: None,
+        }
+    }
+
+    /// The flywheel's payoff step: judge-scored examples actually score
+    /// (no more Invalid-on-every-example), the judge adapter activates
+    /// ONCE for the whole batch (never per call), and the eval adapter is
+    /// restored afterwards.
+    #[tokio::test]
+    async fn judge_scoring_runs_in_deferred_pass_with_single_batch_swap() {
+        let mock = Arc::new(MockEvalGenerator::new().with_force_reply("model answer"));
+        let gen_ = mock.clone() as Arc<dyn EvalGenerator>;
+        let judge = Arc::new(ScriptedJudge {
+            reply: "Score: 1",
+            calls: std::sync::Mutex::new(Vec::new()),
+        });
+
+        let result = run_suite_against_adapter(
+            &judge_suite(),
+            Some("eval-adapter"),
+            None,
+            gen_,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            judge.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.outcomes.len(), 2);
+        for o in &result.outcomes {
+            assert!(
+                matches!(o.kind, EvalOutcomeKind::Pass),
+                "judge-scored example must Pass, got {:?} ({:?})",
+                o.kind,
+                o.detail
+            );
+            assert!(o.prompt_tokens.is_some(), "generation metadata survives");
+        }
+        assert_eq!(result.metrics.num_pass, 2);
+        assert_eq!(judge.calls.lock().unwrap().len(), 2);
+
+        // Swap sequence: eval adapter in, judge adapter ONCE for the
+        // deferred batch, previous adapter restored at the end.
+        let swaps = mock.swap_log.lock().unwrap().clone();
+        assert_eq!(
+            swaps,
+            vec![
+                Some("eval-adapter".to_string()),
+                Some("judge-x".to_string()),
+                None,
+            ],
+            "judge adapter must activate exactly once for the batch"
+        );
+    }
+
+    /// Without a live judge (mock mode / noop runner) judge-scored
+    /// examples degrade to Invalid with the honest detail — never stuck
+    /// on the pass-1 placeholder.
+    #[tokio::test]
+    async fn judge_scoring_without_runner_degrades_to_invalid() {
+        let gen_ = Arc::new(MockEvalGenerator::new().with_force_reply("model answer"))
+            as Arc<dyn EvalGenerator>;
+        let result = run_suite_against_adapter(
+            &judge_suite(),
+            None,
+            None,
+            gen_,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            noop_judge_runner(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.outcomes.len(), 2);
+        for o in &result.outcomes {
+            assert!(matches!(o.kind, EvalOutcomeKind::Invalid));
+            assert_eq!(o.detail.as_deref(), Some("judge runner unavailable"));
+        }
     }
 
     #[tokio::test]

--- a/crates/kiln-server/src/eval/generator.rs
+++ b/crates/kiln-server/src/eval/generator.rs
@@ -331,12 +331,35 @@ fn build_sampling(params: &EvalGenerationParams, completion_index: usize) -> Sam
 
 /// Implementation of `JudgeRunner` that re-enters the live generator for a
 /// judge-style synchronous prompt. Used by the `LlmJudge` scorer.
-pub struct LiveJudgeRunner<'a> {
-    pub generator: &'a LiveEvalGenerator,
-    pub runtime: &'a tokio::runtime::Handle,
+///
+/// Contract: `judge()` MUST be called from a blocking thread (the
+/// executor's deferred judge pass runs scoring inside `spawn_blocking`) —
+/// `Handle::block_on` panics on a tokio worker thread, which is exactly
+/// how the previous borrow-based version would have died had anything
+/// constructed it (nothing did; the worker always installed the no-op
+/// runner, so every judge-scored example silently degraded to Invalid).
+///
+/// The judge adapter is swapped in by the EXECUTOR, once per suite run —
+/// not here. The old per-call `set_adapter` both thrashed the weights for
+/// every judge call and never restored them, so the rest of the suite
+/// would have run on the judge's weights.
+pub struct LiveJudgeRunner {
+    generator: Arc<LiveEvalGenerator>,
+    runtime: tokio::runtime::Handle,
 }
 
-impl<'a> JudgeRunner for LiveJudgeRunner<'a> {
+impl LiveJudgeRunner {
+    /// Capture the current runtime handle; call from async context (the
+    /// eval worker) at construction time.
+    pub fn new(state: AppState) -> Self {
+        Self {
+            generator: Arc::new(LiveEvalGenerator::new(state)),
+            runtime: tokio::runtime::Handle::current(),
+        }
+    }
+}
+
+impl JudgeRunner for LiveJudgeRunner {
     fn judge(&self, adapter: Option<&str>, prompt: &str) -> Option<String> {
         let messages = vec![EvalChatMessage::new("user", prompt)];
         let params = EvalGenerationParams {
@@ -357,7 +380,8 @@ impl<'a> JudgeRunner for LiveJudgeRunner<'a> {
                 return None;
             }
         };
-        let _ = self.runtime.block_on(self.generator.set_adapter(adapter));
+        // `adapter` is a label for the engine request only — the executor
+        // already activated the judge adapter at the batch boundary.
         let run_fut = self.generator.run(&prepared, &params, 0, adapter);
         match self.runtime.block_on(run_fut) {
             Ok(c) => Some(c.text),
@@ -378,6 +402,9 @@ pub struct MockEvalGenerator {
     /// the mock backend never holds real state, but tests want the
     /// previous-adapter return to be plausible.
     active: std::sync::Mutex<Option<String>>,
+    /// Every set_adapter target, in order — tests assert swap batching
+    /// (e.g. the judge adapter activates once per suite, not per call).
+    pub swap_log: std::sync::Mutex<Vec<Option<String>>>,
 }
 
 impl MockEvalGenerator {
@@ -386,6 +413,7 @@ impl MockEvalGenerator {
             force_reply: None,
             adapter_replies: std::collections::HashMap::new(),
             active: std::sync::Mutex::new(None),
+            swap_log: std::sync::Mutex::new(Vec::new()),
         }
     }
     pub fn with_force_reply(mut self, reply: impl Into<String>) -> Self {
@@ -414,6 +442,7 @@ impl EvalGenerator for MockEvalGenerator {
     > {
         let want = adapter.map(str::to_string).filter(|s| !s.is_empty());
         Box::pin(async move {
+            self.swap_log.lock().unwrap().push(want.clone());
             let mut slot = self.active.lock().unwrap();
             let previous = slot.clone();
             *slot = want;

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -108,9 +108,16 @@ async fn run_one_job_with_generator(
         }
     }
 
-    // TODO(eval): swap in a `LiveJudgeRunner` once judge calls are plumbed.
-    // Until then judge scorers degrade to `Invalid` on every example.
-    let judge_runner: Arc<dyn JudgeRunner> = noop_judge_runner();
+    // Live judge on the real backend: LlmJudge scorers re-enter the model
+    // through the executor's deferred judge pass (batch adapter swap +
+    // blocking-thread scoring). Mock mode keeps the no-op runner — judge
+    // scorers degrade to Invalid there, honestly.
+    let judge_runner: Arc<dyn JudgeRunner> = match state.backend.as_ref() {
+        crate::state::ModelBackend::Real { .. } => Arc::new(
+            crate::eval::generator::LiveJudgeRunner::new(state.clone()),
+        ),
+        crate::state::ModelBackend::Mock { .. } => noop_judge_runner(),
+    };
 
     let progress_state = state.eval_jobs.clone();
     let progress_job_id = job_id.clone();

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -4001,6 +4001,12 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
                 <option value="judge">LLM judge (local adapter)</option>
               </select>
             </div>
+            <div class="form-group" id="synth-judge-adapter-group" hidden>
+              <label for="synth-judge-adapter" title="The adapter that grades completions — typically a judge LoRA trained from your A/B picks. Base model when empty.">Judge adapter</label>
+              <select id="synth-judge-adapter">
+                <option value="">Base model</option>
+              </select>
+            </div>
             <div class="form-group">
               <label for="synth-max-examples">Max examples</label>
               <input id="synth-max-examples" type="number" value="100" min="1" max="10000">
@@ -9792,6 +9798,29 @@ document.getElementById('synth-close')?.addEventListener('click', () => {
   activeSynthDataset = null;
 });
 
+// The judge scorer needs to know WHICH adapter judges — typically the
+// judge LoRA trained from A/B picks. Reveal + populate the picker only
+// when the judge scorer is selected.
+document.getElementById('synth-scorer')?.addEventListener('change', () => {
+  const isJudge = document.getElementById('synth-scorer').value === 'judge';
+  const group = document.getElementById('synth-judge-adapter-group');
+  if (group) group.hidden = !isJudge;
+  if (isJudge) populateSynthJudgeAdapters();
+});
+
+async function populateSynthJudgeAdapters() {
+  const sel = document.getElementById('synth-judge-adapter');
+  if (!sel) return;
+  const current = sel.value;
+  try {
+    const res = await api('/v1/adapters');
+    const names = (res.available || []).map(a => a.name);
+    sel.innerHTML = '<option value="">Base model</option>' +
+      names.map(n => `<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join('');
+    if (names.includes(current)) sel.value = current;
+  } catch (_) { /* adapter list unavailable — base-model option remains */ }
+}
+
 function readSynthConfig() {
   const suite_name = document.getElementById('synth-suite-name').value.trim();
   if (!suite_name) { toast('Suite name is required', 'err'); return null; }
@@ -9799,7 +9828,10 @@ function readSynthConfig() {
   const scorerChoice = document.getElementById('synth-scorer').value;
   let scorer;
   if (scorerChoice === 'auto')       scorer = { kind: 'auto_detect' };
-  else if (scorerChoice === 'judge') scorer = { kind: 'judge', judge_adapter: null };
+  else if (scorerChoice === 'judge') {
+    const judgeAdapter = document.getElementById('synth-judge-adapter')?.value || null;
+    scorer = { kind: 'judge', judge_adapter: judgeAdapter };
+  }
   else if (scorerChoice === 'exact_match') scorer = { kind: 'fixed', scorer: { kind: 'exact_match', case_sensitive: false, strip_whitespace: true } };
   else if (scorerChoice === 'contains')    scorer = { kind: 'fixed', scorer: { kind: 'contains', phrases: [], mode: 'any', case_sensitive: false } };
   else if (scorerChoice === 'numeric')     scorer = { kind: 'fixed', scorer: { kind: 'numeric_tolerance', atol: 0, rtol: 0, integer_only: false } };
@@ -11162,10 +11194,17 @@ document.getElementById('compile-btn')?.addEventListener('click', async () => {
       method: 'POST', headers: {'Content-Type':'application/json'},
       body: JSON.stringify({ output_dataset, include_skips: false }),
     });
+    // One-click crank: the dataset is ready — go straight to training a
+    // judge LoRA on it instead of sending the user off to find the
+    // Training tab with an instruction string.
     document.getElementById('compile-output').innerHTML =
       `<div style="padding:10px; background:var(--success-bg); border:1px solid var(--success-bd); border-radius:6px; color:var(--success-fg); font-size:12px;">
-        ${icon('check','icn-sm')} Compiled <strong>${res.rows}</strong> judgments into SFT dataset <code>${escapeHtml(res.dataset.name)}</code> (${res.dataset.num_rows} rows). Train a judge LoRA via the Training tab using this dataset.
+        ${icon('check','icn-sm')} Compiled <strong>${res.rows}</strong> judgments into SFT dataset <code>${escapeHtml(res.dataset.name)}</code> (${res.dataset.num_rows} rows).
+        <button type="button" class="btn btn-primary btn-sm" style="margin-left:8px;" id="compile-train-judge-btn">${icon('flask','icn-sm')} Train judge LoRA now</button>
       </div>`;
+    document.getElementById('compile-train-judge-btn')?.addEventListener('click', () => {
+      trainFromDataset(res.dataset.name, 'sft');
+    });
     toast('Compiled to SFT', 'ok');
     refreshDatasets();
   } catch (e) { toast('Compile failed: ' + e.message, 'err'); }


### PR DESCRIPTION
## Summary

The judgments flywheel — collect A/B picks → compile to SFT → train a judge LoRA → validate it — ended at a dead step: **using** the judge. The eval worker always installed the no-op judge runner (`TODO(eval): swap in a LiveJudgeRunner…`), so every `llm_judge`-scored example silently degraded to `Invalid`, while a fully implemented `LiveJudgeRunner` had **zero construction sites**. Open-ended grading is how agent transcripts get scored, so this blocked "the model gets better" for everything that isn't exact-match.

Naively wiring it would have failed twice (both latent bugs were flagged in the audit):
1. `judge()` used `Handle::block_on` from async context → panic on a tokio worker thread.
2. It swapped the judge adapter **per call without restoring** → the rest of the suite would run on the judge's weights.

## Changes

- **Deferred judge pass in the executor**: generation completes on the eval adapter first; then the judge adapter activates **once per distinct judge** (a single barrier swap, courtesy of #1500), the batch scores on a `spawn_blocking` thread (where `Handle::block_on` is the supported pattern), and the suite's outer restore puts the previous adapter back. Cancellation leaves un-judged placeholders honestly `Invalid`.
- **`LiveJudgeRunner`** is owned (`Arc` state + runtime handle), no longer swaps adapters itself, and documents the blocking-thread contract.
- **Worker wiring**: live runner whenever the backend is real; mock mode keeps the honest no-op degradation.
- **`Scorer::judge_adapter()`** batches composite scorers by the judge they name.
- **UI crank**: the dataset-synthesis judge scorer gains a judge-adapter picker (was hardcoded `null`), and compiling judgments to SFT now offers a one-click **"Train judge LoRA now"** button instead of an instruction string.

## Verification

- New executor tests with a scripted judge: judge-scored examples Pass; the swap sequence is asserted (`eval-adapter` → `judge-x` exactly once → restore); generation metadata survives onto judged outcomes; the no-runner path degrades to `Invalid("judge runner unavailable")` — never stuck on the pass-1 placeholder.
- Full `kiln-server` + `kiln-eval` suites green; dashboard smoke passes.
- Natural attended follow-up: a 2-example judge suite against the live rig (minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)