### PR TITLE
Teacher correctness + fail-fast: adapter-wearing local teachers, registration gates, distill preflight

### DIFF
--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -381,24 +381,7 @@ fn build_self_improve_jobs(
     Ok((opd_phase, crisp_pump, num_tasks))
 }
 
-/// Resolve a teacher alias against the registry, failing with the
-/// remediation-bearing 400 (`teacher_not_registered`) when missing.
-fn require_registered_teacher(
-    state: &AppState,
-    alias: &str,
-    detail: String,
-) -> Result<(), ApiError> {
-    if state.teacher_registry.get(alias).is_some() {
-        return Ok(());
-    }
-    let registered: Vec<String> = state
-        .teacher_registry
-        .list()
-        .into_iter()
-        .map(|spec| spec.alias)
-        .collect();
-    Err(ApiError::teacher_not_registered(detail, &registered))
-}
+use super::teachers::require_registered_teacher;
 
 fn register_agent_job(
     state: &AppState,

--- a/crates/kiln-server/src/api/teachers.rs
+++ b/crates/kiln-server/src/api/teachers.rs
@@ -362,6 +362,7 @@ mod tests {
             url: None,
             api_key_env: None,
             notes: None,
+            adapter: None,
         };
         reg.insert(spec.clone());
         let got = reg.get("qwen3.6-27b@local").unwrap();
@@ -388,6 +389,7 @@ mod tests {
             url: None,
             api_key_env: None,
             notes: Some("unit test".into()),
+            adapter: None,
         });
         reg.save_to_path(&path).unwrap();
 
@@ -410,6 +412,7 @@ mod tests {
             url: Some("https://api".into()),
             api_key_env: None,
             notes: None,
+            adapter: None,
         };
         let caps = resolve_caps_for(&spec).unwrap();
         assert_eq!(caps.teacher_id, "x");
@@ -445,6 +448,7 @@ mod tests {
             url: Some("https://openrouter.ai/api/v1".into()),
             api_key_env: Some("OPENROUTER_API_KEY".into()),
             notes: None,
+            adapter: None,
         };
         let s = serde_json::to_string(&spec).unwrap();
         let parsed: TeacherSpec = serde_json::from_str(&s).unwrap();

--- a/crates/kiln-server/src/api/teachers.rs
+++ b/crates/kiln-server/src/api/teachers.rs
@@ -9,19 +9,20 @@
 //! - `DELETE /v1/teachers/{alias}` — drop a registered teacher.
 //!
 //! The registry maps `alias -> TeacherSpec` (a serializable description
-//! of how to build a `LogitSource`). At resolution time (e.g. inside
-//! `run_opd`) the spec is materialised into a concrete `LogitSource`
-//! impl. For milestone-9 we ship two kinds:
+//! of how to build a `LogitSource`). At resolution time (inside
+//! `run_opd` / the distill runtimes) the spec is materialised into a
+//! concrete `LogitSource`:
 //!
 //! - **Fixture** — in-memory deterministic source for unit tests +
 //!   `kiln-canonical` corpora that ship with pre-baked logits.
-//! - **Local** — placeholder pointing at "the model loaded in this
-//!   process at `model_id`." A second model handle is wired in when
-//!   the §3.1 trainer body lands; for now the resolver returns an
-//!   "OPD runtime not yet implemented" error.
-//!
-//! Future kinds (RemoteTeacher × 8 providers, CachedTeacher) plug in
-//! the same way.
+//! - **Local** — the model loaded in this process, optionally wearing a
+//!   LoRA named by `adapter` (this is what makes "distil toward my
+//!   prior self" and "judge as teacher" mean what they say). On-policy
+//!   runs get a `LiveLocalTeacher`; off-policy runs pre-compute a
+//!   fixture.
+//! - **Remote** — HTTP `prompt_logprobs`. Only vLLM/sglang are wired
+//!   today; registration rejects URLs that resolve to unsupported
+//!   providers instead of letting the job fail at dequeue.
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
@@ -69,6 +70,13 @@ pub struct TeacherSpec {
     /// Free-form notes the user can attach (e.g. "shared cache key").
     #[serde(default)]
     pub notes: Option<String>,
+    /// For `Local` kinds: a LoRA adapter (a directory name under the
+    /// server's adapter dir) the teacher wears. Without this, a Local
+    /// teacher always means the BARE BASE MODEL — which silently broke
+    /// the two flagship continual-learning shapes: `distill_refresh`
+    /// toward a prior self, and `self_improve`'s judge-as-teacher.
+    #[serde(default)]
+    pub adapter: Option<String>,
 }
 
 /// Concrete teacher kind. The §3.2 abstraction stays a closed enum
@@ -208,6 +216,40 @@ async fn register_teacher(
             "Remote teacher requires a `url`".to_string(),
         ));
     }
+    // Fail registrations that are guaranteed to die at job dequeue —
+    // possibly hours later, behind a queue.
+    if let Some(adapter) = spec.adapter.as_deref() {
+        if !matches!(spec.kind, TeacherKind::Local) {
+            return Err(ApiError::training_invalid_request(format!(
+                "`adapter` is only valid on kind=local teachers (got kind={:?})",
+                spec.kind
+            )));
+        }
+        super::adapters::validate_adapter_name(adapter)?;
+        let dir = state.adapter_dir.join(adapter);
+        if !dir.is_dir() {
+            return Err(ApiError::training_invalid_request(format!(
+                "teacher adapter `{adapter}` not found at {} — train or upload it first",
+                dir.display()
+            )));
+        }
+    }
+    if matches!(spec.kind, TeacherKind::Remote) {
+        if let Some(url) = spec.url.as_deref() {
+            let provider = crate::training_queue::guess_remote_provider(url);
+            if !matches!(
+                provider,
+                kiln_train::RemoteProvider::Vllm | kiln_train::RemoteProvider::Sglang
+            ) {
+                return Err(ApiError::training_invalid_request(format!(
+                    "remote provider {provider:?} (inferred from url {url:?}) is not wired \
+                     yet — only vLLM and sglang prompt_logprobs are supported today. Point \
+                     the URL at a vLLM/sglang server, or self-host one in front of your \
+                     provider."
+                )));
+            }
+        }
+    }
     state.teacher_registry.insert(spec.clone());
     // Persist immediately so a crash doesn't lose the registration.
     let teachers_path = state.adapter_dir.join("teachers.json");
@@ -269,6 +311,28 @@ pub fn resolve_teacher(registry: &TeacherRegistry, alias: &str) -> Result<Teache
         teacher_id: alias.to_string(),
         message: format!("teacher alias {alias:?} not registered (POST /v1/teachers first)"),
     })
+}
+
+/// Resolve a teacher alias against the registry, failing with the
+/// remediation-bearing 400 (`teacher_not_registered`) when missing.
+/// Shared by every submission endpoint that names a teacher — a typo'd
+/// alias must fail at submission, not at worker dequeue hours later
+/// behind a queue.
+pub(crate) fn require_registered_teacher(
+    state: &AppState,
+    alias: &str,
+    detail: String,
+) -> Result<(), ApiError> {
+    if state.teacher_registry.get(alias).is_some() {
+        return Ok(());
+    }
+    let registered: Vec<String> = state
+        .teacher_registry
+        .list()
+        .into_iter()
+        .map(|spec| spec.alias)
+        .collect();
+    Err(ApiError::teacher_not_registered(detail, &registered))
 }
 
 /// Shared registry handle stored on AppState.

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -606,14 +606,6 @@ async fn submit_opd(
             "OPD request must specify a teacher alias (e.g. \"qwen3.6-27b@local\")".to_string(),
         ));
     }
-    // The worker resolves the teacher only at dequeue — a typo'd alias
-    // used to enqueue a job guaranteed to fail later, possibly hours
-    // later behind a long queue. Fail here with the remediation.
-    super::teachers::require_registered_teacher(
-        &state,
-        &req.teacher,
-        format!("OPD teacher alias '{}' is not registered", req.teacher),
-    )?;
     // A plain-file dataset_path is pre-scored off-policy teacher JSONL;
     // `agent_traces:` selectors are on-policy prompt sources. The worker
     // enforces this too — but at submission the caller can still fix it.
@@ -654,6 +646,16 @@ async fn submit_opd(
     if let Some(name) = req.config.output_name.as_deref() {
         super::adapters::validate_adapter_name(name)?;
     }
+    // The worker resolves the teacher only at dequeue — a typo'd alias
+    // used to enqueue a job guaranteed to fail later, possibly hours
+    // later behind a long queue. Fail here with the remediation. (After
+    // the pure-input checks above: a malformed request is the caller's
+    // first problem, an unregistered teacher the second.)
+    super::teachers::require_registered_teacher(
+        &state,
+        &req.teacher,
+        format!("OPD teacher alias '{}' is not registered", req.teacher),
+    )?;
     let adapter_name = req
         .config
         .output_name

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -606,6 +606,39 @@ async fn submit_opd(
             "OPD request must specify a teacher alias (e.g. \"qwen3.6-27b@local\")".to_string(),
         ));
     }
+    // The worker resolves the teacher only at dequeue — a typo'd alias
+    // used to enqueue a job guaranteed to fail later, possibly hours
+    // later behind a long queue. Fail here with the remediation.
+    super::teachers::require_registered_teacher(
+        &state,
+        &req.teacher,
+        format!("OPD teacher alias '{}' is not registered", req.teacher),
+    )?;
+    // A plain-file dataset_path is pre-scored off-policy teacher JSONL;
+    // `agent_traces:` selectors are on-policy prompt sources. The worker
+    // enforces this too — but at submission the caller can still fix it.
+    if let Some(path) = req.dataset_path.as_deref() {
+        if !crate::dataset_resolve::is_agent_traces_selector(path)
+            && !matches!(
+                req.config.training_mode,
+                kiln_train::opd::OpdTrainingMode::OffPolicy
+            )
+        {
+            return Err(ApiError::training_invalid_request(
+                "OPD dataset_path (teacher-logprob JSONL) requires config.training_mode = \
+                 \"off_policy\"; for on-policy training on pi sessions use an \
+                 `agent_traces:` selector instead"
+                    .to_string(),
+            ));
+        }
+    }
+    for (i, prompt) in req.prompts.iter().enumerate() {
+        if prompt.messages.is_empty() {
+            return Err(ApiError::training_invalid_request(format!(
+                "OPD prompt {i} has no messages"
+            )));
+        }
+    }
     if req.config.top_k == 0 {
         return Err(ApiError::training_invalid_request(
             "OPD top_k must be > 0".to_string(),
@@ -748,6 +781,14 @@ async fn submit_distill_refresh(
             "DistillRefresh: `behavioural_teacher` alias must be non-empty".to_string(),
         ));
     }
+    super::teachers::require_registered_teacher(
+        &state,
+        &req.behavioural_teacher,
+        format!(
+            "DistillRefresh: behavioural_teacher alias '{}' is not registered",
+            req.behavioural_teacher
+        ),
+    )?;
     if !(0.0..=1.0).contains(&req.require_if_eval_recovery) {
         return Err(ApiError::training_invalid_request(
             "require_if_eval_recovery must be in [0.0, 1.0]".to_string(),
@@ -772,6 +813,17 @@ async fn submit_distill_refresh(
     if matches!(state.backend.as_ref(), ModelBackend::Mock { .. }) {
         return Err(ApiError::mock_mode_no_training());
     }
+
+    // Preflight BEFORE the tracking insert — a 413 here must not leave an
+    // orphaned Queued entry in the jobs map.
+    let reserved_bytes = distill_working_set_reservation(
+        &state,
+        match &req.new_data {
+            kiln_train::NewKnowledgeSource::Inline { examples } => examples.as_slice(),
+            kiln_train::NewKnowledgeSource::Dataset { .. } => &[],
+        },
+        &req.config,
+    )?;
 
     let info = TrainingJobInfo {
         job_id: job_id.clone(),
@@ -804,7 +856,7 @@ async fn submit_distill_refresh(
         let mut q = state.training_queue.lock().unwrap();
         q.push(QueueEntry {
             job_id: job_id.clone(),
-            reserved_bytes: 0, // no preflight estimate for distill refresh
+            reserved_bytes,
             job: QueuedJob::DistillRefresh(req),
         });
         q.len()
@@ -836,7 +888,22 @@ async fn submit_distill_merge(
         ));
     }
     super::adapters::validate_adapter_name(&req.name)?;
+    // A source adapter that doesn't exist on disk is a typo — fail now,
+    // not after the job dequeues and silently falls back to the base
+    // model for that source's prompts.
+    for source in &req.sources {
+        super::adapters::validate_adapter_name(&source.adapter)?;
+        let dir = state.adapter_dir.join(&source.adapter);
+        if !dir.is_dir() {
+            return Err(ApiError::training_invalid_request(format!(
+                "distill_merge: source adapter `{}` not found at {}",
+                source.adapter,
+                dir.display()
+            )));
+        }
+    }
     enforce_queue_caps(&state)?;
+    let reserved_bytes = distill_working_set_reservation(&state, &[], &req.config)?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();
     let auto_load = req.config.auto_load;
@@ -845,6 +912,7 @@ async fn submit_distill_merge(
         &job_id,
         &adapter_name,
         auto_load,
+        reserved_bytes,
         QueuedJob::DistillMerge(req),
     );
     Ok(Json(TrainingResponse {
@@ -867,8 +935,20 @@ async fn submit_distill_pump(
             "distill/pump: `teacher` alias must be non-empty".to_string(),
         ));
     }
+    super::teachers::require_registered_teacher(
+        &state,
+        &req.teacher,
+        format!("distill/pump: teacher alias '{}' is not registered", req.teacher),
+    )?;
     super::adapters::validate_adapter_name(&req.name)?;
     enforce_queue_caps(&state)?;
+    let inline_prompts: &[kiln_train::opd::OpdPrompt] = match &req.mode {
+        kiln_train::DistillPumpMode::Examples { examples } => examples.as_slice(),
+        // Domain/Wide resolve to short seed prompts at run time; the
+        // rollout budget dominates the working set.
+        _ => &[],
+    };
+    let reserved_bytes = distill_working_set_reservation(&state, inline_prompts, &req.config)?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();
     let auto_load = req.config.auto_load;
@@ -877,6 +957,7 @@ async fn submit_distill_pump(
         &job_id,
         &adapter_name,
         auto_load,
+        reserved_bytes,
         QueuedJob::DistillPump(req),
     );
     Ok(Json(TrainingResponse {
@@ -901,6 +982,11 @@ async fn submit_distill_self(
     }
     super::adapters::validate_adapter_name(&req.name)?;
     enforce_queue_caps(&state)?;
+    let reserved_bytes = distill_working_set_reservation(
+        &state,
+        req.prompts.as_deref().unwrap_or(&[]),
+        &req.config,
+    )?;
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req.name.clone();
     let auto_load = req.config.auto_load;
@@ -909,6 +995,7 @@ async fn submit_distill_self(
         &job_id,
         &adapter_name,
         auto_load,
+        reserved_bytes,
         QueuedJob::DistillSelf(req),
     );
     Ok(Json(TrainingResponse {
@@ -936,6 +1023,35 @@ pub(crate) fn enforce_queue_caps(state: &AppState) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// Working-set preflight for distill-family jobs: longest inline prompt
+/// plus the rollout budget, same estimator SFT/GRPO/OPD use. Distill jobs
+/// used to enqueue with `reserved_bytes: 0` — no VRAM check, no governor
+/// reservation — on a host that has been hard-crashed by exactly that
+/// class of unchecked training allocation before.
+fn distill_working_set_reservation(
+    state: &AppState,
+    inline_prompts: &[kiln_train::opd::OpdPrompt],
+    config: &kiln_train::OpdConfig,
+) -> Result<u64, ApiError> {
+    let max_seq_len = training_preflight::approximate_max_seq_len_opd(
+        inline_prompts,
+        config.max_tokens,
+        Some(state.tokenizer.as_ref()),
+    );
+    enforce_training_preflight(
+        state,
+        max_seq_len,
+        EstimateOptions {
+            max_supervised_tokens: None,
+            recompute_boundaries: training_preflight::recompute_checkpoint_boundaries_for_seq_len(
+                max_seq_len,
+            ),
+        },
+        config.lora_rank,
+        false,
+    )
+}
+
 /// Shared registration+enqueue for distill_* endpoints. Same shape as
 /// `submit_distill_refresh`/`submit_opd` but inlined for the simpler
 /// distill variants.
@@ -944,6 +1060,7 @@ fn register_and_enqueue_distill(
     job_id: &str,
     adapter_name: &str,
     auto_load: bool,
+    reserved_bytes: u64,
     job: QueuedJob,
 ) {
     let info = TrainingJobInfo {
@@ -973,7 +1090,7 @@ fn register_and_enqueue_distill(
     let mut q = state.training_queue.lock().unwrap();
     q.push(QueueEntry {
         job_id: job_id.to_string(),
-        reserved_bytes: 0,
+        reserved_bytes,
         job,
     });
 }

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -668,6 +668,7 @@ fn run_opd(
                 tokenizer,
                 weights,
                 model_config,
+                adapter_dir,
                 req.config.top_k,
                 req.config.training_mode,
             )?,
@@ -1070,30 +1071,57 @@ fn build_self_distill_teacher(
 /// Build a `FixtureLogitSource` populated from a local model forward
 /// pass — the §3.2 in-process LocalTeacher made concrete. Each prompt
 /// is tokenized like SFT (chat template with active assistant tokens
-/// marked), the model is run forward once per prompt with no LoRA
-/// applied (base-model teacher per Lu 2025's behavioural-recovery
-/// recipe), and the top-K logprobs at active positions are inserted
-/// into the fixture keyed by tokens_hash.
+/// marked), the model is run forward once per prompt — wearing the
+/// spec's `adapter` LoRA when one is registered, base model otherwise —
+/// and the top-K logprobs at active positions are inserted into the
+/// fixture keyed by tokens_hash.
+#[allow(clippy::too_many_arguments)]
 fn build_local_teacher_for(
     spec: &crate::api::teachers::TeacherSpec,
     prompts: &[kiln_train::opd::OpdPrompt],
     tokenizer: &kiln_core::tokenizer::KilnTokenizer,
     weights: &kiln_model::forward::GpuWeights,
     model_config: &kiln_core::config::ModelConfig,
+    adapter_dir: &std::path::Path,
     top_k: usize,
     training_mode: kiln_train::opd::OpdTrainingMode,
 ) -> std::result::Result<std::sync::Arc<dyn kiln_train::logit_source::LogitSource>, String> {
+    // The teacher's LoRA. A spec that names an adapter MUST wear it —
+    // the silent fall-through to `None` here is what made
+    // `distill_refresh` toward a prior self and `self_improve`'s
+    // judge-as-teacher distil toward the bare base model while claiming
+    // otherwise. Registration validates existence, so a load failure
+    // here is a hard error, not a quiet downgrade.
+    let teacher_lora = match spec.adapter.as_deref() {
+        Some(name) => {
+            let dir = adapter_dir.join(name);
+            let device = weights.embed_tokens.device().clone();
+            Some(
+                kiln_model::lora_loader::LoraWeights::load(&dir, model_config.num_layers, device)
+                    .map_err(|e| {
+                        format!(
+                            "teacher '{}' is registered to wear adapter '{name}' but it \
+                             failed to load from {}: {e}",
+                            spec.alias,
+                            dir.display()
+                        )
+                    })?,
+            )
+        }
+        None => None,
+    };
+
     // ON-POLICY self-distillation (#31): the student generates fresh rollouts, so
     // the teacher must score ARBITRARY token sequences live — a prompt-hash
     // fixture would miss every rollout. Return a LiveLocalTeacher that holds a
     // cheap (Arc-backed) clone of the loaded model and runs a detached forward on
-    // demand. Base-model teacher (no LoRA), per the behavioural-recovery recipe.
+    // demand.
     if matches!(training_mode, kiln_train::opd::OpdTrainingMode::OnPolicy) {
         return Ok(std::sync::Arc::new(kiln_train::opd::LiveLocalTeacher::new(
             spec.alias.clone(),
             weights.clone(),
             model_config.clone(),
-            None,
+            teacher_lora,
             top_k,
         )));
     }
@@ -1129,7 +1157,7 @@ fn build_local_teacher_for(
         &prompts_and_active,
         weights,
         model_config,
-        None,
+        teacher_lora.as_ref(),
         top_k,
         spec.tokenizer_hash.clone(),
     )
@@ -1148,7 +1176,7 @@ pub const DEFAULT_REMOTE_COST_CAP_USD: f64 = 25.0;
 /// adding a provider field — the §3.2 registry is intentionally
 /// minimal. Defaults to `Vllm` (the most common OSS top_logprobs
 /// endpoint shape) when no host token matches.
-fn guess_remote_provider(url: &str) -> kiln_train::RemoteProvider {
+pub(crate) fn guess_remote_provider(url: &str) -> kiln_train::RemoteProvider {
     let lower = url.to_ascii_lowercase();
     if lower.contains("openrouter.ai") {
         kiln_train::RemoteProvider::OpenRouter
@@ -1323,6 +1351,7 @@ fn run_distill_refresh(
             tokenizer,
             weights,
             model_config,
+            adapter_dir,
             req.config.top_k,
             // Distill refresh phase 2 scores fixed teacher turns — fixture path.
             kiln_train::opd::OpdTrainingMode::OffPolicy,
@@ -1681,6 +1710,7 @@ fn run_distill_pump(
             tokenizer,
             weights,
             model_config,
+            adapter_dir,
             req.config.top_k,
             // Distill pump pre-computes against fixed teacher turns — fixture path.
             kiln_train::opd::OpdTrainingMode::OffPolicy,

--- a/crates/kiln-server/tests/agent_teacher_validation.rs
+++ b/crates/kiln-server/tests/agent_teacher_validation.rs
@@ -311,3 +311,176 @@ async fn drift_check_rejects_path_traversal_judge_names() {
     assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
     assert_eq!(response["error"]["code"], "invalid_adapter_name", "{response}");
 }
+
+// ── teacher registration honesty (adapter-wearing + provider gates) ──
+
+/// `adapter` only means something on Local teachers — and it must exist.
+/// Both rejections happen at REGISTRATION, not at job dequeue hours later.
+#[tokio::test]
+async fn teacher_registration_validates_adapter_field() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+
+    // adapter on a fixture teacher: rejected.
+    let (status, response) = post(
+        &app,
+        "/v1/teachers",
+        json!({"alias": "t@f", "kind": "fixture", "model_id": "m", "adapter": "judge-v1"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("kind=local"),
+        "{response}"
+    );
+
+    // Local teacher wearing a missing adapter: rejected with the path.
+    let (status, response) = post(
+        &app,
+        "/v1/teachers",
+        json!({"alias": "self@local", "kind": "local", "model_id": "m", "adapter": "ghost"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert!(
+        response["error"]["message"].as_str().unwrap().contains("ghost"),
+        "{response}"
+    );
+
+    // Local teacher wearing an adapter that exists: accepted, echoed back.
+    std::fs::create_dir(state.adapter_dir.join("prior-self")).unwrap();
+    let (status, response) = post(
+        &app,
+        "/v1/teachers",
+        json!({"alias": "self@local", "kind": "local", "model_id": "m", "adapter": "prior-self"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+    assert_eq!(response["spec"]["adapter"], "prior-self", "{response}");
+}
+
+/// Remote teachers whose URL resolves to a provider the runtime can't
+/// serve ("not yet wired") must be rejected at registration with the
+/// supported list — not enqueued into jobs guaranteed to die.
+#[tokio::test]
+async fn teacher_registration_rejects_unwired_remote_providers() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+
+    let (status, response) = post(
+        &app,
+        "/v1/teachers",
+        json!({"alias": "t@tgi", "kind": "remote", "model_id": "m", "url": "https://tgi.example.com"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(message.contains("vLLM"), "names the supported providers: {message}");
+
+    // A vLLM-shaped URL registers fine.
+    let (status, response) = post(
+        &app,
+        "/v1/teachers",
+        json!({"alias": "t@vllm", "kind": "remote", "model_id": "m", "url": "https://vllm.example.com"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response}");
+}
+
+// ── OPD / distill submission fail-fast ───────────────────────────────
+
+/// A typo'd teacher alias on /v1/train/opd fails at submission with the
+/// registered list, before the mock/queue gates.
+#[tokio::test]
+async fn opd_submission_rejects_unregistered_teacher() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_teacher(&app, "real@t").await;
+    let (status, response) = post(
+        &app,
+        "/v1/train/opd",
+        json!({
+            "prompts": [{"messages": [{"role": "user", "content": "hi"}]}],
+            "teacher": "typo@t",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert_eq!(response["error"]["code"], "teacher_not_registered", "{response}");
+    assert!(
+        response["error"]["message"].as_str().unwrap().contains("typo@t"),
+        "{response}"
+    );
+    assert_no_jobs(&state, "opd unregistered teacher");
+}
+
+/// dataset_path (pre-scored off-policy teacher JSONL) with the default
+/// on-policy mode is a guaranteed worker failure — reject at submission
+/// and point at the agent_traces alternative.
+#[tokio::test]
+async fn opd_submission_rejects_dataset_path_mode_mismatch() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    register_teacher(&app, "real@t").await;
+    let (status, response) = post(
+        &app,
+        "/v1/train/opd",
+        json!({
+            "dataset_path": "/tmp/teacher.jsonl",
+            "teacher": "real@t",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    let message = response["error"]["message"].as_str().unwrap();
+    assert!(message.contains("off_policy"), "{message}");
+    assert!(message.contains("agent_traces"), "offers the on-policy path: {message}");
+    assert_no_jobs(&state, "opd mode mismatch");
+}
+
+/// distill/pump with an unregistered teacher fails at submission.
+#[tokio::test]
+async fn distill_pump_rejects_unregistered_teacher() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    let (status, response) = post(
+        &app,
+        "/v1/distill/pump",
+        json!({"name": "pumped", "teacher": "nope@t", "mode": {"domain": "math"}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert_eq!(response["error"]["code"], "teacher_not_registered", "{response}");
+    assert_no_jobs(&state, "pump unregistered teacher");
+}
+
+/// distill_merge with a source adapter that doesn't exist on disk is a
+/// typo — fail at submission instead of silently distilling that
+/// source's prompts from the base model after dequeue.
+#[tokio::test]
+async fn distill_merge_rejects_missing_source_adapters() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+    std::fs::create_dir(state.adapter_dir.join("exists")).unwrap();
+    let (status, response) = post(
+        &app,
+        "/v1/adapters/distill_merge",
+        json!({
+            "name": "merged",
+            "sources": [
+                {"adapter": "exists", "weight": 1.0},
+                {"adapter": "missing", "weight": 1.0}
+            ],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{response}");
+    assert!(
+        response["error"]["message"].as_str().unwrap().contains("missing"),
+        "{response}"
+    );
+    assert_no_jobs(&state, "merge missing source");
+}


### PR DESCRIPTION
## Summary

Two classes of silent wrongness in the distillation engine, both verified in the audit:

### Semantic: a Local teacher always meant the bare base model

`TeacherSpec` had no `adapter` field and `build_local_teacher_for` hardcoded `None` for the LoRA — so the two flagship continual-learning shapes were quietly broken: **`distill_refresh` toward "my prior self"** and **`self_improve`'s judge-as-teacher** both distilled toward the base model while claiming otherwise. The plumbing already existed (`build_local_teacher_fixture` and `LiveLocalTeacher` both accept a LoRA; `distill_merge` loads source LoRAs as teachers) — it was never connected.

Now: `TeacherSpec.adapter` names the LoRA the teacher wears. Registration validates it (Local-only, must exist on disk); resolution loads it and **hard-fails on a load error** instead of silently downgrading to base — a teacher registered to wear an adapter must wear it.

### Fail-fast: submission-time validation + distill preflight

A typo'd alias, an unsupported remote provider, or a `dataset_path`/mode mismatch was discovered only at worker dequeue — possibly hours later behind a queue. And the `distill_*` family enqueued with `reserved_bytes: 0` (no VRAM preflight, no governor reservation) on a host that has been hard-crashed by exactly that class of unchecked allocation before.

- `POST /v1/teachers` rejects remote URLs resolving to unwired providers (only vLLM/sglang `prompt_logprobs` exist today), naming the supported list.
- `/v1/train/opd` resolves the teacher alias at submission, validates `dataset_path`↔`training_mode` (pointing at `agent_traces:` selectors for on-policy), and rejects empty prompt messages.
- `distill/refresh` + `distill/pump` validate teacher aliases; `distill_merge` validates every source adapter exists.
- All `distill_*` submissions run the same working-set preflight as SFT/GRPO/OPD and carry a real governor reservation; ordering fixed so a 413 can't orphan a Queued tracking entry.
- `require_registered_teacher` shared from `teachers.rs`; the stale "OPD runtime not yet implemented" module doc replaced.

## Verification

6 new integration tests (adapter-field validation incl. exists-on-disk + non-local rejection; unwired-provider rejection; OPD unregistered-teacher + mode-mismatch; pump unregistered teacher; merge missing source) + full `kiln-server` suite green. Natural attended follow-up: one short adapter-wearing-teacher OPD step on the rig, confirming divergent teacher logits vs. base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)