### PR TITLE
Durable corrections store: the flywheel's core dataset stops living in one browser tab

### DIFF
--- a/crates/kiln-server/src/api/corrections.rs
+++ b/crates/kiln-server/src/api/corrections.rs
@@ -1,0 +1,373 @@
+//! Durable corrections store — the server-side home of the dashboard's
+//! corrections basket.
+//!
+//! The basket is, in the dashboard's own words, "the literal mechanism of
+//! 'your model gets better every time you use it'" — and until this module
+//! existed it lived ONLY in one browser's localStorage: invisible to other
+//! machines, unreachable by pi or any script, and (worst) the hand-written
+//! ideal answers were DELETED after training, so the user's most valuable
+//! data — what the model should have said, in their words — ended up
+//! existing nowhere. The repo's own philosophy is "the dataset is the
+//! asset"; this store makes corrections one.
+//!
+//! Storage: one JSON row per line at
+//! `<adapter_dir>/.eval/corrections/data.jsonl`, rewritten atomically on
+//! mutation (the basket is human-scale — tens to hundreds of rows).
+//! Trained rows are MARKED (`trained_into`), never deleted.
+//!
+//! | Method | Path                          | Purpose                          |
+//! |--------|-------------------------------|----------------------------------|
+//! | GET    | /v1/corrections               | List (active by default;         |
+//! |        |                               | `?include_trained=1` for all)    |
+//! | POST   | /v1/corrections               | Upsert one row by `request_id`   |
+//! | DELETE | /v1/corrections/{request_id}  | Remove one row                   |
+//! | DELETE | /v1/corrections               | Clear active (untrained) rows    |
+
+use std::path::{Path, PathBuf};
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::routing::{delete, get};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// One captured correction. Field names mirror the dashboard basket so the
+/// write-through is mechanical; pi (or any script) can file rows with the
+/// same shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorrectionRow {
+    /// Capture identity — the originating request id (chat completion id,
+    /// eval outcome key, or a caller-chosen unique string). Upsert key.
+    pub request_id: String,
+    /// Which client produced the original answer (pi, opencode, eval:suite).
+    #[serde(default)]
+    pub agent: String,
+    /// Serving adapter at capture time (`None`/"base" = base model).
+    #[serde(default)]
+    pub adapter: Option<String>,
+    /// The user prompt the model answered.
+    pub user: String,
+    /// What the model actually answered.
+    #[serde(default)]
+    pub original: String,
+    /// What it SHOULD have answered — the human-authored asset.
+    #[serde(default)]
+    pub ideal: String,
+    /// Captured from a preview-only source (text may be cut short).
+    #[serde(default)]
+    pub truncated: bool,
+    /// RFC3339 capture time. Stamped server-side on first insert.
+    #[serde(default)]
+    pub created_at: String,
+    /// Adapter name this row trained into, once trained. Marked, not
+    /// deleted — the ideal answer outlives the job that consumed it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trained_into: Option<String>,
+    /// RFC3339 time of the training submission that consumed this row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trained_at: Option<String>,
+}
+
+/// Append-only-in-spirit JSONL store, rewritten atomically per mutation.
+pub struct CorrectionsStore {
+    dir: PathBuf,
+}
+
+impl CorrectionsStore {
+    pub fn for_state(state: &AppState) -> Self {
+        Self {
+            dir: state.adapter_dir.join(".eval").join("corrections"),
+        }
+    }
+
+    fn data_path(&self) -> PathBuf {
+        self.dir.join("data.jsonl")
+    }
+
+    pub fn list(&self) -> Vec<CorrectionRow> {
+        let Ok(text) = std::fs::read_to_string(self.data_path()) else {
+            return Vec::new();
+        };
+        text.lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| match serde_json::from_str::<CorrectionRow>(l) {
+                Ok(row) => Some(row),
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping malformed corrections row");
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn write_all(&self, rows: &[CorrectionRow]) -> Result<(), String> {
+        std::fs::create_dir_all(&self.dir).map_err(|e| format!("{e}"))?;
+        let mut body = String::new();
+        for row in rows {
+            body.push_str(&serde_json::to_string(row).map_err(|e| format!("{e}"))?);
+            body.push('\n');
+        }
+        kiln_resource::locked_atomic_write(&self.data_path(), body.as_bytes())
+            .map_err(|e| format!("{e}"))
+    }
+
+    /// Insert or update by `request_id`. First insert stamps `created_at`;
+    /// updates preserve it (and `trained_*` unless the caller sets them).
+    pub fn upsert(&self, mut row: CorrectionRow) -> Result<CorrectionRow, String> {
+        let mut rows = self.list();
+        match rows.iter_mut().find(|r| r.request_id == row.request_id) {
+            Some(existing) => {
+                if row.created_at.is_empty() {
+                    row.created_at = existing.created_at.clone();
+                }
+                if row.trained_into.is_none() {
+                    row.trained_into = existing.trained_into.clone();
+                    row.trained_at = existing.trained_at.clone();
+                }
+                *existing = row.clone();
+            }
+            None => {
+                if row.created_at.is_empty() {
+                    row.created_at = chrono::Utc::now().to_rfc3339();
+                }
+                rows.insert(0, row.clone());
+            }
+        }
+        self.write_all(&rows)?;
+        Ok(row)
+    }
+
+    pub fn remove(&self, request_id: &str) -> Result<bool, String> {
+        let mut rows = self.list();
+        let before = rows.len();
+        rows.retain(|r| r.request_id != request_id);
+        let removed = rows.len() < before;
+        if removed {
+            self.write_all(&rows)?;
+        }
+        Ok(removed)
+    }
+
+    /// Remove every ACTIVE (untrained) row. Trained rows are history and
+    /// survive a basket clear.
+    pub fn clear_active(&self) -> Result<usize, String> {
+        let mut rows = self.list();
+        let before = rows.len();
+        rows.retain(|r| r.trained_into.is_some());
+        let removed = before - rows.len();
+        if removed > 0 {
+            self.write_all(&rows)?;
+        }
+        Ok(removed)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ListQuery {
+    #[serde(default)]
+    include_trained: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ListResponse {
+    corrections: Vec<CorrectionRow>,
+}
+
+async fn list_corrections(
+    State(state): State<AppState>,
+    Query(q): Query<ListQuery>,
+) -> Json<ListResponse> {
+    let include_trained = matches!(q.include_trained.as_deref(), Some("1" | "true" | "yes"));
+    let mut corrections = CorrectionsStore::for_state(&state).list();
+    if !include_trained {
+        corrections.retain(|r| r.trained_into.is_none());
+    }
+    Json(ListResponse { corrections })
+}
+
+async fn upsert_correction(
+    State(state): State<AppState>,
+    Json(row): Json<CorrectionRow>,
+) -> Result<Json<CorrectionRow>, ApiError> {
+    if row.request_id.trim().is_empty() {
+        return Err(ApiError::training_invalid_request(
+            "correction request_id must be non-empty".to_string(),
+        ));
+    }
+    if row.user.trim().is_empty() {
+        return Err(ApiError::training_invalid_request(
+            "correction `user` (the prompt) must be non-empty".to_string(),
+        ));
+    }
+    CorrectionsStore::for_state(&state)
+        .upsert(row)
+        .map(Json)
+        .map_err(|e| ApiError::internal(format!("corrections store: {e}")))
+}
+
+async fn delete_correction(
+    State(state): State<AppState>,
+    AxumPath(request_id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let removed = CorrectionsStore::for_state(&state)
+        .remove(&request_id)
+        .map_err(|e| ApiError::internal(format!("corrections store: {e}")))?;
+    if removed {
+        Ok(Json(serde_json::json!({ "status": "deleted", "request_id": request_id })))
+    } else {
+        Err(ApiError::training_invalid_request(format!(
+            "no correction with request_id {request_id:?}"
+        )))
+    }
+}
+
+async fn clear_corrections(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let removed = CorrectionsStore::for_state(&state)
+        .clear_active()
+        .map_err(|e| ApiError::internal(format!("corrections store: {e}")))?;
+    Ok(Json(serde_json::json!({ "status": "cleared", "removed": removed })))
+}
+
+/// Mark a set of rows as trained into `adapter`. Called by the dashboard
+/// right after a successful corrections-train submit; the rows stay in
+/// the store as history.
+#[derive(Debug, Deserialize)]
+struct MarkTrainedRequest {
+    request_ids: Vec<String>,
+    adapter: String,
+}
+
+async fn mark_trained(
+    State(state): State<AppState>,
+    Json(req): Json<MarkTrainedRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let store = CorrectionsStore::for_state(&state);
+    let mut rows = store.list();
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut marked = 0usize;
+    for row in rows.iter_mut() {
+        if req.request_ids.iter().any(|id| id == &row.request_id) {
+            row.trained_into = Some(req.adapter.clone());
+            row.trained_at = Some(now.clone());
+            marked += 1;
+        }
+    }
+    if marked > 0 {
+        store
+            .write_all(&rows)
+            .map_err(|e| ApiError::internal(format!("corrections store: {e}")))?;
+    }
+    Ok(Json(serde_json::json!({ "status": "marked", "marked": marked })))
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/v1/corrections",
+            get(list_corrections)
+                .post(upsert_correction)
+                .delete(clear_corrections),
+        )
+        .route("/v1/corrections/{request_id}", delete(delete_correction))
+        .route(
+            "/v1/corrections/mark_trained",
+            axum::routing::post(mark_trained),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(dir: &Path) -> CorrectionsStore {
+        CorrectionsStore {
+            dir: dir.join(".eval").join("corrections"),
+        }
+    }
+
+    fn row(id: &str, ideal: &str) -> CorrectionRow {
+        CorrectionRow {
+            request_id: id.to_string(),
+            agent: "pi".to_string(),
+            adapter: None,
+            user: "what is 2+2".to_string(),
+            original: "5".to_string(),
+            ideal: ideal.to_string(),
+            truncated: false,
+            created_at: String::new(),
+            trained_into: None,
+            trained_at: None,
+        }
+    }
+
+    #[test]
+    fn upsert_stamps_created_at_once_and_updates_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path());
+
+        let first = s.upsert(row("r1", "")).unwrap();
+        assert!(!first.created_at.is_empty());
+
+        let updated = s.upsert(row("r1", "4")).unwrap();
+        assert_eq!(updated.created_at, first.created_at, "created_at preserved");
+        let rows = s.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].ideal, "4");
+    }
+
+    #[test]
+    fn trained_rows_survive_clear_and_are_hidden_from_active_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path());
+        s.upsert(row("done", "4")).unwrap();
+        s.upsert(row("pending", "")).unwrap();
+
+        // Mark "done" trained.
+        let mut rows = s.list();
+        rows.iter_mut()
+            .find(|r| r.request_id == "done")
+            .unwrap()
+            .trained_into = Some("fixes-v1".into());
+        s.write_all(&rows).unwrap();
+
+        // Clearing removes only the untrained row.
+        assert_eq!(s.clear_active().unwrap(), 1);
+        let remaining = s.list();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].request_id, "done");
+        assert_eq!(remaining[0].trained_into.as_deref(), Some("fixes-v1"));
+    }
+
+    #[test]
+    fn upsert_preserves_trained_marker_when_caller_omits_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path());
+        let mut r = row("r1", "4");
+        r.trained_into = Some("fixes-v1".into());
+        s.upsert(r).unwrap();
+        // A later ideal-edit upsert without trained fields keeps history.
+        s.upsert(row("r1", "four")).unwrap();
+        let rows = s.list();
+        assert_eq!(rows[0].ideal, "four");
+        assert_eq!(rows[0].trained_into.as_deref(), Some("fixes-v1"));
+    }
+
+    #[test]
+    fn remove_and_persistence_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path());
+        s.upsert(row("a", "x")).unwrap();
+        s.upsert(row("b", "y")).unwrap();
+        assert!(s.remove("a").unwrap());
+        assert!(!s.remove("a").unwrap());
+        // Fresh store handle reads the same file.
+        let s2 = store(dir.path());
+        let rows = s2.list();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].request_id, "b");
+    }
+}

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -9,6 +9,7 @@ mod adapters;
 pub mod agent_traces;
 pub(crate) mod cache;
 pub(crate) mod completions;
+pub mod corrections;
 mod config;
 mod debug_model_state;
 mod eval;
@@ -72,6 +73,7 @@ pub fn router(state: AppState) -> Router {
             crate::request_log::tap,
         )))
         .merge(adapters::routes())
+        .merge(corrections::routes())
         .merge(teachers::routes())
         .merge(recipes::routes())
         .merge(cache::routes())

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -5653,9 +5653,15 @@ function refreshRequestHealth() {
 /* === Corrections basket — the flywheel's core loop, one-click =============
    pi gives a bad answer → "Use as correction" APPENDS it here (not overwrite)
    → you fix the ideal answer inline → "Train" turns the whole basket into ONE
-   SFT job and hot-swaps the result. localStorage-backed so corrections
-   accumulate across a coding session and survive reloads. This is the literal
-   mechanism of "your model gets better every time you use it". */
+   SFT job and hot-swaps the result. This is the literal mechanism of "your
+   model gets better every time you use it".
+
+   Durability: the server's /v1/corrections store is the source of truth —
+   corrections survive across browsers/machines, pi can file them
+   programmatically, and trained rows are MARKED (kept as history with their
+   hand-written ideal answers) rather than deleted. localStorage remains a
+   write-behind cache so the basket still works in the static demo and
+   through transient server hiccups. */
 const CORR_KEY = 'kiln.corrections.v1';
 let correctionsBasket = [];
 // A persistent "training started" receipt shown in the Corrections card after a
@@ -5666,6 +5672,53 @@ function loadCorrections() {
   catch { correctionsBasket = []; }
 }
 function saveCorrections() { try { localStorage.setItem(CORR_KEY, JSON.stringify(correctionsBasket)); } catch {} }
+// ── server write-through (best-effort; the local basket never blocks) ──
+function corrRowForServer(c) {
+  return {
+    request_id: c.request_id,
+    agent: c.agent || '',
+    adapter: (c.adapter && c.adapter !== 'base') ? c.adapter : null,
+    user: c.user || '',
+    original: c.original || '',
+    ideal: c.ideal || '',
+    truncated: !!c.truncated,
+  };
+}
+function corrSyncUpsert(c) {
+  try {
+    api('/v1/corrections', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(corrRowForServer(c)) }).catch(() => {});
+  } catch (_) {}
+}
+function corrSyncRemove(rid) {
+  try { api('/v1/corrections/' + encodeURIComponent(rid), { method: 'DELETE' }).catch(() => {}); } catch (_) {}
+}
+// Debounced upsert per row so typing in the ideal editor doesn't spam the
+// server — flushes 800ms after the last keystroke.
+const corrSyncTimers = {};
+function corrSyncUpsertDebounced(c) {
+  clearTimeout(corrSyncTimers[c.request_id]);
+  corrSyncTimers[c.request_id] = setTimeout(() => corrSyncUpsert(c), 800);
+}
+// On load, the server list wins: rows existing there (incl. ones captured
+// from another browser or filed by pi) replace the local cache; local-only
+// rows (offline captures) are pushed up.
+async function corrSyncFromServer() {
+  let server;
+  try { server = await api('/v1/corrections'); } catch (_) { return; }
+  if (!server || !Array.isArray(server.corrections)) return;
+  const serverRows = server.corrections.map(r => ({
+    request_id: r.request_id, agent: r.agent || 'client', ts: Date.parse(r.created_at) || Date.now(),
+    model: '', adapter: r.adapter || 'base', user: r.user || '',
+    original: r.original || '', truncated: !!r.truncated, ideal: r.ideal || '',
+  }));
+  const serverIds = new Set(serverRows.map(r => r.request_id));
+  const localOnly = correctionsBasket.filter(c => !serverIds.has(c.request_id));
+  localOnly.forEach(corrSyncUpsert);
+  correctionsBasket = serverRows.concat(localOnly);
+  saveCorrections();
+  renderCorrections();
+}
 // Shared basket insert for every capture surface (recent requests, eval
 // drill). Dedupes on request_id; persists + repaints + toasts.
 function addCorrectionItem(item) {
@@ -5675,6 +5728,7 @@ function addCorrectionItem(item) {
   }
   correctionsBasket.unshift(item);
   saveCorrections();
+  corrSyncUpsert(item);
   renderCorrections();
   toast(`Added to corrections (${correctionsBasket.length}) — ${item.ideal ? 'review the ideal answer, then Train' : 'write the ideal answer, then Train'}`, 'ok');
   return true;
@@ -5725,10 +5779,11 @@ function addCorrectionFromEvalOutcome(o, example, scorerKind) {
     ideal: seedIdeal,
   });
 }
-function removeCorrection(rid) { correctionsBasket = correctionsBasket.filter(c => c.request_id !== rid); saveCorrections(); renderCorrections(); }
+function removeCorrection(rid) { correctionsBasket = correctionsBasket.filter(c => c.request_id !== rid); saveCorrections(); corrSyncRemove(rid); renderCorrections(); }
 function clearCorrections() {
   if (correctionsBasket.length && !confirm(`Discard ${correctionsBasket.length} correction${correctionsBasket.length === 1 ? '' : 's'}?`)) return;
   correctionsBasket = []; saveCorrections(); renderCorrections();
+  try { api('/v1/corrections', { method: 'DELETE' }).catch(() => {}); } catch (_) {}
 }
 // A correction trains ONLY if you supplied a genuinely different answer. Empty
 // (untouched) or identical-to-original (reverted) is excluded — the whole point
@@ -5784,13 +5839,13 @@ function renderCorrections() {
   }).join('');
   list.querySelectorAll('[data-corr-ideal]').forEach(ta => ta.addEventListener('input', () => {
     const c = correctionsBasket.find(x => x.request_id === ta.dataset.corrIdeal);
-    if (c) { c.ideal = ta.value; saveCorrections(); markCorrState(c); updateCorrFoot(); }
+    if (c) { c.ideal = ta.value; saveCorrections(); corrSyncUpsertDebounced(c); markCorrState(c); updateCorrFoot(); }
   }));
   list.querySelectorAll('[data-corr-seed]').forEach(b => b.addEventListener('click', () => {
     const c = correctionsBasket.find(x => x.request_id === b.dataset.corrSeed);
     if (!c) return;
     const ta = document.getElementById('corr-ideal-' + c.request_id);
-    if (ta) { ta.value = c.original; c.ideal = c.original; saveCorrections(); markCorrState(c); updateCorrFoot();
+    if (ta) { ta.value = c.original; c.ideal = c.original; saveCorrections(); corrSyncUpsertDebounced(c); markCorrState(c); updateCorrFoot();
       ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
   }));
   list.querySelectorAll('[data-corr-remove]').forEach(b => b.addEventListener('click', () => removeCorrection(b.dataset.corrRemove)));
@@ -5844,10 +5899,17 @@ async function trainFromCorrections() {
     const body = { examples, config: { output_name: name, auto_load: true, epochs: 3, lora_rank: 8 } };
     const res = await api('/v1/train/sft', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
     toast(res.message || `Training ${name} from ${examples.length} correction${examples.length === 1 ? '' : 's'} — it will hot-swap in when done`, 'ok');
-    // Remove ONLY the corrections we actually trained on. Anything still
-    // awaiting an answer stays in the basket so no hand-written work is lost
-    // if a later job is submitted.
+    // Remove the trained corrections from the ACTIVE basket only — the
+    // server keeps them, marked with the adapter they trained into, so
+    // the hand-written ideal answers remain an asset (and re-trainable)
+    // instead of vanishing with the job. Anything still awaiting an
+    // answer stays in the basket so no hand-written work is lost.
     const trained = new Set(trainable.map(c => c.request_id));
+    trainable.forEach(c => { corrSyncUpsert(c); });
+    try {
+      api('/v1/corrections/mark_trained', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ request_ids: [...trained], adapter: name }) }).catch(() => {});
+    } catch (_) {}
     correctionsBasket = correctionsBasket.filter(c => !trained.has(c.request_id));
     // Leave a persistent in-card receipt instead of a disorienting auto-jump —
     // the user stays in context and chooses when to view the job. Keep the
@@ -5861,6 +5923,9 @@ async function trainFromCorrections() {
 function initCorrections() {
   loadCorrections();
   renderCorrections();
+  // Pull the durable store: corrections captured on another machine (or
+  // filed by pi via POST /v1/corrections) appear here too.
+  corrSyncFromServer();
   document.getElementById('corr-clear')?.addEventListener('click', clearCorrections);
   document.getElementById('corr-train')?.addEventListener('click', trainFromCorrections);
   // Inline adapter-name validation so a bad name isn't a submit-time surprise.

--- a/crates/kiln-server/tests/corrections_store.rs
+++ b/crates/kiln-server/tests/corrections_store.rs
@@ -1,0 +1,211 @@
+//! Integration tests: the durable corrections store endpoints.
+//!
+//! The corrections basket is the literal mechanism of "your model gets
+//! better every time you use it" — these pin that it survives the server
+//! (JSONL on disk), that pi can file rows programmatically, and that
+//! trained rows are kept as marked history rather than deleted.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state() -> (AppState, tempfile::TempDir) {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "Qwen3.5-4B".to_string(),
+    );
+    let dir = tempfile::tempdir().unwrap();
+    state.adapter_dir = dir.path().to_path_buf();
+    (state, dir)
+}
+
+async fn req(app: &axum::Router, method: &str, path: &str, body: Option<Value>) -> (StatusCode, Value) {
+    let builder = Request::builder().method(method).uri(path);
+    let request = match body {
+        Some(v) => builder
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&v).unwrap()))
+            .unwrap(),
+        None => builder.body(Body::empty()).unwrap(),
+    };
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+#[tokio::test]
+async fn corrections_crud_round_trip_persists_on_disk() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+
+    // pi files a correction programmatically.
+    let (status, row) = req(
+        &app,
+        "POST",
+        "/v1/corrections",
+        Some(json!({
+            "request_id": "chatcmpl-1",
+            "agent": "pi",
+            "user": "rename the struct",
+            "original": "renamed the wrong struct",
+            "ideal": ""
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{row}");
+    assert!(row["created_at"].as_str().is_some_and(|s| !s.is_empty()));
+
+    // The operator writes the ideal answer — an upsert by request_id.
+    let (status, _) = req(
+        &app,
+        "POST",
+        "/v1/corrections",
+        Some(json!({
+            "request_id": "chatcmpl-1",
+            "agent": "pi",
+            "user": "rename the struct",
+            "original": "renamed the wrong struct",
+            "ideal": "renamed TokenStore and updated 3 call sites"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, list) = req(&app, "GET", "/v1/corrections", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = list["corrections"].as_array().unwrap();
+    assert_eq!(rows.len(), 1, "upsert must not duplicate: {list}");
+    assert_eq!(rows[0]["ideal"], "renamed TokenStore and updated 3 call sites");
+
+    // The store is a real file under the adapter dir.
+    assert!(
+        state
+            .adapter_dir
+            .join(".eval/corrections/data.jsonl")
+            .is_file(),
+        "corrections must live on disk, not in a browser"
+    );
+
+    let (status, _) = req(&app, "DELETE", "/v1/corrections/chatcmpl-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, list) = req(&app, "GET", "/v1/corrections", None).await;
+    assert_eq!(list["corrections"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn trained_rows_become_marked_history_not_garbage() {
+    let (state, _dir) = make_state();
+    let app = api::router(state.clone());
+
+    for id in ["a", "b"] {
+        let (status, _) = req(
+            &app,
+            "POST",
+            "/v1/corrections",
+            Some(json!({"request_id": id, "user": "q", "original": "bad", "ideal": "good"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    let (status, marked) = req(
+        &app,
+        "POST",
+        "/v1/corrections/mark_trained",
+        Some(json!({"request_ids": ["a"], "adapter": "fixes-v1"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{marked}");
+    assert_eq!(marked["marked"], 1);
+
+    // Active view hides the trained row; history view keeps it with the
+    // adapter it trained into.
+    let (_, active) = req(&app, "GET", "/v1/corrections", None).await;
+    assert_eq!(active["corrections"].as_array().unwrap().len(), 1);
+    let (_, all) = req(&app, "GET", "/v1/corrections?include_trained=1", None).await;
+    let rows = all["corrections"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    let trained = rows.iter().find(|r| r["request_id"] == "a").unwrap();
+    assert_eq!(trained["trained_into"], "fixes-v1");
+    assert!(trained["trained_at"].as_str().is_some());
+
+    // Clearing the basket removes only active rows — the trained ideal
+    // answer survives.
+    let (status, cleared) = req(&app, "DELETE", "/v1/corrections", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cleared["removed"], 1);
+    let (_, all) = req(&app, "GET", "/v1/corrections?include_trained=1", None).await;
+    assert_eq!(all["corrections"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn rejects_rows_without_identity_or_prompt() {
+    let (state, _dir) = make_state();
+    let app = api::router(state);
+    let (status, _) = req(
+        &app,
+        "POST",
+        "/v1/corrections",
+        Some(json!({"request_id": "", "user": "q"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let (status, _) = req(
+        &app,
+        "POST",
+        "/v1/corrections",
+        Some(json!({"request_id": "x", "user": "  "})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -325,6 +325,17 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       text(res, '# HELP kiln_mock_info Mock metrics for UI smoke\n# TYPE kiln_mock_info gauge\nkiln_mock_info 1\n');
       return;
     }
+    // Durable corrections store: the basket's init sync (GET) and
+    // write-through (POST/DELETE) run in every scenario.
+    if (url.pathname === '/v1/corrections') {
+      if (req.method === 'GET') { json(res, { corrections: [] }); return; }
+      if (req.method === 'POST') { json(res, { status: 'ok' }); return; }
+      if (req.method === 'DELETE') { json(res, { status: 'cleared', removed: 0 }); return; }
+    }
+    if (url.pathname.startsWith('/v1/corrections/')) {
+      json(res, { status: 'ok' });
+      return;
+    }
     if (url.pathname === '/v1/adapters') {
       json(res, { active: activeAdapter, available: availableAdapters });
       return;


### PR DESCRIPTION
## Summary

The corrections basket — per the dashboard's own comments, *"the literal mechanism of 'your model gets better every time you use it'"* — lived **only in browser localStorage**: invisible to other machines, unreachable by pi or any script, and after training the rows were **deleted** — the user's hand-written ideal answers ended up existing nowhere. The repo's own philosophy is "the dataset is the asset"; this PR makes corrections one.

## Changes

**New `/v1/corrections` surface** (`api/corrections.rs`), JSONL on disk under `<adapter_dir>/.eval/corrections/`:

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/v1/corrections` | Upsert by `request_id` — pi/scripts can file corrections programmatically |
| `GET` | `/v1/corrections[?include_trained=1]` | Active basket vs. full history |
| `DELETE` | `/v1/corrections/{id}` / `/v1/corrections` | Remove one / clear active |
| `POST` | `/v1/corrections/mark_trained` | Trained rows are **marked** with the adapter they trained into — kept, never deleted |

**Dashboard write-through**: pulls the durable store at init (corrections from another machine or filed by pi appear), mirrors every add/edit/remove/clear (ideal-editor edits debounced), and on train marks consumed rows server-side instead of discarding them. localStorage remains a write-behind cache (static demo + offline captures keep working); sync is best-effort and never blocks the local UX.

## Verification

- 4 store unit tests + 3 endpoint integration tests: round-trip persists on disk; trained rows become marked history that survives a basket clear; identity/prompt validation.
- Full `kiln-server` suite green; dashboard smoke passes (its mock server taught the new routes).

Follow-up (separate PR, next on the list's spirit): `POST /v1/requests/mine` to mine the rotated request log into datasets — the high-volume path for overnight pi traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)