### PR TITLE
MTP speculative decoding for tuned adapters: LoRA-threaded verify + adapter-carried MTP draft LoRA

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -26592,6 +26592,7 @@ pub fn mtp_forward_step(
     mtp_block_table: &BlockTable,
     base_pos: usize,
     mtp_pos: usize,
+    lora: Option<&crate::lora_loader::LoraWeights>,
 ) -> Result<(Tensor, Tensor)> {
     kiln_nvtx::range!(c"kiln/mtp/step");
     let mtp = weights.mtp_weights()?;
@@ -26821,7 +26822,10 @@ pub fn mtp_forward_step(
         mtp_cache,
         mtp_block_table,
         /* full_attn_layer_idx = */ 0,
-        /* lora = */ None,
+        // The adapter's MTP draft-block LoRA, when the adapter was
+        // trained with MTP alignment. Absent → base draft weights
+        // (verify stays exact; acceptance is what degrades).
+        lora.and_then(|l| l.mtp.as_ref().map(|m| (m, l.scale))),
     );
     // Always disarm in both success and error paths (`mtp_hidden_result`
     // is `?`-propagated below, so we cannot rely on the function tail).

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -6651,6 +6651,7 @@ impl ModelRunner {
                 params,
                 &self.eos_token_ids,
                 &mut rng,
+                self.active_lora.as_ref(),
             );
             crate::mtp_debug::clear_h_main_replay_prefix_tokens();
             let result = result.context("mtp speculative decode step failed")?;
@@ -7077,6 +7078,7 @@ impl ModelRunner {
                 params,
                 &self.eos_token_ids,
                 &mut rng,
+                self.active_lora.as_ref(),
             );
             crate::mtp_debug::clear_h_main_replay_prefix_tokens();
             let result = result.context("mtp speculative decode step failed")?;

--- a/crates/kiln-model/src/lora_loader.rs
+++ b/crates/kiln-model/src/lora_loader.rs
@@ -97,6 +97,13 @@ impl LoraLayerWeights {
 pub struct LoraWeights {
     /// Per-layer LoRA weights, indexed by layer number.
     pub layers: Vec<LoraLayerWeights>,
+    /// LoRA weights for the native MTP (multi-token-prediction) draft
+    /// block, when the adapter was trained with MTP alignment. Keyed in
+    /// the safetensors as `...mtp.layers.0.{self_attn,mlp}.{module}...`.
+    /// `None` for adapters that predate MTP training — the draft block
+    /// then runs base weights (correct, but acceptance degrades as the
+    /// tuned model diverges from the base).
+    pub mtp: Option<LoraLayerWeights>,
     /// LoRA rank.
     pub rank: usize,
     /// LoRA alpha (scaling factor).
@@ -119,7 +126,7 @@ impl LoraWeights {
         if !ResidencyBackend::runtime_supports_resident_activation(backend) {
             return Ok(());
         }
-        for layer in &self.layers {
+        for layer in self.layers.iter().chain(self.mtp.as_ref()) {
             let mut maybe_err: Option<anyhow::Error> = None;
             layer.for_each_projection(|proj| {
                 if maybe_err.is_some() {
@@ -152,7 +159,7 @@ impl LoraWeights {
         if !ResidencyBackend::runtime_supports_resident_activation(backend) {
             return;
         }
-        for layer in &self.layers {
+        for layer in self.layers.iter().chain(self.mtp.as_ref()) {
             layer.for_each_projection(|proj| {
                 // #1082: `evict_resident_activation` now takes a kt
                 // `&kiln_tensor::Tensor`, so pass `proj.a` / `proj.b`
@@ -205,11 +212,18 @@ impl LoraWeights {
             .context("failed to deserialize safetensors")?;
 
         // Parse all tensor names into a map: (layer_idx, module_name, "A"|"B") -> tensor_name
+        // MTP-block keys (`...mtp.layers.0...`) go to their own map — they
+        // would otherwise collide with main layer 0.
         let mut tensor_map: HashMap<(usize, String, String), String> = HashMap::new();
+        let mut mtp_tensor_map: HashMap<(String, String), String> = HashMap::new();
 
         for name in tensors.names() {
             if let Some(parsed) = parse_peft_key(name) {
-                tensor_map.insert((parsed.layer, parsed.module, parsed.ab), name.to_string());
+                if parsed.is_mtp {
+                    mtp_tensor_map.insert((parsed.module, parsed.ab), name.to_string());
+                } else {
+                    tensor_map.insert((parsed.layer, parsed.module, parsed.ab), name.to_string());
+                }
             }
         }
 
@@ -257,8 +271,53 @@ impl LoraWeights {
             layers.push(layer);
         }
 
+        // Optional MTP draft-block LoRA (one full-attention layer, k=1).
+        let mut mtp_layer = LoraLayerWeights::default();
+        let mut mtp_any = false;
+        for module in &config.target_modules {
+            let a_key = mtp_tensor_map.get(&(module.clone(), "A".to_string()));
+            let b_key = mtp_tensor_map.get(&(module.clone(), "B".to_string()));
+            if let (Some(a_name), Some(b_name)) = (a_key, b_key) {
+                let a_view = tensors
+                    .tensor(a_name)
+                    .with_context(|| format!("failed to get tensor {a_name}"))?;
+                let b_view = tensors
+                    .tensor(b_name)
+                    .with_context(|| format!("failed to get tensor {b_name}"))?;
+                let a = safetensor_to_kt(&a_view, device)
+                    .with_context(|| format!("converting {a_name}"))?;
+                let b = safetensor_to_kt(&b_view, device)
+                    .with_context(|| format!("converting {b_name}"))?;
+                let proj = LoraProjectionWeights { a, b };
+                mtp_any = true;
+                match module.as_str() {
+                    "q_proj" => mtp_layer.q_proj = Some(proj),
+                    "k_proj" => mtp_layer.k_proj = Some(proj),
+                    "v_proj" => mtp_layer.v_proj = Some(proj),
+                    "o_proj" => mtp_layer.o_proj = Some(proj),
+                    "gate_proj" => mtp_layer.gate_proj = Some(proj),
+                    "up_proj" => mtp_layer.up_proj = Some(proj),
+                    "down_proj" => mtp_layer.down_proj = Some(proj),
+                    _ => {
+                        mtp_any = mtp_any
+                            && (mtp_layer.q_proj.is_some()
+                                || mtp_layer.k_proj.is_some()
+                                || mtp_layer.v_proj.is_some()
+                                || mtp_layer.o_proj.is_some()
+                                || mtp_layer.gate_proj.is_some()
+                                || mtp_layer.up_proj.is_some()
+                                || mtp_layer.down_proj.is_some());
+                        tracing::warn!(
+                            "unsupported MTP LoRA target module: {module}, skipping"
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(Self {
             layers,
+            mtp: mtp_any.then_some(mtp_layer),
             rank,
             alpha,
             scale,
@@ -271,6 +330,9 @@ struct ParsedKey {
     layer: usize,
     module: String,
     ab: String, // "A" or "B"
+    /// Key addresses the MTP draft block (`...mtp.layers.{i}...`) rather
+    /// than a main-model layer.
+    is_mtp: bool,
 }
 
 /// Parse a PEFT-style safetensors key into layer index, module name, and A/B indicator.
@@ -299,10 +361,15 @@ fn parse_peft_key(key: &str) -> Option<ParsedKey> {
     // The module name is the part just before "lora_A" or "lora_B"
     let module = parts.get(lora_pos.checked_sub(1)?)?.to_string();
 
+    // `...mtp.layers.0...` keys address the MTP draft block; without this
+    // check they'd alias main layer 0.
+    let is_mtp = parts[..layer_pos].contains(&"mtp");
+
     Some(ParsedKey {
         layer: layer_idx,
         module,
         ab,
+        is_mtp,
     })
 }
 
@@ -501,6 +568,110 @@ mod tests {
     fn test_parse_peft_key_invalid() {
         assert!(parse_peft_key("random.key.name").is_none());
         assert!(parse_peft_key("layers.abc.q_proj.lora_A.weight").is_none());
+    }
+
+    /// MTP draft-block keys must parse as MTP — without the flag they'd
+    /// alias main layer 0 and silently corrupt its LoRA.
+    #[test]
+    fn test_parse_peft_key_mtp() {
+        let key = "base_model.model.model.mtp.layers.0.self_attn.q_proj.lora_A.weight";
+        let parsed = parse_peft_key(key).unwrap();
+        assert!(parsed.is_mtp);
+        assert_eq!(parsed.layer, 0);
+        assert_eq!(parsed.module, "q_proj");
+
+        let main_key = "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight";
+        assert!(!parse_peft_key(main_key).unwrap().is_mtp);
+    }
+
+    /// Full load round-trip: an adapter carrying both main-layer and MTP
+    /// keys loads with `mtp: Some(...)`; an adapter without MTP keys
+    /// (every adapter trained before MTP alignment) loads `mtp: None`.
+    #[test]
+    fn test_load_adapter_with_and_without_mtp_keys() -> Result<()> {
+        use std::collections::BTreeMap;
+
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("adapter_config.json"),
+            r#"{"r": 2, "lora_alpha": 4.0, "target_modules": ["q_proj", "gate_proj"]}"#,
+        )?;
+
+        let a_data: Vec<f32> = vec![0.1; 2 * 4]; // [rank=2, in=4]
+        let b_data: Vec<f32> = vec![0.2; 4 * 2]; // [out=4, rank=2]
+        fn bytemuck_cast_slice_f32(data: &[f32]) -> &[u8] {
+            unsafe {
+                std::slice::from_raw_parts(data.as_ptr() as *const u8, std::mem::size_of_val(data))
+            }
+        }
+        fn mk<'a>(data: &'a [f32], shape: Vec<usize>) -> safetensors::tensor::TensorView<'a> {
+            safetensors::tensor::TensorView::new(
+                safetensors::Dtype::F32,
+                shape,
+                bytemuck_cast_slice_f32(data),
+            )
+            .unwrap()
+        }
+
+        let mut tensors: BTreeMap<String, safetensors::tensor::TensorView<'_>> = BTreeMap::new();
+        tensors.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".into(),
+            mk(&a_data, vec![2, 4]),
+        );
+        tensors.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".into(),
+            mk(&b_data, vec![4, 2]),
+        );
+        tensors.insert(
+            "base_model.model.model.mtp.layers.0.self_attn.q_proj.lora_A.weight".into(),
+            mk(&a_data, vec![2, 4]),
+        );
+        tensors.insert(
+            "base_model.model.model.mtp.layers.0.self_attn.q_proj.lora_B.weight".into(),
+            mk(&b_data, vec![4, 2]),
+        );
+        tensors.insert(
+            "base_model.model.model.mtp.layers.0.mlp.gate_proj.lora_A.weight".into(),
+            mk(&a_data, vec![2, 4]),
+        );
+        tensors.insert(
+            "base_model.model.model.mtp.layers.0.mlp.gate_proj.lora_B.weight".into(),
+            mk(&b_data, vec![4, 2]),
+        );
+        let st = safetensors::serialize(&tensors, None)?;
+        std::fs::write(dir.path().join("adapter_model.safetensors"), st)?;
+
+        let loaded = LoraWeights::load(dir.path(), 1, Device::Cpu)?;
+        assert!(loaded.layers[0].q_proj.is_some(), "main layer parsed");
+        assert!(
+            loaded.layers[0].gate_proj.is_none(),
+            "MTP keys must not bleed into main layer 0"
+        );
+        let mtp = loaded.mtp.as_ref().expect("MTP block parsed");
+        assert!(mtp.q_proj.is_some());
+        assert!(mtp.gate_proj.is_some());
+        assert!(mtp.o_proj.is_none());
+
+        // Legacy adapter (no MTP keys) → mtp: None.
+        let dir2 = tempfile::tempdir()?;
+        std::fs::write(
+            dir2.path().join("adapter_config.json"),
+            r#"{"r": 2, "lora_alpha": 4.0, "target_modules": ["q_proj"]}"#,
+        )?;
+        let mut legacy: BTreeMap<String, safetensors::tensor::TensorView<'_>> = BTreeMap::new();
+        legacy.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".into(),
+            mk(&a_data, vec![2, 4]),
+        );
+        legacy.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".into(),
+            mk(&b_data, vec![4, 2]),
+        );
+        let st2 = safetensors::serialize(&legacy, None)?;
+        std::fs::write(dir2.path().join("adapter_model.safetensors"), st2)?;
+        let legacy_loaded = LoraWeights::load(dir2.path(), 1, Device::Cpu)?;
+        assert!(legacy_loaded.mtp.is_none());
+        Ok(())
     }
 
     #[test]

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -838,6 +838,7 @@ pub fn speculative_mtp_decode_step(
     _params: &SamplingParams,
     eos_token_ids: &[TokenId],
     _rng: &mut StdRng,
+    lora: Option<&crate::lora_loader::LoraWeights>,
 ) -> Result<MtpSpeculativeStepResult> {
     // 1. Draft: one MTP step produces a single candidate next token.
     //
@@ -861,6 +862,7 @@ pub fn speculative_mtp_decode_step(
         mtp_block_table,
         base_pos,
         mtp_pos,
+        lora,
     )
     .context("mtp draft step failed")?;
     // Phase C35 H13 A/B — optional FP32 promotion before argmax. See
@@ -880,6 +882,11 @@ pub fn speculative_mtp_decode_step(
         .snapshot_for_decode_rollback()
         .context("snapshot linear attention state before MTP verify")?;
     let verify_input = [last_token, draft_token];
+    // The verify pass is the correctness anchor: with the adapter applied
+    // here, every COMMITTED token is exactly what the tuned model would
+    // emit — a base-weight draft can only cost acceptance rate, never
+    // output fidelity. (The old `None` was scaffolding parity from before
+    // adapters could ride this path at all.)
     let (verify_logits, hidden_after_draft) = model_forward_paged_with_last_hidden(
         backend,
         &verify_input,
@@ -889,7 +896,7 @@ pub fn speculative_mtp_decode_step(
         base_block_table,
         base_pos,
         Some(linear_state),
-        None, // no LoRA on the verify pass — keep parity with scaffolding.
+        lora,
         None, // positions_gpu: let the forward pass build positions internally.
     )
     .context("mtp two-token verify forward failed")?;
@@ -1027,7 +1034,7 @@ pub fn speculative_mtp_decode_step(
             base_block_table,
             base_pos,
             Some(linear_state),
-            None,
+            lora,
             None,
         )
         .context("mtp rejection replay forward failed")?;

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -3607,10 +3607,19 @@ fn resolve_speculative_mode_from_config(
             .map(ResolvedSpeculativeMode::SkipLayer)
             .unwrap_or(ResolvedSpeculativeMode::Off),
         SpecMethod::Mtp => {
-            let greedy_without_lora = sampling.temperature == 0.0 && !has_active_lora;
+            let greedy = sampling.temperature == 0.0;
+            // MTP now rides with an active LoRA: the verify pass applies
+            // the adapter, so committed tokens are exactly the tuned
+            // model's output. The draft block applies the adapter's
+            // `mtp.*` LoRA when present (MTP-trained adapters); without
+            // it the base draft can only cost acceptance rate, never
+            // fidelity. The old `!has_active_lora` gate predates the
+            // adapter-threaded MTP path and silently denied the speedup
+            // to every tuned adapter — the product's primary traffic.
+            let greedy_without_lora = greedy && !has_active_lora;
             if mtp_supported
                 && native_mtp_allowed
-                && greedy_without_lora
+                && greedy
                 && prompt_tokens <= speculative_policy.mtp_max_prompt_tokens
             {
                 ResolvedSpeculativeMode::Mtp
@@ -10479,7 +10488,7 @@ mod tests {
     }
 
     #[test]
-    fn mtp_requires_greedy_request_and_no_lora() {
+    fn mtp_requires_greedy_request() {
         let cfg = SpeculativeDecodingConfig {
             enabled: true,
             method: SpecMethod::Mtp,
@@ -10511,6 +10520,10 @@ mod tests {
         );
         assert!(matches!(sampled, ResolvedSpeculativeMode::Off));
 
+        // An active LoRA no longer disables MTP: the verify pass applies
+        // the adapter (output fidelity is anchored there), and MTP-trained
+        // adapters bring their own draft-block LoRA. Tuned adapters are
+        // kiln's primary traffic — they keep the speedup.
         let with_lora = resolve_speculative_mode_from_config(
             &ModelConfig::qwen3_5_4b(),
             &cfg,
@@ -10521,7 +10534,7 @@ mod tests {
             true,
             default_speculative_policy_for_test(),
         );
-        assert!(matches!(with_lora, ResolvedSpeculativeMode::Off));
+        assert!(matches!(with_lora, ResolvedSpeculativeMode::Mtp));
 
         let long_prompt = resolve_speculative_mode_from_config(
             &ModelConfig::qwen3_5_4b(),

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -2334,6 +2334,8 @@ fn bench_latency_paged_mtp(
             &params,
             &eos_token_ids,
             &mut rng,
+            // The bench measures base-model MTP throughput — no adapter.
+            None,
         );
         kiln_model::mtp_debug::clear_h_main_replay_prefix_tokens();
         let step = step.context("speculative_mtp_decode_step failed")?;

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1275,6 +1275,7 @@ impl TrainableLoraParams {
 
         LoraWeights {
             layers,
+            mtp: None,
             rank: self.rank,
             alpha: self.alpha,
             scale: self.scale,
@@ -5920,6 +5921,7 @@ fn lora_snapshot_capture_or_blend(
         .collect::<Result<Vec<_>>>()?;
     Ok(LoraWeights {
         layers,
+        mtp: None,
         rank: current.rank,
         alpha: current.alpha,
         scale: current.scale,
@@ -7850,6 +7852,7 @@ pub(crate) fn lora_weights_detached(params: &TrainableLoraParams) -> LoraWeights
 
     LoraWeights {
         layers,
+        mtp: None,
         rank: params.rank,
         alpha: params.alpha,
         scale: params.scale,

--- a/docs/plans/mtp-training-plan.md
+++ b/docs/plans/mtp-training-plan.md
@@ -1,0 +1,86 @@
+# MTP Training Plan — keep the draft head aligned with the tuned model
+
+**Status:** PR-A (serving + adapter format) shipped: `LoraWeights.mtp`,
+LoRA-threaded MTP verify/replay, draft-block LoRA application, dispatch
+gate lifted. This document specifies PR-B: actually *training* the MTP
+draft block whenever an adapter trains.
+
+## Why
+
+Qwen3.5-4B ships one native MTP layer (k=1). Speculative decoding with it
+drafts ~2 tokens per base forward when the draft agrees with the model.
+The draft head was distilled against the BASE model — every LoRA step
+moves the served distribution away from it, so acceptance rate (and the
+entire speedup) decays exactly in proportion to how much the user has
+personalized their model. "Your model gets better every time you use it"
+must not mean "…and slower."
+
+PR-A guarantees output fidelity under adapters (the verify pass applies
+the LoRA), so the ONLY thing at stake in PR-B is restoring acceptance
+rate — a pure speed win with no correctness risk.
+
+## Shape of the feature
+
+A post-SFT **MTP alignment phase** inside `sft_train` (GRPO/OPD later),
+gated on `config.train_mtp` (default ON when the checkpoint has `mtp.*`
+tensors) and skipped silently when the model has no MTP weights.
+
+1. **Trainable params:** LoRA A/B for the MTP block's
+   `{q,k,v,o,gate,up,down}_proj` at the run's rank/alpha. The `fc`
+   (2H→H), the three norms, and the tied lm_head stay frozen — the block
+   carries the capacity.
+2. **Data:** the same tokenized SFT examples (tokens + label_mask) the
+   main phase just trained on.
+3. **Hiddens:** one inference forward per example with the FRESHLY
+   TRAINED adapter applied —
+   `model_forward_paged_normed_hidden(tokens, …, lora)` returns the
+   post-final-norm hiddens `[1, T, H]` (exactly what `mtp_forward_step`
+   consumes as `h_prev` at serve time). Detach; allocate a temporary
+   PagedKvCache + BlockTable sized for T (freed after the phase).
+4. **MTP forward (tape scope armed):** for positions `t` in `0..T-2`:
+   `fused_t = fc( concat( pre_fc_norm_embedding(embed(tok_{t+1})),
+   pre_fc_norm_hidden(h_t) ) )` → MTP transformer block (causal
+   full-attention over the fused sequence, RoPE at absolute positions,
+   LoRA on the seven projections via the tape's lora-linear) →
+   `final_layernorm` → logits via the tied `embed_tokens_t`.
+   All ops exist as tape primitives (`try_tape_matmul_kt`,
+   `try_tape_rms_norm_kt`, `try_tape_concat_kt`, `try_tape_rope_kt`,
+   `try_tape_flash_attn_kt`, `try_tape_lora_linear_kt`,
+   `try_tape_cross_entropy_from_logits_kt`).
+5. **Loss:** CE against the +2-shifted labels, masked to positions where
+   `label_mask[t+2]` (the MTP target must itself be a supervised token).
+   Skip examples with < 3 supervised positions.
+6. **Optimizer:** the run's optimizer (Muon default) over just the MTP
+   LoRA params; a handful of epochs over the same examples (cheap: one
+   tiny block).
+7. **Save:** write the trained pairs under the PR-A key scheme
+   `base_model.model.model.mtp.layers.0.{self_attn,mlp}.{module}.lora_{A,B}.weight`
+   into the same `adapter_model.safetensors`.
+8. **Receipt:** `mtp_alignment: { trained: bool, examples, final_ce,
+   skipped_reason }` so the adapter records whether its draft head is
+   aligned.
+
+## Implementation notes
+
+- Mirror how `standard_forward_backward_tape_authoritative_kt` arms the
+  tape scope and registers LoRA `Parameter`s as leaves; the MTP block is
+  structurally identical to a main full-attention layer, so its training
+  forward is the same composition with the fc/concat prologue and
+  tied-head epilogue added.
+- The hiddens forward (step 3) runs OUTSIDE the tape scope (no leaves →
+  no recording) — gradients never flow into the main model. The
+  alignment phase is fully separable from the main SFT step.
+- Validation (bounded, attended): finite-difference check on one MTP
+  LoRA pair (mirror `grpo_logit_grad_matches_finite_difference_f32`);
+  CE-decreases-over-epochs assertion on a tiny fixture; then one real
+  adapter on the rig with the C1 attribution CSV
+  (`KILN_C1_ATTR_PATH`) comparing acceptance rate: base draft vs
+  aligned draft on the same prompts.
+
+## Follow-ups after PR-B
+
+- GRPO/OPD runs get the same phase (hiddens from their own forwards).
+- `kiln self-improve` includes MTP alignment automatically (it's SFT
+  under the hood once the agent-traces bridge resolves prompts).
+- Dashboard: show draft acceptance rate per adapter (the data already
+  exists in `MtpGenerationOutput::draft_accepted_count`).


### PR DESCRIPTION
## Summary

Native MTP speculative decoding was **hard-disabled whenever a LoRA was active** (`greedy_without_lora` in the dispatch gate) — the spec-decode speedup never applied to tuned adapters, i.e. kiln's entire product. The plumbing also had no way to carry adapter weights: `mtp_forward_step` hardcoded `lora: None` into the shared transformer block, and the verify/replay forwards inside `speculative_mtp_decode_step` ran base-only.

This is **PR-A of the MTP-training plan** (serving + adapter format). PR-B adds the trainer phase.

## Changes

- **LoRA-threaded verify**: `speculative_mtp_decode_step` threads the active adapter through both base-model forwards (two-token verify + rejection replay). The verify pass is the correctness anchor — every *committed* token is exactly what the tuned model would emit; a base-weight draft can only cost acceptance rate, never output fidelity.
- **Adapter-carried MTP LoRA**: `LoraWeights.mtp: Option<LoraLayerWeights>` — adapters can carry draft-block LoRA under PEFT-style `...mtp.layers.0.{self_attn,mlp}.*` keys (parsed distinctly so they can't alias main layer 0; legacy adapters load `mtp: None`). Residency registration/eviction covers the MTP pairs. `mtp_forward_step` applies it via the existing `transformer_block_paged` LoRA slot.
- **Gate lifted**: the Mtp dispatch arm drops `!has_active_lora` (greedy-only + prompt-size policies unchanged; SkipLayer untouched).

## PR-B design (next)

Post-SFT **MTP alignment** phase: tape-forward the MTP block (frozen `fc`/norms/tied head; LoRA on q/k/v/o + MLP — all tape ops already exist) over the tuned model's detached hiddens, CE against +2-shifted labels, saved under the `mtp.*` keys this PR defines. That trains the draft to follow the *tuned* model, restoring acceptance rate.

## Verification

- New parse + load round-trip tests (MTP keys parse as MTP and never bleed into layer 0; legacy adapters → `None`; partial module sets OK).
- Updated gate test: active LoRA now resolves to `Mtp`.
- Full `kiln-model` / `kiln-server` / `kiln-train` suites green.
- Natural attended follow-up: acceptance-rate A/B on the rig (tuned adapter, MTP on vs. off) — outputs are verify-anchored so this is purely a speed measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)