### PR TITLE
Docs truth pass: ECHO claims match the code; README API table covers the real surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ See [docs/GRPO_GUIDE.md](docs/GRPO_GUIDE.md) for worked verifiable-rewards examp
 
 ### Agentic GRPO with ECHO (multi-turn rollouts)
 
-For multi-turn agentic rollouts — tool calls, command output, file contents — kiln's GRPO is **ECHO-by-default** (Shrivastava, Awadallah, Papailiopoulos, MSR AI Frontiers 2026). ECHO adds a length-normalized cross-entropy loss on environment-observation tokens to the standard policy-gradient loss, with **zero extra forward-pass cost** — the env tokens were already in the rollout context. Paper headline: roughly doubles TerminalBench-2.0 pass@1.
+For multi-turn agentic rollouts — tool calls, command output, file contents — kiln's GRPO is **ECHO-ready** (Shrivastava, Awadallah, Papailiopoulos, MSR AI Frontiers 2026): the trajectory format carries environment segments end-to-end, from rollout JSONL through tokenization and masking to the training receipt. ECHO adds a length-normalized cross-entropy loss on environment-observation tokens to the standard policy-gradient loss, with **zero extra forward-pass cost** — the env tokens are already in the rollout context. Paper headline: roughly doubles TerminalBench-2.0 pass@1. The env-CE term itself is **temporarily disabled** pending its kt-tape gradient root (#1082) — enabling it on rollouts with env tokens fails fast at submission (`unsupported_loss_config`) rather than silently training without the term.
 
-When your rollouts carry a `trajectory` field with `kind: "action"` / `kind: "observation"` segments, kiln-train's `tokenize_grpo_group` builds separate `action_mask` (policy-gradient targets) and `env_mask` (ECHO env-CE targets); both contribute to the same forward pass at default `λ_echo = 0.05`. Legacy single-turn rollouts (no `trajectory` field) get ECHO contribution = 0 — bit-identical behavior to the pre-ECHO loss.
+When your rollouts carry a `trajectory` field with `kind: "action"` / `kind: "observation"` segments, kiln-train's `tokenize_grpo_group` builds separate `action_mask` (policy-gradient targets) and `env_mask` (ECHO env-CE targets, `λ_echo = 0.05` once the term is re-enabled). Today the action-token policy loss trains on the full trajectory while the env mask is carried through for diagnostics and the planned resurrection. Legacy single-turn rollouts (no `trajectory` field) behave bit-identically to the pre-ECHO loss.
 
 ```python
 import requests
@@ -152,7 +152,10 @@ requests.post("http://localhost:8420/v1/train/agentic", json={
             ]
         }]
     }],
-    "config": {"loss": {"echo": {"lambda": 0.05}}}
+    # loss.echo is off by default; enabling it alongside observation
+    # segments fails fast (unsupported_loss_config) until #1082's
+    # env-CE gradient root is restored.
+    "config": {}
 })
 ```
 
@@ -164,7 +167,8 @@ For saturated tasks where reward-only GRPO is low signal, kiln-train also
 accepts off-policy teacher distillation data: prompt messages plus a teacher
 response, optionally with per-token teacher top-logprobs for reverse-KL. The
 same agentic `trajectory` shape can be attached so action tokens receive OPD
-supervision while observation tokens are accounted for ECHO.
+supervision while observation tokens stay masked out of it (they are reserved
+for ECHO's env-CE once that term is restored).
 
 See [docs/OPD_TEACHER_JSONL.md](docs/OPD_TEACHER_JSONL.md) for the JSONL
 schema and the `reverse_kl` vs `cross_entropy` objective contract.
@@ -369,13 +373,24 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | POST | `/v1/completions` | vLLM-compatible prompt logprobs for remote OPD teachers |
 | POST | `/v1/completions/batch` | Batch generation API for GRPO (up to 64 prompts per request) |
 | POST | `/v1/train/sft` | Submit SFT training examples (optionally with a `post_eval` hook) |
-| POST | `/v1/train/grpo` | Submit GRPO scored completions (optionally with a `post_eval` hook). Supports the new `agentic_groups` shape with multi-turn `trajectory` fields; ECHO env-CE applies automatically. |
+| POST | `/v1/train/grpo` | Submit GRPO scored completions (optionally with a `post_eval` hook). Supports the new `agentic_groups` shape with multi-turn `trajectory` fields; action/observation masks are built end-to-end, but the ECHO env-CE term is temporarily disabled (#1082) — enabling it with env tokens fails fast (`unsupported_loss_config`). |
 | POST | `/v1/train/agentic` | Canonical alias of `/v1/train/grpo` — same handler, semantically-honest name for multi-turn rollouts |
 | GET | `/v1/train/status` | Training queue and job status |
 | GET | `/v1/train/status/{job_id}` | Inspect one training job |
 | GET | `/v1/train/jobs/{job_id}` | Rich training job detail (loss curve + linked-eval back-references) |
 | GET | `/v1/train/queue` | List queued training jobs |
 | DELETE | `/v1/train/queue/{job_id}` | Cancel a queued job |
+| POST | `/v1/distill/refresh` | Continual-learning distillation refresh job |
+| POST | `/v1/distill/pump` | Continual-learning distillation pump job |
+| GET / POST | `/v1/corrections` | Durable corrections store — the basket survives the browser; pi can file corrections |
+| DELETE | `/v1/corrections/{request_id}` | Remove a correction |
+| POST | `/v1/corrections/mark_trained` | Mark correction rows as trained into an adapter (kept as history) |
+| GET / POST | `/v1/teachers` | Teacher registry for OPD/distillation (local teachers may wear an adapter) |
+| DELETE | `/v1/teachers/{alias}` | Remove a registered teacher |
+| POST | `/v1/agent/traces/discover` | Index pi/agent session traces for training |
+| GET | `/v1/agent/traces` | List discovered agent session traces |
+| POST | `/v1/agent/self_improve` | One-call agentic self-improvement (traces → OPD + judge distill) |
+| POST | `/v1/agent/judge_distill` | Distill a judge LoRA from agent traces |
 | GET | `/v1/adapters` | List saved/available LoRA adapters and identify the active adapter |
 | GET | `/v1/adapters/{name}/detail` | Files + training history + eval history for one adapter |
 | POST | `/v1/adapters/load` | Load adapter from disk |
@@ -384,6 +399,7 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | POST | `/v1/adapters/upload` | Multipart tar.gz import of an adapter |
 | GET  | `/v1/adapters/{name}/download` | Stream adapter as tar.gz (export) |
 | POST | `/v1/adapters/merge` | Merge adapters (weighted_average, TIES, or concatenation modes) |
+| POST | `/v1/adapters/distill_merge` | Behaviour-space adapter merge |
 | GET / POST | `/v1/eval/suites` | List or register eval suites (body = `EvalSuite`) |
 | GET / DELETE | `/v1/eval/suites/{name}` | Fetch / delete one suite |
 | POST | `/v1/eval/run` | Submit an eval (registered suite or inline) |

--- a/docs/ECHO_GUIDE.md
+++ b/docs/ECHO_GUIDE.md
@@ -13,35 +13,37 @@ This guide is the operational companion to the integration plan
 
 ## Quick decisions
 
-**Is ECHO on by default?** Yes. `GrpoConfig::default()` ships with `loss.echo = Some(EchoConfig { lambda: 0.05, ... })` (paper §3.3 recommended). To opt out: pass `--no-echo` to `cuda_grpo_ablation` or set `loss.echo = None` in JSON.
+**Is ECHO on by default?** No — not anymore. ECHO defaulted ON historically, but the env-CE term lost its gradient path when candle was removed (#1082), so `LossConfig::default()` now ships `loss.echo = None` (`default_echo_some()` in `crates/kiln-train/src/lib.rs`). Explicitly enabling ECHO on rollouts that carry environment/observation tokens **fails fast at submission** with `unsupported_loss_config` (`LossConfig::validate_for_kt_tape`) instead of silently training without the term. Pure-completion rollouts (no env tokens) accept an enabled config, but the term contributes nothing and the receipt records `enabled: false` with a `dropped_reason`. Resurrection is planned (env-CE as (softmax − one-hot) rows on the GRPO tape root); until it lands, the rest of this guide describes the *intended* semantics.
 
 **Do my legacy single-turn GRPO rollouts get ECHO?** No, but they get no harm either. For rollouts without a `trajectory` field, `env_mask` is empty → ECHO contributes exactly zero. The loss math is bit-identical to the pre-ECHO commit.
 
 **Do I need to change my capability code?** No, if you're on the new shared lib. The shared `capabilities/agentic-grpo/lib/pi_trajectory.py` already emits the canonical trajectory schema; cap authors call `pi_trajectory.build_scored_rollout(...)` instead of hand-concatenating turns.
 
-**Does ECHO work on all backends?** Yes. CUDA / CPU / Metal share `crates/kiln-train/src/trainer.rs` (both the uncheckpointed loss path and the checkpointed analytic-tail variant — ECHO is folded into both). Vulkan-native gets the same loss term via `crates/kiln-train/src/vk_train.rs::vk_recompute_grpo_train_step_with_state` (paper §3.1 `|O|` normalization preserved).
+**Does ECHO work on all backends?** The plumbing does — the trajectory schema, env-mask construction, and receipt diagnostics are backend-shared. But the env-CE *loss term* is currently disabled on every backend: its gradient producer was deleted with candle (#1082), and `LossConfig::validate_for_kt_tape` rejects enabled-with-env-tokens configs up front rather than burning rollout forwards on a step that cannot train. When the kt-tape env-CE root lands, the term comes back uniformly for CUDA / CPU / Metal / Vulkan.
 
 ## How to use ECHO
 
 ### From the CLI
 
 ```bash
-# Default — ECHO on at λ=0.05.
+# Default — ECHO off (env-CE term disabled pending #1082 resurrection).
 cuda_grpo_ablation \
     --data train.jsonl --model /workspace/Qwen3.5-4B \
     --output adapter --mode phase1
 
-# Override λ.
+# Enable with explicit λ — NOTE: currently rejected at submission
+# (unsupported_loss_config) when rollouts carry observation tokens.
 cuda_grpo_ablation ... --echo-lambda 0.02
 
-# Ablation — disable ECHO entirely.
+# Explicitly disable ECHO (matches the current default).
 cuda_grpo_ablation ... --no-echo
 
-# Verifier-free env-only adaptation (paper §5.5).
+# Verifier-free env-only adaptation (paper §5.5) — intended semantics;
+# currently always rejected (no gradient source with the policy term masked).
 cuda_grpo_ablation ... --no-policy-loss --echo-lambda 0.05
 ```
 
-`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Used for keeping a strong agent improving on tasks where no programmatic verifier is available.
+`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Intended for keeping a strong agent improving on tasks where no programmatic verifier is available — but since the env-CE term has no gradient path post-#1082, `validate_for_kt_tape` rejects it unconditionally for now.
 
 ### From the kiln-server HTTP API
 
@@ -78,6 +80,8 @@ curl -X POST http://localhost:8420/v1/train/agentic \
   }'
 ```
 
+> **Current behavior:** this exact payload — `loss.echo` enabled plus `kind: "observation"` segments — is rejected at submission with `unsupported_loss_config` until the env-CE term regains its gradient root (#1082). Omit the `"echo"` key (or set it to `null`) and the action-token policy loss trains on the full trajectory today; the enabled form above is the intended post-resurrection usage.
+
 The legacy `/v1/train/grpo` endpoint accepts the same payload shape; both routes serve the same handler. Legacy clients posting `{ groups: [{messages, completions: [{text, reward}, ...]}] }` keep working — `completions` is a serde alias for `rollouts`, and `text`-only rollouts deserialize as one-segment Action trajectories.
 
 ### From environment variables
@@ -93,6 +97,8 @@ For ops / CI orchestration without editing the request payload:
 | `KILN_ECHO_WARNING_FILTER=false` | include harness warning prefix in env_mask |
 
 Env vars take **precedence over CLI flags** in `cuda_grpo_ablation` — CLI is for inline dev tweaks; env vars are the right tool for shell-scripted orchestration.
+
+Note: `KILN_ECHO_ENABLED=1` / `KILN_ECHO_LAMBDA` produce an *enabled* config, which is subject to the same fail-fast validation — submission with environment tokens errors with `unsupported_loss_config` until the env-CE gradient root is restored.
 
 ## How to read the diagnostics
 
@@ -124,7 +130,7 @@ The trainer writes ECHO-specific fields to `<adapter_dir>/receipt.json` (when re
 
 ## When to turn ECHO off
 
-Three cases where opting out (`--no-echo`) is the right move:
+ECHO is already off by default today (see [Quick decisions](#quick-decisions)). Once the resurrected term flips the default back on, three cases where opting out (`--no-echo`) is the right move:
 
 1. **Single-turn rollouts with no observations.** ECHO is mathematically a no-op (env_mask is empty), so the cost is zero — but the diagnostic noise might be confusing. Cleaner to flip it off.
 2. **λ tuning ablations.** Run a paired `--no-echo` baseline so the ECHO contribution is visible as a delta.
@@ -174,7 +180,7 @@ This composition is what the integration plan §1 framing calls *"completing the
 When writing a new agentic-GRPO cap, you basically don't need to do anything ECHO-specific. The defaults handle it:
 
 1. **`rollout.py`:** import `pi_trajectory` from `capabilities/agentic-grpo/lib/` and call `pi_trajectory.build_scored_rollout(session_path, reward=...)`. Done — your JSONL now carries the canonical trajectory schema.
-2. **`capability.config.json`:** leave `loss.echo` at its default (which is `null` if you omit, but the trainer's `GrpoConfig::default()` will fill in `Some(EchoConfig::default())` at deserialize time). Explicit:
+2. **`capability.config.json`:** leave `loss.echo` at its default — which is `null` (ECHO off) since the #1082 candle removal. Do **not** explicitly enable it: an enabled config on trajectories with observation segments is rejected at submission (`unsupported_loss_config`) until the env-CE term's kt-tape root lands. When resurrection ships, the intended explicit form is:
    ```json
    "loss": { "echo": { "lambda": 0.05, "env_mask_mode": "env_only", "warning_filter": true } }
    ```


### PR DESCRIPTION
## Summary

Documentation audit (worst lies first), every claim verified against code before editing:

1. **ECHO**: README + ECHO_GUIDE claimed GRPO is "ECHO-by-default"/"applies automatically" — but since the #1082 candle removal severed the env-CE gradient path, the default is **OFF** (`LossConfig::default() → echo: None`) and an echo-enabled config with environment tokens **fails fast** at submission (`unsupported_loss_config`). A user following the guide verbatim would have their request rejected by the docs' own example. Reworded to **ECHO-ready** (the trajectory format genuinely is carried end-to-end), examples fixed, fail-fast behavior + receipt semantics (`enabled:false`, `dropped_reason`) documented, resurrection plan referenced.
2. **README API table**: 12 missing rows added — corrections store, teacher registry, agent traces, `self_improve`/`judge_distill`, `distill/refresh|pump`, `distill_merge` — each verified against the actual `routes()` fns.

## Verification

Markdown tables pipe-balanced; claims cross-checked against `kiln-train/src/lib.rs` (`default_echo_some`, `validate_for_kt_tape`), `train_receipt.rs`, and the `kiln-server` API route modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)