### PR TITLE
ECHO resurrection PR2: env-CE gradient on the fused GRPO tape root — ECHO-by-default again

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ See [docs/GRPO_GUIDE.md](docs/GRPO_GUIDE.md) for worked verifiable-rewards examp
 
 ### Agentic GRPO with ECHO (multi-turn rollouts)
 
-For multi-turn agentic rollouts — tool calls, command output, file contents — kiln's GRPO is **ECHO-ready** (Shrivastava, Awadallah, Papailiopoulos, MSR AI Frontiers 2026): the trajectory format carries environment segments end-to-end, from rollout JSONL through tokenization and masking to the training receipt. ECHO adds a length-normalized cross-entropy loss on environment-observation tokens to the standard policy-gradient loss, with **zero extra forward-pass cost** — the env tokens are already in the rollout context. Paper headline: roughly doubles TerminalBench-2.0 pass@1. The env-CE term itself is **temporarily disabled** pending its kt-tape gradient root (#1082) — enabling it on rollouts with env tokens fails fast at submission (`unsupported_loss_config`) rather than silently training without the term.
+For multi-turn agentic rollouts — tool calls, command output, file contents — kiln's GRPO is **ECHO-by-default** (Shrivastava, Awadallah, Papailiopoulos, MSR AI Frontiers 2026): the trajectory format carries environment segments end-to-end, from rollout JSONL through tokenization and masking to the training receipt, and the env-CE term **trains by default at `λ = 0.05`** on any trajectory with observation segments. ECHO adds a length-normalized cross-entropy loss on environment-observation tokens to the standard policy-gradient loss, with **zero extra forward-pass cost** — the env tokens are already in the rollout context. Paper headline: roughly doubles TerminalBench-2.0 pass@1. Opt out with `--no-echo` / `loss.echo: null` / `KILN_ECHO_ENABLED=0`.
 
-When your rollouts carry a `trajectory` field with `kind: "action"` / `kind: "observation"` segments, kiln-train's `tokenize_grpo_group` builds separate `action_mask` (policy-gradient targets) and `env_mask` (ECHO env-CE targets, `λ_echo = 0.05` once the term is re-enabled). Today the action-token policy loss trains on the full trajectory while the env mask is carried through for diagnostics and the planned resurrection. Legacy single-turn rollouts (no `trajectory` field) behave bit-identically to the pre-ECHO loss.
+When your rollouts carry a `trajectory` field with `kind: "action"` / `kind: "observation"` segments, kiln-train's `tokenize_grpo_group` builds separate `action_mask` (policy-gradient targets) and `env_mask` (ECHO env-CE targets, `λ_echo = 0.05` by default). The env-CE gradient lives on the same fused GRPO tape root as constant-coefficient `(softmax − one-hot)` rows, and the training receipt records `echo.enabled: true` plus the initial/final env-CE. Legacy single-turn rollouts (no `trajectory` field) behave bit-identically to the pre-ECHO loss — with no env tokens the term contributes exactly zero.
 
 ```python
 import requests
@@ -152,9 +152,11 @@ requests.post("http://localhost:8420/v1/train/agentic", json={
             ]
         }]
     }],
-    # loss.echo is off by default; enabling it alongside observation
-    # segments fails fast (unsupported_loss_config) until #1082's
-    # env-CE gradient root is restored.
+    # ECHO env-CE applies by default (λ = 0.05) to the observation
+    # segments above — no config needed. To tune it explicitly:
+    #   "config": {"loss": {"echo": {"lambda": 0.02,
+    #       "env_mask_mode": "env_only", "warning_filter": true}}}
+    # or disable it with "loss": {"echo": null}.
     "config": {}
 })
 ```
@@ -167,8 +169,9 @@ For saturated tasks where reward-only GRPO is low signal, kiln-train also
 accepts off-policy teacher distillation data: prompt messages plus a teacher
 response, optionally with per-token teacher top-logprobs for reverse-KL. The
 same agentic `trajectory` shape can be attached so action tokens receive OPD
-supervision while observation tokens stay masked out of it (they are reserved
-for ECHO's env-CE once that term is restored).
+supervision while observation tokens stay masked out of it. Note the ECHO
+env-CE term is not yet wired into the OPD path — OPD receipts record
+`echo_combined: false`.
 
 See [docs/OPD_TEACHER_JSONL.md](docs/OPD_TEACHER_JSONL.md) for the JSONL
 schema and the `reverse_kl` vs `cross_entropy` objective contract.
@@ -373,7 +376,7 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | POST | `/v1/completions` | vLLM-compatible prompt logprobs for remote OPD teachers |
 | POST | `/v1/completions/batch` | Batch generation API for GRPO (up to 64 prompts per request) |
 | POST | `/v1/train/sft` | Submit SFT training examples (optionally with a `post_eval` hook) |
-| POST | `/v1/train/grpo` | Submit GRPO scored completions (optionally with a `post_eval` hook). Supports the new `agentic_groups` shape with multi-turn `trajectory` fields; action/observation masks are built end-to-end, but the ECHO env-CE term is temporarily disabled (#1082) — enabling it with env tokens fails fast (`unsupported_loss_config`). |
+| POST | `/v1/train/grpo` | Submit GRPO scored completions (optionally with a `post_eval` hook). Supports the new `agentic_groups` shape with multi-turn `trajectory` fields; action/observation masks are built end-to-end, and the ECHO env-CE term applies by default (λ=0.05) to trajectories with observation segments. |
 | POST | `/v1/train/agentic` | Canonical alias of `/v1/train/grpo` — same handler, semantically-honest name for multi-turn rollouts |
 | GET | `/v1/train/status` | Training queue and job status |
 | GET | `/v1/train/status/{job_id}` | Inspect one training job |

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -1469,11 +1469,13 @@ mod tests {
         validate_grpo_submission_source(&inline).unwrap();
     }
 
-    /// Post candle-drop (#1082) the kt-tape trainer cannot train ECHO
-    /// env-CE or no_policy_loss — submissions must fail HERE, not at
-    /// worker dequeue hours later behind a queue.
+    /// ECHO env-CE trains again (resurrection PR2), so echo-enabled
+    /// submissions with Observation segments now pass validation — the
+    /// flagship agentic shape. Still rejected at submission (not at worker
+    /// dequeue hours later): no_policy_loss (not yet re-wired) and the
+    /// reserved OPD slot.
     #[test]
-    fn grpo_submission_rejects_untrainable_loss_configs() {
+    fn grpo_submission_validates_loss_configs() {
         // ECHO + a rollout carrying an Observation segment.
         let mut group = grpo_group();
         group.completions[0].trajectory = vec![
@@ -1494,10 +1496,10 @@ mod tests {
         ];
         let mut req = grpo_req(None, vec![group.clone()]);
         req.config.loss.echo = Some(kiln_train::EchoConfig::default());
-        let err = validate_grpo_submission_source(&req).unwrap_err();
-        assert!(err.message.contains("no gradient path"), "{}", err.message);
+        validate_grpo_submission_source(&req)
+            .expect("echo + observation segments is the flagship agentic shape");
 
-        // Same data WITHOUT echo: fine — the policy loss trains the
+        // Same data WITHOUT echo: also fine — the policy loss trains the
         // trajectory's action tokens.
         let req = grpo_req(None, vec![group]);
         validate_grpo_submission_source(&req).unwrap();

--- a/crates/kiln-train/src/grpo_tape_shim.rs
+++ b/crates/kiln-train/src/grpo_tape_shim.rs
@@ -66,18 +66,21 @@
 //! (eliminating those I/O copies is a separate later #1082 task); the gradient
 //! math is otherwise entirely kt on-device.
 //!
+//! # ECHO env-CE (resurrection PR2 — COVERED)
+//!
+//! The ECHO term (`λ · mean_envCE`) IS folded into this root: the env rows
+//! are the same `coeff · (onehot − softmax)` assembly with the constant
+//! coefficient `−λ/|O|` (`EchoEnvSpec` / `EchoEnvNodeState`), the scalar
+//! gains `λ · (−Σ_env log p / |O|)` before `tape.record`, and the backward
+//! adds the env hidden-grad onto the PG hidden-grad. The Vulkan fused
+//! active-rows route does not carry env rows — ECHO-active steps take the
+//! KtComposite route instead (trainer dispatch).
+//!
 //! # Carve-outs (NOT covered by this tape root)
 //!
-//! * **ECHO env-CE.** The ECHO term (`λ · mean_envCE`) composes against the
-//!   SAME `policy_logits` and COULD be folded in here as extra
-//!   `(softmax − onehot)` rows at env positions — that is exactly the ECHO
-//!   resurrection plan's PR2. Until then there is NO fallback: the candle
-//!   gradient-checkpointing path that used to carry ECHO steps was deleted
-//!   in #1082, so ECHO-with-env-tokens configs are rejected at submission
-//!   and trainer entry (`LossConfig::validate_for_kt_tape`), never
-//!   dispatched.
-//! * **`no_policy_loss`.** With ECHO unavailable this is a constant-zero
-//!   loss; rejected at the same validation points.
+//! * **`no_policy_loss`** (verifier-free, ECHO-only training): not yet
+//!   re-wired — needs the PG coefficients zeroed while the env rows drive;
+//!   still rejected at validation.
 //! * **`KlEstimator` / `IsLevel`** are all SUPPORTED — the numeric-`coeff`
 //!   derivation handles every variant uniformly because it just re-runs
 //!   `grpo_loss`. CUDA/ROCm additionally use a device-resident fast path for
@@ -1069,6 +1072,164 @@ pub(crate) fn selected_log_probs_from_normed_hidden_chunked_kt(
     .map(|state| state.policy_log_probs)
 }
 
+/// ECHO env-CE spec for the fused GRPO loss roots (resurrection PR2).
+///
+/// `env_mask` selects environment-observation TARGET positions with the
+/// same shifted convention as `action_mask` (position `p` contributes when
+/// `env_mask[p+1]`, label = `input_ids[p+1]`). `total_obs_len` is `|O|` —
+/// the PRE-warning-filter observation token count (paper §3.1: normalize
+/// by `|O|`, not by the filtered `|O'|`, so filtered rows still count in
+/// the denominator). `lambda` is the ECHO weight.
+///
+/// Loss contribution: `λ · (−Σ_env' log p) / |O|`. Gradient contribution
+/// per env row: `(λ/|O|) · (softmax − onehot)` — i.e. the SAME
+/// `coeff · (onehot − softmax)` row assembly as the PG term with the
+/// constant coefficient `coeff = −λ/|O|`, which is why the env rows reuse
+/// the proven chunked builder via `coeff_override`.
+#[cfg(any(
+    feature = "cuda",
+    feature = "metal",
+    feature = "vulkan",
+    feature = "rocm"
+))]
+#[derive(Debug, Clone)]
+pub(crate) struct EchoEnvSpec {
+    pub env_mask: Vec<bool>,
+    pub total_obs_len: usize,
+    pub lambda: f64,
+}
+
+/// Saved env-row state on the fused node: everything the backward needs to
+/// rebuild the env softmax rows chunk-by-chunk, plus the constant
+/// per-row coefficient magnitude `λ/|O|` (the backward negates and scales
+/// by the upstream seed).
+#[cfg(any(
+    feature = "cuda",
+    feature = "metal",
+    feature = "vulkan",
+    feature = "rocm"
+))]
+#[derive(Debug)]
+struct EchoEnvNodeState {
+    env_log_probs: kiln_tensor::Tensor,
+    env_idx: kiln_tensor::Tensor,
+    env_labels: Vec<u32>,
+    env_running_max: kiln_tensor::Tensor,
+    env_running_sumexp: kiln_tensor::Tensor,
+    /// λ / |O| — positive magnitude; the backward applies `−(λ/|O|)·seed`.
+    coeff_magnitude: f64,
+}
+
+/// Compute the env-row chunked state + the ECHO env-CE scalar for one
+/// completion. Returns `None` when the spec selects no env rows (legacy
+/// single-turn rollouts) or `|O| == 0` — the term then contributes exactly
+/// nothing, matching the original pre-#1082 semantics.
+#[cfg(any(
+    feature = "cuda",
+    feature = "metal",
+    feature = "vulkan",
+    feature = "rocm"
+))]
+fn echo_env_state_and_value_kt(
+    normed_hidden: &kiln_tensor::Tensor,
+    head_t: &kiln_tensor::Tensor,
+    input_ids: &[u32],
+    spec: &EchoEnvSpec,
+    chunk_size: usize,
+    device: &Device,
+) -> Result<Option<(EchoEnvNodeState, kiln_tensor::Tensor, f64)>> {
+    if spec.total_obs_len == 0 || spec.lambda == 0.0 {
+        return Ok(None);
+    }
+    let has_env = input_ids
+        .len()
+        .checked_sub(1)
+        .map(|n| (0..n).any(|p| spec.env_mask.get(p + 1).copied().unwrap_or(false)))
+        .unwrap_or(false);
+    if !has_env {
+        return Ok(None);
+    }
+    let env_state = selected_log_probs_from_normed_hidden_chunked_state_kt(
+        normed_hidden,
+        head_t,
+        input_ids,
+        &spec.env_mask,
+        chunk_size,
+        device,
+    )
+    .context("echo_env_state_and_value_kt: env log-prob state")?;
+    if env_state.active_labels.is_empty() {
+        return Ok(None);
+    }
+    // env_CE = −Σ log p / |O| (paper §3.1) — scalar on-device, then the λ
+    // weight is applied by the caller when composing the total loss.
+    let inv_obs = -1.0 / spec.total_obs_len as f64;
+    let env_ce_kt = env_state
+        .policy_log_probs
+        .sum_all()
+        .and_then(|s| s.affine(inv_obs, 0.0))
+        .map_err(|e| anyhow::anyhow!("echo_env_state_and_value_kt: env CE scalar: {e}"))?;
+    let env_ce_val = env_ce_kt
+        .to_dtype(kiln_tensor::DType::F32)
+        .and_then(|t| t.to_scalar::<f32>())
+        .map(f64::from)
+        .map_err(|e| anyhow::anyhow!("echo_env_state_and_value_kt: env CE to_scalar: {e}"))?;
+    let node_state = EchoEnvNodeState {
+        env_log_probs: env_state.policy_log_probs,
+        env_idx: env_state.active_idx,
+        env_labels: env_state.active_labels,
+        env_running_max: env_state.running_max,
+        env_running_sumexp: env_state.running_sumexp,
+        coeff_magnitude: spec.lambda / spec.total_obs_len as f64,
+    };
+    Ok(Some((node_state, env_ce_kt, env_ce_val)))
+}
+
+/// Build the env-row hidden gradient for one completion: the same chunked
+/// `coeff · (onehot − softmax)` assembly as the PG rows, with the constant
+/// coefficient `−(λ/|O|) · grad_scalar` injected via `coeff_override`.
+#[cfg(any(
+    feature = "cuda",
+    feature = "metal",
+    feature = "vulkan",
+    feature = "rocm"
+))]
+fn echo_env_grad_from_normed_hidden_kt(
+    normed_hidden: &kiln_tensor::Tensor,
+    head_t: &kiln_tensor::Tensor,
+    echo: &EchoEnvNodeState,
+    loss_params: GrpoLossParams,
+    grpo_kl_auxiliary_route: GrpoKlAuxiliaryRoute,
+    grad_scalar: f64,
+    device: &Device,
+    chunk_size: usize,
+) -> Result<kiln_tensor::Tensor> {
+    let n = echo.env_labels.len();
+    let coeff = (-(echo.coeff_magnitude) * grad_scalar) as f32;
+    let coeff_col = kiln_tensor::Tensor::from_vec_on(*device, vec![coeff; n], vec![n, 1])
+        .map_err(|e| anyhow::anyhow!("echo_env_grad_from_normed_hidden_kt: coeff col: {e}"))?;
+    grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt(
+        normed_hidden,
+        head_t,
+        &echo.env_idx,
+        &echo.env_labels,
+        // With `coeff_override` set the builder never reads the log-prob /
+        // ref / loss-param inputs — they exist only for the PG coefficient
+        // derivation. Pass the env log-probs for shape-compatible refs.
+        &echo.env_log_probs,
+        &echo.env_log_probs,
+        loss_params,
+        grpo_kl_auxiliary_route,
+        grad_scalar,
+        device,
+        chunk_size,
+        &echo.env_running_max,
+        &echo.env_running_sumexp,
+        Some(&coeff_col),
+    )
+    .context("echo_env_grad_from_normed_hidden_kt: env rows grad")
+}
+
 #[cfg(any(
     feature = "cuda",
     feature = "metal",
@@ -1093,6 +1254,9 @@ struct GrpoPgLossFromNormedHiddenBackward {
     /// upstream seed is the implicit unit scalar `dL/dL = 1`. Avoid reading
     /// that scalar back from the device on the production long-context path.
     unit_root_grad: bool,
+    /// ECHO env-CE rows for this completion (resurrection PR2). `None`
+    /// when ECHO is off, the rollout has no env rows, or `|O| == 0`.
+    echo_env: Option<EchoEnvNodeState>,
 }
 
 #[cfg(any(
@@ -1138,12 +1302,38 @@ impl BackwardOp for GrpoPgLossFromNormedHiddenBackward {
             self.chunk_size,
             &self.running_max,
             &self.running_sumexp,
+            None,
         )
         .map_err(|e| {
             kiln_tensor::Error::Msg(format!(
                 "GrpoPgLossFromNormedHiddenBackward: analytic hidden-grad: {e:#}"
             ))
         })?;
+
+        // ECHO env-CE rows (resurrection PR2): the env term's gradient is
+        // the same row assembly with the constant coefficient −(λ/|O|),
+        // added onto the PG hidden grad.
+        let grad_hidden = match self.echo_env.as_ref() {
+            None => grad_hidden,
+            Some(echo) => {
+                let env_grad = echo_env_grad_from_normed_hidden_kt(
+                    &self.normed_hidden,
+                    &self.head_t,
+                    echo,
+                    self.loss_params,
+                    self.grpo_kl_auxiliary_route,
+                    grad_scalar,
+                    &self.device,
+                    self.chunk_size,
+                )
+                .map_err(|e| {
+                    kiln_tensor::Error::Msg(format!(
+                        "GrpoPgLossFromNormedHiddenBackward: ECHO env-CE hidden-grad: {e:#}"
+                    ))
+                })?;
+                (&grad_hidden + &env_grad)?
+            }
+        };
 
         Ok(vec![Some(grad_hidden), None])
     }
@@ -1195,6 +1385,7 @@ pub(crate) fn grpo_pg_loss_from_normed_hidden_grad_kt(
         chunk_size,
         &state.running_max,
         &state.running_sumexp,
+        None,
     )
 }
 
@@ -1219,6 +1410,11 @@ fn grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt(
     chunk_size: usize,
     running_max: &kiln_tensor::Tensor,
     running_sumexp: &kiln_tensor::Tensor,
+    // When set, the per-row coefficients are taken verbatim ([rows, 1] F32,
+    // already seed-scaled) and the PG derivation (fast path + host path,
+    // which read the log-prob/ref/loss-param inputs) is skipped entirely.
+    // The ECHO env-CE rows use this with the constant `−(λ/|O|)·seed`.
+    coeff_override: Option<&kiln_tensor::Tensor>,
 ) -> Result<kiln_tensor::Tensor> {
     use kiln_tensor::ops::{matmul_rhs_transposed, mul_scalar, scatter_add};
     use kiln_tensor::{DType as KtDType, Tensor as KtTensor};
@@ -1286,7 +1482,15 @@ fn grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt(
         "grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt: empty vocab"
     );
 
-    let coeff_col = match grpo_loss_coeff_col_device_fast_path_kt(
+    let coeff_col = if let Some(c) = coeff_override {
+        anyhow::ensure!(
+            c.dims() == [num_active, 1],
+            "grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt: coeff_override shape {:?} != [{num_active}, 1]",
+            c.dims()
+        );
+        c.clone()
+    } else {
+        match grpo_loss_coeff_col_device_fast_path_kt(
         grpo_kl_auxiliary_route,
         policy_log_probs_kt,
         ref_log_probs_kt,
@@ -1318,6 +1522,7 @@ fn grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt(
             KtTensor::from_vec_on(*device, coeff_scaled, vec![num_active, 1])
                 .context("grpo_pg_loss_from_normed_hidden_grad_with_logsum_kt: coeff_col")?
         }
+    }
     };
     let mut grad_active_hidden =
         KtTensor::zeros(vec![num_active, hidden_size], KtDType::F32, *device).context(
@@ -1441,7 +1646,8 @@ pub(crate) fn grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
     grad_scalar: f64,
     device: &Device,
     chunk_size: usize,
-) -> Result<(kiln_tensor::Tensor, kiln_tensor::Tensor)> {
+    echo_env: Option<&EchoEnvSpec>,
+) -> Result<(kiln_tensor::Tensor, kiln_tensor::Tensor, Option<f64>)> {
     let state = selected_log_probs_from_normed_hidden_chunked_state_kt(
         normed_hidden,
         head_t,
@@ -1473,9 +1679,58 @@ pub(crate) fn grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
         chunk_size,
         &state.running_max,
         &state.running_sumexp,
+        None,
     )
     .context("grpo_pg_loss_from_normed_hidden_loss_and_grad_kt: hidden grad")?;
-    Ok((loss_kt, grad_hidden))
+
+    // ECHO env-CE term (resurrection PR2): value `λ·(−Σ_env log p / |O|)`
+    // added to the scalar; gradient = constant-coefficient rows added onto
+    // the PG hidden grad. Contributes exactly nothing when the rollout has
+    // no env rows.
+    let echo_state = match echo_env {
+        Some(spec) => echo_env_state_and_value_kt(
+            normed_hidden,
+            head_t,
+            input_ids,
+            spec,
+            chunk_size,
+            device,
+        )
+        .context("grpo_pg_loss_from_normed_hidden_loss_and_grad_kt: env state")?,
+        None => None,
+    };
+    let (loss_kt, grad_hidden, env_ce) = match echo_state {
+        None => (loss_kt, grad_hidden, None),
+        Some((node_state, env_ce_kt, env_ce_val)) => {
+            let lambda = echo_env.map(|s| s.lambda).unwrap_or(0.0);
+            let loss_kt = env_ce_kt
+                .affine(lambda, 0.0)
+                .and_then(|weighted| &loss_kt + &weighted)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "grpo_pg_loss_from_normed_hidden_loss_and_grad_kt: echo compose: {e}"
+                    )
+                })?;
+            let env_grad = echo_env_grad_from_normed_hidden_kt(
+                normed_hidden,
+                head_t,
+                &node_state,
+                loss_params,
+                grpo_kl_auxiliary_route,
+                grad_scalar,
+                device,
+                chunk_size,
+            )
+            .context("grpo_pg_loss_from_normed_hidden_loss_and_grad_kt: env grad")?;
+            let grad_hidden = (&grad_hidden + &env_grad).map_err(|e| {
+                anyhow::anyhow!(
+                    "grpo_pg_loss_from_normed_hidden_loss_and_grad_kt: echo grad add: {e}"
+                )
+            })?;
+            (loss_kt, grad_hidden, Some(env_ce_val))
+        }
+    };
+    Ok((loss_kt, grad_hidden, env_ce))
 }
 
 /// kt-native analytic `dL/d(logits)` for the GRPO scalar loss. Pure kt ops on
@@ -1808,7 +2063,8 @@ pub(crate) fn try_tape_grpo_pg_loss_from_normed_hidden_kt(
     grpo_kl_auxiliary_route: GrpoKlAuxiliaryRoute,
     device: &Device,
     chunk_size: usize,
-) -> Result<Option<kiln_tensor::Tensor>> {
+    echo_env: Option<&EchoEnvSpec>,
+) -> Result<Option<(kiln_tensor::Tensor, Option<f64>)>> {
     if !tape_forward_enabled() {
         return Ok(None);
     }
@@ -1857,6 +2113,37 @@ pub(crate) fn try_tape_grpo_pg_loss_from_normed_hidden_kt(
     )
     .context("try_tape_grpo_pg_loss_from_normed_hidden_kt: grpo_loss")?;
 
+    // ECHO env-CE (resurrection PR2): compose `λ·env_CE` into the recorded
+    // scalar BEFORE tape.record so the node output id IS the composite
+    // loss; the backward adds the matching constant-coefficient env rows.
+    let echo_state = match echo_env {
+        Some(spec) => echo_env_state_and_value_kt(
+            normed_hidden,
+            head_t,
+            input_ids,
+            spec,
+            chunk_size,
+            device,
+        )
+        .context("try_tape_grpo_pg_loss_from_normed_hidden_kt: env state")?,
+        None => None,
+    };
+    let (loss_kt_forward, echo_node, env_ce) = match echo_state {
+        None => (loss_kt_forward, None, None),
+        Some((node_state, env_ce_kt, env_ce_val)) => {
+            let lambda = echo_env.map(|s| s.lambda).unwrap_or(0.0);
+            let composed = env_ce_kt
+                .affine(lambda, 0.0)
+                .and_then(|weighted| &loss_kt_forward + &weighted)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "try_tape_grpo_pg_loss_from_normed_hidden_kt: echo compose: {e}"
+                    )
+                })?;
+            (composed, Some(node_state), Some(env_ce_val))
+        }
+    };
+
     let loss_kt = match with_active_tape(|tape: &mut Tape| -> Result<_> {
         let loss_kt = loss_kt_forward;
         tape.record(
@@ -1876,6 +2163,7 @@ pub(crate) fn try_tape_grpo_pg_loss_from_normed_hidden_kt(
                 device: *device,
                 chunk_size,
                 unit_root_grad: true,
+                echo_env: echo_node,
             }) as Box<dyn BackwardOp>,
         );
         Ok(loss_kt)
@@ -1885,7 +2173,7 @@ pub(crate) fn try_tape_grpo_pg_loss_from_normed_hidden_kt(
     };
     let loss_kt =
         loss_kt.context("try_tape_grpo_pg_loss_from_normed_hidden_kt: kt-tape forward failed")?;
-    Ok(Some(loss_kt))
+    Ok(Some((loss_kt, env_ce)))
 }
 
 #[cfg(feature = "vulkan")]
@@ -2097,6 +2385,177 @@ mod tests {
     }
 
     #[cfg(any(feature = "cuda", feature = "vulkan"))]
+    /// Resurrection PR2 correctness gate: the ECHO env-CE rows added by
+    /// the fused root must match the dense closed form EXACTLY —
+    /// `Δgrad_hidden = Σ_env (λ/|O|)·(softmax_p − onehot_{y_p}) @ head_tᵀ`
+    /// at env rows and ZERO everywhere else, and
+    /// `Δloss = λ·(−Σ_env log p)/|O|`. The env coefficient is constant, so
+    /// this is a noise-free analytic check (no finite differences needed).
+    #[test]
+    fn grpo_normed_hidden_echo_env_grad_matches_closed_form_cpu() {
+        let device = kiln_tensor::Device::Cpu;
+        let (seq_len, hidden_size, vocab) = (6usize, 5usize, 13usize);
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2];
+        let action_mask = vec![false, false, true, true, false, true];
+        // Disjoint env targets at shifted rows {0, 3} (env_mask[p+1]).
+        let env_mask = vec![false, true, false, false, true, false];
+        let total_obs_len = 3usize; // |O| > filtered rows: §3.1 denominator
+        let lambda = 0.05f64;
+        let num_active = action_mask[1..].iter().filter(|m| **m).count();
+        let hidden_host: Vec<f32> = (0..seq_len * hidden_size)
+            .map(|i| (((i * 7) % 19) as f32 - 9.0) * 0.041)
+            .collect();
+        let head_host: Vec<f32> = (0..hidden_size * vocab)
+            .map(|i| (((i * 11) % 23) as f32 - 11.0) * 0.037)
+            .collect();
+        let normed_hidden =
+            KtTensor::from_vec_on(device, hidden_host.clone(), vec![1, seq_len, hidden_size])
+                .expect("hidden");
+        let head_t =
+            KtTensor::from_vec_on(device, head_host.clone(), vec![hidden_size, vocab])
+                .expect("head");
+        let read = |t: &KtTensor| -> Vec<f32> {
+            t.to_dtype(KtDType::F32)
+                .unwrap()
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap()
+        };
+
+        // Reference log-probs for a stable PG term.
+        let plp = super::selected_log_probs_from_normed_hidden_chunked_kt(
+            &normed_hidden,
+            &head_t,
+            &input_ids,
+            &action_mask,
+            3,
+            &device,
+        )
+        .unwrap();
+        let ref_host: Vec<f32> = read(&plp).iter().map(|&p| p - 0.1).collect();
+        let ref_kt = KtTensor::from_vec_on(device, ref_host, vec![num_active]).expect("ref");
+        let params = GrpoLossParams {
+            advantage: 0.7,
+            clip_low: 0.8,
+            clip_high: 1.2,
+            kl_coeff: 0.1,
+            kl_estimator: crate::KlEstimator::K1,
+            loss_normalizer: 1.0 / num_active as f64,
+            is_level: crate::IsLevel::Token,
+            reinforce: false,
+            entropy_aware_kl_quantile: None,
+        };
+
+        let (loss_base, grad_base, env_ce_base) =
+            super::grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
+                &normed_hidden,
+                &head_t,
+                &input_ids,
+                &action_mask,
+                &ref_kt,
+                params,
+                GrpoKlAuxiliaryRoute::HostComposite,
+                1.0,
+                &device,
+                3,
+                None,
+            )
+            .unwrap();
+        assert!(env_ce_base.is_none());
+
+        let spec = super::EchoEnvSpec {
+            env_mask: env_mask.clone(),
+            total_obs_len,
+            lambda,
+        };
+        let (loss_echo, grad_echo, env_ce) =
+            super::grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
+                &normed_hidden,
+                &head_t,
+                &input_ids,
+                &action_mask,
+                &ref_kt,
+                params,
+                GrpoKlAuxiliaryRoute::HostComposite,
+                1.0,
+                &device,
+                3,
+                Some(&spec),
+            )
+            .unwrap();
+        let env_ce = env_ce.expect("env rows present → env_ce reported");
+
+        // --- Dense closed form on the host. ---
+        let row_logits = |p: usize| -> Vec<f32> {
+            (0..vocab)
+                .map(|v| {
+                    (0..hidden_size)
+                        .map(|h| hidden_host[p * hidden_size + h] * head_host[h * vocab + v])
+                        .sum()
+                })
+                .collect()
+        };
+        let softmax = |logits: &[f32]| -> Vec<f32> {
+            let m = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = logits.iter().map(|&l| (l - m).exp()).collect();
+            let z: f32 = exps.iter().sum();
+            exps.iter().map(|&e| e / z).collect()
+        };
+        let env_rows: Vec<usize> = (0..seq_len - 1).filter(|&p| env_mask[p + 1]).collect();
+        assert_eq!(env_rows.len(), 2, "fixture sanity");
+
+        // Expected Δloss and env_ce.
+        let mut sum_logp = 0.0f64;
+        for &p in &env_rows {
+            let probs = softmax(&row_logits(p));
+            sum_logp += (probs[input_ids[p + 1] as usize] as f64).ln();
+        }
+        let expected_env_ce = -sum_logp / total_obs_len as f64;
+        assert!(
+            (env_ce - expected_env_ce).abs() < 1e-5,
+            "env_ce {env_ce} vs closed form {expected_env_ce}"
+        );
+        let loss_base_v = read(&loss_base)[0] as f64;
+        let loss_echo_v = read(&loss_echo)[0] as f64;
+        assert!(
+            ((loss_echo_v - loss_base_v) - lambda * expected_env_ce).abs() < 1e-5,
+            "Δloss {} vs λ·env_ce {}",
+            loss_echo_v - loss_base_v,
+            lambda * expected_env_ce
+        );
+
+        // Expected Δgrad: (λ/|O|)·(softmax − onehot) @ head_tᵀ at env rows.
+        let grad_base_v = read(&grad_base);
+        let grad_echo_v = read(&grad_echo);
+        assert_eq!(grad_base_v.len(), grad_echo_v.len());
+        let coeff = (lambda / total_obs_len as f64) as f32;
+        for p in 0..seq_len {
+            for h in 0..hidden_size {
+                let idx = p * hidden_size + h;
+                let delta = grad_echo_v[idx] - grad_base_v[idx];
+                let expected = if env_rows.contains(&p) {
+                    let probs = softmax(&row_logits(p));
+                    let label = input_ids[p + 1] as usize;
+                    (0..vocab)
+                        .map(|v| {
+                            let sm_minus_onehot =
+                                probs[v] - if v == label { 1.0 } else { 0.0 };
+                            coeff * sm_minus_onehot * head_host[h * vocab + v]
+                        })
+                        .sum::<f32>()
+                } else {
+                    0.0
+                };
+                assert!(
+                    (delta - expected).abs() < 1e-5,
+                    "env grad drift at pos {p} dim {h}: Δ={delta} expected={expected}"
+                );
+            }
+        }
+    }
+
+    #[cfg(any(feature = "cuda", feature = "vulkan"))]
     #[test]
     fn grpo_normed_hidden_chunked_matches_full_logits_cpu() {
         let device = kiln_tensor::Device::Cpu;
@@ -2249,7 +2708,7 @@ mod tests {
             )
             .unwrap();
             let loss_expected = grpo_loss(&plp_hidden, &ref_kt, params, &device).unwrap();
-            let (loss_cached, cached_hidden) =
+            let (loss_cached, cached_hidden, _env_ce) =
                 super::grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
                     &normed_hidden,
                     &head_t,
@@ -2261,6 +2720,7 @@ mod tests {
                     1.0,
                     &device,
                     3,
+                    None,
                 )
                 .unwrap();
             let loss_diff = (read(&loss_expected)[0] - read(&loss_cached)[0]).abs();

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -776,11 +776,12 @@ fn default_reward_filter_min_groups() -> usize {
 //           + λ_echo · L_envCE(observations) [paper: Shrivastava 2026]
 //           + λ_opd  · L_revKL(actions)      [paper: Lu 2025; wired in OPD merge]
 //
-// `LossConfig::default()` has ECHO OFF: the candle drop (#1082) deleted
-// the only env-CE gradient producer, so until the kt-tape root is
-// restored (ECHO resurrection plan) an enabled term either contributes
-// nothing (no env tokens) or hard-errors (env tokens present). Explicit
-// opt-in is validated up front via `LossConfig::validate_for_kt_tape`.
+// `LossConfig::default()` has ECHO ON (λ=0.05, paper §3.3): the env-CE
+// term regained its gradient root on the fused GRPO tape node (ECHO
+// resurrection PR2 — `grpo_tape_shim::EchoEnvSpec`), so default-config
+// agentic GRPO on real pi trajectories trains the observation tokens
+// again. Rollouts with no env tokens pay nothing (the term contributes
+// exactly zero and the receipt's env_ce stays None).
 // `opd` is a placeholder None; its shape is reserved so the composition
 // stays orthogonal.
 
@@ -826,14 +827,14 @@ fn default_echo_lambda() -> f64 {
 fn default_warning_filter() -> bool {
     true
 }
-/// ECHO default. OFF until the env-CE term regains a gradient path: the
-/// candle drop (#1082) deleted the only producer that could backpropagate
-/// it, so a default-ON config made default-config agentic GRPO on real pi
-/// trajectories fail by design — after burning the rollout/reference
-/// forwards. Flip back to `Some(EchoConfig::default())` when the kt-tape
-/// env-CE root lands (ECHO resurrection plan, PR2).
+/// ECHO default: ON at λ=0.05 (paper §3.3). The term was forced OFF
+/// between the #1082 candle drop (which deleted the only env-CE gradient
+/// producer) and resurrection PR2 (which rebuilt it as constant-coefficient
+/// `(softmax − onehot)` rows on the fused GRPO tape root). Legacy
+/// single-turn rollouts carry no env tokens, so the default costs them
+/// exactly nothing.
 fn default_echo_some() -> Option<EchoConfig> {
-    None
+    Some(EchoConfig::default())
 }
 
 impl Default for EchoConfig {
@@ -871,11 +872,11 @@ pub struct LossConfig {
     /// trainer reads them from the surrounding GrpoConfig.
     ///
     /// Observation-token cross-entropy (paper: Shrivastava et al. 2026).
-    /// Default: `None` until the env-CE term regains a kt-tape gradient
-    /// root (deleted with the candle drop, #1082). Explicitly enabling it
-    /// fails fast at submission/trainer entry when the data carries
-    /// Observation segments — the term would otherwise silently train
-    /// nothing or hard-error mid-run after the rollout forwards.
+    /// Default: `Some(EchoConfig::default())` — ON at λ=0.05 (resurrection
+    /// PR2 rebuilt the env-CE gradient on the fused GRPO tape root after
+    /// the #1082 candle drop severed it). Rollouts without environment
+    /// tokens pay nothing; set to `null` (or pass `--no-echo`) to train
+    /// the action-token policy loss alone.
     #[serde(default = "default_echo_some")]
     pub echo: Option<EchoConfig>,
     /// Action-token reverse-KL to a teacher (OPD; Lu 2025). Default: None.
@@ -905,29 +906,22 @@ impl Default for LossConfig {
 
 impl LossConfig {
     /// Validate this composition against the kt-tape training path BEFORE
-    /// any GPU work. Post-candle-drop (#1082) the ECHO env-CE term has no
-    /// tape gradient root and `no_policy_loss` therefore has no gradient
-    /// source at all; both previously failed mid-run, after the rollout
-    /// and reference forwards had already burned GPU time.
+    /// any GPU work. The ECHO env-CE term is live again (resurrection PR2:
+    /// constant-coefficient rows on the fused GRPO tape root), so
+    /// echo-enabled configs with environment tokens TRAIN now. Still
+    /// rejected: `no_policy_loss` (verifier-free ECHO-only training needs
+    /// the PG coefficients zeroed while the env rows drive — not yet
+    /// re-wired) and the reserved `opd` slot.
     /// `has_env_tokens` = the training data carries trajectory
     /// Observation/tool segments that the env mask would cover.
-    pub fn validate_for_kt_tape(&self, has_env_tokens: bool) -> Result<(), String> {
+    pub fn validate_for_kt_tape(&self, _has_env_tokens: bool) -> Result<(), String> {
         if self.no_policy_loss {
             return Err(
-                "loss.no_policy_loss requires the ECHO env-CE gradient root, which was \
-                 removed in the candle drop (#1082) — there is currently nothing to train \
-                 on with the policy term masked out. Remove no_policy_loss (restoration \
-                 is tracked in the ECHO resurrection plan)."
-                    .to_string(),
-            );
-        }
-        if self.echo_enabled() && has_env_tokens {
-            return Err(
-                "loss.echo is enabled and the rollouts carry Observation/tool segments, \
-                 but the ECHO env-CE term has no gradient path post candle-drop (#1082) — \
-                 the step would fail after the rollout forwards. Set loss.echo to null \
-                 (or pass --no-echo); the action-token policy loss still trains on the \
-                 full trajectory. Restoration is tracked in the ECHO resurrection plan."
+                "loss.no_policy_loss (verifier-free, ECHO-only training) is not yet \
+                 re-wired on the kt-tape path: it needs the policy-gradient \
+                 coefficients zeroed while the env-CE rows drive the update. Remove \
+                 no_policy_loss — the ECHO env-CE term itself is live again and \
+                 composes with the standard policy loss."
                     .to_string(),
             );
         }
@@ -1436,18 +1430,16 @@ mod tests {
     }
 
     #[test]
-    fn loss_config_default_has_echo_off_until_tape_root_restored() {
+    fn loss_config_default_has_echo_on_again() {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
         let cfg = LossConfig::default();
-        // The env-CE term lost its gradient path in the candle drop
-        // (#1082): default-ON made default-config agentic GRPO on real pi
-        // trajectories fail by design. Flip back to ON alongside the
-        // kt-tape env-CE root (ECHO resurrection plan PR2).
-        assert!(
-            cfg.echo.is_none(),
-            "ECHO must default OFF while the env-CE term has no gradient path"
-        );
+        // Resurrection PR2: the env-CE term regained its gradient root on
+        // the fused GRPO tape node, so the paper default (λ=0.05) is the
+        // out-of-the-box behavior again — and a default config with env
+        // tokens VALIDATES.
+        let echo = cfg.echo.as_ref().expect("ECHO defaults ON post-resurrection");
+        assert!((echo.lambda - 0.05).abs() < 1e-12, "paper §3.3 default λ");
         assert!(cfg.opd.is_none(), "OPD should be off by default");
         assert!(cfg.validate_for_kt_tape(true).is_ok());
     }
@@ -1457,16 +1449,18 @@ mod tests {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
 
-        // Explicit ECHO + env tokens: would fail mid-run after the rollout
-        // forwards — must be rejected up front, with the remediation.
+        // ECHO + env tokens trains again (resurrection PR2) — both shapes
+        // validate.
         let mut cfg = LossConfig::default();
         cfg.echo = Some(EchoConfig::default());
-        assert!(cfg.validate_for_kt_tape(false).is_ok(), "no env tokens = zero term, harmless");
-        let err = cfg.validate_for_kt_tape(true).unwrap_err();
-        assert!(err.contains("no gradient path"), "{err}");
-        assert!(err.contains("--no-echo"), "{err}");
+        assert!(cfg.validate_for_kt_tape(false).is_ok());
+        assert!(
+            cfg.validate_for_kt_tape(true).is_ok(),
+            "echo + env tokens is the flagship agentic shape — must validate"
+        );
 
-        // no_policy_loss: constant-zero loss post candle-drop.
+        // no_policy_loss: verifier-free ECHO-only training is not yet
+        // re-wired (PG coefficients must be zeroed while env rows drive).
         let mut cfg = LossConfig::default();
         cfg.no_policy_loss = true;
         let err = cfg.validate_for_kt_tape(false).unwrap_err();
@@ -1578,11 +1572,11 @@ mod tests {
     fn kiln_echo_no_env_vars_leaves_config_unchanged() {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_kiln_echo_env_vars();
-        // Both the (now-OFF) default and an explicit opt-in survive a pass
-        // with no env vars set.
+        // Both the (ON again) default and an explicit config survive a
+        // pass with no env vars set.
         let mut cfg = LossConfig::default();
         cfg.apply_kiln_echo_env_overrides();
-        assert!(cfg.echo.is_none(), "default OFF stays OFF");
+        assert!(cfg.echo.is_some(), "default ON stays ON");
 
         let mut cfg = LossConfig::default();
         cfg.echo = Some(EchoConfig::default());

--- a/crates/kiln-train/src/train_receipt.rs
+++ b/crates/kiln-train/src/train_receipt.rs
@@ -771,9 +771,9 @@ pub fn classify_training_failure(message: &str) -> TrainFailureReason {
     }
     // Untrainable loss compositions (validate_for_kt_tape) — must match
     // BEFORE the zero-env-tokens patterns since both mention env tokens.
-    if lower.contains("no gradient path")
-        || lower.contains("no_policy_loss requires")
-        || (lower.contains("echo") && lower.contains("post candle-drop"))
+    if lower.contains("no_policy_loss (verifier-free")
+        || lower.contains("not yet re-wired on the kt-tape path")
+        || lower.contains("loss.opd composition on grpo is reserved")
     {
         return TrainFailureReason::UnsupportedLossConfig;
     }

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -3746,20 +3746,10 @@ pub fn grpo_dry_run_jsonl(
                 token_counts.action_tokens > 0,
                 "GRPO dry run: dataset has no action tokens after mask construction"
             );
-            // The dry run pins the same constraint the real run enforces.
-            // (It used to demand the OPPOSITE — env tokens required when
-            // ECHO was on — so a dataset that passed the dry run was
-            // exactly one that failed the real run.)
-            if config.loss.echo_enabled() {
-                anyhow::ensure!(
-                    token_counts.env_tokens == 0,
-                    "GRPO dry run: ECHO is enabled and the dataset carries environment \
-                     tokens, but the env-CE term has no gradient path post candle-drop \
-                     (#1082) — the real run would fail after the rollout forwards. Pass \
-                     --no-echo (or set loss.echo to null); the action-token policy loss \
-                     still trains on the full trajectory."
-                );
-            }
+            // ECHO + env tokens is trainable again (resurrection PR2):
+            // the env-CE term has a fused-root gradient, so the dry run no
+            // longer rejects ECHO-enabled datasets with environment tokens.
+            // The report's env-token counts stand on their own.
         }
 
         Ok(GrpoDryRunReport {
@@ -5353,7 +5343,23 @@ fn train_tokenized_grpo_group_with_grad_norms(
                 feature = "rocm"
             ))]
             {
-                let (lv, kt_grads) = if let Some(segs) = segments {
+                // ECHO env-CE spec (resurrection PR2): built when the term
+                // is enabled and this completion actually has env rows; the
+                // fused loss roots add λ·env_CE to the value and the matching
+                // constant-coefficient rows to the gradient.
+                let echo_env_spec = if config.loss.echo_enabled()
+                    && comp_env_count > 0
+                    && comp.total_obs_len > 0
+                {
+                    Some(crate::grpo_tape_shim::EchoEnvSpec {
+                        env_mask: comp.env_mask.clone(),
+                        total_obs_len: comp.total_obs_len,
+                        lambda: config.loss.echo_lambda(),
+                    })
+                } else {
+                    None
+                };
+                let (lv, env_ce, kt_grads) = if let Some(segs) = segments {
                     let step_started = Instant::now();
                     let out = checkpointed_grpo_forward_backward_tape_authoritative_kt(
                         backend,
@@ -5366,6 +5372,7 @@ fn train_tokenized_grpo_group_with_grad_norms(
                         loss_params,
                         segs,
                         device,
+                        echo_env_spec.as_ref(),
                     )?;
                     let step_elapsed = step_started.elapsed();
                     if let Some(t) = timings.as_deref_mut() {
@@ -5401,10 +5408,11 @@ fn train_tokenized_grpo_group_with_grad_norms(
                         streaming_tile_tokens,
                         checkpoint_segments,
                         timings.as_deref_mut(),
+                        echo_env_spec.as_ref(),
                     )?
                 };
                 loss_val = lv;
-                comp_echo_env_ce = None;
+                comp_echo_env_ce = env_ce;
                 GradSource::Kt(kt_grads)
             }
             #[cfg(not(any(
@@ -8862,12 +8870,13 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
     streaming_tile_tokens: usize,
     checkpoint_segments: usize,
     mut timings: Option<&mut GrpoBenchmarkTimings>,
-) -> Result<(f64, kiln_autograd::GradStore)> {
+    echo_env: Option<&crate::grpo_tape_shim::EchoEnvSpec>,
+) -> Result<(f64, Option<f64>, kiln_autograd::GradStore)> {
     let lora_weights = params.as_lora_weights();
     let mut linear_state = LinearAttentionState::new(model_config, device)?;
     let step_started = Instant::now();
 
-    let (loss_val, _loss_kt, grads_by_candle_raw) =
+    let ((loss_val, env_ce), _loss_kt, grads_by_candle_raw) =
         kiln_kt_bridge::tape_bridge::with_tape_authoritative_scope_kt(|| {
             // Single policy forward through final RMSNorm, without materializing
             // `[1, T, V]` logits. The GRPO loss root chunks the frozen tied head
@@ -8883,9 +8892,11 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
             .context("GRPO tape-authoritative(kt) no-head policy forward")
             .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("{e:#}")))?;
 
+            // The Vulkan fused active-rows root carries no env rows — an
+            // ECHO-active step takes the KtComposite root below instead.
             #[cfg(feature = "vulkan")]
             let mut loss_opt = match TrainingLossBackend::runtime_grpo_loss_route(backend) {
-                GrpoLossRoute::VulkanActiveRows => {
+                GrpoLossRoute::VulkanActiveRows if echo_env.is_none() => {
                     crate::grpo_tape_shim::try_tape_grpo_pg_loss_from_normed_hidden_vulkan_kt(
                         &policy_hidden,
                         &weights.embed_tokens,
@@ -8896,8 +8907,9 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
                     )
                     .context("GRPO tape-authoritative(kt) Vulkan fused scalar loss")
                     .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("{e:#}")))?
+                    .map(|l| (l, None))
                 }
-                GrpoLossRoute::KtComposite => None,
+                _ => None,
             };
             #[cfg(not(feature = "vulkan"))]
             let mut loss_opt = None;
@@ -8913,13 +8925,14 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
                         grpo_kl_auxiliary_route_for_backend(backend),
                         device,
                         DEFAULT_CHUNK_SIZE,
+                        echo_env,
                     )
                     .context("GRPO tape-authoritative(kt) scalar loss")
                     .map_err(|e| kiln_kt_bridge::BridgeError::new(format!("{e:#}")))?;
             }
 
-            let loss = match loss_opt {
-                Some(l) => l,
+            let (loss, env_ce) = match loss_opt {
+                Some(pair) => pair,
                 None => {
                     return Err(kiln_kt_bridge::BridgeError::new(
                         "GRPO tape-authoritative(kt): try_tape_grpo_pg_loss_from_normed_hidden_kt \
@@ -8935,7 +8948,7 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
                     kiln_kt_bridge::BridgeError::new(format!("GRPO(kt) loss.to_scalar: {e}"))
                 })?
                 as f64;
-            Ok((loss_val, loss))
+            Ok(((loss_val, env_ce), loss))
         })
         .map_err(|e| anyhow::anyhow!("GRPO tape-authoritative(kt) backward: {e}"))?;
 
@@ -9002,7 +9015,7 @@ fn grpo_step_forward_backward_tape_authoritative_kt(
         "GRPO step end (tape-authoritative kt)"
     );
 
-    Ok((loss_val, grads))
+    Ok((loss_val, env_ce, grads))
 }
 
 #[cfg(any(
@@ -9023,7 +9036,8 @@ fn checkpointed_grpo_forward_backward_tape_authoritative_kt(
     loss_params: GrpoLossParams,
     segments: &[(usize, usize)],
     device: &Device,
-) -> Result<(f64, kiln_autograd::GradStore)> {
+    echo_env: Option<&crate::grpo_tape_shim::EchoEnvSpec>,
+) -> Result<(f64, Option<f64>, kiln_autograd::GradStore)> {
     let num_segments = segments.len();
     anyhow::ensure!(
         num_segments > 0,
@@ -9073,25 +9087,31 @@ fn checkpointed_grpo_forward_backward_tape_authoritative_kt(
 
     let normed = model_forward_final_norm(&final_hidden, weights, model_config)
         .context("checkpointed GRPO final norm")?;
+    // The Vulkan fused active-rows tail carries no env rows — ECHO-active
+    // steps take the KtComposite tail instead.
     #[cfg(feature = "vulkan")]
-    let fused_vulkan_tail = match TrainingLossBackend::runtime_grpo_loss_route(backend) {
-        GrpoLossRoute::VulkanActiveRows => {
-            crate::grpo_tape_shim::vulkan_grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
-                &normed,
-                &weights.embed_tokens,
-                input_ids,
-                action_mask,
-                ref_log_probs,
-                loss_params,
-            )
-            .context("checkpointed GRPO Vulkan fused tail loss/gradient")?
+    let fused_vulkan_tail = if echo_env.is_some() {
+        None
+    } else {
+        match TrainingLossBackend::runtime_grpo_loss_route(backend) {
+            GrpoLossRoute::VulkanActiveRows => {
+                crate::grpo_tape_shim::vulkan_grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
+                    &normed,
+                    &weights.embed_tokens,
+                    input_ids,
+                    action_mask,
+                    ref_log_probs,
+                    loss_params,
+                )
+                .context("checkpointed GRPO Vulkan fused tail loss/gradient")?
+            }
+            GrpoLossRoute::KtComposite => None,
         }
-        GrpoLossRoute::KtComposite => None,
     };
     #[cfg(not(feature = "vulkan"))]
     let fused_vulkan_tail = None;
-    let (loss_kt, grad_normed) = match fused_vulkan_tail {
-        Some(pair) => pair,
+    let (loss_kt, grad_normed, env_ce) = match fused_vulkan_tail {
+        Some((l, g)) => (l, g, None),
         None => crate::grpo_tape_shim::grpo_pg_loss_from_normed_hidden_loss_and_grad_kt(
             &normed,
             &weights.embed_tokens_t,
@@ -9103,6 +9123,7 @@ fn checkpointed_grpo_forward_backward_tape_authoritative_kt(
             1.0,
             device,
             DEFAULT_CHUNK_SIZE,
+            echo_env,
         )
         .context("checkpointed GRPO tail loss/gradient")?,
     };
@@ -9183,7 +9204,7 @@ fn checkpointed_grpo_forward_backward_tape_authoritative_kt(
         }
     }
 
-    Ok((loss_val, grads))
+    Ok((loss_val, env_ce, grads))
 }
 
 /// Bundled parameters for the GRPO surrogate / KL loss.
@@ -9879,14 +9900,13 @@ pub(crate) mod tests {
         assert!(err.to_string().contains("empty action_mask"));
     }
 
-    /// The dry run must pin the same constraint the real run enforces:
-    /// ECHO + env tokens has no gradient path post candle-drop (#1082), so
-    /// it REJECTS — while ECHO + legacy single-turn rollouts (zero env
-    /// tokens, zero contribution) passes. The pre-fix gate demanded the
-    /// exact opposite, so a dataset that passed the dry run was precisely
-    /// one that failed the real run.
+    /// Resurrection PR2: ECHO + env tokens TRAINS again, so the dry run
+    /// accepts both shapes — legacy single-turn rollouts (zero env tokens,
+    /// zero contribution) and trajectory rollouts WITH observations (the
+    /// flagship agentic shape). The report's env-token counts distinguish
+    /// them.
     #[test]
-    fn grpo_dry_run_rejects_echo_with_env_tokens_and_writes_receipt() -> Result<()> {
+    fn grpo_dry_run_accepts_echo_with_and_without_env_tokens() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         let tok = make_echo_smoke_tokenizer()?;
 
@@ -9908,7 +9928,8 @@ pub(crate) mod tests {
         )?;
         assert_eq!(report.token_counts.env_tokens, 0);
 
-        // Trajectory rollouts WITH observations: rejected up front.
+        // Trajectory rollouts WITH observations: accepted, env tokens
+        // counted in the report.
         let env_group = dry_run_group(vec![
             crate::ScoredRollout::from_trajectory(
                 vec![
@@ -9926,7 +9947,7 @@ pub(crate) mod tests {
             crate::ScoredRollout::legacy("b".to_string(), 1.0),
         ]);
         let env_data = dry_run_dataset(tmp.path(), "echo-env.jsonl", &[env_group]);
-        let err = grpo_dry_run_jsonl(
+        let env_report = grpo_dry_run_jsonl(
             &env_data,
             &dry_run_config(true, false),
             &ModelConfig::qwen3_5_4b(),
@@ -9934,25 +9955,10 @@ pub(crate) mod tests {
             &output,
             "echo-env",
             false,
-        )
-        .unwrap_err();
-
+        )?;
         assert!(
-            err.to_string().contains("failure_reason=unsupported_loss_config"),
-            "{err}"
-        );
-        assert!(err.to_string().contains("--no-echo"), "{err}");
-        let receipt =
-            crate::train_receipt::TrainReceipt::read_from_adapter_dir(&output.join("echo-env"))?
-                .unwrap();
-        assert_eq!(
-            receipt.status,
-            crate::train_receipt::TrainReceiptStatus::Failed
-        );
-        assert!(receipt.token_counts.env_tokens > 0);
-        assert_eq!(
-            receipt.failure_reason.as_deref(),
-            Some("unsupported_loss_config")
+            env_report.token_counts.env_tokens > 0,
+            "observation tokens must be counted: {env_report:?}"
         );
         Ok(())
     }
@@ -13836,7 +13842,7 @@ pub(crate) mod tests {
         };
 
         let backend = backend::for_device_kt(&device);
-        let (loss_val, grads) = grpo_step_forward_backward_tape_authoritative_kt(
+        let (loss_val, _env_ce, grads) = grpo_step_forward_backward_tape_authoritative_kt(
             &*backend,
             &input_ids,
             &weights,
@@ -13852,6 +13858,7 @@ pub(crate) mod tests {
             0,          // streaming_tile_tokens (no streaming)
             0,          // checkpoint_segments (no checkpointing)
             None,       // timings
+            None,       // echo_env
         )
         .expect("grpo_step_forward_backward_tape_authoritative_kt (F32 Vulkan GRPO)");
 
@@ -14070,7 +14077,7 @@ pub(crate) mod tests {
         };
 
         let backend = backend::for_device_kt(&device);
-        let (loss_val, grads) = grpo_step_forward_backward_tape_authoritative_kt(
+        let (loss_val, _env_ce, grads) = grpo_step_forward_backward_tape_authoritative_kt(
             &*backend,
             &input_ids,
             &weights,
@@ -14086,6 +14093,7 @@ pub(crate) mod tests {
             0,
             0,
             None,
+            None, // echo_env
         )
         .expect("grpo_step_forward_backward_tape_authoritative_kt (BF16 Vulkan GRPO)");
 

--- a/docs/ECHO_GUIDE.md
+++ b/docs/ECHO_GUIDE.md
@@ -13,37 +13,37 @@ This guide is the operational companion to the integration plan
 
 ## Quick decisions
 
-**Is ECHO on by default?** No — not anymore. ECHO defaulted ON historically, but the env-CE term lost its gradient path when candle was removed (#1082), so `LossConfig::default()` now ships `loss.echo = None` (`default_echo_some()` in `crates/kiln-train/src/lib.rs`). Explicitly enabling ECHO on rollouts that carry environment/observation tokens **fails fast at submission** with `unsupported_loss_config` (`LossConfig::validate_for_kt_tape`) instead of silently training without the term. Pure-completion rollouts (no env tokens) accept an enabled config, but the term contributes nothing and the receipt records `enabled: false` with a `dropped_reason`. Resurrection is planned (env-CE as (softmax − one-hot) rows on the GRPO tape root); until it lands, the rest of this guide describes the *intended* semantics.
+**Is ECHO on by default?** Yes. `LossConfig::default()` ships `loss.echo = Some(EchoConfig::default())` — `λ = 0.05`, `env_mask_mode: env_only`, `warning_filter: true` (`default_echo_some()` in `crates/kiln-train/src/lib.rs`). (One sentence of history: the term was disabled between the #1082 candle removal, which deleted its only gradient producer, and resurrection PR2, which rebuilt env-CE as constant-coefficient `(softmax − one-hot)` rows on the fused GRPO tape root — `λ/|O|` per row, |O| = pre-warning-filter observation length per paper §3.1, validated by a closed-form CPU gradient test.) Submissions with ECHO plus observation segments validate and train; the receipt records `echo.enabled: true` with `initial_env_ce` / `final_env_ce`. Rollouts with no env tokens pay nothing — the term contributes exactly zero and the receipt's env-CE fields stay unset.
 
 **Do my legacy single-turn GRPO rollouts get ECHO?** No, but they get no harm either. For rollouts without a `trajectory` field, `env_mask` is empty → ECHO contributes exactly zero. The loss math is bit-identical to the pre-ECHO commit.
 
 **Do I need to change my capability code?** No, if you're on the new shared lib. The shared `capabilities/agentic-grpo/lib/pi_trajectory.py` already emits the canonical trajectory schema; cap authors call `pi_trajectory.build_scored_rollout(...)` instead of hand-concatenating turns.
 
-**Does ECHO work on all backends?** The plumbing does — the trajectory schema, env-mask construction, and receipt diagnostics are backend-shared. But the env-CE *loss term* is currently disabled on every backend: its gradient producer was deleted with candle (#1082), and `LossConfig::validate_for_kt_tape` rejects enabled-with-env-tokens configs up front rather than burning rollout forwards on a step that cannot train. When the kt-tape env-CE root lands, the term comes back uniformly for CUDA / CPU / Metal / Vulkan.
+**Does ECHO work on all backends?** Yes. The trajectory schema, env-mask construction, and receipt diagnostics are backend-shared, and the env-CE term rides the fused GRPO loss root, which is itself backend-shared — CUDA / CPU / Metal / Vulkan all train the same math. One backend wrinkle: Vulkan's fused active-rows fast path falls back to the composite root for ECHO steps — same math, different dispatch path.
 
 ## How to use ECHO
 
 ### From the CLI
 
 ```bash
-# Default — ECHO off (env-CE term disabled pending #1082 resurrection).
+# Default — ECHO on (λ = 0.05, env_mask_mode env_only, warning_filter on).
 cuda_grpo_ablation \
     --data train.jsonl --model /workspace/Qwen3.5-4B \
     --output adapter --mode phase1
 
-# Enable with explicit λ — NOTE: currently rejected at submission
-# (unsupported_loss_config) when rollouts carry observation tokens.
+# Tune λ explicitly.
 cuda_grpo_ablation ... --echo-lambda 0.02
 
-# Explicitly disable ECHO (matches the current default).
+# Explicitly disable ECHO (paired baselines, mask debugging).
 cuda_grpo_ablation ... --no-echo
 
-# Verifier-free env-only adaptation (paper §5.5) — intended semantics;
-# currently always rejected (no gradient source with the policy term masked).
+# Verifier-free env-only adaptation (paper §5.5) — NOT yet available;
+# rejected at submission (the PG coefficients aren't yet zeroed while
+# the env-CE rows drive the update).
 cuda_grpo_ablation ... --no-policy-loss --echo-lambda 0.05
 ```
 
-`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Intended for keeping a strong agent improving on tasks where no programmatic verifier is available — but since the env-CE term has no gradient path post-#1082, `validate_for_kt_tape` rejects it unconditionally for now.
+`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Intended for keeping a strong agent improving on tasks where no programmatic verifier is available — but it is **not yet available**: `validate_for_kt_tape` rejects it at submission because it needs the policy-gradient coefficients zeroed while the env-CE rows drive the update, and that wiring hasn't landed. The env-CE term itself is live and composes with the standard policy loss.
 
 ### From the kiln-server HTTP API
 
@@ -80,7 +80,7 @@ curl -X POST http://localhost:8420/v1/train/agentic \
   }'
 ```
 
-> **Current behavior:** this exact payload — `loss.echo` enabled plus `kind: "observation"` segments — is rejected at submission with `unsupported_loss_config` until the env-CE term regains its gradient root (#1082). Omit the `"echo"` key (or set it to `null`) and the action-token policy loss trains on the full trajectory today; the enabled form above is the intended post-resurrection usage.
+> **Current behavior:** this exact payload — `loss.echo` enabled plus `kind: "observation"` segments — validates and trains. The env-CE term fires on the observation tokens and the receipt records `echo.enabled: true` with `initial_env_ce` / `final_env_ce`. Since ECHO is on by default, the explicit `"echo"` block is only needed to tune the knobs; set `"echo": null` to disable.
 
 The legacy `/v1/train/grpo` endpoint accepts the same payload shape; both routes serve the same handler. Legacy clients posting `{ groups: [{messages, completions: [{text, reward}, ...]}] }` keep working — `completions` is a serde alias for `rollouts`, and `text`-only rollouts deserialize as one-segment Action trajectories.
 
@@ -98,11 +98,11 @@ For ops / CI orchestration without editing the request payload:
 
 Env vars take **precedence over CLI flags** in `cuda_grpo_ablation` — CLI is for inline dev tweaks; env vars are the right tool for shell-scripted orchestration.
 
-Note: `KILN_ECHO_ENABLED=1` / `KILN_ECHO_LAMBDA` produce an *enabled* config, which is subject to the same fail-fast validation — submission with environment tokens errors with `unsupported_loss_config` until the env-CE gradient root is restored.
+Note: `KILN_ECHO_ENABLED=1` / `KILN_ECHO_LAMBDA` produce an *enabled* config — which matches the default — so in practice they're for re-enabling ECHO after a `--no-echo` / `loss.echo: null` opt-out, or for overriding λ across a fleet of runs.
 
 ## How to read the diagnostics
 
-The trainer writes ECHO-specific fields to `<adapter_dir>/receipt.json` (when receipt-writing lands; the schema is in place today):
+The training receipt records the term firing today: `echo.enabled: true` (whenever configured with λ ≠ 0) plus `initial_env_ce` / `final_env_ce`. The richer adapter-dir `receipt.json::diagnostic_summary.echo` block below has its schema in place but is not yet auto-populated by the trainer:
 
 ```json
 {
@@ -130,7 +130,7 @@ The trainer writes ECHO-specific fields to `<adapter_dir>/receipt.json` (when re
 
 ## When to turn ECHO off
 
-ECHO is already off by default today (see [Quick decisions](#quick-decisions)). Once the resurrected term flips the default back on, three cases where opting out (`--no-echo`) is the right move:
+ECHO is on by default (see [Quick decisions](#quick-decisions)). Three cases where opting out (`--no-echo`) is the right move:
 
 1. **Single-turn rollouts with no observations.** ECHO is mathematically a no-op (env_mask is empty), so the cost is zero — but the diagnostic noise might be confusing. Cleaner to flip it off.
 2. **λ tuning ablations.** Run a paired `--no-echo` baseline so the ECHO contribution is visible as a delta.
@@ -180,7 +180,7 @@ This composition is what the integration plan §1 framing calls *"completing the
 When writing a new agentic-GRPO cap, you basically don't need to do anything ECHO-specific. The defaults handle it:
 
 1. **`rollout.py`:** import `pi_trajectory` from `capabilities/agentic-grpo/lib/` and call `pi_trajectory.build_scored_rollout(session_path, reward=...)`. Done — your JSONL now carries the canonical trajectory schema.
-2. **`capability.config.json`:** leave `loss.echo` at its default — which is `null` (ECHO off) since the #1082 candle removal. Do **not** explicitly enable it: an enabled config on trajectories with observation segments is rejected at submission (`unsupported_loss_config`) until the env-CE term's kt-tape root lands. When resurrection ships, the intended explicit form is:
+2. **`capability.config.json`:** leave `loss.echo` at its default — ECHO is on at `λ = 0.05` and applies automatically to trajectories with observation segments. Spell it out only to tune the knobs:
    ```json
    "loss": { "echo": { "lambda": 0.05, "env_mask_mode": "env_only", "warning_filter": true } }
    ```


### PR DESCRIPTION
## Summary

The #1082 candle removal deleted the only producer that could backpropagate ECHO's environment cross-entropy term; PR1 (#1502) made that honest (default OFF + fail-fast). This PR **rebuilds the gradient and flips the default back** — kiln's GRPO is ECHO-by-default again, for real.

## The math

The fused GRPO root already derives `dL/d(logits)` analytically as `coeff_a · (onehot − softmax)` rows at action positions. The env-CE term `λ·(−Σ_env log p / |O|)` is the **same row shape with constant coefficient `−λ/|O|`** (|O| = pre-warning-filter observation length, paper §3.1 — recovered verbatim from the pre-#1082 implementation via git history). Env rows therefore reuse 100% of the proven chunked row assembly (including the CUDA in-place kernel branch) via a new `coeff_override` slot.

## Changes

- **`grpo_tape_shim`**: `EchoEnvSpec`/`EchoEnvNodeState`; env softmax stats from a second mask-parameterized selection pass; `λ·env_CE` composed into the scalar **before** `tape.record`; backward adds env hidden-grad onto PG hidden-grad. Checkpointed `loss_and_grad` variant extended identically. Vulkan's fused active-rows route dispatch-gates to the composite root for ECHO steps (same math).
- **trainer**: per-completion spec built when `echo_enabled() && env_count > 0 && |O| > 0`; per-step `env_ce` flows into the existing `EchoActivityMetrics` → receipt `initial/final_env_ce`; eligibility/dry-run/entry gates lifted; receipt records `enabled: true`.
- **lib.rs**: `default_echo_some() → Some(EchoConfig::default())` (λ=0.05); `validate_for_kt_tape` accepts echo+env. Still rejected: `no_policy_loss` (needs PG coefficients zeroed while env rows drive — follow-up) and the reserved OPD slot.
- **Docs**: README + ECHO_GUIDE back to ECHO-by-default, truthfully, with the two honest not-yet notes kept.

## Verification

- **New closed-form CPU gradient test**: `Δgrad_hidden == Σ_env (λ/|O|)·(softmax−onehot)@head_tᵀ` at env rows and **zero everywhere else**, `Δloss == λ·env_CE`, reported `env_ce` matches dense softmax — analytic equality at 1e-5, no finite differences.
- PR1's rejection tests flipped to their positive forms (default-ON, validation accepts, dry-run accepts + counts env tokens, submission validates).
- `kiln-train` green on default features and `--features vulkan` (2 pre-existing `perf_regression_sft` failures reproduce on main, unrelated); `kiln-server` suite green.
- Natural attended follow-up on the rig: one short GRPO run with observation segments → receipt shows `env_ce` decreasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)