### PR TITLE
Training-job control: cancel RUNNING jobs cooperatively at step boundaries

### DIFF
--- a/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
+++ b/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
@@ -260,6 +260,7 @@ fn run_one(
         if let Ok(mut g) = final_loss_cb.lock() {
             *g = Some(step.loss);
         }
+        kiln_train::trainer::TrainControl::Continue
     });
 
     let t0 = Instant::now();

--- a/crates/kiln-server/src/api/pit_of_success.rs
+++ b/crates/kiln-server/src/api/pit_of_success.rs
@@ -170,6 +170,7 @@ async fn submit_front_door(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs

--- a/crates/kiln-server/src/api/recipes.rs
+++ b/crates/kiln-server/src/api/recipes.rs
@@ -574,6 +574,7 @@ fn register_step_job(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -407,6 +407,7 @@ fn register_agent_job(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -355,6 +355,7 @@ async fn submit_sft(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -517,6 +518,7 @@ async fn submit_grpo(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -723,6 +725,7 @@ async fn submit_opd(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -847,6 +850,7 @@ async fn submit_distill_refresh(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -1083,6 +1087,7 @@ fn register_and_enqueue_distill(
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -1196,17 +1201,33 @@ async fn list_queue(State(state): State<AppState>) -> Json<QueueResponse> {
     })
 }
 
-/// DELETE /v1/train/queue/:job_id — cancel a queued job.
+/// DELETE /v1/train/queue/:job_id — cancel a queued OR running job.
+///
+/// Queued: removed from the queue immediately. Running: the job's
+/// cooperative cancel flag is set; the trainer aborts at the next step
+/// boundary (typically one decode/optimizer step) and the job lands in
+/// `Failed` with error "cancelled by user" and receipt failure_reason
+/// "cancelled".
 async fn cancel_queued_job(
     State(state): State<AppState>,
     AxumPath(job_id): AxumPath<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    // Check if the job exists and is in Queued state
+    // Check job state; flag running jobs for cooperative cancellation.
     {
         let jobs = state.training_jobs.read().unwrap();
         let job = jobs
             .get(&job_id)
             .ok_or_else(|| ApiError::training_job_not_found(&job_id))?;
+        if job.state == TrainingState::Running {
+            job.cancel_requested
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            tracing::info!(job_id = %job_id, "cancellation requested for running training job");
+            return Ok(Json(serde_json::json!({
+                "job_id": job_id,
+                "status": "cancelling",
+                "message": "stop requested — the trainer aborts at the next step boundary"
+            })));
+        }
         if job.state != TrainingState::Queued {
             return Err(ApiError::training_job_not_cancellable(
                 &job_id,

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -2507,6 +2507,7 @@ fn bench_training(
             "    Step {}/{}: loss={:.6}",
             progress.step, progress.total_steps, progress.loss
         );
+        kiln_train::trainer::TrainControl::Continue
     }) as kiln_train::trainer::ProgressCallback);
 
     let start = Instant::now();

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -574,6 +574,7 @@ mod tests {
                 linked_eval_job_ids: Vec::new(),
                 post_eval_verdict: None,
                 loss_history: Vec::new(),
+                cancel_requested: Default::default(),
             },
         );
     }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -282,6 +282,14 @@ pub struct TrainingJobInfo {
     /// left unpromoted because the eval itself errored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub post_eval_verdict: Option<String>,
+    /// Cooperative cancellation flag for a RUNNING job: set by
+    /// `DELETE /v1/train/queue/{id}`, read by the training worker's
+    /// per-step progress callback, which then returns
+    /// `TrainControl::Stop` and the trainer aborts at the next step
+    /// boundary. Shared (`Arc`) so the in-flight worker observes flips
+    /// on the tracked entry. Never serialized.
+    #[serde(skip, default)]
+    pub cancel_requested: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Loss history for live charts. Each sample is
     /// `{epoch, progress, loss, elapsed_secs}`. Capped at
     /// `TRAINING_LOSS_HISTORY_CAP` to bound memory; once full, every

--- a/crates/kiln-server/src/training_history.rs
+++ b/crates/kiln-server/src/training_history.rs
@@ -149,6 +149,7 @@ mod tests {
             linked_eval_job_ids: vec![],
             post_eval_verdict: None,
             loss_history: vec![],
+            cancel_requested: Default::default(),
         }
     }
 

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -2085,6 +2085,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
     let started_instant = std::time::Instant::now();
     let progress_cb = Box::new(move |progress: trainer::TrainingProgress| {
         let mut jobs = training_jobs_cb.write().unwrap();
+        let mut control = trainer::TrainControl::Continue;
         if let Some(job) = jobs.get_mut(&job_id_cb) {
             job.progress = progress.progress;
             job.loss = Some(progress.loss);
@@ -2098,7 +2099,17 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                     elapsed_secs: started_instant.elapsed().as_secs_f64(),
                 },
             );
+            // The per-step progress call doubles as the cancellation
+            // point: DELETE /v1/train/queue/{id} on a RUNNING job sets
+            // this flag and the trainer aborts at the next boundary.
+            if job
+                .cancel_requested
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                control = trainer::TrainControl::Stop;
+            }
         }
+        control
     });
 
     // Apply server-level checkpoint_interval default if not set per-job
@@ -2439,12 +2450,26 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             }
         }
         Err(e) => {
-            tracing::error!(job_id = %job_id, job_type = ?job_type, "training failed: {e}");
+            // Operator cancellation surfaces as a distinguishable error
+            // from the trainer's step-boundary check; record it under the
+            // Cancelled metric (not Failed) so dashboards don't count a
+            // deliberate stop as a training failure.
+            let cancelled = e.contains("cancelled by user");
+            if cancelled {
+                tracing::info!(job_id = %job_id, job_type = ?job_type, "training cancelled by user");
+            } else {
+                tracing::error!(job_id = %job_id, job_type = ?job_type, "training failed: {e}");
+            }
             let error_msg = e.clone();
             finalize_job(&state, &job_id, TrainingState::Failed, Some(e));
-            state
-                .metrics
-                .inc_training(metric_type, TrainingMetricStatus::Failed);
+            state.metrics.inc_training(
+                metric_type,
+                if cancelled {
+                    TrainingMetricStatus::Cancelled
+                } else {
+                    TrainingMetricStatus::Failed
+                },
+            );
 
             if let Some(ref url) = state.training_webhook_url {
                 let event = TrainingCompletionEvent {

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -7641,6 +7641,10 @@ function renderTrainingCard(j, state) {
   let actionBtn = '';
   if (state === 'queued') {
     actionBtn = `<button class="btn btn-sm" data-train-cancel data-job-id="${escapeHtml(j.job_id)}" type="button" style="margin-left:auto;">Cancel</button>`;
+  } else if (state === 'running') {
+    // Running jobs are stoppable too: the server sets a cooperative flag
+    // and the trainer aborts at the next step boundary.
+    actionBtn = `<button class="btn btn-sm" data-train-cancel data-job-id="${escapeHtml(j.job_id)}" type="button" style="margin-left:auto;" title="Stop at the next training step">Stop</button>`;
   } else if (stateNormForActions === 'completed' && j.adapter_name) {
     actionBtn = `<button class="btn btn-sm" data-train-prove data-adapter="${escapeHtml(j.adapter_name)}" type="button" style="margin-left:auto;" title="Grade ${escapeHtml(j.adapter_name)} against base on an eval suite">Prove it vs base</button>`;
   }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -869,6 +869,7 @@ fn loss_capture_cb() -> (
     let cb: kiln_train::trainer::ProgressCallback =
         Box::new(move |p: kiln_train::trainer::TrainingProgress| {
             sink.lock().unwrap().push(p.loss);
+            kiln_train::trainer::TrainControl::Continue
         });
     (losses, cb)
 }

--- a/crates/kiln-server/tests/training_failed_job_error.rs
+++ b/crates/kiln-server/tests/training_failed_job_error.rs
@@ -99,6 +99,7 @@ fn enqueue_sft_job(state: &AppState, job_id: &str) {
         linked_eval_job_ids: Vec::new(),
         post_eval_verdict: None,
         loss_history: Vec::new(),
+        cancel_requested: Default::default(),
     };
     state
         .training_jobs
@@ -208,4 +209,70 @@ async fn queued_job_status_omits_error_key() {
         body.get("error").is_none(),
         "queued job must not serialize an error key: {body}"
     );
+}
+
+/// DELETE on a RUNNING job sets the cooperative cancel flag (the trainer's
+/// per-step progress callback observes it and aborts at the next step
+/// boundary) and answers "cancelling" — it must NOT remove the job or mark
+/// it terminal; the worker does that when the trainer actually stops.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_running_job_sets_flag_without_terminal_transition() {
+    let (state, _dir) = make_state();
+    enqueue_sft_job(&state, "job-running");
+    {
+        let mut jobs = state.training_jobs.write().unwrap();
+        jobs.get_mut("job-running").unwrap().state = TrainingState::Running;
+    }
+    let app = api::router(state.clone());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/train/queue/job-running")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["status"], "cancelling", "{body}");
+
+    let jobs = state.training_jobs.read().unwrap();
+    let job = jobs.get("job-running").unwrap();
+    assert_eq!(job.state, TrainingState::Running, "stays Running until the trainer stops");
+    assert!(
+        job.cancel_requested
+            .load(std::sync::atomic::Ordering::Relaxed),
+        "the cooperative flag must be set"
+    );
+}
+
+/// Terminal jobs are not cancellable — the existing contract holds.
+#[tokio::test]
+async fn cancelling_terminal_job_is_rejected() {
+    let (state, _dir) = make_state();
+    enqueue_sft_job(&state, "job-done");
+    {
+        let mut jobs = state.training_jobs.write().unwrap();
+        jobs.get_mut("job-done").unwrap().state = TrainingState::Completed;
+    }
+    let app = api::router(state.clone());
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/v1/train/queue/job-done")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }

--- a/crates/kiln-server/tests/training_tracked_cap.rs
+++ b/crates/kiln-server/tests/training_tracked_cap.rs
@@ -112,6 +112,7 @@ fn fill_tracked(
                 linked_eval_job_ids: Vec::new(),
                 post_eval_verdict: None,
                 loss_history: Vec::new(),
+                cancel_requested: Default::default(),
             },
         );
     }
@@ -271,6 +272,7 @@ fn gc_evicts_terminal_entries_past_ttl() {
                 linked_eval_job_ids: Vec::new(),
                 post_eval_verdict: None,
                 loss_history: Vec::new(),
+                cancel_requested: Default::default(),
             },
         );
         jobs.insert(
@@ -293,6 +295,7 @@ fn gc_evicts_terminal_entries_past_ttl() {
                 linked_eval_job_ids: Vec::new(),
                 post_eval_verdict: None,
                 loss_history: Vec::new(),
+                cancel_requested: Default::default(),
             },
         );
     }

--- a/crates/kiln-train/examples/cuda_grpo_ablation.rs
+++ b/crates/kiln-train/examples/cuda_grpo_ablation.rs
@@ -898,6 +898,7 @@ fn main() -> Result<()> {
             progress.loss,
             current_vram_mib()
         );
+        kiln_train::trainer::TrainControl::Continue
     }) as kiln_train::trainer::ProgressCallback);
 
     let result = grpo_train_jsonl(

--- a/crates/kiln-train/examples/cuda_opd_remote.rs
+++ b/crates/kiln-train/examples/cuda_opd_remote.rs
@@ -339,6 +339,7 @@ fn main() -> Result<()> {
             p.loss,
             current_vram_mib()
         );
+        kiln_train::trainer::TrainControl::Continue
     }) as kiln_train::trainer::ProgressCallback);
 
     let out = opd_train(

--- a/crates/kiln-train/examples/cuda_sft_file.rs
+++ b/crates/kiln-train/examples/cuda_sft_file.rs
@@ -434,6 +434,7 @@ fn main() -> Result<()> {
             progress.progress,
             current_vram_mib()
         );
+        kiln_train::trainer::TrainControl::Continue
     }) as kiln_train::trainer::ProgressCallback);
 
     let result = match args.trainer {

--- a/crates/kiln-train/src/train_receipt.rs
+++ b/crates/kiln-train/src/train_receipt.rs
@@ -57,8 +57,12 @@ pub enum TrainFailureReason {
     ZeroGroups,
     ZeroActionTokens,
     ZeroEnvTokens,
+    /// The operator cancelled the running job (DELETE
+    /// /v1/train/queue/{id}) — the trainer aborted cooperatively at a
+    /// step boundary.
+    Cancelled,
     /// The loss composition asked for a term the kt-tape path cannot
-    /// train (ECHO env-CE with env tokens / no_policy_loss) — see
+    /// train (no_policy_loss / reserved OPD slot) — see
     /// `LossConfig::validate_for_kt_tape`.
     UnsupportedLossConfig,
     NanLoss,
@@ -77,6 +81,7 @@ impl TrainFailureReason {
             Self::ZeroGroups => "zero_groups",
             Self::ZeroActionTokens => "zero_action_tokens",
             Self::ZeroEnvTokens => "zero_env_tokens",
+            Self::Cancelled => "cancelled",
             Self::UnsupportedLossConfig => "unsupported_loss_config",
             Self::NanLoss => "nan_loss",
             Self::Oom => "oom",
@@ -756,6 +761,11 @@ pub fn read_adapter_canary_status_from_adapter_dir(
 
 pub fn classify_training_failure(message: &str) -> TrainFailureReason {
     let lower = message.to_ascii_lowercase();
+    // Operator cancellation: match FIRST — the message is unambiguous and
+    // nothing else should reclassify it.
+    if lower.contains("cancelled by user") {
+        return TrainFailureReason::Cancelled;
+    }
 
     if lower.contains("unsafe lora scaling") || lower.contains("lora rank must") {
         return TrainFailureReason::UnsafeLoraScale;

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1503,8 +1503,21 @@ impl TrainableLoraParams {
     }
 }
 
-/// Progress callback for training.
-pub type ProgressCallback = Box<dyn Fn(TrainingProgress) + Send>;
+/// Flow-control verdict a progress callback returns. `Stop` requests a
+/// cooperative cancellation at the next step boundary — the run aborts
+/// with a "training cancelled by user" error and the receipt records
+/// failure_reason "cancelled".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrainControl {
+    Continue,
+    Stop,
+}
+
+/// Progress callback for training. Returns a [`TrainControl`] verdict —
+/// the per-step call site doubles as the cancellation point, so a running
+/// job can be stopped without threading a separate flag through every
+/// train loop.
+pub type ProgressCallback = Box<dyn Fn(TrainingProgress) -> TrainControl + Send>;
 
 /// Training progress update.
 #[derive(Debug, Clone)]
@@ -2836,7 +2849,7 @@ pub fn sft_train(
                 }
 
                 if let Some(ref cb) = progress_cb {
-                    cb(TrainingProgress {
+                    let control = cb(TrainingProgress {
                         epoch: epoch + 1,
                         total_epochs: config.epochs,
                         step: global_step,
@@ -2844,6 +2857,11 @@ pub fn sft_train(
                         loss: loss_val,
                         progress: global_step as f32 / total_steps as f32,
                     });
+                    if control == TrainControl::Stop {
+                        anyhow::bail!(
+                            "training cancelled by user (stop requested at step boundary)"
+                        );
+                    }
                 }
 
                 if global_step % 10 == 0 || global_step == total_steps {
@@ -3440,7 +3458,7 @@ pub fn grpo_train(
             }
 
             if let Some(ref cb) = progress_cb {
-                cb(TrainingProgress {
+                let control = cb(TrainingProgress {
                     epoch: 1,
                     total_epochs: 1,
                     step: global_step,
@@ -3448,6 +3466,11 @@ pub fn grpo_train(
                     loss: avg_group_loss,
                     progress: global_step as f32 / total_steps as f32,
                 });
+                            if control == TrainControl::Stop {
+                    anyhow::bail!(
+                        "training cancelled by user (stop requested at step boundary)"
+                    );
+                }
             }
 
             tracing::info!(
@@ -4309,7 +4332,7 @@ pub fn grpo_train_jsonl(
 
             let (step, total_steps, progress) = jsonl_byte_progress(total_bytes, bytes_read);
             if let Some(ref cb) = progress_cb {
-                cb(TrainingProgress {
+                let control = cb(TrainingProgress {
                     epoch: 1,
                     total_epochs: 1,
                     step,
@@ -4317,6 +4340,11 @@ pub fn grpo_train_jsonl(
                     loss: avg_group_loss,
                     progress,
                 });
+                            if control == TrainControl::Stop {
+                    anyhow::bail!(
+                        "training cancelled by user (stop requested at step boundary)"
+                    );
+                }
             }
 
             tracing::info!(
@@ -12671,6 +12699,7 @@ pub(crate) mod tests {
                 let loss_sink = std::sync::Arc::clone(&losses);
                 let progress: ProgressCallback = Box::new(move |progress| {
                     loss_sink.lock().unwrap().push(progress.loss);
+                    TrainControl::Continue
                 });
                 let dir = grpo_train(
                     &groups,


### PR DESCRIPTION
## Summary

A running training job was unkillable — `DELETE /v1/train/queue/{id}` only removed queued entries, so a bad submission held the single GPU until it finished or the server died.

**Mechanism**: the trainer's per-step progress callback doubles as the cancellation point. `ProgressCallback` now returns a `TrainControl` verdict (`Continue`/`Stop`); the three per-step call sites (SFT, GRPO, streamed GRPO) bail with `"training cancelled by user"` on `Stop`. No new plumbing through the train loops.

- `TrainingJobInfo.cancel_requested: Arc<AtomicBool>` (never serialized); `DELETE` on a Running job sets it and answers `{"status":"cancelling"}` — the job stays Running until the trainer actually stops (typically one step), then lands in `Failed` / `"cancelled by user"`.
- New `TrainFailureReason::Cancelled` matched first in the failure classifier; metrics count `Cancelled`, not `Failed`.
- Dashboard: running job cards get a **Stop** button.

## Verification

Endpoint tests (running → `"cancelling"` + flag set with **no** terminal transition; terminal → 409; queued unchanged), full `kiln-server` + `kiln-train` suites green, dashboard smoke passes. Attended follow-up: stop a live run on the rig (the cancel fires from a real training step's callback).

Pre-existing note: the `perf_regression_sft` cpu-smoke pair is cfg'd to `cuda|vulkan` but requires a matching device — it never runs green anywhere today (reproduces on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)