### PR TITLE
Eval results become signals: terminal-eval completion webhook with gate verdict

### DIFF
--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -52,11 +52,19 @@ pub struct EvalConfig {
     pub max_queued_jobs: usize,
     /// Maximum tracked eval-job entries (terminal entries TTL out).
     pub max_tracked_jobs: usize,
+    /// When set, every eval job that reaches a terminal state fires a
+    /// POST to this URL with `{job_id, suite, adapters, status,
+    /// headline_accuracy, gate_verdict, error, timestamp}` —
+    /// fire-and-forget, same contract as `training.webhook_url`. Eval
+    /// results become signals other systems can act on (CI gates,
+    /// alerting, retrain triggers) instead of numbers in a dashboard.
+    pub webhook_url: Option<String>,
 }
 
 impl Default for EvalConfig {
     fn default() -> Self {
         Self {
+            webhook_url: None,
             eval_dir: None,
             max_queued_jobs: 32,
             max_tracked_jobs: 1024,

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -189,6 +189,36 @@ async fn run_one_job_with_generator(
         // with min_accuracy). Apply the verdict now that the run is
         // terminal.
         apply_post_eval_gate(&state, &snapshot).await;
+
+        // Eval results become signals: fire the completion webhook AFTER
+        // the gate so the payload carries the promotion verdict. The gate
+        // stamps its verdict on the LINKED TRAINING job; re-read it here.
+        if let Some(ref url) = state.eval_webhook_url {
+            let gate_verdict = snapshot
+                .post_eval_gate
+                .as_ref()
+                .and_then(|gate| {
+                    let jobs = state.training_jobs.read().unwrap();
+                    jobs.get(&gate.training_job_id)
+                        .and_then(|j| j.post_eval_verdict.clone())
+                });
+            let event = serde_json::json!({
+                "event": "eval_completed",
+                "job_id": snapshot.job_id,
+                "suite": snapshot.suite_name,
+                "adapters": snapshot.adapters,
+                "status": match snapshot.state {
+                    EvalJobState::Completed => "completed",
+                    EvalJobState::Cancelled => "cancelled",
+                    _ => "failed",
+                },
+                "headline_accuracy": snapshot.headline_accuracy,
+                "gate_verdict": gate_verdict,
+                "error": snapshot.error,
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+            });
+            crate::training_queue::fire_webhook_json(url.clone(), event);
+        }
     }
 
     // Back-linking from eval-completion → training-job is intentionally

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -576,6 +576,10 @@ async fn main() -> Result<()> {
     if let Some(cfg) = config.eval.as_ref() {
         state.max_queued_eval_jobs = cfg.max_queued_jobs;
         state.max_tracked_eval_jobs = cfg.max_tracked_jobs;
+        state.eval_webhook_url = cfg.webhook_url.clone();
+        if let Some(ref url) = state.eval_webhook_url {
+            tracing::info!(url = %url, "eval completion webhook enabled");
+        }
     }
 
     // Durable request/response log: every inference request becomes a JSONL

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1489,6 +1489,9 @@ pub struct AppState {
     /// Maximum tracked eval entries in `eval_jobs`. Mirrors
     /// `max_tracked_jobs`.
     pub max_tracked_eval_jobs: usize,
+    /// Fire-and-forget webhook for terminal eval jobs (`eval.webhook_url`
+    /// in the TOML). Mirrors `training_webhook_url`.
+    pub eval_webhook_url: Option<String>,
 }
 
 impl AppState {
@@ -1670,6 +1673,7 @@ impl AppState {
             judgment_store: None,
             max_queued_eval_jobs: 32,
             max_tracked_eval_jobs: 1024,
+            eval_webhook_url: None,
         }
     }
 
@@ -2320,6 +2324,7 @@ impl AppState {
             judgment_store: None,
             max_queued_eval_jobs: 32,
             max_tracked_eval_jobs: 1024,
+            eval_webhook_url: None,
         }
     }
 }

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -75,6 +75,24 @@ impl TrainingCompletionEvent {
 /// network I/O. Webhook failures are logged at WARN but never propagate
 /// — a successful training job stays "completed" even if the
 /// notification POST fails.
+/// Fire-and-forget POST of an arbitrary JSON event. Same contract as
+/// [`fire_completion_webhook`]: failures are logged at WARN and never
+/// affect the job that emitted the event.
+pub fn fire_webhook_json(url: String, event: serde_json::Value) {
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        match client.post(&url).json(&event).send().await {
+            Ok(resp) if !resp.status().is_success() => {
+                tracing::warn!(url = %url, status = %resp.status(), "webhook POST returned non-success");
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(url = %url, error = %e, "webhook POST failed");
+            }
+        }
+    });
+}
+
 pub fn fire_completion_webhook(url: String, event: TrainingCompletionEvent) {
     tokio::spawn(async move {
         // Defensive: an operator-set webhook URL that 302s into internal infra
@@ -2939,6 +2957,66 @@ mod tests {
     /// End-to-end test: spin up a tiny axum mock server, fire a webhook
     /// at it, and assert that the captured POST body matches the
     /// documented payload shape.
+    /// The eval-signals webhook helper posts arbitrary JSON with the
+    /// same fire-and-forget contract as the typed training event.
+    #[tokio::test]
+    async fn test_fire_webhook_json_posts_payload() {
+        use axum::Json;
+        use axum::extract::State;
+        use axum::routing::post;
+        use std::sync::Arc as StdArc;
+        use std::sync::Mutex as StdMutex;
+
+        let captured: StdArc<StdMutex<Vec<serde_json::Value>>> =
+            StdArc::new(StdMutex::new(Vec::new()));
+
+        async fn handler(
+            State(captured): State<StdArc<StdMutex<Vec<serde_json::Value>>>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> &'static str {
+            captured.lock().unwrap().push(body);
+            "ok"
+        }
+
+        let app = axum::Router::new()
+            .route("/hook", post(handler))
+            .with_state(captured.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        fire_webhook_json(
+            format!("http://{addr}/hook"),
+            serde_json::json!({
+                "event": "eval_completed",
+                "job_id": "eval-1",
+                "suite": "math-sentinel",
+                "status": "completed",
+                "headline_accuracy": 0.85,
+                "gate_verdict": "promoted (accuracy 0.85 >= 0.8)",
+            }),
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !captured.lock().unwrap().is_empty() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "webhook never arrived"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let got = captured.lock().unwrap();
+        assert_eq!(got[0]["event"], "eval_completed");
+        assert_eq!(got[0]["suite"], "math-sentinel");
+        assert_eq!(got[0]["headline_accuracy"], 0.85);
+        server.abort();
+    }
+
     #[tokio::test]
     async fn test_fire_completion_webhook_posts_expected_payload() {
         use axum::Json;


### PR DESCRIPTION
## Summary

Eval outcomes lived only in the dashboard — nothing outside the process could react to a suite finishing, a §8.7 gate failing, or an eval erroring. Training already had `webhook_url`; eval now gets the same contract.

- `eval.webhook_url` (TOML) → fire-and-forget POST on every terminal eval job, **after** `apply_post_eval_gate` so the payload carries the promotion verdict: `{event: "eval_completed", job_id, suite, adapters, status, headline_accuracy, gate_verdict, error, timestamp}`.
- `fire_webhook_json`: generic JSON sibling of the typed training webhook (same WARN-and-continue contract).

Sentinel schedules (recurring eval crons) remain a follow-up — they want real scheduler infrastructure.

## Verification

Round-trip webhook test against a local listener (payload shape asserted); full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)