### PR TITLE
MTP observability: KILN_SPEC_METHOD implies enabled; serve-path C1 acceptance-CSV drain

### DIFF
--- a/crates/kiln-model/src/c1_attr.rs
+++ b/crates/kiln-model/src/c1_attr.rs
@@ -171,23 +171,40 @@ pub fn row_from_csv_line(line: &str) -> Result<C1Row> {
     })
 }
 
-/// Drain the sink and write all rows as CSV to `path`. No-op when the sink
-/// is empty. Always clears the sink, even on I/O error, so a failed write
-/// never leaks into the next run.
+/// Drain the sink and APPEND all rows as CSV to `path` (header written
+/// only when the file is new/empty). No-op when the sink is empty. Always
+/// clears the sink, even on I/O error, so a failed write never leaks into
+/// the next run.
+///
+/// Append semantics matter: the serve path drains after EVERY MTP
+/// generation, so an overwrite (the old `fs::write`) would keep only the
+/// last request's rows and the measured acceptance rate would be a
+/// one-request sample.
 pub fn drain_to_csv(path: &str) -> Result<usize> {
+    use std::io::Write;
+
     let rows = drain();
     let n = rows.len();
     if n == 0 {
         return Ok(0);
     }
+    let needs_header = std::fs::metadata(path).map(|m| m.len() == 0).unwrap_or(true);
     let mut out = String::with_capacity(128 + n * 64);
-    out.push_str(CSV_HEADER);
-    out.push('\n');
+    if needs_header {
+        out.push_str(CSV_HEADER);
+        out.push('\n');
+    }
     for row in &rows {
         out.push_str(&row_to_csv_line(row));
         out.push('\n');
     }
-    std::fs::write(path, out).with_context(|| format!("write C1 attribution CSV to {path}"))?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open C1 attribution CSV at {path}"))?;
+    f.write_all(out.as_bytes())
+        .with_context(|| format!("append C1 attribution CSV to {path}"))?;
     Ok(n)
 }
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1592,6 +1592,24 @@ pub(crate) fn encode_prompt_tokens(
     Ok(tokens)
 }
 
+/// Flush MTP acceptance-attribution rows (`KILN_C1_ATTR_PATH`) to the
+/// CSV. Appends and clears the in-memory sink; no-op (and free) when the
+/// env var is unset. The bench driver has always drained — this hook
+/// gives plain HTTP serving the same observability so the acceptance
+/// A/B can run against a live server.
+fn drain_c1_attr_csv_if_enabled() {
+    if !kiln_model::c1_attr::is_enabled() {
+        return;
+    }
+    if let Ok(path) = std::env::var("KILN_C1_ATTR_PATH") {
+        match kiln_model::c1_attr::drain_to_csv(&path) {
+            Ok(0) => {}
+            Ok(n) => tracing::debug!(rows = n, path = %path, "drained C1 MTP acceptance rows"),
+            Err(e) => tracing::warn!(error = %e, "C1 attr CSV drain failed"),
+        }
+    }
+}
+
 /// The serving context ceiling: the model's positional limit capped by
 /// what the KV pool can physically hold. `None` = no enforcible signal
 /// (mock backend).
@@ -5756,6 +5774,11 @@ async fn generate_real(
             ResolvedSpeculativeMode::Mtp => {
                 *prefix_cache_diagnostic_inner.lock().unwrap() = "not_used_speculative";
                 let output = runner_guard.generate_mtp_speculative(&prompt, &params)?;
+                // KILN_C1_ATTR_PATH acceptance instrumentation: rows are
+                // pushed per draft step but only the bench driver ever
+                // drained them — over plain HTTP serving the CSV never
+                // materialized and the acceptance-rate A/B was unmeasurable.
+                drain_c1_attr_csv_if_enabled();
                 Ok(TimedGenerationOutput::without_timings(GenerationOutput {
                     text: output.text,
                     token_ids: output.token_ids,
@@ -6279,7 +6302,12 @@ async fn generate_real_streaming(
                         let _gpu_guard = gpu_coordination_read_guard(&gpu_lock);
                         let runner_guard = runner.read().unwrap();
                         *prefix_cache_diagnostic.lock().unwrap() = "not_used_speculative";
-                        runner_guard.generate_streaming_mtp_speculative(&prompt, &params)
+                        let rx = runner_guard.generate_streaming_mtp_speculative(&prompt, &params);
+                        // Streaming drains at spawn end — rows from this
+                        // generation flush on the NEXT request or shutdown;
+                        // the non-streaming arm drains synchronously.
+                        drain_c1_attr_csv_if_enabled();
+                        rx
                     })
                     .await
                     {

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -570,6 +570,17 @@ impl SpeculativeDecodingConfig {
         if let Ok(v) = std::env::var("KILN_SPEC_METHOD") {
             if let Some(m) = SpecMethod::parse_env(&v) {
                 self.method = m;
+                // Asking for a method IS asking for speculative decoding:
+                // `KILN_SPEC_METHOD=mtp` alone used to be a silent no-op
+                // (`effective_method()` returns Off unless `enabled`),
+                // which cost an operator-validation cycle to discover.
+                // An explicit KILN_SPEC_ENABLED still wins (it is read
+                // first above and re-checked here for ordering safety).
+                if !matches!(m, SpecMethod::Off)
+                    && std::env::var("KILN_SPEC_ENABLED").is_err()
+                {
+                    self.enabled = true;
+                }
             } else {
                 tracing::warn!(
                     "ignoring unknown KILN_SPEC_METHOD='{}' (expected off|skip_layer|mtp)",


### PR DESCRIPTION
## Summary

Two operator-validation findings, fixed:

1. **`KILN_SPEC_METHOD=mtp` alone was a silent no-op** — `effective_method()` returns `Off` unless `enabled`, which only `KILN_SPEC_ENABLED` set. A non-off `KILN_SPEC_METHOD` now implies enabled; an explicit `KILN_SPEC_ENABLED` still wins.
2. **The C1 acceptance CSV never materialized over HTTP serving** — rows were pushed per draft step but only the bench driver drained. The serve path now drains after each MTP generation, and `drain_to_csv` **appends** (header once on create) instead of overwriting, so the measured acceptance rate accumulates across requests instead of being a one-request sample.

## Verification

`c1_attr` round-trip tests green with the append contract; full `kiln-server` + `kiln-model` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)