### PR TITLE
Vulkan training groundwork: substrate-aware policy sentinels, bf16w fallbacks, training-session residency machinery (opt-in)

### DIFF
--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -43,6 +43,15 @@ pub fn mark_vulkan_active() {
 }
 
 /// Returns true once `mark_vulkan_active()` has been called in this process.
+/// Whether THIS process trains on the Vulkan hybrid substrate: vulkan
+/// feature compiled in AND a Vulkan device present (same runtime probe
+/// `for_device_kt` keys on). Used by the trainer to place training
+/// state (LoRA params, optimizer moments) on the activation device.
+#[cfg(feature = "vulkan")]
+pub fn vulkan_training_substrate_active() -> bool {
+    vulkan::vulkan_is_available()
+}
+
 pub fn vulkan_active() -> bool {
     VULKAN_ACTIVE.load(Ordering::Relaxed)
 }
@@ -1872,9 +1881,12 @@ pub fn training_precision_policy_for_device_kt(
             TrainingLossBackend::runtime_training_precision_policy(&backend)
         }
         _ => {
-            // CPU-as-Vulkan-sentinel: see the doc comment above.
+            // CPU-as-Vulkan-sentinel: see the doc comment above. Keyed on
+            // the same runtime probe `for_device_kt` uses (NOT the
+            // mark_vulkan_active flag, whose state depends on incidental
+            // initialization order).
             #[cfg(feature = "vulkan")]
-            if matches!(device, kiln_tensor::Device::Cpu) && vulkan_active() {
+            if matches!(device, kiln_tensor::Device::Cpu) && vulkan::vulkan_is_available() {
                 return TrainingPrecisionPolicy::vulkan();
             }
             let backend = cpu::CpuBackend::new(device);
@@ -1917,7 +1929,7 @@ pub fn training_tape_route_for_device_kt(device: kiln_tensor::Device) -> Trainin
             // trains on kt CPU-storage tensors, and the tape recorders'
             // device gates must see the Vulkan route for them.
             #[cfg(feature = "vulkan")]
-            if matches!(device, kiln_tensor::Device::Cpu) && vulkan_active() {
+            if matches!(device, kiln_tensor::Device::Cpu) && vulkan::vulkan_is_available() {
                 let backend = vulkan::VulkanBackend::new(kiln_tensor::Device::Cpu);
                 return TrainingLossBackend::runtime_tape_forward_backward_route(&backend);
             }

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -1838,8 +1838,14 @@ pub fn for_device_kt(device: &kiln_tensor::Device) -> Arc<dyn BackendRuntime> {
 /// Training precision policy selected through the concrete backend facet.
 ///
 /// `for_device_kt` intentionally treats CPU as a Vulkan runtime-detect sentinel
-/// in Vulkan-enabled binaries. Training policy callers need CPU tensors to keep
-/// the portable CPU policy, so this helper constructs the exact runtime family
+/// in Vulkan-enabled binaries — and so does THIS lookup when a Vulkan backend
+/// is ACTIVE in the process: on the Vulkan substrate the training tensors are
+/// kt CPU-storage tensors (hybrid residency), so a bare `Device::Cpu` match
+/// here returned the portable policy and the F32-activation × BF16-base-weight
+/// mixed exception never fired — production BF16 checkpoints failed in the
+/// first GDN projection ("MatmulOp: dtype mismatch a=f32 b=bf16") while the
+/// F32 unit fixtures passed. Processes that never constructed a Vulkan
+/// backend (pure-CPU tests in vulkan-feature builds) keep the portable policy
 /// needed for the policy query and then delegates to `TrainingLossBackend`.
 pub fn training_precision_policy_for_device_kt(
     device: kiln_tensor::Device,
@@ -1866,6 +1872,11 @@ pub fn training_precision_policy_for_device_kt(
             TrainingLossBackend::runtime_training_precision_policy(&backend)
         }
         _ => {
+            // CPU-as-Vulkan-sentinel: see the doc comment above.
+            #[cfg(feature = "vulkan")]
+            if matches!(device, kiln_tensor::Device::Cpu) && vulkan_active() {
+                return TrainingPrecisionPolicy::vulkan();
+            }
             let backend = cpu::CpuBackend::new(device);
             TrainingLossBackend::runtime_training_precision_policy(&backend)
         }
@@ -1901,6 +1912,15 @@ pub fn training_tape_route_for_device_kt(device: kiln_tensor::Device) -> Trainin
             TrainingLossBackend::runtime_tape_forward_backward_route(&backend)
         }
         _ => {
+            // CPU-as-Vulkan-sentinel (matches `for_device_kt` and the
+            // precision-policy lookup above): an active-Vulkan process
+            // trains on kt CPU-storage tensors, and the tape recorders'
+            // device gates must see the Vulkan route for them.
+            #[cfg(feature = "vulkan")]
+            if matches!(device, kiln_tensor::Device::Cpu) && vulkan_active() {
+                let backend = vulkan::VulkanBackend::new(kiln_tensor::Device::Cpu);
+                return TrainingLossBackend::runtime_tape_forward_backward_route(&backend);
+            }
             let backend = cpu::CpuBackend::new(device);
             TrainingLossBackend::runtime_tape_forward_backward_route(&backend)
         }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -36337,10 +36337,19 @@ mod tests {
             STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
         ));
         assert_eq!(streaming_tile_tokens(), STREAMING_PREFILL_DEFAULT_TILE);
-        assert_eq!(
-            streaming_tile_tokens_for(&Device::Cpu),
+        // CPU-as-Vulkan-sentinel: on a Vulkan-capable host (feature +
+        // device present) the per-device policy treats CPU-device tensors
+        // as the Vulkan substrate, so the tile is the Vulkan-tuned value;
+        // on hosts without a Vulkan device (CI runners) it stays portable.
+        #[cfg(feature = "vulkan")]
+        let expected_cpu_tile = if crate::backend::vulkan_training_substrate_active() {
+            crate::backend::TrainingPrecisionPolicy::vulkan().streaming_prefill_tile_tokens
+        } else {
             STREAMING_PREFILL_DEFAULT_TILE
-        );
+        };
+        #[cfg(not(feature = "vulkan"))]
+        let expected_cpu_tile = STREAMING_PREFILL_DEFAULT_TILE;
+        assert_eq!(streaming_tile_tokens_for(&Device::Cpu), expected_cpu_tile);
         assert_eq!(
             streaming_tile_tokens_for(&Device::Cuda(0)),
             STREAMING_PREFILL_CUDA_DEFAULT_TILE

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3608,6 +3608,38 @@ impl MtpGpuWeightsSlot {
         slot
     }
 
+    /// Training-session residency companion to
+    /// [`GpuWeights::to_device_deep`]. An uploaded slot deep-copies its
+    /// tensors onto `device` (eager); a lazy slot keeps its CPU source and
+    /// re-targets the device.
+    pub fn to_device_deep(
+        &self,
+        device: Device,
+        mv_layer: &dyn Fn(&GpuLayerWeights) -> Result<GpuLayerWeights>,
+    ) -> Result<MtpGpuWeightsSlot> {
+        if let Some(mtp) = self.weights.get() {
+            let mv = |t: &Tensor| -> Result<Tensor> {
+                t.to_device(device)
+                    .map_err(|e| anyhow::anyhow!("mtp to_device_deep: {e}"))
+            };
+            let moved = MtpGpuWeights {
+                fc: mv(&mtp.fc)?,
+                fc_t: mv(&mtp.fc_t)?,
+                pre_fc_norm_embedding: mv(&mtp.pre_fc_norm_embedding)?,
+                pre_fc_norm_hidden: mv(&mtp.pre_fc_norm_hidden)?,
+                layer: mv_layer(&mtp.layer)?,
+                final_layernorm: mv(&mtp.final_layernorm)?,
+            };
+            return Ok(MtpGpuWeightsSlot::eager(moved, &device));
+        }
+        Ok(MtpGpuWeightsSlot {
+            weights: OnceLock::new(),
+            source: self.source.clone(),
+            device,
+            init_lock: Mutex::new(()),
+        })
+    }
+
     pub fn is_uploaded(&self) -> bool {
         self.weights.get().is_some()
     }
@@ -6072,6 +6104,119 @@ fn install_marlin_packed(
 impl GpuWeights {
     pub fn has_mtp(&self) -> bool {
         self.mtp.is_some()
+    }
+
+    /// Deep-copy every tensor onto `device` — the training-session
+    /// residency primitive. On the Vulkan hybrid substrate the serving
+    /// weights are kt CPU-storage (with VulkanBuffer caches managed
+    /// separately), but TRAINING needs every operand on ONE device or the
+    /// tape recorders die on "inputs on different devices". A trainer
+    /// uploads a resident copy once per job (≈8 GB BF16 for Qwen3.5-4B —
+    /// affordable on unified-memory APUs), trains against it, and drops
+    /// it; the serving copy is never touched.
+    ///
+    /// Same-device moves are cheap (`Tensor::to_device` returns an Arc
+    /// clone), so calling this unconditionally is safe.
+    pub fn to_device_deep(&self, device: Device) -> Result<GpuWeights> {
+        let mv = |t: &Tensor| -> Result<Tensor> {
+            t.to_device(device)
+                .map_err(|e| anyhow::anyhow!("to_device_deep: {e}"))
+        };
+        let mv_opt = |t: &Option<Tensor>| -> Result<Option<Tensor>> {
+            t.as_ref().map(|t| mv(t)).transpose()
+        };
+        let mv_w8 =
+            |w: &Option<crate::rocm_w8_proj::RocmW8Proj>| -> Result<Option<crate::rocm_w8_proj::RocmW8Proj>> {
+                w.as_ref()
+                    .map(|w| w.to_device_deep(device))
+                    .transpose()
+            };
+        let mv_marlin = |w: &Option<crate::marlin_proj::MarlinPackedProj>| -> Result<Option<crate::marlin_proj::MarlinPackedProj>> {
+            w.as_ref().map(|w| w.to_device_deep(device)).transpose()
+        };
+        let mv_ffn = |m: &GpuFfnWeights| -> Result<GpuFfnWeights> {
+            Ok(GpuFfnWeights {
+                gate_proj: mv(&m.gate_proj)?,
+                up_proj: mv(&m.up_proj)?,
+                down_proj: mv(&m.down_proj)?,
+                gate_proj_t: mv(&m.gate_proj_t)?,
+                up_proj_t: mv(&m.up_proj_t)?,
+                down_proj_t: mv(&m.down_proj_t)?,
+                gate_up_proj_t: mv_opt(&m.gate_up_proj_t)?,
+                gate_proj_marlin: mv_marlin(&m.gate_proj_marlin)?,
+                up_proj_marlin: mv_marlin(&m.up_proj_marlin)?,
+                down_proj_marlin: mv_marlin(&m.down_proj_marlin)?,
+                gate_up_proj_w8: mv_w8(&m.gate_up_proj_w8)?,
+                down_proj_w8: mv_w8(&m.down_proj_w8)?,
+            })
+        };
+        let mv_layer = |l: &GpuLayerWeights| -> Result<GpuLayerWeights> {
+            let attention = match &l.attention {
+                GpuAttentionWeights::Full(a) => GpuAttentionWeights::Full(GpuFullAttentionWeights {
+                    q_proj: mv(&a.q_proj)?,
+                    k_proj: mv(&a.k_proj)?,
+                    v_proj: mv(&a.v_proj)?,
+                    o_proj: mv(&a.o_proj)?,
+                    q_norm: mv(&a.q_norm)?,
+                    k_norm: mv(&a.k_norm)?,
+                    q_proj_t: mv(&a.q_proj_t)?,
+                    k_proj_t: mv(&a.k_proj_t)?,
+                    v_proj_t: mv(&a.v_proj_t)?,
+                    qkv_proj_t: mv_opt(&a.qkv_proj_t)?,
+                    o_proj_t: mv(&a.o_proj_t)?,
+                    qkv_proj_w8: mv_w8(&a.qkv_proj_w8)?,
+                    o_proj_w8: mv_w8(&a.o_proj_w8)?,
+                    q_proj_marlin: mv_marlin(&a.q_proj_marlin)?,
+                }),
+                GpuAttentionWeights::Linear(a) => {
+                    GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
+                        in_proj_qkv: mv(&a.in_proj_qkv)?,
+                        in_proj_z: mv(&a.in_proj_z)?,
+                        out_proj: mv(&a.out_proj)?,
+                        in_proj_a: mv(&a.in_proj_a)?,
+                        in_proj_b: mv(&a.in_proj_b)?,
+                        conv1d: mv(&a.conv1d)?,
+                        norm: mv(&a.norm)?,
+                        a_log: mv(&a.a_log)?,
+                        a_log_gates: mv(&a.a_log_gates)?,
+                        dt_bias: mv(&a.dt_bias)?,
+                        in_proj_qkv_t: mv(&a.in_proj_qkv_t)?,
+                        in_proj_z_t: mv(&a.in_proj_z_t)?,
+                        in_proj_a_t: mv(&a.in_proj_a_t)?,
+                        in_proj_b_t: mv(&a.in_proj_b_t)?,
+                        in_proj_ab_t: mv_opt(&a.in_proj_ab_t)?,
+                        out_proj_t: mv(&a.out_proj_t)?,
+                        out_proj_marlin: mv_marlin(&a.out_proj_marlin)?,
+                        in_proj_qkvzab_w8: mv_w8(&a.in_proj_qkvzab_w8)?,
+                    })
+                }
+            };
+            Ok(GpuLayerWeights {
+                input_layernorm: mv(&l.input_layernorm)?,
+                post_attention_layernorm: mv(&l.post_attention_layernorm)?,
+                attention,
+                mlp: mv_ffn(&l.mlp)?,
+            })
+        };
+
+        let layers = self
+            .layers
+            .iter()
+            .map(&mv_layer)
+            .collect::<Result<Vec<_>>>()?;
+        let mtp = match &self.mtp {
+            None => None,
+            Some(slot) => Some(slot.to_device_deep(device, &mv_layer)?),
+        };
+        Ok(GpuWeights {
+            embed_tokens: mv(&self.embed_tokens)?,
+            embed_tokens_t: mv(&self.embed_tokens_t)?,
+            layers,
+            final_norm: mv(&self.final_norm)?,
+            rotary_inv_freq: mv(&self.rotary_inv_freq)?,
+            lm_head_w8: mv_w8(&self.lm_head_w8)?,
+            mtp,
+        })
     }
 
     pub fn mtp_weights(&self) -> Result<&MtpGpuWeights> {

--- a/crates/kiln-model/src/marlin_proj.rs
+++ b/crates/kiln-model/src/marlin_proj.rs
@@ -384,3 +384,24 @@ pub fn parallel_pack_disabled() -> bool {
         Some("1") | Some("true") | Some("yes")
     )
 }
+
+impl MarlinPackedProj {
+    /// Training-session residency companion to
+    /// `GpuWeights::to_device_deep`: deep-copy the packed weight + scales
+    /// onto `device`; `groupsize`/`k`/`n` are metadata.
+    pub fn to_device_deep(&self, device: kiln_tensor::Device) -> anyhow::Result<Self> {
+        Ok(Self {
+            b_packed: self
+                .b_packed
+                .to_device(device)
+                .map_err(|e| anyhow::anyhow!("marlin b_packed to_device: {e}"))?,
+            scales: self
+                .scales
+                .to_device(device)
+                .map_err(|e| anyhow::anyhow!("marlin scales to_device: {e}"))?,
+            groupsize: self.groupsize,
+            k: self.k,
+            n: self.n,
+        })
+    }
+}

--- a/crates/kiln-model/src/rocm_w8_proj.rs
+++ b/crates/kiln-model/src/rocm_w8_proj.rs
@@ -219,3 +219,23 @@ pub fn gumbel_sample_bf16(
 pub fn argmax_bf16(_x: &kiln_tensor::Tensor, _w: &RocmW8Proj) -> Result<u32> {
     anyhow::bail!("rocm_w8_proj::argmax_bf16 requires the rocm feature")
 }
+
+impl RocmW8Proj {
+    /// Training-session residency companion to
+    /// `GpuWeights::to_device_deep`: deep-copy the packed weight + scales
+    /// onto `device`; `k`/`n` are metadata.
+    pub fn to_device_deep(&self, device: kiln_tensor::Device) -> anyhow::Result<Self> {
+        Ok(Self {
+            q_weight: self
+                .q_weight
+                .to_device(device)
+                .map_err(|e| anyhow::anyhow!("w8 q_weight to_device: {e}"))?,
+            scales: self
+                .scales
+                .to_device(device)
+                .map_err(|e| anyhow::anyhow!("w8 scales to_device: {e}"))?,
+            k: self.k,
+            n: self.n,
+        })
+    }
+}

--- a/crates/kiln-tensor/src/device_op.rs
+++ b/crates/kiln-tensor/src/device_op.rs
@@ -251,10 +251,14 @@ pub fn dispatch1<Op: DeviceOp1 + ?Sized>(op: &Op, input: &Tensor) -> Result<Tens
 pub fn dispatch2<Op: DeviceOp2 + ?Sized>(op: &Op, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     if a.device() != b.device() {
         return Err(crate::Error::Msg(format!(
-            "DeviceOp2 {:?}: inputs on different devices: a={}, b={}",
+            "DeviceOp2 {:?}: inputs on different devices: a={} {:?} {:?}, b={} {:?} {:?}",
             op.name(),
             a.device(),
-            b.device()
+            a.dtype(),
+            a.shape(),
+            b.device(),
+            b.dtype(),
+            b.shape()
         )));
     }
     let result = match a.device() {

--- a/crates/kiln-tensor/src/vulkan_storage.rs
+++ b/crates/kiln-tensor/src/vulkan_storage.rs
@@ -881,6 +881,26 @@ pub fn vulkan_contiguous(t: &crate::Tensor) -> Result<crate::Tensor> {
 // vulkan_matmul_bf16w — #1443 step1: F32-act × BF16-weight mixed-precision GEMM
 // ----------------------------------------------------------------------
 
+
+/// Whether `t` is backed by [`VulkanStorage`] (resident on the GPU pool).
+fn is_vulkan_backed(t: &crate::Tensor) -> bool {
+    t.storage().as_any().downcast_ref::<VulkanStorage>().is_some()
+}
+
+/// One-shot WARN for the non-resident mixed-precision fallback so hybrid
+/// (CPU-storage) training runs are honest about taking the slow path.
+fn warn_bf16w_host_fallback_once() {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        eprintln!(
+            "WARN vulkan_matmul_bf16w: inputs are not Vulkan-resident (hybrid \
+             CPU-storage training) — falling back to a host cast-to-F32 \
+             matmul. Correct but slow; the Vulkan residency port removes \
+             this path."
+        );
+    });
+}
+
 /// Vulkan mixed-precision linear `out = x @ W.T` where `x` is an F32
 /// activation `[rows, K]` and `W` is a **frozen** BF16-packed weight in the
 /// transposed `[N, K]` layout (`N = out_dim`, `K = hidden`). Returns an F32
@@ -939,6 +959,23 @@ pub fn vulkan_matmul_bf16w(x: &crate::Tensor, weight_t: &crate::Tensor) -> Resul
             x.shape()[1],
             weight_t.shape()[1]
         )));
+    }
+    // Hybrid (CPU-storage) training fallback: the kernel needs
+    // Vulkan-resident buffers; until the residency port, production
+    // training tensors are kt CPU-storage. Cast the frozen weight to F32
+    // and run the equal-dtype matmul — bitwise-equivalent math (the
+    // kernel also widens BF16 to F32 in-shader), just slower.
+    if !is_vulkan_backed(x) || !is_vulkan_backed(weight_t) {
+        warn_bf16w_host_fallback_once();
+        // Hybrid residency can mix devices (vulkan-resident activations,
+        // CPU-storage weights). Compute on host — moving the small
+        // activation is far cheaper than uploading the full F32 weight —
+        // then return to x's device.
+        let x_dev = x.device();
+        let x_host = x.to_device(Device::Cpu)?;
+        let w_f32 = weight_t.to_device(Device::Cpu)?.to_dtype(DType::F32)?;
+        let y = crate::ops::matmul_rhs_transposed(&x_host, &w_f32)?;
+        return y.to_device(x_dev);
     }
     let device_index = vulkan_device_index(x, "vulkan_matmul_bf16w")?;
 
@@ -1001,6 +1038,15 @@ pub fn vulkan_matmul_bf16w_bwd(
             grad_out.shape()[1],
             weight_t.shape()[0]
         )));
+    }
+    // Hybrid (CPU-storage) fallback — see `vulkan_matmul_bf16w`.
+    if !is_vulkan_backed(grad_out) || !is_vulkan_backed(weight_t) {
+        warn_bf16w_host_fallback_once();
+        let go_dev = grad_out.device();
+        let go_host = grad_out.to_device(Device::Cpu)?;
+        let w_f32 = weight_t.to_device(Device::Cpu)?.to_dtype(DType::F32)?;
+        let dx = go_host.matmul(&w_f32)?;
+        return dx.to_device(go_dev);
     }
     let device_index = vulkan_device_index(grad_out, "vulkan_matmul_bf16w_bwd")?;
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -2921,6 +2921,32 @@ fn run_mtp_alignment_phase(
     Ok(Some((trained, initial_ce, final_ce)))
 }
 
+/// The device training state (LoRA params, optimizer moments, linear
+/// state) must live on. Usually the weights' device — EXCEPT on the
+/// Vulkan hybrid substrate, where base weights are kt CPU-storage but
+/// the forward's ACTIVATIONS are Vulkan-resident (the embedding gather
+/// returns resident output by design). Training state must match the
+/// activations, not the frozen weights: a CPU LoRA pair against a
+/// Vulkan activation dies in the recorder with
+/// "inputs on different devices" (the operator-validation finding,
+/// 2026-06-11). Mixed frozen-weight projections are handled by the
+/// vulkan_matmul_bf16w host fallback.
+fn training_device_for_weights(weights: &GpuWeights) -> Device {
+    // NOTE (2026-06-11 operator validation, Strix Halo): two placements
+    // were tested for the Vulkan hybrid substrate (CPU-storage BF16 base
+    // weights, Vulkan-resident activations from the embedding gather):
+    //   * weights' device (Cpu): the FIRST GDN projection's recorder dies
+    //     on "inputs on different devices" (vulkan activation × cpu LoRA
+    //     param).
+    //   * Device::Vulkan(0): the failure moves INSIDE the GDN block
+    //     (a=cpu × b=vulkan in a later matmul) — mixed-device ops are
+    //     pervasive, not localized.
+    // Either way hybrid BF16-checkpoint training is unsupported until the
+    // residency port puts ALL training tensors on one device end to end.
+    // Keep the weights' device so the failure stays early and clean.
+    weights.embed_tokens.device()
+}
+
 pub fn sft_train(
     examples: &[SftExample],
     config: &SftConfig,
@@ -2951,7 +2977,7 @@ pub fn sft_train(
     // forward/backward), so keep `device` kt downstream. The only candle
     // touch left is the safetensors adapter I/O, which bridges the kt device
     // to candle locally inside `load_from_safetensors`/`save_peft`.
-    let device = weights.embed_tokens.device();
+    let device = training_device_for_weights(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 
@@ -3497,7 +3523,7 @@ pub fn grpo_train(
     // kt-native (kt `Parameter`s, kt AdamW state, kt tape forward/backward),
     // so keep `device` kt downstream. The only candle touch is safetensors
     // adapter I/O, which bridges kt->candle locally inside save/load.
-    let device = weights.embed_tokens.device();
+    let device = training_device_for_weights(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 
@@ -4365,7 +4391,7 @@ pub fn grpo_train_jsonl(
     // kt-native (kt `Parameter`s, kt AdamW state, kt tape forward/backward), so
     // keep `device` kt downstream. The only candle touch is safetensors adapter
     // I/O, which bridges kt->candle locally inside save/load.
-    let device = weights.embed_tokens.device();
+    let device = training_device_for_weights(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -2932,19 +2932,57 @@ fn run_mtp_alignment_phase(
 /// 2026-06-11). Mixed frozen-weight projections are handled by the
 /// vulkan_matmul_bf16w host fallback.
 fn training_device_for_weights(weights: &GpuWeights) -> Device {
-    // NOTE (2026-06-11 operator validation, Strix Halo): two placements
-    // were tested for the Vulkan hybrid substrate (CPU-storage BF16 base
-    // weights, Vulkan-resident activations from the embedding gather):
-    //   * weights' device (Cpu): the FIRST GDN projection's recorder dies
-    //     on "inputs on different devices" (vulkan activation × cpu LoRA
-    //     param).
-    //   * Device::Vulkan(0): the failure moves INSIDE the GDN block
-    //     (a=cpu × b=vulkan in a later matmul) — mixed-device ops are
-    //     pervasive, not localized.
-    // Either way hybrid BF16-checkpoint training is unsupported until the
-    // residency port puts ALL training tensors on one device end to end.
-    // Keep the weights' device so the failure stays early and clean.
-    weights.embed_tokens.device()
+    // Training-session residency experiment (2026-06-11, Strix Halo,
+    // probe-verified): the Vulkan backend has TWO half-substrates —
+    //   (A) kt CPU-device handles + backend kernel BRIDGES (production
+    //       inference; the bridges REQUIRE Device::Cpu inputs and return
+    //       CPU outputs), and
+    //   (B) Device::Vulkan kt-storage ops (the vk_*_proof tests; never
+    //       exercised on the FULL model forward).
+    // Training needs ONE of them complete. Uploading weights + training
+    // state to Vulkan(0) (this experiment, with GpuWeights::to_device_deep)
+    // pushes the forward off (A)'s bridges onto (B), which lacks ops —
+    // the GDN recurrent step dies on a host-composite piece
+    // (a=cpu [1,nv,T,dk] × b=vulkan [1,nv,dk,dv]). Completing (B) for the
+    // full model IS the residency port. Until then the one-device path is
+    // an explicit OPT-IN for porting work; the default stays on the
+    // weights' device, failing early and clean.
+    let device = weights.embed_tokens.device();
+    #[cfg(feature = "vulkan")]
+    {
+        if matches!(device, Device::Cpu)
+            && kiln_model::backend::vulkan_training_substrate_active()
+            && std::env::var("KILN_TRAIN_RESIDENT").is_ok_and(|v| v == "1")
+        {
+            return Device::Vulkan(0);
+        }
+    }
+    device
+}
+
+/// Upload a training-session resident copy of the weights when the
+/// training device differs from the weights' storage device (the Vulkan
+/// hybrid substrate). Returns `None` when no copy is needed — the caller
+/// keeps using the serving weights directly. The copy (~8 GB BF16 for
+/// Qwen3.5-4B) lives for the duration of the job and drops with the
+/// returned value; the serving weights are never touched.
+fn resident_training_weights(
+    weights: &GpuWeights,
+    training_device: &Device,
+) -> Result<Option<GpuWeights>> {
+    if weights.embed_tokens.device() == *training_device {
+        return Ok(None);
+    }
+    let started = Instant::now();
+    let resident = weights
+        .to_device_deep(*training_device)
+        .context("uploading training-session resident weights")?;
+    tracing::info!(
+        device = ?training_device,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "uploaded training-session resident weights"
+    );
+    Ok(Some(resident))
 }
 
 pub fn sft_train(
@@ -2978,6 +3016,11 @@ pub fn sft_train(
     // touch left is the safetensors adapter I/O, which bridges the kt device
     // to candle locally inside `load_from_safetensors`/`save_peft`.
     let device = training_device_for_weights(weights);
+    // Training-session residency: upload a one-device copy of the weights
+    // when the substrate needs it (Vulkan hybrid). Shadow `weights` so the
+    // whole body trains against the resident copy; it drops at return.
+    let resident_weights = resident_training_weights(weights, &device)?;
+    let weights = resident_weights.as_ref().unwrap_or(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 
@@ -3524,6 +3567,11 @@ pub fn grpo_train(
     // so keep `device` kt downstream. The only candle touch is safetensors
     // adapter I/O, which bridges kt->candle locally inside save/load.
     let device = training_device_for_weights(weights);
+    // Training-session residency: upload a one-device copy of the weights
+    // when the substrate needs it (Vulkan hybrid). Shadow `weights` so the
+    // whole body trains against the resident copy; it drops at return.
+    let resident_weights = resident_training_weights(weights, &device)?;
+    let weights = resident_weights.as_ref().unwrap_or(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 
@@ -4392,6 +4440,11 @@ pub fn grpo_train_jsonl(
     // keep `device` kt downstream. The only candle touch is safetensors adapter
     // I/O, which bridges kt->candle locally inside save/load.
     let device = training_device_for_weights(weights);
+    // Training-session residency: upload a one-device copy of the weights
+    // when the substrate needs it (Vulkan hybrid). Shadow `weights` so the
+    // whole body trains against the resident copy; it drops at return.
+    let resident_weights = resident_training_weights(weights, &device)?;
+    let weights = resident_weights.as_ref().unwrap_or(weights);
     let backend = backend::for_device_kt(&device);
     let training_precision_policy = training_precision_policy_for_backend(backend.as_ref());
 


### PR DESCRIPTION
## Summary

Groundwork from the operator-validation investigation, probe-verified on the Strix Halo. Default behavior is unchanged on non-Vulkan hosts; on Vulkan hosts, training gets strictly further and diagnostics get strictly sharper.

**The architectural finding (probe-verified):** the Vulkan backend has two half-substrates — (A) kt CPU-device handles + backend kernel bridges (production inference; bridges *require* CPU inputs), and (B) `Device::Vulkan` kt-storage ops (the `vk_*_proof` tests; never exercised on the full model forward). Server-side training on the BF16 checkpoint needs one of them complete; completing (B) is the residency port. This PR ships the port's working scaffold:

- **CPU-as-Vulkan-sentinel** for `training_precision_policy_for_device_kt` + `training_tape_route_for_device_kt`, keyed on the same runtime probe `for_device_kt` uses — on Vulkan hosts, CPU-device tensors get the Vulkan mixed-precision policy (F32 activations × BF16 base weights admitted) and the tape route, so recorders engage instead of dying on the first dtype mismatch.
- **`vulkan_matmul_bf16w{,_bwd}` host fallbacks** for non-resident/mixed-device operands (device-aligned: compute on host, return to the activation's device) with a one-shot WARN.
- **`GpuWeights::to_device_deep`** — complete deep-copy traversal (every tensor incl. quant slots + the MTP slot) with `RocmW8Proj`/`MarlinPackedProj` companions, plus a trainer hook (`resident_training_weights`) that uploads a one-device copy per job. **Opt-in** via `KILN_TRAIN_RESIDENT=1`: with it, the forward leaves (A)'s bridges and runs on (B), which currently stops at a GDN recurrent host-composite — the precise next porting target, with a one-command repro.
- **Shape-rich `DeviceOp2` errors** (device + dtype + shape for both operands) — the change that made the whole diagnosis possible.
- Substrate-aware streaming-tile test expectation (Vulkan hosts correctly get the Vulkan-tuned tile for CPU-device tensors).

## Verification

Full `kiln-model`/`kiln-train`/`kiln-tensor`/`kiln-server` suites green on default features AND `--features vulkan` (the one pre-existing `perf_regression_sft` pair excepted, reproduces on main). Live-server repro of each failure layer documented in the commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)