### PR TITLE
Surface the §8.7 promotion verdict: status API, dashboard gate pill, CLI

### DIFF
--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -1122,6 +1122,7 @@ fn training_status_from_info(j: &crate::state::TrainingJobInfo) -> TrainingStatu
             .into(),
         ),
         error: j.error.clone(),
+        post_eval_verdict: j.post_eval_verdict.clone(),
     }
 }
 

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -2352,6 +2352,18 @@ fn print_job_summary(job: &serde_json::Value) {
         println!("  {} {loss:.4}", style("Loss:").dim());
     }
     println!("  {} {}s", style("Elapsed:").dim(), elapsed);
+    if let Some(verdict) = job.get("post_eval_verdict").and_then(|v| v.as_str()) {
+        // §8.7 promotion gate: color by outcome so a demotion can't be
+        // missed in a wall of job summaries.
+        let styled = if verdict.contains("promoted") && !verdict.contains("NOT") {
+            style(verdict).green()
+        } else if verdict.contains(".failed") || verdict.contains("demoted") {
+            style(verdict).red()
+        } else {
+            style(verdict).yellow()
+        };
+        println!("  {} {}", style("Gate:").dim(), styled);
+    }
     if state == "failed" {
         if let Some(err) = job.get("error").and_then(|v| v.as_str()) {
             println!("  {} {}", style("Error:").red().bold(), style(err).red());

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -3170,6 +3170,11 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .train-data-pick select { flex: 1; }
   .train-data-pick-empty { font-size: var(--text-xs); color: var(--text-muted); line-height: 1.5; }
   /* Inline failure reason on failed training cards — never make the user hunt */
+  .training-card-gate { display: flex; align-items: center; gap: 6px; font-size: 12px;
+    margin-top: 4px; padding: 4px 8px; border-radius: 6px; }
+  .training-card-gate.gate-ok { color: var(--ok, #3fb950); background: rgba(63,185,80,.08); }
+  .training-card-gate.gate-err { color: var(--err, #f85149); background: rgba(248,81,73,.08); }
+  .training-card-gate.gate-warn { color: var(--warn, #d29922); background: rgba(210,153,34,.08); }
   .training-card-error { display: flex; align-items: flex-start; gap: 7px; margin-top: var(--space-2);
     padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm);
     background: var(--danger-bg); border: 1px solid var(--danger-bd);
@@ -7648,6 +7653,16 @@ function renderTrainingCard(j, state) {
   } else if (stateNormForActions === 'completed' && j.adapter_name) {
     actionBtn = `<button class="btn btn-sm" data-train-prove data-adapter="${escapeHtml(j.adapter_name)}" type="button" style="margin-left:auto;" title="Grade ${escapeHtml(j.adapter_name)} against base on an eval suite">Prove it vs base</button>`;
   }
+  // §8.7 promotion-gate verdict pill: green = promoted, red = demoted to
+  // .failed, amber = not measured (eval errored). Rendered whenever the
+  // backend stamped a verdict so a silent demotion can't hide.
+  let gateLine = '';
+  if (j.post_eval_verdict) {
+    const v = String(j.post_eval_verdict);
+    const cls = (v.includes('promoted') && !v.includes('NOT')) ? 'ok'
+      : (v.includes('.failed') || v.includes('demoted')) ? 'err' : 'warn';
+    gateLine = `<div class="training-card-gate gate-${cls}" title="${escapeHtml(v)}">${icon(cls === 'ok' ? 'check' : 'warning', 'icn-sm')} ${escapeHtml(v.slice(0, 160))}</div>`;
+  }
   const errLine = (stateNormForActions === 'failed' && j.error)
     ? `<div class="training-card-error">${icon('warning', 'icn-sm')} ${escapeHtml(String(j.error).slice(0, 220))}</div>`
     : '';
@@ -7681,7 +7696,7 @@ function renderTrainingCard(j, state) {
         <span class="training-stat-label">${j.current_loss != null ? 'loss' : 'not started'}</span>
       </div>
     </div>
-    ${errLine}
+    ${gateLine}${errLine}
     <div class="training-card-curve" id="training-curve-${escapeHtml(j.job_id)}"></div>
   </div>`;
 }

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -1106,6 +1106,12 @@ pub struct TrainingStatus {
     /// payloads that predate the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// §8.7 promotion-gate verdict, stamped by the eval worker when the
+    /// request carried `post_eval.min_accuracy`: whether the adapter was
+    /// promoted, demoted to `<name>.failed`, or left unpromoted because
+    /// the eval errored. Absent for ungated jobs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_eval_verdict: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

The §8.7 gate (#1501) promotes, demotes to `<name>.failed`, or withholds unmeasured adapters — but the verdict only existed on the job-detail route; the normal surfaces could miss a demotion entirely. (Discovery round 2, item 4.)

- `TrainingStatus.post_eval_verdict` (absent for ungated jobs — payloads unchanged unless a gate ran).
- Dashboard job cards: gate pill — green promoted / red demoted / amber not-measured, full verdict in the tooltip.
- `kiln train status`: color-coded `Gate:` line.

## Verification

`kiln-server` + `kiln-train` suites green; dashboard smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)