### PR TITLE
Streaming correctness: incremental detokenizer, stop holdback, stop-aware tool parsing

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -611,6 +611,10 @@ pub struct StreamDone {
     pub finish_reason: FinishReason,
     /// Total number of generated tokens.
     pub completion_tokens: usize,
+    /// Text held back by the emit gates (UTF-8 char-boundary + stop-window
+    /// holdback) that became safe to emit only at end-of-stream. Empty
+    /// after a stop match (the held text WAS the stop) and on error paths.
+    pub trailing_text: String,
 }
 
 /// Events emitted during streaming generation.
@@ -1495,39 +1499,73 @@ fn sample_first_decode_token(
     }
 }
 
+/// Composite per-request emit gate: incremental detokenization + stop
+/// holdback. One per streaming generation; finish() drains residue at
+/// non-stop exits (a stop can complete inside held bytes).
+struct StreamTextGate {
+    detok: crate::stream_text::IncrementalDetokenizer,
+    stop: crate::stream_text::StopTailGate,
+}
+
+impl StreamTextGate {
+    fn new(stop_sequences: &[String]) -> Self {
+        Self {
+            detok: crate::stream_text::IncrementalDetokenizer::new(),
+            stop: crate::stream_text::StopTailGate::new(stop_sequences),
+        }
+    }
+
+    /// Non-stop loop exit: push the detokenizer residual through the stop
+    /// gate, then drain the stop holdback. Returns
+    /// `(trailing_text, late_stop)` — when `late_stop` is `Some`, a stop
+    /// completed inside the held bytes and the caller must override its
+    /// finish reason.
+    fn finish(
+        &mut self,
+        tokenizer: &KilnTokenizer,
+        tokens: &[TokenId],
+    ) -> (String, Option<String>) {
+        let residual = self.detok.flush(tokenizer, tokens);
+        let scan = self.stop.push(&residual);
+        if let Some(stop) = scan.matched_stop {
+            return (scan.emit, Some(stop));
+        }
+        let mut trailing = scan.emit;
+        trailing.push_str(&self.stop.flush());
+        (trailing, None)
+    }
+}
+
 fn emit_stream_token(
     tx: &mpsc::Sender<StreamEvent>,
     tokenizer: &KilnTokenizer,
+    gate: &mut StreamTextGate,
     generated_tokens: &mut Vec<TokenId>,
     token: TokenId,
-    stop_sequences: &[String],
 ) -> StreamTokenDisposition {
     generated_tokens.push(token);
 
-    let token_text = tokenizer.decode(&[token]).unwrap_or_default();
+    // CHECK BEFORE EMIT: the delta passes the stop gate first, so the
+    // matched stop never reaches the wire (the pre-gate code emitted the
+    // token THEN ran the stop check on the full decoded prefix — pi's
+    // stop-marker parsers saw phantom delimiters in every stream).
+    // Exactly one StreamEvent::Token per accepted token (text may be ""),
+    // keeping completion-token counting and usage exact.
+    let delta = gate.detok.next_delta(tokenizer, generated_tokens);
+    let scan = gate.stop.push(&delta);
     if tx
         .send(StreamEvent::Token(StreamToken {
             token_id: token,
-            text: token_text,
+            text: scan.emit,
         }))
         .is_err()
     {
         return StreamTokenDisposition::ReceiverDropped;
     }
-
-    if !stop_sequences.is_empty() {
-        if let Ok(text) = tokenizer.decode(generated_tokens) {
-            for stop_seq in stop_sequences {
-                if text.contains(stop_seq.as_str()) {
-                    return StreamTokenDisposition::Finished(FinishReason::StopSequence(
-                        stop_seq.clone(),
-                    ));
-                }
-            }
-        }
+    match scan.matched_stop {
+        Some(stop) => StreamTokenDisposition::Finished(FinishReason::StopSequence(stop)),
+        None => StreamTokenDisposition::Continue,
     }
-
-    StreamTokenDisposition::Continue
 }
 
 /// Why generation stopped.
@@ -1950,6 +1988,7 @@ impl ModelRunner {
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut step_seed = params.seed;
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
 
         let mut next_token = if params.is_effectively_greedy() {
             greedy_sample(&logits)?
@@ -1968,41 +2007,23 @@ impl ModelRunner {
                 break;
             }
 
-            generated_tokens.push(next_token);
-
-            // Decode this token's text
-            let token_text = self.tokenizer.decode(&[next_token]).unwrap_or_default();
-
-            // Send token event; if receiver dropped, stop early
-            if tx
-                .send(StreamEvent::Token(StreamToken {
-                    token_id: next_token,
-                    text: token_text,
-                }))
-                .is_err()
-            {
-                return Ok(rx);
-            }
-
-            // Check stop sequences
-            if !params.stop.is_empty() {
-                let decoded_so_far = self
-                    .tokenizer
-                    .decode(&generated_tokens)
-                    .map_err(|e| anyhow::anyhow!("{e}"))
-                    .ok();
-                if let Some(text) = &decoded_so_far {
-                    for stop_seq in &params.stop {
-                        if text.contains(stop_seq.as_str()) {
-                            finish_reason = FinishReason::StopSequence(stop_seq.clone());
-                            let _ = tx.send(StreamEvent::Done(StreamDone {
-                                finish_reason,
-                                completion_tokens: generated_tokens.len(),
-                            }));
-                            return Ok(rx);
-                        }
-                    }
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut gate,
+                &mut generated_tokens,
+                next_token,
+            ) {
+                StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+                StreamTokenDisposition::Finished(reason) => {
+                    let _ = tx.send(StreamEvent::Done(StreamDone {
+                        finish_reason: reason,
+                        completion_tokens: generated_tokens.len(),
+                        trailing_text: String::new(),
+                    }));
+                    return Ok(rx);
                 }
+                StreamTokenDisposition::Continue => {}
             }
 
             if generated_tokens.len() >= params.max_tokens {
@@ -2029,9 +2050,15 @@ impl ModelRunner {
             };
         }
 
+        let (trailing_text, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, trailing_text) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, trailing_text),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text,
         }));
 
         Ok(rx)
@@ -6785,6 +6812,7 @@ impl ModelRunner {
 
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
             None => rand::make_rng::<rand::rngs::StdRng>(),
@@ -6809,9 +6837,9 @@ impl ModelRunner {
             match emit_stream_token(
                 &tx,
                 &self.tokenizer,
+                &mut gate,
                 &mut generated_tokens,
                 last_token,
-                &params.stop,
             ) {
                 StreamTokenDisposition::Continue => {}
                 StreamTokenDisposition::Finished(reason) => {
@@ -6819,6 +6847,7 @@ impl ModelRunner {
                     let _ = tx.send(StreamEvent::Done(StreamDone {
                         finish_reason: reason,
                         completion_tokens,
+                        trailing_text: String::new(),
                     }));
                     return Ok(rx);
                 }
@@ -6863,9 +6892,9 @@ impl ModelRunner {
                 match emit_stream_token(
                     &tx,
                     &self.tokenizer,
+                    &mut gate,
                     &mut generated_tokens,
                     token,
-                    &params.stop,
                 ) {
                     StreamTokenDisposition::Continue => {}
                     StreamTokenDisposition::Finished(reason) => {
@@ -6873,6 +6902,7 @@ impl ModelRunner {
                         let _ = tx.send(StreamEvent::Done(StreamDone {
                             finish_reason: reason,
                             completion_tokens,
+                            trailing_text: String::new(),
                         }));
                         return Ok(rx);
                     }
@@ -6900,9 +6930,15 @@ impl ModelRunner {
             }
         }
 
+        let (gate_trailing, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, gate_trailing) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, gate_trailing),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text: gate_trailing,
         }));
 
         Ok(rx)
@@ -7019,6 +7055,7 @@ impl ModelRunner {
         let mut mtp_pos = 0usize;
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
             None => rand::make_rng::<rand::rngs::StdRng>(),
@@ -7037,9 +7074,9 @@ impl ModelRunner {
             match emit_stream_token(
                 &tx,
                 &self.tokenizer,
+                &mut gate,
                 &mut generated_tokens,
                 last_token,
-                &params.stop,
             ) {
                 StreamTokenDisposition::Continue => {}
                 StreamTokenDisposition::Finished(reason) => {
@@ -7047,6 +7084,7 @@ impl ModelRunner {
                     let _ = tx.send(StreamEvent::Done(StreamDone {
                         finish_reason: reason,
                         completion_tokens,
+                        trailing_text: String::new(),
                     }));
                     return Ok(rx);
                 }
@@ -7098,9 +7136,9 @@ impl ModelRunner {
                 match emit_stream_token(
                     &tx,
                     &self.tokenizer,
+                    &mut gate,
                     &mut generated_tokens,
                     token,
-                    &params.stop,
                 ) {
                     StreamTokenDisposition::Continue => {}
                     StreamTokenDisposition::Finished(reason) => {
@@ -7108,6 +7146,7 @@ impl ModelRunner {
                         let _ = tx.send(StreamEvent::Done(StreamDone {
                             finish_reason: reason,
                             completion_tokens,
+                            trailing_text: String::new(),
                         }));
                         return Ok(rx);
                     }
@@ -7135,9 +7174,15 @@ impl ModelRunner {
             }
         }
 
+        let (gate_trailing, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, gate_trailing) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, gate_trailing),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text: gate_trailing,
         }));
 
         Ok(rx)
@@ -7328,6 +7373,7 @@ impl ModelRunner {
                     let _ = tx.send(StreamEvent::Done(StreamDone {
                         finish_reason: FinishReason::MaxTokens,
                         completion_tokens: 0,
+                        trailing_text: String::new(),
                     }));
                 }
                 drop(tx);
@@ -7638,6 +7684,7 @@ impl ModelRunner {
                     let _ = tx.send(StreamEvent::Done(StreamDone {
                         finish_reason: FinishReason::MaxTokens,
                         completion_tokens: 0,
+                        trailing_text: String::new(),
                     }));
                 }
                 drop(tx);
@@ -8093,6 +8140,7 @@ impl ModelRunner {
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut step_seed = params.seed;
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
 
         for _step in 0..params.max_tokens {
             if let Some(s) = step_seed.as_mut() {
@@ -8107,9 +8155,9 @@ impl ModelRunner {
             match emit_stream_token(
                 tx,
                 &self.tokenizer,
+                &mut gate,
                 &mut generated_tokens,
                 next_token,
-                &params.stop,
             ) {
                 StreamTokenDisposition::Continue => {}
                 StreamTokenDisposition::Finished(reason) => {
@@ -8140,9 +8188,15 @@ impl ModelRunner {
             seq_len += 1;
         }
 
+        let (gate_trailing, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, gate_trailing) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, gate_trailing),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text: gate_trailing,
         }));
 
         Ok(())
@@ -8201,6 +8255,7 @@ impl ModelRunner {
         let mut base_pos = prompt_tokens.len();
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
         let mut last_token = greedy_sample(&logits)?;
 
         loop {
@@ -8216,9 +8271,9 @@ impl ModelRunner {
             match emit_stream_token(
                 &tx,
                 &self.tokenizer,
+                &mut gate,
                 &mut generated_tokens,
                 last_token,
-                &params.stop,
             ) {
                 StreamTokenDisposition::Continue => {}
                 StreamTokenDisposition::Finished(reason) => {
@@ -8270,9 +8325,9 @@ impl ModelRunner {
                 match emit_stream_token(
                     &tx,
                     &self.tokenizer,
+                    &mut gate,
                     &mut generated_tokens,
                     token,
-                    &params.stop,
                 ) {
                     StreamTokenDisposition::Continue => {}
                     StreamTokenDisposition::Finished(reason) => {
@@ -8302,9 +8357,15 @@ impl ModelRunner {
             }
         }
 
+        let (gate_trailing, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, gate_trailing) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, gate_trailing),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text: gate_trailing,
         }));
 
         Ok(rx)
@@ -8404,6 +8465,7 @@ impl ModelRunner {
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut step_seed = params.seed;
         let mut finish_reason = FinishReason::MaxTokens;
+        let mut gate = StreamTextGate::new(&params.stop);
 
         // Acquire CUDA graph runner for decode steps
         let mut graph_runner = self
@@ -8427,41 +8489,27 @@ impl ModelRunner {
                 break;
             }
 
-            generated_tokens.push(next_token);
-
-            let token_text = self.tokenizer.decode(&[next_token]).unwrap_or_default();
-
-            if tx
-                .send(StreamEvent::Token(StreamToken {
-                    token_id: next_token,
-                    text: token_text,
-                }))
-                .is_err()
-            {
-                block_manager.free_all(&allocated_blocks);
-                return Ok(rx);
-            }
-
-            // Check stop sequences
-            if !params.stop.is_empty() {
-                let decoded_so_far = self
-                    .tokenizer
-                    .decode(&generated_tokens)
-                    .map_err(|e| anyhow::anyhow!("{e}"))
-                    .ok();
-                if let Some(text) = &decoded_so_far {
-                    for stop_seq in &params.stop {
-                        if text.contains(stop_seq.as_str()) {
-                            finish_reason = FinishReason::StopSequence(stop_seq.clone());
-                            let _ = tx.send(StreamEvent::Done(StreamDone {
-                                finish_reason,
-                                completion_tokens: generated_tokens.len(),
-                            }));
-                            block_manager.free_all(&allocated_blocks);
-                            return Ok(rx);
-                        }
-                    }
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut gate,
+                &mut generated_tokens,
+                next_token,
+            ) {
+                StreamTokenDisposition::ReceiverDropped => {
+                    block_manager.free_all(&allocated_blocks);
+                    return Ok(rx);
                 }
+                StreamTokenDisposition::Finished(reason) => {
+                    let _ = tx.send(StreamEvent::Done(StreamDone {
+                        finish_reason: reason,
+                        completion_tokens: generated_tokens.len(),
+                        trailing_text: String::new(),
+                    }));
+                    block_manager.free_all(&allocated_blocks);
+                    return Ok(rx);
+                }
+                StreamTokenDisposition::Continue => {}
             }
 
             if generated_tokens.len() >= params.max_tokens {
@@ -8543,9 +8591,15 @@ impl ModelRunner {
             };
         }
 
+        let (gate_trailing, late_stop) = gate.finish(&self.tokenizer, &generated_tokens);
+        let (finish_reason, gate_trailing) = match late_stop {
+            Some(stop) => (FinishReason::StopSequence(stop), String::new()),
+            None => (finish_reason, gate_trailing),
+        };
         let _ = tx.send(StreamEvent::Done(StreamDone {
             finish_reason,
             completion_tokens: generated_tokens.len(),
+            trailing_text: gate_trailing,
         }));
 
         block_manager.free_all(&allocated_blocks);

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -11,6 +11,7 @@ pub mod engine;
 pub mod forward;
 pub mod fp8;
 pub mod generate;
+pub mod stream_text;
 pub mod kv_cache;
 pub mod loader;
 pub mod lora;

--- a/crates/kiln-model/src/stream_text.rs
+++ b/crates/kiln-model/src/stream_text.rs
@@ -1,0 +1,358 @@
+//! Streaming text gates: incremental detokenization and stop-sequence
+//! holdback.
+//!
+//! Two composable, allocation-light gates that sit between raw generated
+//! token ids and the SSE wire:
+//!
+//! 1. [`IncrementalDetokenizer`] — HF/vLLM-style two-offset incremental
+//!    decode. Fixes the U+FFFD mojibake that per-token decode produces
+//!    when a multi-byte character spans token boundaries, and replaces the
+//!    O(n²) full-prefix re-decode with a bounded window.
+//! 2. [`StopTailGate`] — check-before-emit stop-sequence gating with a
+//!    rolling tail holdback (the longest suffix that is still a proper
+//!    prefix of any stop). The matched stop NEVER reaches the wire; pi's
+//!    stop-marker parsers stop seeing phantom delimiters mid-stream.
+//!
+//! Both follow the server's `ReasoningSplitter` contract: `push` returns
+//! what is safe to emit now, `flush` drains the holdback at end-of-stream
+//! so no bytes are silently dropped on non-stop exits.
+
+use kiln_core::token::TokenId;
+use kiln_core::tokenizer::KilnTokenizer;
+
+/// HF/vLLM two-offset incremental detokenizer.
+///
+/// Call [`Self::next_delta`] after appending each newly accepted token to
+/// the full generated sequence. Text is emitted only once its UTF-8
+/// characters are complete; a token that splits a multi-byte character
+/// yields `""` and the character arrives whole with the next token.
+#[derive(Debug, Default)]
+pub struct IncrementalDetokenizer {
+    /// Start of the decode window (tokens before this are already final).
+    prefix_offset: usize,
+    /// End of the already-emitted tokens within the window.
+    read_offset: usize,
+}
+
+impl IncrementalDetokenizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The new complete-character text after the latest token, or `""`
+    /// while the tail is an incomplete UTF-8 sequence.
+    pub fn next_delta(&mut self, tokenizer: &KilnTokenizer, tokens: &[TokenId]) -> String {
+        let prefix_text = tokenizer
+            .decode(&tokens[self.prefix_offset..self.read_offset])
+            .unwrap_or_default();
+        let new_text = match tokenizer.decode(&tokens[self.prefix_offset..]) {
+            Ok(t) => t,
+            Err(_) => {
+                // Decode failure: fall back to single-token decode (the
+                // pre-gate behavior) and resync so nothing re-emits.
+                self.prefix_offset = tokens.len().saturating_sub(1);
+                self.read_offset = tokens.len();
+                return tokenizer
+                    .decode(&tokens[tokens.len().saturating_sub(1)..])
+                    .unwrap_or_default();
+            }
+        };
+        if new_text.len() <= prefix_text.len() || new_text.ends_with('\u{FFFD}') {
+            // No growth, or the newest token split a multi-byte character —
+            // hold until it completes.
+            return String::new();
+        }
+        // Byte-level BPE keeps the decoded prefix stable; guard anyway
+        // (mirrors the strip_prefix fallback the server used per token).
+        let delta = match new_text.strip_prefix(prefix_text.as_str()) {
+            Some(d) => d.to_string(),
+            None => tokenizer
+                .decode(&tokens[self.read_offset..])
+                .unwrap_or_default(),
+        };
+        self.prefix_offset = self.read_offset;
+        self.read_offset = tokens.len();
+        delta
+    }
+
+    /// End-of-stream residual. May legitimately contain U+FFFD when
+    /// generation stopped mid-character.
+    pub fn flush(&mut self, tokenizer: &KilnTokenizer, tokens: &[TokenId]) -> String {
+        let prefix_text = tokenizer
+            .decode(&tokens[self.prefix_offset..self.read_offset])
+            .unwrap_or_default();
+        let new_text = tokenizer
+            .decode(&tokens[self.prefix_offset..])
+            .unwrap_or_default();
+        self.prefix_offset = tokens.len();
+        self.read_offset = tokens.len();
+        new_text
+            .strip_prefix(prefix_text.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+}
+
+/// Result of pushing a delta through the [`StopTailGate`].
+#[derive(Debug, Default)]
+pub struct StopScan {
+    /// Text safe to emit now (stop-clean).
+    pub emit: String,
+    /// The stop sequence that just matched, if any. After a match the
+    /// gate self-mutes: every later push emits nothing.
+    pub matched_stop: Option<String>,
+}
+
+/// Check-before-emit stop-sequence gate with a rolling tail holdback.
+///
+/// Invariant: the un-emitted tail always retains every suffix that could
+/// still grow into a stop, so no proper prefix of a stop is ever emitted —
+/// any stop that completes is found entirely within `pending` and the
+/// truncation is exact.
+#[derive(Debug)]
+pub struct StopTailGate {
+    stops: Vec<String>,
+    pending: String,
+    matched: Option<String>,
+}
+
+impl StopTailGate {
+    pub fn new(stop_sequences: &[String]) -> Self {
+        Self {
+            // An empty stop would match instantly — filter, mirroring the
+            // generation-side normalization.
+            stops: stop_sequences
+                .iter()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .collect(),
+            pending: String::new(),
+            matched: None,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.stops.is_empty()
+    }
+
+    pub fn matched(&self) -> Option<&str> {
+        self.matched.as_deref()
+    }
+
+    /// Append `delta` and return what is now safe to emit. The EARLIEST
+    /// positional match wins (ties → first in the stop list), matching
+    /// OpenAI semantics rather than list-order scanning.
+    pub fn push(&mut self, delta: &str) -> StopScan {
+        if self.matched.is_some() {
+            return StopScan::default();
+        }
+        if self.stops.is_empty() {
+            return StopScan {
+                emit: delta.to_string(),
+                matched_stop: None,
+            };
+        }
+        self.pending.push_str(delta);
+
+        // Earliest full occurrence across all stops.
+        let mut best: Option<(usize, usize)> = None; // (byte idx, stop idx)
+        for (si, s) in self.stops.iter().enumerate() {
+            if let Some(i) = self.pending.find(s.as_str()) {
+                if best.map(|(bi, _)| i < bi).unwrap_or(true) {
+                    best = Some((i, si));
+                }
+            }
+        }
+        if let Some((idx, si)) = best {
+            let emit = self.pending[..idx].to_string();
+            let stop = self.stops[si].clone();
+            self.pending.clear();
+            self.matched = Some(stop.clone());
+            return StopScan {
+                emit,
+                matched_stop: Some(stop),
+            };
+        }
+
+        // Holdback: the longest suffix of `pending` that is a PROPER
+        // prefix of any stop (char-boundary iteration).
+        let mut hold = 0usize;
+        for s in &self.stops {
+            for k in (1..s.len()).rev() {
+                if k > self.pending.len() || k <= hold {
+                    continue;
+                }
+                if s.is_char_boundary(k) && self.pending.ends_with(&s[..k]) {
+                    hold = k;
+                    break;
+                }
+            }
+        }
+        let emit_end = self.pending.len() - hold;
+        let emit = self.pending[..emit_end].to_string();
+        self.pending.drain(..emit_end);
+        StopScan {
+            emit,
+            matched_stop: None,
+        }
+    }
+
+    /// Drain the holdback at end-of-stream when no stop matched (`""`
+    /// after a match — the held text WAS the stop).
+    pub fn flush(&mut self) -> String {
+        if self.matched.is_some() {
+            return String::new();
+        }
+        std::mem::take(&mut self.pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn fixture_tokenizer() -> KilnTokenizer {
+        // Byte-level BPE with a vocab that includes a CJK char split
+        // across two tokens: "好" = E5 A5 BD; GPT-2 byte alphabet maps
+        // E5→"å", A5→"¥", BD→"½".
+        let mut vocab: HashMap<String, u32> = HashMap::new();
+        vocab.insert("A".into(), 0);
+        vocab.insert("ĠB".into(), 1); // " B"
+        vocab.insert("å¥".into(), 2); // bytes E5 A5 (first 2/3 of 好)
+        vocab.insert("½".into(), 3); // byte BD (last 1/3 of 好)
+        vocab.insert("ĠObservation".into(), 4);
+        vocab.insert(":".into(), 5);
+        vocab.insert("ĠC".into(), 6);
+        let json = serde_json::json!({
+            "version": "1.0",
+            "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+            "decoder": { "type": "ByteLevel", "add_prefix_space": true, "trim_offsets": true, "use_regex": true },
+            "added_tokens": []
+        });
+        KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+    }
+
+    /// CJK split-token: the first token ends mid-character — nothing
+    /// emits (no U+FFFD ever); the character arrives whole with the
+    /// second token.
+    #[test]
+    fn detokenizer_holds_split_multibyte_chars() {
+        let tok = fixture_tokenizer();
+        let mut d = IncrementalDetokenizer::new();
+        let mut tokens: Vec<TokenId> = Vec::new();
+
+        tokens.push(2); // E5 A5 — incomplete
+        let delta = d.next_delta(&tok, &tokens);
+        assert_eq!(delta, "", "mid-character bytes must be held");
+
+        tokens.push(3); // BD — completes 好
+        let delta = d.next_delta(&tok, &tokens);
+        assert_eq!(delta, "好");
+        assert!(!delta.contains('\u{FFFD}'));
+
+        // Clean end: nothing left.
+        assert_eq!(d.flush(&tok, &tokens), "");
+    }
+
+    #[test]
+    fn detokenizer_flush_returns_residue_when_stream_ends_mid_char() {
+        let tok = fixture_tokenizer();
+        let mut d = IncrementalDetokenizer::new();
+        let tokens: Vec<TokenId> = vec![0, 2]; // "A" + incomplete bytes
+        assert_eq!(d.next_delta(&tok, &tokens[..1]), "A");
+        assert_eq!(d.next_delta(&tok, &tokens), "", "held");
+        let residue = d.flush(&tok, &tokens);
+        assert!(
+            residue.contains('\u{FFFD}'),
+            "mid-char end legitimately surfaces the replacement char: {residue:?}"
+        );
+    }
+
+    #[test]
+    fn detokenizer_ascii_passthrough() {
+        let tok = fixture_tokenizer();
+        let mut d = IncrementalDetokenizer::new();
+        let mut tokens: Vec<TokenId> = Vec::new();
+        let mut out = String::new();
+        for t in [0u32, 1, 6] {
+            tokens.push(t);
+            out.push_str(&d.next_delta(&tok, &tokens));
+        }
+        assert_eq!(out, "A B C");
+    }
+
+    /// The required stop="Observation:" case: the marker never reaches
+    /// the emitted stream, split across deltas or in one delta.
+    #[test]
+    fn stop_gate_observation_marker_never_emits() {
+        let mut g = StopTailGate::new(&["Observation:".to_string()]);
+        let mut out = String::new();
+        let s1 = g.push("I should check\nObs");
+        out.push_str(&s1.emit);
+        assert!(s1.matched_stop.is_none());
+        let s2 = g.push("ervation:");
+        out.push_str(&s2.emit);
+        assert_eq!(s2.matched_stop.as_deref(), Some("Observation:"));
+        // Post-match pushes are muted.
+        let s3 = g.push(" extra");
+        assert_eq!(s3.emit, "");
+        assert_eq!(out, "I should check\n");
+        assert_eq!(g.flush(), "", "the held text WAS the stop");
+
+        // Single-delta variant.
+        let mut g = StopTailGate::new(&["Observation:".to_string()]);
+        let s = g.push("text before\nObservation: the file");
+        assert_eq!(s.emit, "text before\n");
+        assert_eq!(s.matched_stop.as_deref(), Some("Observation:"));
+    }
+
+    #[test]
+    fn stop_gate_false_alarm_releases_all_bytes() {
+        let mut g = StopTailGate::new(&["Observation:".to_string()]);
+        let mut out = String::new();
+        out.push_str(&g.push("Observ").emit);
+        out.push_str(&g.push("able systems").emit);
+        out.push_str(&g.flush());
+        assert_eq!(out, "Observable systems");
+    }
+
+    #[test]
+    fn stop_gate_earliest_match_wins_and_multibyte_stops_hold_on_boundaries() {
+        let mut g = StopTailGate::new(&["ZZ".to_string(), "B".to_string()]);
+        let s = g.push("A B then ZZ");
+        assert_eq!(s.emit, "A ");
+        assert_eq!(s.matched_stop.as_deref(), Some("B"), "earliest position wins");
+
+        // Multi-byte stop: holdback never splits a char boundary.
+        let mut g = StopTailGate::new(&["。end".to_string()]);
+        let s = g.push("sentence。");
+        assert!(s.matched_stop.is_none());
+        assert_eq!(s.emit, "sentence");
+        let s2 = g.push("end");
+        assert_eq!(s2.matched_stop.as_deref(), Some("。end"));
+    }
+
+    #[test]
+    fn stop_gate_empty_stops_filtered_and_inactive_passthrough() {
+        let mut g = StopTailGate::new(&["".to_string()]);
+        assert!(!g.is_active());
+        let s = g.push("anything");
+        assert_eq!(s.emit, "anything");
+        assert!(s.matched_stop.is_none());
+    }
+
+    /// Property: while the gate is live, no emitted prefix could have
+    /// been the start of a stop that later completes.
+    #[test]
+    fn stop_gate_never_emits_a_live_stop_prefix() {
+        let stop = "</tool_call>".to_string();
+        let mut g = StopTailGate::new(&[stop.clone()]);
+        let mut out = String::new();
+        for chunk in ["abc</to", "ol_", "call>tail"] {
+            out.push_str(&g.push(chunk).emit);
+        }
+        assert_eq!(out, "abc");
+        assert_eq!(g.matched(), Some("</tool_call>"));
+    }
+}

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1066,6 +1066,37 @@ fn assistant_output_from_model_output(
     assistant_output_from_split_parts(req, reasoning_content, content, finish_reason)
 }
 
+/// Parse-then-truncate: run tool-call parsing on the UNTRUNCATED engine
+/// text, applying the stop truncation only when no tool calls parse.
+///
+/// Order matters: tools-bearing requests carry an implicit
+/// `</tool_call>` stop, and the Qwen3 XML extractor REQUIRES the close
+/// tag — truncating first (#1510's original shape) stripped the tag from
+/// every stop-finished tool call, so the call failed to parse and the
+/// raw XML leaked into `content`.
+fn assistant_output_from_model_output_stop_aware(
+    req: &ChatCompletionRequest,
+    model_output: &str,
+    prompt_text: &str,
+    wire_finish: &str,
+    engine_finish: &kiln_model::FinishReason,
+) -> AssistantOutputParts {
+    let parsed =
+        assistant_output_from_model_output(req, model_output, prompt_text, wire_finish);
+    if parsed.tool_calls.is_some() {
+        return parsed;
+    }
+    let mut parsed = parsed;
+    parsed.content = truncate_at_matched_stop(&parsed.content, engine_finish).to_string();
+    if parsed.content.is_empty() {
+        if let Some(reasoning) = parsed.reasoning_content.take() {
+            let truncated = truncate_at_matched_stop(&reasoning, engine_finish).to_string();
+            parsed.reasoning_content = (!truncated.is_empty()).then_some(truncated);
+        }
+    }
+    parsed
+}
+
 fn assistant_output_from_cached_parts(
     req: &ChatCompletionRequest,
     content: String,
@@ -1096,6 +1127,41 @@ fn assistant_output_from_split_parts(
         reasoning_content,
         content,
         finish_reason,
+    )
+}
+
+/// Stream-finish parsing with stop reconstruction: the emit gates strip
+/// the matched stop from `content_buf` (it must never reach the wire or
+/// the cache), but the implicit `</tool_call>` stop is part of the XML
+/// grammar — the extractor REQUIRES the close tag. Re-append the matched
+/// stop FOR PARSING ONLY; when no calls parse, fall back to the clean
+/// buffer so the stop text can't leak into content.
+fn stream_assistant_output_with_stop_reconstruction(
+    buffer_tool_content: bool,
+    reasoning_content: Option<String>,
+    content_buf: &str,
+    matched_stop: Option<&str>,
+    finish: &str,
+) -> AssistantOutputParts {
+    if buffer_tool_content {
+        if let Some(stop) = matched_stop {
+            let reconstructed = format!("{content_buf}{stop}");
+            let out = assistant_output_from_split_parts_with_tool_parsing(
+                true,
+                reasoning_content.clone(),
+                reconstructed,
+                finish,
+            );
+            if out.tool_calls.is_some() {
+                return out;
+            }
+        }
+    }
+    assistant_output_from_split_parts_with_tool_parsing(
+        buffer_tool_content,
+        reasoning_content,
+        content_buf.to_string(),
+        finish,
     )
 }
 
@@ -5040,9 +5106,13 @@ async fn generate_real_batched(
         .unwrap_or_else(|| state.served_model_id.clone());
     let completion_tokens =
         completion_usage_tokens(output.completion_tokens, &output.finish_reason);
-    let response_text = truncate_at_matched_stop(&output.text, &output.finish_reason);
-    let assistant_output =
-        assistant_output_from_model_output(req, response_text, prompt_text, finish_reason);
+    let assistant_output = assistant_output_from_model_output_stop_aware(
+        req,
+        &output.text,
+        prompt_text,
+        finish_reason,
+        &output.finish_reason,
+    );
     let metadata =
         chat_completion_metadata_from_prompt_and_output(state, req, prompt_text, &assistant_output);
     let assistant_output = apply_reasoning_content_policy(
@@ -5156,6 +5226,7 @@ async fn generate_real_batched_streaming(
     let prompt_starts_in_reasoning = prompt_starts_in_reasoning(prompt_text);
     let buffer_tool_content = request_allows_tool_call_parsing(req);
     let batching_engine = batching_engine.clone();
+    let stop_sequences = sampling.stop.clone();
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
 
     tokio::task::spawn({
@@ -5169,7 +5240,13 @@ async fn generate_real_batched_streaming(
             let mut content_buf = String::new();
             let mut completion_token_count: u32 = 0;
             let mut generated_tokens: Vec<TokenId> = Vec::new();
-            let mut decoded_prefix = String::new();
+            // Server-side emit gates for the engine path (the engine emits
+            // raw token ids; the server decodes): incremental detokenizer
+            // (no U+FFFD on multi-byte chars, bounded decode window instead
+            // of the old O(n²) full-prefix re-decode) + stop holdback (the
+            // matched stop never reaches the wire).
+            let mut detok = kiln_model::stream_text::IncrementalDetokenizer::new();
+            let mut stop_gate = kiln_model::stream_text::StopTailGate::new(&stop_sequences);
             let record = |finish_reason: String, completion: &str, completion_tokens: u32| {
                 let record = RequestRecord {
                     user_agent: req_user_agent.clone(),
@@ -5269,15 +5346,9 @@ async fn generate_real_batched_streaming(
                                 completion_token_count = completion_token_count.saturating_add(1);
                                 metrics.add_tokens(1);
 
-                                let decoded = tokenizer
-                                    .decode(&generated_tokens)
-                                    .unwrap_or_else(|_| decoded_prefix.clone());
-                                let delta = decoded
-                                    .strip_prefix(&decoded_prefix)
-                                    .map(str::to_owned)
-                                    .unwrap_or_else(|| tokenizer.decode(&[token]).unwrap_or_default());
-                                decoded_prefix = decoded;
-                                let chunk = reasoning_splitter.push(&delta);
+                                let delta = detok.next_delta(&tokenizer, &generated_tokens);
+                                let scan = stop_gate.push(&delta);
+                                let chunk = reasoning_splitter.push(&scan.emit);
                                 // The emit awaits channel capacity — a client
                                 // that stops reading (zero TCP window) would
                                 // otherwise park this task INSIDE the select
@@ -5324,6 +5395,42 @@ async fn generate_real_batched_streaming(
                                     kiln_model::FinishReason::MaxTokens => "length",
                                     kiln_model::FinishReason::StopSequence(_) => "stop",
                                 };
+                                // Flush the emit gates: detokenizer residue
+                                // passes the stop gate (a stop can complete
+                                // inside held bytes), then the splitter —
+                                // BEFORE the splitter's own flush.
+                                {
+                                    let residual =
+                                        detok.flush(&tokenizer, &generated_tokens);
+                                    let scan = stop_gate.push(&residual);
+                                    let mut gate_tail = scan.emit;
+                                    if scan.matched_stop.is_none() {
+                                        gate_tail.push_str(&stop_gate.flush());
+                                    }
+                                    if !gate_tail.is_empty() {
+                                        let chunk = reasoning_splitter.push(&gate_tail);
+                                        if !emit_or_buffer_reasoning_chunk(
+                                            &tx,
+                                            &id,
+                                            created,
+                                            &model,
+                                            chunk,
+                                            &mut completion_buf,
+                                            &mut reasoning_buf,
+                                            &mut content_buf,
+                                            buffer_tool_content,
+                                        )
+                                        .await
+                                        {
+                                            record(
+                                                "client_disconnect".to_string(),
+                                                &completion_buf,
+                                                completion_token_count,
+                                            );
+                                            return;
+                                        }
+                                    }
+                                }
                                 let trailing = reasoning_splitter.flush();
                                 if !emit_or_buffer_reasoning_chunk(
                                     &tx,
@@ -5350,11 +5457,21 @@ async fn generate_real_batched_streaming(
                                 } else {
                                     Some(reasoning_buf.clone())
                                 };
+                                let matched_stop = stop_gate
+                                    .matched()
+                                    .map(str::to_string)
+                                    .or(match &output.finish_reason {
+                                        kiln_model::FinishReason::StopSequence(s) => {
+                                            Some(s.clone())
+                                        }
+                                        _ => None,
+                                    });
                                 let assistant_output =
-                                    assistant_output_from_split_parts_with_tool_parsing(
+                                    stream_assistant_output_with_stop_reconstruction(
                                         buffer_tool_content,
                                         reasoning_content,
-                                        content_buf.clone(),
+                                        &content_buf,
+                                        matched_stop.as_deref(),
                                         finish,
                                     );
                                 if assistant_output.tool_calls.is_some()
@@ -5842,9 +5959,13 @@ async fn generate_real(
     // clients can render the two channels separately. For non-reasoning
     // templates this returns `(None, output.text)` and the response shape
     // is byte-identical to before.
-    let response_text = truncate_at_matched_stop(&output.text, &output.finish_reason);
-    let assistant_output =
-        assistant_output_from_model_output(req, response_text, prompt_text, finish_reason);
+    let assistant_output = assistant_output_from_model_output_stop_aware(
+        req,
+        &output.text,
+        prompt_text,
+        finish_reason,
+        &output.finish_reason,
+    );
     let metadata =
         chat_completion_metadata_from_prompt_and_output(state, req, prompt_text, &assistant_output);
     let assistant_output = apply_reasoning_content_policy(
@@ -6406,6 +6527,31 @@ async fn generate_real_streaming(
                                     kiln_model::FinishReason::MaxTokens => "length",
                                     kiln_model::FinishReason::StopSequence(_) => "stop",
                                 };
+                                // The engine-side emit gate (UTF-8 boundary +
+                                // stop-window holdback) releases its residue
+                                // at end-of-stream. It must pass through the
+                                // splitter BEFORE the splitter flush or a
+                                // `</think>` inside the residue would leak
+                                // into reasoning_content.
+                                if !done.trailing_text.is_empty() {
+                                    let chunk =
+                                        reasoning_splitter.push(&done.trailing_text);
+                                    if !emit_or_buffer_reasoning_chunk(
+                                        &tx,
+                                        &id,
+                                        created,
+                                        &model,
+                                        chunk,
+                                        &mut completion_buf,
+                                        &mut reasoning_buf,
+                                        &mut content_buf,
+                                        buffer_tool_content,
+                                    )
+                                    .await
+                                    {
+                                        break;
+                                    }
+                                }
                                 // Drain any partial-tag tail buffered in the
                                 // splitter before signaling end-of-stream so
                                 // we don't silently swallow up-to-7 chars
@@ -6436,11 +6582,18 @@ async fn generate_real_streaming(
                                 } else {
                                     Some(reasoning_buf.clone())
                                 };
+                                let matched_stop = match &done.finish_reason {
+                                    kiln_model::FinishReason::StopSequence(s) => {
+                                        Some(s.as_str())
+                                    }
+                                    _ => None,
+                                };
                                 let assistant_output =
-                                    assistant_output_from_split_parts_with_tool_parsing(
+                                    stream_assistant_output_with_stop_reconstruction(
                                         buffer_tool_content,
                                         reasoning_content,
-                                        content_buf.clone(),
+                                        &content_buf,
+                                        matched_stop,
                                         finish,
                                     );
                                 if assistant_output.tool_calls.is_some()
@@ -8893,6 +9046,40 @@ mod tests {
         assert_eq!(key.temperature, resolved.temperature);
         assert_eq!(key.presence_penalty, resolved.presence_penalty);
         assert_eq!(key.top_k, resolved.top_k);
+    }
+
+    /// Stream-finish stop reconstruction: a tool call terminated by the
+    /// implicit `</tool_call>` stop (which the emit gates strip) must
+    /// still parse — and when no call parses, the stop text must NOT
+    /// leak back into content.
+    #[test]
+    fn stream_stop_reconstruction_preserves_tool_calls_without_leaking() {
+        let xml = "<tool_call>\n<function=bash>\n<parameter=command>\nls\n</parameter>\n</function>\n";
+        let out = stream_assistant_output_with_stop_reconstruction(
+            true,
+            None,
+            &format!("Sure.\n{xml}"),
+            Some("</tool_call>"),
+            "stop",
+        );
+        assert!(
+            out.tool_calls.is_some(),
+            "the reconstructed close tag must let the call parse: {out:?}"
+        );
+        assert_eq!(out.finish_reason, "tool_calls");
+        assert!(!out.content.contains("<tool_call>"), "{:?}", out.content);
+
+        // Plain text + a custom stop: nothing reconstructs, nothing leaks.
+        let out = stream_assistant_output_with_stop_reconstruction(
+            true,
+            None,
+            "I should check the file.\n",
+            Some("Observation:"),
+            "stop",
+        );
+        assert!(out.tool_calls.is_none());
+        assert!(!out.content.contains("Observation:"));
+        assert_eq!(out.content, "I should check the file.\n");
     }
 
     /// OpenAI semantics: the matched stop sequence must never appear in


### PR DESCRIPTION
## Summary

Three streaming defects that hit every pi session (discovery round 2, items 2+6 core; implemented from the workflow-authored design):

1. **U+FFFD mojibake** — per-token decode broke multi-byte chars spanning token boundaries. New `IncrementalDetokenizer` (HF/vLLM two-offset): char-boundary-exact deltas, and the O(n²) full-prefix re-decode becomes a bounded window on both streaming paths.
2. **Stop text leaked into streams** — emit ran before the stop check (#1510 fixed non-streaming only), and the streaming path cached untruncated buffers. New `StopTailGate`: check-before-emit with a rolling tail holdback; the matched stop never reaches the wire or the cache. Wired engine-side (`StreamDone.trailing_text` carries end-of-stream residue through the reasoning splitter) and server-side on the batching-engine path.
3. **Stop-stripped tool calls** — the implicit `</tool_call>` stop is part of the XML grammar; stripping it broke parsing. Non-streaming was broken on main since #1510 (truncate-then-parse) — now parses-then-truncates. Stream finish re-appends the matched stop **for parsing only**, falling back to the clean buffer so stop text can't leak.

**Deferred to the next PR** (design ready): `ToolCallGate` eager content streaming on tools-bearing requests — full-buffering behavior preserved here.

## Verification

8 gate unit tests (CJK split-token / no U+FFFD ever; `Observation:` split + single-delta; false-alarm release; earliest-match; multi-byte boundaries; live-prefix property), stop-reconstruction test, full `kiln-model` + `kiln-server` suites green, dashboard smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)