### PR TITLE
self_improve auto-discovers pi traces; KILN_PI_SESSIONS_DIR override

### DIFF
--- a/crates/kiln-server/src/api/agent_traces.rs
+++ b/crates/kiln-server/src/api/agent_traces.rs
@@ -134,6 +134,14 @@ struct DiscoverResponse {
 }
 
 fn default_pi_sessions_dir() -> PathBuf {
+    // KILN_PI_SESSIONS_DIR overrides the conventional location — for
+    // non-standard pi setups, and so tests can isolate auto-discovery
+    // from the developer's real ~/.pi sessions.
+    if let Ok(dir) = std::env::var("KILN_PI_SESSIONS_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     if let Ok(home) = std::env::var("HOME") {
         PathBuf::from(home).join(".pi").join("agent").join("sessions")
     } else {
@@ -175,6 +183,51 @@ fn scan_sessions_dir(dir: &Path, depth_left: usize, index: &mut AgentTraceIndex)
     count
 }
 
+/// Build and persist `agent_traces.json` from a sessions directory —
+/// shared by the explicit POST /v1/agent/traces/discover route and the
+/// self_improve/judge_distill auto-discovery below. Returns the number
+/// of indexed sessions.
+pub(crate) fn discover_traces_into(
+    sessions_dir: &Path,
+    adapter_dir: &Path,
+) -> std::io::Result<usize> {
+    let mut index = AgentTraceIndex::default();
+    let count = scan_sessions_dir(sessions_dir, SESSIONS_SCAN_MAX_DEPTH, &mut index);
+    index.save_to_path(&adapter_dir.join("agent_traces.json"))?;
+    Ok(count)
+}
+
+/// Auto-discovery for the §10.6 endpoints: when `agent_traces.json` is
+/// missing, scan the default pi sessions dir and build it — the
+/// canonical onboarding (`kiln serve` → use pi → `kiln self-improve`)
+/// must not hard-fail asking for a manual POST
+/// /v1/agent/traces/discover first. An existing index is left alone
+/// (re-discovery stays explicit), and a missing sessions dir falls
+/// through to the resolver's actionable error.
+pub(crate) fn ensure_agent_trace_index(adapter_dir: &Path) -> Option<usize> {
+    if adapter_dir.join("agent_traces.json").exists() {
+        return None;
+    }
+    let sessions = default_pi_sessions_dir();
+    if !sessions.exists() {
+        return None;
+    }
+    match discover_traces_into(&sessions, adapter_dir) {
+        Ok(count) => {
+            tracing::info!(
+                indexed = count,
+                sessions_dir = %sessions.display(),
+                "auto-discovered pi agent traces for self_improve"
+            );
+            Some(count)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "agent-trace auto-discovery failed");
+            None
+        }
+    }
+}
+
 async fn discover_traces(
     State(state): State<AppState>,
     Json(req): Json<DiscoverRequest>,
@@ -189,12 +242,13 @@ async fn discover_traces(
             path.display()
         )));
     }
-    let mut index = AgentTraceIndex::default();
-    let count = scan_sessions_dir(&path, SESSIONS_SCAN_MAX_DEPTH, &mut index);
-    let out_path = state.adapter_dir.join("agent_traces.json");
-    if let Err(e) = index.save_to_path(&out_path) {
-        tracing::warn!(error = %e, "failed to persist agent_traces.json");
-    }
+    let count = match discover_traces_into(&path, &state.adapter_dir) {
+        Ok(count) => count,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to persist agent_traces.json");
+            0
+        }
+    };
     Ok(Json(DiscoverResponse {
         indexed: count,
         path: path.display().to_string(),
@@ -667,5 +721,30 @@ mod tests {
         let loaded = AgentTraceIndex::load_from_path(&path);
         assert_eq!(loaded.traces.len(), 1);
         assert_eq!(loaded.traces.get("abc").unwrap().num_turns, 5);
+    }
+    /// The shared discovery routine persists the index, and
+    /// ensure_agent_trace_index leaves an existing index alone (explicit
+    /// re-discovery only).
+    #[test]
+    fn discover_traces_into_persists_and_ensure_respects_existing() {
+        let sessions = tempfile::tempdir().unwrap();
+        let adapters = tempfile::tempdir().unwrap();
+        write_jsonl(
+            &sessions.path().join("s.jsonl"),
+            &[serde_json::json!({"type":"session","id":"s1","timestamp":"2026-06-01T10:00:00Z","cwd":"/p"}),
+              serde_json::json!({"type":"message","timestamp":"2026-06-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}})],
+        );
+        let count = discover_traces_into(sessions.path(), adapters.path()).unwrap();
+        assert_eq!(count, 1);
+        let index_path = adapters.path().join("agent_traces.json");
+        assert!(index_path.exists());
+
+        // An existing index is never clobbered by the auto path.
+        std::fs::write(&index_path, "{\"sessions\":[]}").unwrap();
+        assert!(ensure_agent_trace_index(adapters.path()).is_none());
+        assert_eq!(
+            std::fs::read_to_string(&index_path).unwrap(),
+            "{\"sessions\":[]}"
+        );
     }
 }

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -309,6 +309,7 @@ fn build_judge_pump_request(
     adapter_dir: &std::path::Path,
     req: &JudgeDistillRequest,
 ) -> Result<(DistillPumpRequest, usize), ApiError> {
+    super::agent_traces::ensure_agent_trace_index(adapter_dir);
     let judge_prompts = crate::dataset_resolve::resolve_agent_trace_prompts(
         adapter_dir,
         "agent_traces:judge_turns",
@@ -341,6 +342,10 @@ fn build_self_improve_jobs(
     req: &SelfImproveRequest,
 ) -> Result<(OpdRequest, Option<DistillPumpRequest>, usize), ApiError> {
     let now_ms = crate::recent_requests::now_unix_ms() as i64;
+    // Canonical onboarding: build the trace index from the default pi
+    // sessions dir when it doesn't exist yet, instead of hard-failing
+    // and demanding a manual POST /v1/agent/traces/discover.
+    super::agent_traces::ensure_agent_trace_index(adapter_dir);
     let weekly = crate::dataset_resolve::resolve_agent_trace_prompts(
         adapter_dir,
         "agent_traces:weekly",
@@ -588,9 +593,18 @@ mod tests {
     #[test]
     fn judge_pump_without_index_carries_discover_remediation() {
         let dir = tempfile::tempdir().unwrap();
+        // Point auto-discovery away from the developer's real ~/.pi
+        // sessions so the missing-index path actually exercises. Restored
+        // after the call; tests in this mod run on separate adapter dirs.
+        let prev = std::env::var("KILN_PI_SESSIONS_DIR").ok();
+        unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", "/nonexistent/pi/sessions") };
         let req: JudgeDistillRequest = serde_json::from_str("{}").unwrap();
-        let err = build_judge_pump_request(dir.path(), &req).unwrap_err();
-        let msg = format!("{err:?}");
+        let result = build_judge_pump_request(dir.path(), &req);
+        match prev {
+            Some(v) => unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", v) },
+            None => unsafe { std::env::remove_var("KILN_PI_SESSIONS_DIR") },
+        }
+        let msg = format!("{:?}", result.unwrap_err());
         assert!(msg.contains("/v1/agent/traces/discover"), "{msg}");
     }
 

--- a/crates/kiln-server/tests/agent_teacher_validation.rs
+++ b/crates/kiln-server/tests/agent_teacher_validation.rs
@@ -157,6 +157,10 @@ async fn judge_distill_registered_teacher_proceeds_past_resolution() {
     let (state, _dir) = make_state();
     let app = api::router(state.clone());
     register_teacher(&app, "fixture@t").await;
+    // Isolate from the developer's real ~/.pi sessions: auto-discovery
+    // (ensure_agent_trace_index) would otherwise build a populated index
+    // and sail past the corpus-resolution 400 this test asserts.
+    unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", "/nonexistent/pi/sessions") };
     let (status, response) = post(
         &app,
         "/v1/agent/judge_distill",
@@ -201,6 +205,7 @@ async fn self_improve_registered_judge_proceeds_past_resolution() {
     let (state, _dir) = make_state();
     let app = api::router(state.clone());
     register_teacher(&app, "judge-pi-v1").await;
+    unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", "/nonexistent/pi/sessions") };
     let (status, response) = post(
         &app,
         "/v1/agent/self_improve",

--- a/crates/kiln-server/tests/agent_traces_bridge.rs
+++ b/crates/kiln-server/tests/agent_traces_bridge.rs
@@ -176,6 +176,9 @@ fn assert_no_jobs(state: &AppState, context: &str) {
 
 #[tokio::test]
 async fn self_improve_without_trace_index_fails_fast_with_remediation() {
+    // Isolate from the developer's real ~/.pi sessions (auto-discovery
+    // would build a real index and defeat the missing-index assertion).
+    unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", "/nonexistent/pi/sessions") };
     let (state, _dir) = make_state();
     let app = api::router(state.clone());
     register_fixture_teacher(&app, "judge-pi-v1").await;
@@ -219,6 +222,9 @@ async fn self_improve_with_traces_passes_data_resolution() {
 
 #[tokio::test]
 async fn judge_distill_without_trace_index_fails_fast() {
+    // Isolate from the developer's real ~/.pi sessions (auto-discovery
+    // would build a real index and defeat the missing-index assertion).
+    unsafe { std::env::set_var("KILN_PI_SESSIONS_DIR", "/nonexistent/pi/sessions") };
     let (state, _dir) = make_state();
     let app = api::router(state.clone());
     register_fixture_teacher(&app, "qwen3.6-27b@local").await;


### PR DESCRIPTION
## Summary

Discovery round 3, item 3. Canonical onboarding broke at the last step: `kiln serve` → use pi → `kiln self-improve` hard-failed demanding a manual `POST /v1/agent/traces/discover`. The §10.6 endpoints now auto-build the trace index from the default pi sessions dir when `agent_traces.json` is missing; an existing index is never clobbered, and a missing sessions dir falls through to the resolver's actionable error.

Also adds `KILN_PI_SESSIONS_DIR` (overrides `~/.pi/agent/sessions`) — for non-standard setups, and to isolate the missing-index tests from the developer's real pi sessions (they only passed on machines without a `~/.pi`).

## Verification

`discover_traces_into` round-trip + existing-index no-op test; four missing-index tests isolated via the override; full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)