### PR TITLE
Cancelled engine requests keep their prefix-cache registration

### DIFF
--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -739,18 +739,25 @@ impl DecodeForward for RealDecodeForward {
         } = slot
         {
             self.release_hit(hit_entry_id);
-            let mut output = kiln_model::PrefixCachedGenerationOutput {
-                output: GenerationOutput {
-                    text: String::new(),
-                    token_ids: state.generated_tokens,
-                    finish_reason: FinishReason::MaxTokens,
-                },
-                registration: None,
-                extra_registrations: Vec::new(),
-                allocated_blocks: state.allocated_blocks,
-                prefill_duration: state.prefill_duration,
-                decode_duration: state.decode_duration,
+            // Route through the SAME finish path as a completed request so
+            // the prefill's prefix-cache registration survives. The old
+            // shape here dropped `state.registration` on the floor
+            // (registration: None), so a cancelled request — every pi
+            // ESC/steer — paid a full re-prefill of the identical
+            // multi-thousand-token context on the very next message.
+            let finished = match self.runner_guard().and_then(|runner| {
+                runner.finish_paged_batched_decode(state, FinishReason::MaxTokens)
+            }) {
+                Ok(output) => output,
+                Err(err) => {
+                    tracing::warn!(
+                        error = %format!("{err:#}"),
+                        "failed to finish discarded request; its blocks may leak                          until the next cache eviction"
+                    );
+                    return;
+                }
             };
+            let mut output = finished;
             if let Err(err) = self.free_uncached_blocks(&mut output, adapter) {
                 tracing::warn!(
                     error = %format!("{err:#}"),


### PR DESCRIPTION
## Summary

Discovery round 3, item 6. `discard_request` built a synthetic output with `registration: None`, discarding the fully-computed prompt KV the prefill had registered — so every cancellation (every pi ESC/steer on a 10–30K-token context) paid a complete re-prefill of the identical prefix on the next message.

Discard now routes through the same `finish_paged_batched_decode` + `free_uncached_blocks` pair as a completed request: registrations (incl. extended block-boundary ones) reach the prefix cache identically; only the output is dropped.

## Verification

Full `kiln-server` suite green; the mechanics are the shared finish-path code completed requests already exercise. Live A/B (cancel mid-decode → re-send → near-zero prefill) needs a real backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)