### PR TITLE
The flywheel runs itself: [agent] self_improve_interval_hours scheduler

### DIFF
--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -19,7 +19,7 @@ mod metrics;
 mod models;
 pub(crate) mod pit_of_success;
 pub(crate) mod recipes;
-pub(crate) mod self_improve;
+pub mod self_improve;
 mod stats;
 pub(crate) mod teachers;
 pub mod terminal;

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -150,6 +150,14 @@ pub struct SelfImproveRequest {
     pub post_eval: Option<kiln_eval::PostEvalConfig>,
 }
 
+impl Default for SelfImproveRequest {
+    /// The same defaults an empty POST body gets (serde field defaults) —
+    /// the scheduler's no-config case must match `{}` exactly.
+    fn default() -> Self {
+        serde_json::from_str("{}").expect("empty SelfImproveRequest parses")
+    }
+}
+
 fn default_agent_name() -> String {
     "pi-coder-current".to_string()
 }
@@ -158,16 +166,27 @@ fn default_crisp_enabled() -> bool {
 }
 
 #[derive(Debug, Serialize)]
-struct SelfImproveResponse {
-    job_ids: Vec<String>,
-    state: TrainingState,
-    message: String,
+pub struct SelfImproveResponse {
+    pub job_ids: Vec<String>,
+    pub state: TrainingState,
+    pub message: String,
 }
 
 async fn self_improve(
     State(state): State<AppState>,
     Json(req): Json<SelfImproveRequest>,
 ) -> Result<Json<SelfImproveResponse>, ApiError> {
+    submit_self_improve(&state, req).map(Json)
+}
+
+/// The §10.6.2 submission body, callable without an HTTP request — the
+/// `[agent] self_improve_interval_hours` scheduler drives the same code
+/// path the POST handler does, so validation, teacher gating, and queue
+/// caps apply identically to scheduled rounds.
+pub fn submit_self_improve(
+    state: &AppState,
+    req: SelfImproveRequest,
+) -> Result<SelfImproveResponse, ApiError> {
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
@@ -183,7 +202,7 @@ async fn self_improve(
     // when the worker dequeues the job — so an unregistered judge used to
     // enqueue jobs that were guaranteed to fail later.
     require_registered_teacher(
-        &state,
+        state,
         &req.judge,
         format!(
             "self_improve: judge '{}' must be registered as a teacher alias \
@@ -199,7 +218,7 @@ async fn self_improve(
     // are included.)
     let (opd_phase, crisp_pump, num_tasks) =
         build_self_improve_jobs(&state.adapter_dir, &req)?;
-    super::training::enforce_queue_caps(&state)?;
+    super::training::enforce_queue_caps(state)?;
 
     // §10.6.2: score with judge → GRPO → CRISP pass. Each phase
     // queues independently. The trainer body (#31) wires the
@@ -208,7 +227,7 @@ async fn self_improve(
 
     let opd_job = uuid::Uuid::new_v4().to_string();
     register_agent_job(
-        &state,
+        state,
         &opd_job,
         &format!("{}-improve", req.agent),
         QueuedJob::Opd(opd_phase),
@@ -218,7 +237,7 @@ async fn self_improve(
     if let Some(crisp_pump) = crisp_pump {
         let crisp_job = uuid::Uuid::new_v4().to_string();
         register_agent_job(
-            &state,
+            state,
             &crisp_job,
             &format!("{}-crisp", req.agent),
             QueuedJob::DistillPump(crisp_pump),
@@ -226,7 +245,7 @@ async fn self_improve(
         job_ids.push(crisp_job);
     }
 
-    Ok(Json(SelfImproveResponse {
+    Ok(SelfImproveResponse {
         job_ids,
         state: TrainingState::Queued,
         message: format!(
@@ -235,7 +254,7 @@ async fn self_improve(
              Phase 2 = CRISP terseness pass.",
             req.agent, req.judge, req.crisp
         ),
-    }))
+    })
 }
 
 /// §10.6.3 judge drift check.
@@ -485,6 +504,27 @@ mod tests {
         assert_eq!(req.agent, "pi-coder-current");
         assert_eq!(req.judge, "judge-pi-v1");
         assert!(req.crisp, "§10.6.4 CRISP pass is on by default");
+    }
+
+    /// The scheduler's no-config request must equal an empty POST body,
+    /// and an [agent.self_improve] table must deserialize through the
+    /// same shape the endpoint accepts.
+    #[test]
+    fn scheduler_request_defaults_match_empty_post_body() {
+        let from_default = SelfImproveRequest::default();
+        let from_empty: SelfImproveRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(from_default.agent, from_empty.agent);
+        assert_eq!(from_default.judge, from_empty.judge);
+        assert_eq!(from_default.crisp, from_empty.crisp);
+        assert!(from_default.post_eval.is_none());
+
+        let toml_like = serde_json::json!({
+            "agent": "pi-coder-current",
+            "judge": "judge-pi-v1",
+            "post_eval": {"suite": "agentic-core", "min_accuracy": 0.7}
+        });
+        let req: SelfImproveRequest = serde_json::from_value(toml_like).unwrap();
+        assert_eq!(req.post_eval.unwrap().min_accuracy, Some(0.7));
     }
 
     #[test]

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -38,6 +38,29 @@ pub struct KilnConfig {
     /// (mine→filter→train flywheel). See [`crate::request_log`].
     #[serde(default)]
     pub request_log: crate::request_log::RequestLogConfig,
+    /// §10.6 self-improvement automation. `None` / omitted section means
+    /// the weekly loop stays manual (`kiln self-improve`).
+    #[serde(default)]
+    pub agent: Option<AgentConfig>,
+}
+
+/// `[agent]` — the self-improvement flywheel scheduler.
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentConfig {
+    /// Run the §10.6.2 self_improve loop every N hours (168 = weekly).
+    /// Omit to disable. The first run fires one full interval after
+    /// startup — never at boot, so a crash-looping server can't spam
+    /// training jobs.
+    #[serde(default)]
+    pub self_improve_interval_hours: Option<u64>,
+    /// The request the scheduler submits — same shape as
+    /// POST /v1/agent/self_improve. Defaults: agent pi-coder-current,
+    /// judge judge-pi-v1, CRISP on, no promotion gate. Set
+    /// `post_eval = { suite = "...", min_accuracy = ... }` to make every
+    /// scheduled round gated (§8.7: auto-load defers; failures demote).
+    #[serde(default)]
+    pub self_improve: Option<serde_json::Value>,
 }
 
 /// Eval subsystem configuration.
@@ -453,6 +476,7 @@ impl Default for KilnConfig {
             adapters: AdaptersConfig::default(),
             eval: None,
             request_log: crate::request_log::RequestLogConfig::default(),
+            agent: None,
         }
     }
 }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -612,6 +612,59 @@ async fn main() -> Result<()> {
     // Spawn the background eval queue worker
     kiln_server::eval::spawn_eval_worker(state.clone(), shutdown_flag.clone());
 
+    // §10.6 flywheel scheduler: [agent] self_improve_interval_hours runs
+    // the weekly loop automatically through the SAME submission path as
+    // POST /v1/agent/self_improve (validation, teacher gate, queue caps).
+    // First run fires one full interval after startup — never at boot.
+    if let Some(agent_cfg) = config.agent.clone() {
+        if let Some(hours) = agent_cfg.self_improve_interval_hours.filter(|&h| h > 0) {
+            let scheduler_state = state.clone();
+            let req_template = agent_cfg.self_improve.clone();
+            tracing::info!(
+                interval_hours = hours,
+                "self_improve scheduler armed (first run in one interval)"
+            );
+            tokio::spawn(async move {
+                let interval = std::time::Duration::from_secs(hours.saturating_mul(3600));
+                loop {
+                    tokio::time::sleep(interval).await;
+                    if scheduler_state
+                        .shutdown
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                    {
+                        break;
+                    }
+                    let req = match &req_template {
+                        Some(v) => match serde_json::from_value(v.clone()) {
+                            Ok(req) => req,
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    "[agent].self_improve config invalid; scheduler stopping"
+                                );
+                                break;
+                            }
+                        },
+                        None => Default::default(),
+                    };
+                    match kiln_server::api::self_improve::submit_self_improve(
+                        &scheduler_state,
+                        req,
+                    ) {
+                        Ok(resp) => tracing::info!(
+                            jobs = resp.job_ids.len(),
+                            "scheduled self_improve round queued"
+                        ),
+                        Err(e) => tracing::warn!(
+                            error = ?e,
+                            "scheduled self_improve round failed to queue; will retry next interval"
+                        ),
+                    }
+                }
+            });
+        }
+    }
+
     let tokenizer_prewarm = state.tokenizer.clone();
     let prewarm_state = state.clone();
     // Cheap clones so the shutdown handler can reach the batching engine

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -133,6 +133,21 @@ draft_layers = 8                      # First N layers used as draft model
 # max_tokens = 512
 # seed = 42
 
+# §10.6 self-improvement flywheel scheduler. Omit the section (or the
+# interval) to keep the weekly loop manual (`kiln self-improve`).
+#
+# [agent]
+# # Run the self_improve loop every N hours (168 = weekly). The first run
+# # fires one full interval after startup — never at boot.
+# self_improve_interval_hours = 168
+# # Optional request overrides (same shape as POST /v1/agent/self_improve).
+# # Add post_eval to gate every scheduled round behind §8.7 promotion:
+# # auto-load defers until the eval passes; failures demote to <name>.failed.
+# [agent.self_improve]
+# agent = "pi-coder-current"
+# judge = "judge-pi-v1"
+# post_eval = { suite = "agentic-core", min_accuracy = 0.7 }
+
 [request_log]
 # Durable request/response log for the inference endpoints
 # (/v1/chat/completions, /v1/completions, /v1/completions/batch). Every


### PR DESCRIPTION
## Summary

Discovery round 3, item 2. The §10.6 self-improvement loop was 100% manual. A new `[agent]` config section arms a scheduler driving the **same submission path** as `POST /v1/agent/self_improve` — validation, teacher gating, queue caps, trace auto-discovery (#1526), warm-start + §8.7 gate passthrough (#1519) all apply identically to scheduled rounds.

```toml
[agent]
self_improve_interval_hours = 168    # weekly; omit to disable
[agent.self_improve]                 # optional request overrides
post_eval = { suite = "agentic-core", min_accuracy = 0.7 }
```

Safety posture: first run fires one full interval after startup (a crash-looping server can't spam training jobs); failed rounds warn and retry next interval; invalid config stops the scheduler loudly; shutdown exits the loop.

## Verification

Defaults-equivalence test (scheduler's no-config request == empty POST body) + config-shape test; full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)