### PR TITLE
Per-adapter MTP draft acceptance: always-on counters + /v1/stats/mtp-acceptance

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -5790,6 +5790,8 @@ async fn generate_real(
     let memory_budget = state.memory_budget.clone();
     let metrics = state.metrics.clone();
     let timeout = state.request_timeout;
+    let mtp_acceptance = state.mtp_acceptance.clone();
+    let acceptance_adapter = adapter.clone().unwrap_or_else(|| "base".to_string());
     let prefix_cache_diagnostic = std::sync::Arc::new(std::sync::Mutex::new("unknown"));
     let prefix_cache_diagnostic_inner = prefix_cache_diagnostic.clone();
     // Cooperative cancellation: `tokio::time::timeout` cancels the outer
@@ -5965,6 +5967,18 @@ async fn generate_real(
             ResolvedSpeculativeMode::Mtp => {
                 *prefix_cache_diagnostic_inner.lock().unwrap() = "not_used_speculative";
                 let output = runner_guard.generate_mtp_speculative(&prompt, &params)?;
+                // Per-adapter acceptance counters — the always-on
+                // measurement (no KILN_C1_ATTR_PATH needed) that makes a
+                // draft head's alpha visible per serving adapter.
+                if output.total_draft_attempts > 0 {
+                    if let Ok(mut counters) = mtp_acceptance.lock() {
+                        let entry = counters
+                            .entry(acceptance_adapter.clone())
+                            .or_insert((0, 0));
+                        entry.0 += output.draft_accepted_count as u64;
+                        entry.1 += output.total_draft_attempts as u64;
+                    }
+                }
                 // KILN_C1_ATTR_PATH acceptance instrumentation: rows are
                 // pushed per draft step but only the bench driver ever
                 // drained them — over plain HTTP serving the CSV never

--- a/crates/kiln-server/src/api/stats.rs
+++ b/crates/kiln-server/src/api/stats.rs
@@ -23,6 +23,41 @@ async fn get_decode_stats(State(state): State<AppState>) -> Json<DecodeStatsSnap
     Json(snap)
 }
 
+/// Per-adapter MTP/speculative draft acceptance, fed by the serve path
+/// after each MTP generation. `acceptance = accepted / attempts` is the
+/// draft head's live alpha — the number MTP training exists to raise.
+#[derive(Debug, serde::Serialize)]
+struct MtpAcceptanceEntry {
+    adapter: String,
+    accepted: u64,
+    attempts: u64,
+    acceptance: f64,
+}
+
+async fn get_mtp_acceptance(State(state): State<AppState>) -> Json<Vec<MtpAcceptanceEntry>> {
+    let mut entries: Vec<MtpAcceptanceEntry> = state
+        .mtp_acceptance
+        .lock()
+        .map(|counters| {
+            counters
+                .iter()
+                .map(|(adapter, &(accepted, attempts))| MtpAcceptanceEntry {
+                    adapter: adapter.clone(),
+                    accepted,
+                    attempts,
+                    acceptance: if attempts > 0 {
+                        accepted as f64 / attempts as f64
+                    } else {
+                        0.0
+                    },
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    entries.sort_by(|a, b| a.adapter.cmp(&b.adapter));
+    Json(entries)
+}
+
 async fn get_recent_requests(State(state): State<AppState>) -> Json<Vec<RequestRecord>> {
     let snap = state
         .recent_requests
@@ -35,6 +70,7 @@ async fn get_recent_requests(State(state): State<AppState>) -> Json<Vec<RequestR
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/v1/stats/decode", get(get_decode_stats))
+        .route("/v1/stats/mtp-acceptance", get(get_mtp_acceptance))
         .route("/v1/stats/recent-requests", get(get_recent_requests))
 }
 
@@ -189,5 +225,37 @@ mod tests {
             "tok_per_sec should be ~50, got {}",
             tok_per_sec
         );
+    }
+    #[tokio::test]
+    async fn mtp_acceptance_endpoint_reports_per_adapter_alpha() {
+        let state = make_test_state();
+        state
+            .mtp_acceptance
+            .lock()
+            .unwrap()
+            .insert("pi-coder-current".to_string(), (75, 100));
+        state
+            .mtp_acceptance
+            .lock()
+            .unwrap()
+            .insert("base".to_string(), (1, 4));
+        let app = routes().with_state(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/stats/mtp-acceptance")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let entries: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["adapter"], "base");
+        assert_eq!(entries[1]["adapter"], "pi-coder-current");
+        assert!((entries[1]["acceptance"].as_f64().unwrap() - 0.75).abs() < 1e-9);
+        assert_eq!(entries[1]["attempts"], 100);
     }
 }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1353,6 +1353,13 @@ pub struct AppState {
     /// This can differ from `active_adapter_name` during explicit per-request
     /// chat adapter overrides; missing `adapter` requests reload the default.
     pub loaded_adapter_name: Arc<std::sync::RwLock<Option<String>>>,
+    /// Per-adapter MTP/speculative draft acceptance counters:
+    /// adapter name ("base" when none) → (accepted, attempts). Fed by the
+    /// serve path after each MTP generation; surfaced via /v1/stats so
+    /// the draft head's alpha is measurable per adapter without the
+    /// KILN_C1_ATTR_PATH CSV.
+    pub mtp_acceptance:
+        Arc<std::sync::Mutex<std::collections::HashMap<String, (u64, u64)>>>,
     /// Last adapter load failure by adapter name. Used by the registry so
     /// automation can distinguish "not loaded" from "failed to load".
     pub adapter_load_errors: Arc<std::sync::RwLock<HashMap<String, String>>>,
@@ -1616,6 +1623,7 @@ impl AppState {
             adapter_dir: PathBuf::from("adapters"),
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
+            mtp_acceptance: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
             adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
@@ -2266,6 +2274,7 @@ impl AppState {
             adapter_dir,
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
+            mtp_acceptance: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
             adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),


### PR DESCRIPTION
## Summary

Discovery round 3, item 7. The MTP draft head's live alpha was invisible per adapter (only the env-gated, adapter-less C1 CSV existed) — yet acceptance is the number MTP training exists to raise.

`AppState.mtp_acceptance` accumulates `(accepted, attempts)` per serving adapter at the MTP serve arm (from counts `MtpGenerationOutput` already carried and discarded), and `GET /v1/stats/mtp-acceptance` reports the computed ratios — the per-adapter A/B that MTP PR-B's alignment phase needs, as a curl.

## Verification

Endpoint test (two adapters, exact alpha math); full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)