### PR TITLE
Round-4 flywheel correctness: re-land the recipe gate, fix compounding, validate gate suites

### DIFF
--- a/crates/kiln-server/src/api/recipes.rs
+++ b/crates/kiln-server/src/api/recipes.rs
@@ -297,18 +297,46 @@ async fn run_recipe(
     // queued — never a partially-enqueued recipe.
     let mut prepared = Vec::with_capacity(recipe.steps.len());
     let mut previous_adapter: Option<String> = None;
-    for step in &recipe.steps {
-        if matches!(step, RecipeStep::PostEval { .. }) {
-            tracing::info!(
-                recipe = %recipe_name,
-                step = ?step,
-                "PostEval step queued as no-op — real eval gating ships with the eval-suite registry follow-up"
-            );
+    for (idx, step) in recipe.steps.iter().enumerate() {
+        if let RecipeStep::PostEval { suite, adapter, .. } = step {
+            // A PostEval step is the §8.7 gate ON the preceding training
+            // step (attached via the lookahead below), never its own job.
+            // Validate placement here so a dangling/mismatched gate
+            // rejects the whole recipe before anything enqueues.
+            let Some(prev) = previous_adapter.as_deref() else {
+                return Err(ApiError::training_invalid_request(format!(
+                    "recipe '{recipe_name}': PostEval (suite={suite}) must follow a \
+                     training step — it gates that step's output adapter"
+                )));
+            };
+            if adapter != prev {
+                return Err(ApiError::training_invalid_request(format!(
+                    "recipe '{recipe_name}': PostEval adapter '{adapter}' does not match \
+                     the preceding step's output adapter '{prev}'"
+                )));
+            }
             continue;
         }
+        // Lookahead: a directly-following PostEval step becomes this
+        // job's promotion gate — auto-load defers until the eval passes
+        // and a failing adapter demotes to <name>.failed (the same
+        // training_queue §8.7 machinery direct submissions use).
+        let post_eval = match recipe.steps.get(idx + 1) {
+            Some(RecipeStep::PostEval {
+                suite,
+                require_min_score,
+                ..
+            }) => Some(kiln_eval::PostEvalConfig {
+                suite: suite.clone(),
+                generation: None,
+                min_accuracy: Some(*require_min_score as f32),
+                include_baseline: false,
+            }),
+            _ => None,
+        };
         let job_id = uuid::Uuid::new_v4().to_string();
         let (adapter_name, queued) =
-            step_to_queued_job(&state, step, previous_adapter.as_deref(), &job_id)?;
+            step_to_queued_job(&state, step, previous_adapter.as_deref(), &job_id, post_eval)?;
         previous_adapter = Some(adapter_name.clone());
         prepared.push((job_id, adapter_name, queued));
     }
@@ -344,6 +372,7 @@ fn step_to_queued_job(
     step: &RecipeStep,
     previous_adapter: Option<&str>,
     _job_id: &str,
+    post_eval: Option<kiln_eval::PostEvalConfig>,
 ) -> Result<(String, crate::training_queue::QueuedJob), ApiError> {
     use crate::training_queue::QueuedJob;
     // Every training step's `name` becomes a directory under adapter_dir —
@@ -393,7 +422,7 @@ fn step_to_queued_job(
                     dataset: None,
                     examples,
                     config: sft_config,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                 }),
             ))
         }
@@ -435,7 +464,7 @@ fn step_to_queued_job(
                     dataset_path: None,
                     teacher: teacher.clone(),
                     config: opd_config,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                 }),
             ))
         }
@@ -456,7 +485,7 @@ fn step_to_queued_job(
                     student: student.clone(),
                     rollout_budget: *rollout_budget,
                     config: c,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                 }),
             ))
         }
@@ -481,7 +510,7 @@ fn step_to_queued_job(
                     rollout_budget: 50_000,
                     use_cache: true,
                     config: c,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                 }),
             ))
         }
@@ -504,7 +533,7 @@ fn step_to_queued_job(
                     require_if_eval_recovery: 0.95,
                     require_internal_qa_gain: 0.05,
                     config: c,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                     if_eval_suite: None,
                     new_knowledge_eval_suite: None,
                 }),
@@ -525,7 +554,7 @@ fn step_to_queued_job(
                     ground_truth: None,
                     documents: None,
                     config: c,
-                    post_eval: None,
+                    post_eval: post_eval.clone(),
                 }),
             ))
         }
@@ -623,7 +652,7 @@ mod tests {
     #[test]
     fn post_eval_step_parses_and_validates_placement() {
         let recipe: Recipe = serde_yaml::from_str(
-            "name: gated\nsteps:\n  - kind: post_eval\n    suite: agentic-core\n    adapter: x\n    require_min_score: 0.7\n",
+            "name: gated\nsteps:\n  - kind: post_eval\n    suite: qwen3.5-agentic-core\n    adapter: x\n    require_min_score: 0.7\n",
         )
         .unwrap();
         let RecipeStep::PostEval {
@@ -634,7 +663,7 @@ mod tests {
         else {
             panic!("expected PostEval step");
         };
-        assert_eq!(suite, "agentic-core");
+        assert_eq!(suite, "qwen3.5-agentic-core");
         assert_eq!(adapter, "x");
         assert!((require_min_score - 0.7).abs() < 1e-9);
         // The lookahead conversion used by the prepare loop.

--- a/crates/kiln-server/src/api/self_improve.rs
+++ b/crates/kiln-server/src/api/self_improve.rs
@@ -109,6 +109,7 @@ async fn judge_distill(
     // to generic seed prompts and reported success.
     let (pump_req, num_pairs) =
         build_judge_pump_request(&state.adapter_dir, &req)?;
+    super::training::validate_post_eval_suite(&state, req.post_eval.as_ref())?;
     super::training::enforce_queue_caps(&state)?;
 
     let job_id = uuid::Uuid::new_v4().to_string();
@@ -385,6 +386,17 @@ fn build_self_improve_jobs(
         if config.base_adapter.is_some() {
             return config.base_adapter.clone();
         }
+        // The round's OUTPUT is "{agent}-improve" (register_agent_job
+        // below) — so that is what the NEXT round must continue from, or
+        // every scheduled cycle silently retrains from base and
+        // overwrites last week's product (round-4 discovery caught the
+        // original checking only the bare agent name, which nothing
+        // creates). Fall back to the bare agent dir for operators who
+        // maintain one by hand.
+        let improve_name = format!("{}-improve", req.agent);
+        if adapter_dir.join(&improve_name).is_dir() {
+            return Some(improve_name);
+        }
         adapter_dir
             .join(&req.agent)
             .is_dir()
@@ -527,7 +539,7 @@ mod tests {
         let toml_like = serde_json::json!({
             "agent": "pi-coder-current",
             "judge": "judge-pi-v1",
-            "post_eval": {"suite": "agentic-core", "min_accuracy": 0.7}
+            "post_eval": {"suite": "qwen3.5-agentic-core", "min_accuracy": 0.7}
         });
         let req: SelfImproveRequest = serde_json::from_value(toml_like).unwrap();
         assert_eq!(req.post_eval.unwrap().min_accuracy, Some(0.7));
@@ -696,6 +708,22 @@ mod tests {
             Some("pi-coder-current")
         );
 
+        // THE COMPOUNDING CASE (round-4 discovery): each round's output
+        // is "{agent}-improve" — when it exists, the next round must
+        // continue from IT, not the bare agent dir (and never from
+        // base). Without this, the weekly scheduler retrained from base
+        // and overwrote last week's product forever.
+        std::fs::create_dir(dir.path().join("pi-coder-current-improve")).unwrap();
+        let (opd, crisp, _) = build_self_improve_jobs(dir.path(), &req).unwrap();
+        assert_eq!(
+            opd.config.base_adapter.as_deref(),
+            Some("pi-coder-current-improve")
+        );
+        assert_eq!(
+            crisp.unwrap().config.base_adapter.as_deref(),
+            Some("pi-coder-current-improve")
+        );
+
         // Explicit base_adapter wins over the warm-start default.
         let req: SelfImproveRequest = serde_json::from_str(
             r#"{"config": {"base_adapter": "my-pinned-base"}}"#,
@@ -712,15 +740,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         seeded_trace_index(dir.path());
         let req: SelfImproveRequest = serde_json::from_str(
-            r#"{"post_eval": {"suite": "agentic-core", "min_accuracy": 0.7}}"#,
+            r#"{"post_eval": {"suite": "qwen3.5-agentic-core", "min_accuracy": 0.7}}"#,
         )
         .unwrap();
         let (opd, crisp, _) = build_self_improve_jobs(dir.path(), &req).unwrap();
-        assert_eq!(opd.post_eval.as_ref().unwrap().suite, "agentic-core");
+        assert_eq!(opd.post_eval.as_ref().unwrap().suite, "qwen3.5-agentic-core");
         assert_eq!(opd.post_eval.as_ref().unwrap().min_accuracy, Some(0.7));
         assert_eq!(
             crisp.unwrap().post_eval.as_ref().unwrap().suite,
-            "agentic-core"
+            "qwen3.5-agentic-core"
         );
     }
 

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -225,6 +225,8 @@ async fn submit_sft(
         return Err(ApiError::shutting_down());
     }
 
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
+
     // Reject when the queue is at its configured cap. This protects the
     // server from queue-exhaustion DoS where a client submits jobs faster
     // than the trainer can drain them. Audit reference: security-audit-v0.1
@@ -418,6 +420,8 @@ async fn submit_grpo(
         return Err(ApiError::shutting_down());
     }
 
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
+
     // Train-by-dataset-name: resolve an uploaded dataset (the eval dataset
     // store) to its on-disk JSONL and ride the existing dataset_path
     // streaming path. Callers send just the name — no rows round-trip.
@@ -599,6 +603,8 @@ async fn submit_opd(
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
+
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
 
     // Queue / tracking caps — mirror SFT/GRPO.
     let max_queued = state.max_queued_training_jobs;
@@ -793,6 +799,8 @@ async fn submit_distill_refresh(
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
+
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
     let max_queued = state.max_queued_training_jobs;
     let queued_now = state.training_queue.lock().unwrap().len();
     if queued_now >= max_queued {
@@ -912,6 +920,8 @@ async fn submit_distill_merge(
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
+
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
     if req.sources.is_empty() {
         return Err(ApiError::training_invalid_request(
             "distill_merge: `sources` must be non-empty".to_string(),
@@ -965,6 +975,8 @@ async fn submit_distill_pump(
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
+
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
     if req.teacher.trim().is_empty() {
         return Err(ApiError::training_invalid_request(
             "distill/pump: `teacher` alias must be non-empty".to_string(),
@@ -1010,6 +1022,8 @@ async fn submit_distill_self(
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
+
+    validate_post_eval_suite(&state, req.post_eval.as_ref())?;
     if req.name.trim().is_empty() {
         return Err(ApiError::training_invalid_request(
             "distill/self: `name` must be non-empty".to_string(),
@@ -1043,6 +1057,39 @@ async fn submit_distill_self(
 /// Shared submission gate: queue cap, tracked-jobs cap, and mock-mode
 /// rejection. Used by the distill_* endpoints and every other surface
 /// that enqueues training jobs (front door, recipes, agent endpoints).
+/// Submission-time §8.7 gate validation: a post_eval naming a suite that
+/// isn't installed must reject NOW, not after training burns GPU-hours
+/// and the eval worker discovers the name resolves to nothing (round-4
+/// discovery: docs/tests pointed at "agentic-core" while the installed
+/// builtin is "qwen3.5-agentic-core" — gated rounds trained forever and
+/// never promoted).
+pub(crate) fn validate_post_eval_suite(
+    state: &AppState,
+    post_eval: Option<&kiln_eval::PostEvalConfig>,
+) -> Result<(), ApiError> {
+    let Some(cfg) = post_eval else {
+        return Ok(());
+    };
+    let Some(registry) = state.suite_registry.as_ref() else {
+        // No registry on this state (mock/test shapes) — the eval worker
+        // will surface the failure; don't block submission.
+        return Ok(());
+    };
+    if registry.load(&cfg.suite).is_err() {
+        let available: Vec<String> = registry
+            .list()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        return Err(ApiError::training_invalid_request(format!(
+            "post_eval.suite '{}' is not an installed eval suite — available: [{}]",
+            cfg.suite,
+            available.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn enforce_queue_caps(state: &AppState) -> Result<(), ApiError> {
     let max_queued = state.max_queued_training_jobs;
     if state.training_queue.lock().unwrap().len() >= max_queued {

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -146,7 +146,7 @@ draft_layers = 8                      # First N layers used as draft model
 # [agent.self_improve]
 # agent = "pi-coder-current"
 # judge = "judge-pi-v1"
-# post_eval = { suite = "agentic-core", min_accuracy = 0.7 }
+# post_eval = { suite = "qwen3.5-agentic-core", min_accuracy = 0.7 }
 
 [request_log]
 # Durable request/response log for the inference endpoints


### PR DESCRIPTION
## Summary

Discovery round 4 audited the freshly-merged flywheel and caught three gaps — two in this session's own work:

1. **Re-land #1527's implementation** — the merged commit had the comments and test but not the prepare-loop lookahead or the six gate-threading sites (the editing script's assert failed after those replacements and discarded them before writing — the same failure mode that ate #1512's eligibility hunk). Grep-verified post-commit this time.
2. **The flywheel never compounded** — warm-start checked the bare `{agent}` dir but each round outputs `{agent}-improve`; every scheduled cycle retrained from base and overwrote last week's product. Warm-start now prefers `{agent}-improve`.
3. **Gate suites validate at submission** — `post_eval.suite` must name an installed suite (400 with the available list otherwise), wired into all seven submission handlers + self_improve. Also fixed the phantom `"agentic-core"` name (real: `qwen3.5-agentic-core`) in the example config and tests.

## Verification

Compounding test (round 2 continues from round 1's output); recipe-gate grep + placement test; full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)