### PR TITLE
docs: the flywheel is discoverable — QUICKSTART/README/ECHO_GUIDE/api.html truth pass

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -721,12 +721,29 @@ kiln train grpo --file grpo-batch.json --adapter support-bot
 kiln train status --job-id train_123
     Check a specific training job; omit --job-id to show the queue.
 
+kiln train cancel --job-id train_123
+    Cancel a job: queued jobs leave the queue; running jobs stop at the next step boundary.
+
+kiln self-improve
+    Run the §10.6 weekly loop once: index this week's pi sessions, re-roll them
+    on-policy scored by the judge (warm-starting from last round's adapter), then
+    the CRISP terseness pass. Add a post_eval gate to promote only on a passing eval.
+
+kiln judge distill
+    Distill the frozen teacher's judgment into a local judge LoRA (the scorer
+    self-improve uses).
+
 kiln adapters list
 kiln adapters load support-bot
 kiln adapters unload
 kiln adapters delete support-bot
     List, load, unload the active adapter to revert to the base model, or delete a saved adapter on the running server.
 ```
+
+Set it and forget it: `[agent] self_improve_interval_hours = 168` in kiln.toml runs the
+self-improve loop weekly through the same path as the CLI/API — auto-discovering traces,
+warm-starting from the previous round, and honoring the `post_eval` promotion gate
+(see `kiln.example.toml`'s `[agent]` section).
 
 The CLI currently covers the basic adapter lifecycle: `list`, `load`, `unload`, and `delete`. For advanced adapter download, upload, merge, and composition flows — plus training-completion webhooks — use the dashboard or the HTTP API examples in [9. Advanced API Examples](#9-advanced-api-examples).
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | GET | `/v1/train/status/{job_id}` | Inspect one training job |
 | GET | `/v1/train/jobs/{job_id}` | Rich training job detail (loss curve + linked-eval back-references) |
 | GET | `/v1/train/queue` | List queued training jobs |
+| DELETE | `/v1/train/queue/{job_id}` | Cancel a job (queued: dequeued; running: stops at the next step boundary) |
+| GET | `/v1/stats/mtp-acceptance` | Per-adapter MTP draft acceptance (live alpha) |
 | DELETE | `/v1/train/queue/{job_id}` | Cancel a queued job |
 | POST | `/v1/distill/refresh` | Continual-learning distillation refresh job |
 | POST | `/v1/distill/pump` | Continual-learning distillation pump job |

--- a/docs/ECHO_GUIDE.md
+++ b/docs/ECHO_GUIDE.md
@@ -43,7 +43,7 @@ cuda_grpo_ablation ... --no-echo
 cuda_grpo_ablation ... --no-policy-loss --echo-lambda 0.05
 ```
 
-`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Intended for keeping a strong agent improving on tasks where no programmatic verifier is available — but it is **not yet available**: `validate_for_kt_tape` rejects it at submission because it needs the policy-gradient coefficients zeroed while the env-CE rows drive the update, and that wiring hasn't landed. The env-CE term itself is live and composes with the standard policy loss.
+`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients — the §5.5 verifier-free mode for keeping a strong agent improving on tasks with no programmatic verifier. It is **live**: with ECHO enabled (the default), the fused tape root records `λ·env_CE` alone and the backward emits only the env rows (closed-form verified). `no_policy_loss` without an enabled ECHO term is rejected at submission — with both off there would be nothing to train on.
 
 ### From the kiln-server HTTP API
 

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -501,7 +501,7 @@ kiln serve --config kiln.toml</code></pre>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/jobs/{job_id}</code> &mdash; rich job detail (loss curve + linked-eval back-references).</div>
           <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/jobs/{job_id}</code> &mdash; remove an archived terminal job.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/queue</code> &mdash; list queued training jobs.</div>
-          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/queue/{job_id}</code> &mdash; cancel a queued job.</div>
+          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/queue/{job_id}</code> &mdash; cancel a job: queued jobs leave the queue; running jobs stop at the next step boundary.</div>
         </div>
         <div class="code-block mt-4" data-placeholder="JOB_ID=<job-id>"><pre><code>curl -s http://localhost:8420/v1/train/queue | python3 -m json.tool
 JOB_ID=&lt;job-id&gt;

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -181,10 +181,11 @@ def parse_cli_surface() -> CliSurface:
     command_variants = parse_variant_blocks(extract_block_after(text, "pub enum Commands"))
     train_variants = parse_variant_blocks(extract_block_after(text, "pub enum TrainCommands"))
     adapter_variants = parse_variant_blocks(extract_block_after(text, "pub enum AdapterCommands"))
+    judge_variants = parse_variant_blocks(extract_block_after(text, "pub enum JudgeCommands"))
 
     commands: dict[tuple[str, ...], CommandSpec] = {}
     for variant, block in command_variants.items():
-        if variant in {"Train", "Adapters"}:
+        if variant in {"Train", "Adapters", "Judge"}:
             continue
         cli_name = "config" if variant == "ConfigCheck" else variant_name_to_cli(variant)
         flags, positionals = parse_arg_fields(block)
@@ -197,6 +198,10 @@ def parse_cli_surface() -> CliSurface:
     for variant, block in adapter_variants.items():
         flags, positionals = parse_arg_fields(block)
         commands[("adapters", variant_name_to_cli(variant))] = CommandSpec(frozenset(flags), positionals)
+
+    for variant, block in judge_variants.items():
+        flags, positionals = parse_arg_fields(block)
+        commands[("judge", variant_name_to_cli(variant))] = CommandSpec(frozenset(flags), positionals)
 
     return CliSurface(frozenset(global_flags), commands)
 
@@ -318,7 +323,7 @@ def command_key(tokens: list[str], surface: CliSurface) -> tuple[tuple[str, ...]
         return None, index, None
 
     first = tokens[index]
-    if first in {"train", "adapters"}:
+    if first in {"train", "adapters", "judge"}:
         if index + 1 >= len(tokens):
             return None, index, f"unknown subcommand {' '.join(tokens[1:index + 1])!r}"
         key = (first, tokens[index + 1])


### PR DESCRIPTION
## Summary

Round-4 discovery item 2: the headline capability — the self-improving flywheel — was invisible from the front-door docs, and three claims went stale during the 40-PR wave. QUICKSTART gains the flywheel commands (`train cancel`, `self-improve`, `judge distill`) and the `[agent]` scheduler pointer; README's endpoint table gains cancel + mtp-acceptance; ECHO_GUIDE's `--no-policy-loss` claim flips to live (§5.5); api.html's cancel description covers running jobs.

## Verification

Command names checked against the clap definitions; full `kiln-server` suite green (docs-adjacent tests unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)