### PR TITLE
§8.7 gates detect regressions: compare against the previous generation via the paired sign test

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -721,12 +721,29 @@ kiln train grpo --file grpo-batch.json --adapter support-bot
 kiln train status --job-id train_123
     Check a specific training job; omit --job-id to show the queue.
 
+kiln train cancel --job-id train_123
+    Cancel a job: queued jobs leave the queue; running jobs stop at the next step boundary.
+
+kiln self-improve
+    Run the §10.6 weekly loop once: index this week's pi sessions, re-roll them
+    on-policy scored by the judge (warm-starting from last round's adapter), then
+    the CRISP terseness pass. Add a post_eval gate to promote only on a passing eval.
+
+kiln judge distill
+    Distill the frozen teacher's judgment into a local judge LoRA (the scorer
+    self-improve uses).
+
 kiln adapters list
 kiln adapters load support-bot
 kiln adapters unload
 kiln adapters delete support-bot
     List, load, unload the active adapter to revert to the base model, or delete a saved adapter on the running server.
 ```
+
+Set it and forget it: `[agent] self_improve_interval_hours = 168` in kiln.toml runs the
+self-improve loop weekly through the same path as the CLI/API — auto-discovering traces,
+warm-starting from the previous round, and honoring the `post_eval` promotion gate
+(see `kiln.example.toml`'s `[agent]` section).
 
 The CLI currently covers the basic adapter lifecycle: `list`, `load`, `unload`, and `delete`. For advanced adapter download, upload, merge, and composition flows — plus training-completion webhooks — use the dashboard or the HTTP API examples in [9. Advanced API Examples](#9-advanced-api-examples).
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | GET | `/v1/train/status/{job_id}` | Inspect one training job |
 | GET | `/v1/train/jobs/{job_id}` | Rich training job detail (loss curve + linked-eval back-references) |
 | GET | `/v1/train/queue` | List queued training jobs |
+| DELETE | `/v1/train/queue/{job_id}` | Cancel a job (queued: dequeued; running: stops at the next step boundary) |
+| GET | `/v1/stats/mtp-acceptance` | Per-adapter MTP draft acceptance (live alpha) |
 | DELETE | `/v1/train/queue/{job_id}` | Cancel a queued job |
 | POST | `/v1/distill/refresh` | Continual-learning distillation refresh job |
 | POST | `/v1/distill/pump` | Continual-learning distillation pump job |

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -283,6 +283,48 @@ async fn apply_post_eval_gate(state: &AppState, snapshot: &crate::eval::queue::E
         return;
     };
 
+    // Regression detection: gated runs are Compare jobs carrying the
+    // previous generation's run alongside the new adapter's. Pair the
+    // per-example outcomes and reject promotion when the new adapter is
+    // SIGNIFICANTLY worse (#1497 exact sign test) — a static floor alone
+    // happily promotes a regressed adapter as long as it clears the bar.
+    if let Some(baseline_run) = snapshot
+        .finished_runs
+        .iter()
+        .find(|run| run.adapter.as_deref() != Some(gate.adapter_name.as_str()))
+    {
+        if let Some(new_run) = snapshot
+            .finished_runs
+            .iter()
+            .find(|run| run.adapter.as_deref() == Some(gate.adapter_name.as_str()))
+        {
+            let mut improved = 0u32;
+            let mut regressed = 0u32;
+            for (b, n) in baseline_run.outcomes.iter().zip(new_run.outcomes.iter()) {
+                if b.example_id != n.example_id {
+                    continue;
+                }
+                if n.score > b.score {
+                    improved += 1;
+                } else if n.score < b.score {
+                    regressed += 1;
+                }
+            }
+            let test = kiln_eval::result::sign_test(improved, regressed);
+            if regressed > improved && test.significant() {
+                stamp_verdict(format!(
+                    "REGRESSION: `{}` significantly worse than `{}` \
+                     (improved {improved}, regressed {regressed}, p={:.4}) — \
+                     NOT promoted despite accuracy {accuracy:.3}",
+                    gate.adapter_name,
+                    baseline_run.adapter.as_deref().unwrap_or("base"),
+                    test.p_value
+                ));
+                return;
+            }
+        }
+    }
+
     if accuracy >= gate.min_accuracy {
         if gate.auto_load_on_pass {
             let adapter_dir = state.adapter_dir.join(&gate.adapter_name);

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -2563,7 +2563,41 @@ pub fn enqueue_post_training_eval(
     if cfg.include_baseline {
         linked_ids.push(push(None));
     }
-    let adapter_eval_id = push(Some(adapter_name.to_string()));
+    // Regression detection (round-4 discovery): a gated run compares the
+    // new adapter against the CURRENT ACTIVE adapter (the previous
+    // generation; base model when none) in ONE Compare job, so the gate
+    // can reject a significant regression via the paired sign test even
+    // when the static min_accuracy floor passes. Ungated runs keep the
+    // single-adapter shape.
+    let baseline_for_gate: Option<String> = if cfg.min_accuracy.is_some() {
+        state
+            .active_adapter_name
+            .read()
+            .unwrap()
+            .clone()
+            .filter(|name| name != adapter_name)
+    } else {
+        None
+    };
+    let adapter_eval_id = if cfg.min_accuracy.is_some() {
+        let baseline_slot = baseline_for_gate.clone().unwrap_or_default();
+        state.enqueue_eval(
+            cfg.suite.clone(),
+            vec![
+                Some(baseline_slot.clone()).filter(|s| !s.is_empty()),
+                Some(adapter_name.to_string()),
+            ],
+            crate::eval::queue::EvalSubmissionKind::PostTraining,
+            Some(training_job_id.to_string()),
+            crate::eval::queue::QueuedEvalJob::Compare(kiln_eval::EvalCompareSpec {
+                suite: cfg.suite.clone(),
+                adapters: vec![baseline_slot, adapter_name.to_string()],
+                generation: cfg.generation.clone(),
+            }),
+        )
+    } else {
+        push(Some(adapter_name.to_string()))
+    };
     linked_ids.push(adapter_eval_id.clone());
 
     // §8.7 promotion gate: when the request set `min_accuracy`, the
@@ -2926,25 +2960,33 @@ mod tests {
         assert_eq!(jobs.len(), 2);
         let mut gated = 0;
         for job in jobs.values() {
-            match job.adapters.first() {
-                Some(Some(name)) => {
-                    assert_eq!(name, "trained-adapter");
-                    let gate = job
-                        .post_eval_gate
-                        .as_ref()
-                        .expect("adapter run carries the §8.7 gate");
-                    assert_eq!(gate.min_accuracy, 0.8);
-                    assert_eq!(gate.training_job_id, "train-gated");
-                    assert!(gate.auto_load_on_pass);
-                    gated += 1;
-                }
-                Some(None) => {
-                    assert!(
-                        job.post_eval_gate.is_none(),
-                        "baseline run must never carry the gate"
-                    );
-                }
-                None => panic!("job without adapters"),
+            if job
+                .adapters
+                .iter()
+                .any(|a| a.as_deref() == Some("trained-adapter"))
+            {
+                // The gated job is a COMPARE over [previous-active (base
+                // here — no active adapter in this fixture), new adapter]
+                // so the verdict can run the paired sign test for
+                // regression detection.
+                let gate = job
+                    .post_eval_gate
+                    .as_ref()
+                    .expect("adapter compare job carries the §8.7 gate");
+                assert_eq!(gate.min_accuracy, 0.8);
+                assert_eq!(gate.training_job_id, "train-gated");
+                assert!(gate.auto_load_on_pass);
+                assert_eq!(
+                    job.adapters.len(),
+                    2,
+                    "gated runs compare [baseline, new] for the sign test"
+                );
+                gated += 1;
+            } else {
+                assert!(
+                    job.post_eval_gate.is_none(),
+                    "the include_baseline job never carries the gate"
+                );
             }
         }
         assert_eq!(gated, 1);

--- a/docs/ECHO_GUIDE.md
+++ b/docs/ECHO_GUIDE.md
@@ -43,7 +43,7 @@ cuda_grpo_ablation ... --no-echo
 cuda_grpo_ablation ... --no-policy-loss --echo-lambda 0.05
 ```
 
-`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients. Intended for keeping a strong agent improving on tasks where no programmatic verifier is available — but it is **not yet available**: `validate_for_kt_tape` rejects it at submission because it needs the policy-gradient coefficients zeroed while the env-CE rows drive the update, and that wiring hasn't landed. The env-CE term itself is live and composes with the standard policy loss.
+`--no-policy-loss` masks out the GRPO surrogate so only the ECHO env-CE drives gradients — the §5.5 verifier-free mode for keeping a strong agent improving on tasks with no programmatic verifier. It is **live**: with ECHO enabled (the default), the fused tape root records `λ·env_CE` alone and the backward emits only the env rows (closed-form verified). `no_policy_loss` without an enabled ECHO term is rejected at submission — with both off there would be nothing to train on.
 
 ### From the kiln-server HTTP API
 

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -501,7 +501,7 @@ kiln serve --config kiln.toml</code></pre>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/jobs/{job_id}</code> &mdash; rich job detail (loss curve + linked-eval back-references).</div>
           <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/jobs/{job_id}</code> &mdash; remove an archived terminal job.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/train/queue</code> &mdash; list queued training jobs.</div>
-          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/queue/{job_id}</code> &mdash; cancel a queued job.</div>
+          <div class="endpoint"><span class="method">DELETE</span> <code>/v1/train/queue/{job_id}</code> &mdash; cancel a job: queued jobs leave the queue; running jobs stop at the next step boundary.</div>
         </div>
         <div class="code-block mt-4" data-placeholder="JOB_ID=<job-id>"><pre><code>curl -s http://localhost:8420/v1/train/queue | python3 -m json.tool
 JOB_ID=&lt;job-id&gt;

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -181,10 +181,11 @@ def parse_cli_surface() -> CliSurface:
     command_variants = parse_variant_blocks(extract_block_after(text, "pub enum Commands"))
     train_variants = parse_variant_blocks(extract_block_after(text, "pub enum TrainCommands"))
     adapter_variants = parse_variant_blocks(extract_block_after(text, "pub enum AdapterCommands"))
+    judge_variants = parse_variant_blocks(extract_block_after(text, "pub enum JudgeCommands"))
 
     commands: dict[tuple[str, ...], CommandSpec] = {}
     for variant, block in command_variants.items():
-        if variant in {"Train", "Adapters"}:
+        if variant in {"Train", "Adapters", "Judge"}:
             continue
         cli_name = "config" if variant == "ConfigCheck" else variant_name_to_cli(variant)
         flags, positionals = parse_arg_fields(block)
@@ -197,6 +198,10 @@ def parse_cli_surface() -> CliSurface:
     for variant, block in adapter_variants.items():
         flags, positionals = parse_arg_fields(block)
         commands[("adapters", variant_name_to_cli(variant))] = CommandSpec(frozenset(flags), positionals)
+
+    for variant, block in judge_variants.items():
+        flags, positionals = parse_arg_fields(block)
+        commands[("judge", variant_name_to_cli(variant))] = CommandSpec(frozenset(flags), positionals)
 
     return CliSurface(frozenset(global_flags), commands)
 
@@ -318,7 +323,7 @@ def command_key(tokens: list[str], surface: CliSurface) -> tuple[tuple[str, ...]
         return None, index, None
 
     first = tokens[index]
-    if first in {"train", "adapters"}:
+    if first in {"train", "adapters", "judge"}:
         if index + 1 >= len(tokens):
             return None, index, f"unknown subcommand {' '.join(tokens[1:index + 1])!r}"
         key = (first, tokens[index + 1])


### PR DESCRIPTION
## Summary

Round-4 discovery item 3. The gate was a static accuracy floor — a warm-started weekly retrain that **regressed** could promote happily as long as it cleared the bar; the #1497 sign test was CLI/dashboard-only and `include_baseline`'s run landed in a separate job nobody read.

Gated runs now enqueue one **Compare** job over `[previous active adapter (base when none), new adapter]`; `apply_post_eval_gate` pairs per-example outcomes by `example_id` and runs the exact two-sided sign test — significantly-worse rejects promotion with a `REGRESSION:` verdict even when the static floor passes. Ungated runs keep the single-adapter shape.

Note: this PR is based on the docs branch (#1536) and includes its commits; merge #1536 first or this absorbs it.

## Verification

Gate-installation test updated to the Compare contract; full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)