### PR TITLE
SFT holds the GPU lock per step, not per job — live streams interleave with training

### DIFF
--- a/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
+++ b/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
@@ -275,6 +275,7 @@ fn run_one(
         &adapter_name,
         Some(progress),
         None,
+        None,
     );
     let elapsed = t0.elapsed().as_secs_f64();
     stop.store(true, Ordering::Relaxed);

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -2537,6 +2537,7 @@ fn bench_training(
             "bench-adapter",
             progress_cb,
             None,
+            None,
         )
     };
     #[cfg(not(feature = "cuda"))]
@@ -2559,6 +2560,7 @@ fn bench_training(
             &adapter_dir,
             "bench-adapter",
             progress_cb,
+            None,
             None,
         )
     };

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -370,6 +370,7 @@ fn run_sft(
     progress_cb: trainer::ProgressCallback,
     replay_ctx: trainer::ReplayContext,
     job_id: &str,
+    gpu_step_lock: Option<std::sync::Arc<std::sync::RwLock<()>>>,
 ) -> std::result::Result<PathBuf, String> {
     if native_route_enabled {
         #[cfg(feature = "cuda")]
@@ -413,6 +414,7 @@ fn run_sft(
         adapter_name,
         Some(progress_cb),
         Some(replay_ctx),
+        gpu_step_lock,
     )
     .map_err(|e| format!("{e:#}"))
 }
@@ -1352,6 +1354,7 @@ fn run_distill_refresh(
         &midtrain_name,
         Some(progress_cb),
         None,
+        None,
     )
     .map_err(|e| format!("distill_refresh phase 1 (SFT midtrain) failed: {e:#}"))?;
 
@@ -2216,7 +2219,12 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 request_body,
                 base_model: base_model.clone(),
             };
-            let _gpu_guard = gpu_coordination_write_guard(&state.gpu_lock);
+            // Per-STEP GPU coordination (the state.rs contract): the
+            // trainer acquires the write lock around each step's
+            // forward/backward/optimizer instead of this arm holding it
+            // job-long — in-flight inference streams interleave between
+            // steps rather than freezing mid-token for the whole job
+            // (which the [agent] scheduler now triggers unattended).
             let guard = runner_arc.read().unwrap();
             let training_dispatch = guard.backend_capabilities().training.server_dispatch;
             let native_route_enabled = training_dispatch.native_route_enabled();
@@ -2232,6 +2240,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 progress_cb,
                 _replay_ctx,
                 &job_id,
+                Some(state.gpu_lock.clone()),
             )
         }
         QueuedJob::Grpo(mut req) => {

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -1115,6 +1115,7 @@ fn test_real_model_gdn_sft_metal() {
         "gdn-sft-metal-smoke",
         Some(cb),
         None,
+        None,
     )
     .expect("GDN SFT training on Device::Metal(0) should complete");
     assert_adapter_written(&out);
@@ -1200,6 +1201,7 @@ fn test_real_model_sft_metal() {
         adapter_dir.path(),
         "sft-metal-smoke",
         Some(cb),
+        None,
         None,
     )
     .expect("SFT training on Device::Metal(0) should complete");

--- a/crates/kiln-train/src/cuda_train.rs
+++ b/crates/kiln-train/src/cuda_train.rs
@@ -72,6 +72,7 @@ pub fn cuda_native_sft_train(
         adapter_name,
         progress_cb,
         None,
+        None,
     )
 }
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -2990,6 +2990,7 @@ pub fn sft_train(
     adapter_name: &str,
     progress_cb: Option<ProgressCallback>,
     replay_ctx: Option<ReplayContext>,
+    gpu_step_lock: Option<std::sync::Arc<std::sync::RwLock<()>>>,
 ) -> Result<PathBuf> {
     let run_started = Instant::now();
     let output_dir = adapter_dir.join(adapter_name);
@@ -3260,6 +3261,16 @@ pub fn sft_train(
                     tokenize_for_training(&examples[ex_idx], tokenizer)
                         .with_context(|| format!("retokenize SFT example {ex_idx}"))?;
                 let loss_val;
+
+                // Per-STEP GPU coordination (the state.rs contract the
+                // job-long server guard violated): hold the write lock
+                // only across this step's forward/backward/optimizer so
+                // in-flight inference streams interleave between steps
+                // instead of freezing mid-token for the whole job.
+                // Tokenization above runs lock-free (CPU work).
+                let _step_gpu = gpu_step_lock
+                    .as_ref()
+                    .map(|l| l.write().unwrap_or_else(|p| p.into_inner()));
 
                 // (#1082 candle-drop) The SFT forward/backward is now UNCONDITIONALLY
                 // kt tape-authoritative — the candle checkpointed reverse + candle

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -14000,6 +14000,7 @@ fn grpo_dry_run_accepts_echo_with_and_without_env_tokens() -> Result<()> {
             "perf-regression-smoke",
             None,
             None,
+            None,
         )?;
         let elapsed = started.elapsed();
         let elapsed_ms = elapsed.as_millis();
@@ -14111,6 +14112,7 @@ fn grpo_dry_run_accepts_echo_with_and_without_env_tokens() -> Result<()> {
             &tokenizer,
             adapter_dir.path(),
             "perf-regression-tracing-smoke",
+            None,
             None,
             None,
         )?;


### PR DESCRIPTION
## Summary

Round-4 discovery item 7 (SFT slice). Every training arm held `gpu_coordination_write_guard` for the whole job — contradicting the per-segment contract documented on the lock itself — so in-flight pi streams froze mid-token for entire training runs, now on a weekly timer thanks to the scheduler.

`sft_train` takes an optional `gpu_step_lock` and acquires the write lock around each step's forward/backward/optimizer (tokenization lock-free); the queue's SFT arm passes the server lock instead of holding its job-long guard. Decode interleaves at every step boundary; VRAM-collision protection is preserved (compute never overlaps). GRPO/OPD keep the job-long guard for now — their loops drive inference rollouts mid-job and need separate treatment (tracked).

## Verification

`kiln-server` + `kiln-train` suites green (vulkan: pre-existing perf pair only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)