### PR TITLE
distill_refresh dual gates enforced: recovery/gain thresholds reach the eval worker

### DIFF
--- a/crates/kiln-server/src/api/corrections.rs
+++ b/crates/kiln-server/src/api/corrections.rs
@@ -113,54 +113,82 @@ impl CorrectionsStore {
             .map_err(|e| format!("{e}"))
     }
 
+    /// Locked read-modify-write over the whole store. EVERY mutation goes
+    /// through here: the file lock covers the read AND the write, so two
+    /// concurrent mutators (the training worker's completion-time
+    /// mark_trained_into vs a dashboard upsert) merge instead of the
+    /// later write_all clobbering the earlier one — the exact lost-update
+    /// race the old unlocked list() → write_all() pattern had.
+    fn locked_mutate<R>(
+        &self,
+        mutate: impl FnOnce(&mut Vec<CorrectionRow>) -> R,
+    ) -> Result<R, String> {
+        std::fs::create_dir_all(&self.dir).map_err(|e| format!("{e}"))?;
+        let mut result: Option<R> = None;
+        kiln_resource::locked_update(&self.data_path(), |existing| {
+            let mut rows: Vec<CorrectionRow> = existing
+                .map(|bytes| {
+                    String::from_utf8_lossy(bytes)
+                        .lines()
+                        .filter(|l| !l.trim().is_empty())
+                        .filter_map(|l| serde_json::from_str::<CorrectionRow>(l).ok())
+                        .collect()
+                })
+                .unwrap_or_default();
+            result = Some(mutate(&mut rows));
+            let mut body = String::new();
+            for row in &rows {
+                body.push_str(&serde_json::to_string(row).map_err(std::io::Error::other)?);
+                body.push('\n');
+            }
+            Ok(body.into_bytes())
+        })
+        .map_err(|e| format!("{e}"))?;
+        result.ok_or_else(|| "corrections locked_mutate: closure did not run".to_string())
+    }
+
     /// Insert or update by `request_id`. First insert stamps `created_at`;
     /// updates preserve it (and `trained_*` unless the caller sets them).
     pub fn upsert(&self, mut row: CorrectionRow) -> Result<CorrectionRow, String> {
-        let mut rows = self.list();
-        match rows.iter_mut().find(|r| r.request_id == row.request_id) {
-            Some(existing) => {
-                if row.created_at.is_empty() {
-                    row.created_at = existing.created_at.clone();
+        self.locked_mutate(move |rows| {
+            match rows.iter_mut().find(|r| r.request_id == row.request_id) {
+                Some(existing) => {
+                    if row.created_at.is_empty() {
+                        row.created_at = existing.created_at.clone();
+                    }
+                    if row.trained_into.is_none() {
+                        row.trained_into = existing.trained_into.clone();
+                        row.trained_at = existing.trained_at.clone();
+                    }
+                    *existing = row.clone();
                 }
-                if row.trained_into.is_none() {
-                    row.trained_into = existing.trained_into.clone();
-                    row.trained_at = existing.trained_at.clone();
+                None => {
+                    if row.created_at.is_empty() {
+                        row.created_at = chrono::Utc::now().to_rfc3339();
+                    }
+                    rows.insert(0, row.clone());
                 }
-                *existing = row.clone();
             }
-            None => {
-                if row.created_at.is_empty() {
-                    row.created_at = chrono::Utc::now().to_rfc3339();
-                }
-                rows.insert(0, row.clone());
-            }
-        }
-        self.write_all(&rows)?;
-        Ok(row)
+            row
+        })
     }
 
     pub fn remove(&self, request_id: &str) -> Result<bool, String> {
-        let mut rows = self.list();
-        let before = rows.len();
-        rows.retain(|r| r.request_id != request_id);
-        let removed = rows.len() < before;
-        if removed {
-            self.write_all(&rows)?;
-        }
-        Ok(removed)
+        self.locked_mutate(|rows| {
+            let before = rows.len();
+            rows.retain(|r| r.request_id != request_id);
+            rows.len() < before
+        })
     }
 
     /// Remove every ACTIVE (untrained) row. Trained rows are history and
     /// survive a basket clear.
     pub fn clear_active(&self) -> Result<usize, String> {
-        let mut rows = self.list();
-        let before = rows.len();
-        rows.retain(|r| r.trained_into.is_some());
-        let removed = before - rows.len();
-        if removed > 0 {
-            self.write_all(&rows)?;
-        }
-        Ok(removed)
+        self.locked_mutate(|rows| {
+            let before = rows.len();
+            rows.retain(|r| r.trained_into.is_some());
+            before - rows.len()
+        })
     }
 }
 
@@ -279,23 +307,24 @@ impl CorrectionsStore {
     /// job COMPLETION (not submission), so failed jobs leave the basket
     /// intact. Returns how many rows flipped.
     pub fn mark_trained_into(&self, request_ids: &[String], adapter: &str) -> usize {
-        let mut rows = self.list();
         let now = chrono::Utc::now().to_rfc3339();
-        let mut marked = 0usize;
-        for row in rows.iter_mut() {
-            if request_ids.iter().any(|id| id == &row.request_id) {
-                row.trained_into = Some(adapter.to_string());
-                row.trained_at = Some(now.clone());
-                marked += 1;
+        match self.locked_mutate(|rows| {
+            let mut marked = 0usize;
+            for row in rows.iter_mut() {
+                if request_ids.iter().any(|id| id == &row.request_id) {
+                    row.trained_into = Some(adapter.to_string());
+                    row.trained_at = Some(now.clone());
+                    marked += 1;
+                }
+            }
+            marked
+        }) {
+            Ok(marked) => marked,
+            Err(e) => {
+                tracing::warn!(error = %e, "corrections store: mark_trained_into failed");
+                0
             }
         }
-        if marked > 0 {
-            if let Err(e) = self.write_all(&rows) {
-                tracing::warn!(error = %e, "corrections store: mark_trained_into write failed");
-                return 0;
-            }
-        }
-        marked
     }
 }
 
@@ -304,21 +333,9 @@ async fn mark_trained(
     Json(req): Json<MarkTrainedRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let store = CorrectionsStore::for_state(&state);
-    let mut rows = store.list();
-    let now = chrono::Utc::now().to_rfc3339();
-    let mut marked = 0usize;
-    for row in rows.iter_mut() {
-        if req.request_ids.iter().any(|id| id == &row.request_id) {
-            row.trained_into = Some(req.adapter.clone());
-            row.trained_at = Some(now.clone());
-            marked += 1;
-        }
-    }
-    if marked > 0 {
-        store
-            .write_all(&rows)
-            .map_err(|e| ApiError::internal(format!("corrections store: {e}")))?;
-    }
+    // Locked RMW — this route races the training worker's
+    // completion-time marking and dashboard upserts.
+    let marked = store.mark_trained_into(&req.request_ids, &req.adapter);
     Ok(Json(serde_json::json!({ "status": "marked", "marked": marked })))
 }
 
@@ -467,5 +484,52 @@ mod tests {
         // …and the next feed no longer includes them.
         let (ids2, _) = store.trainable_rows();
         assert!(ids2.is_empty());
+    }
+    /// The lost-update race (round-5 discovery): a training-worker
+    /// mark_trained_into racing a dashboard upsert must merge — the old
+    /// unlocked list() → write_all() pattern dropped one side.
+    #[test]
+    fn concurrent_upsert_and_mark_trained_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(CorrectionsStore {
+            dir: dir.path().to_path_buf(),
+        });
+        let row = |id: &str| CorrectionRow {
+            request_id: id.to_string(),
+            agent: "pi".to_string(),
+            adapter: None,
+            user: format!("prompt {id}"),
+            original: "wrong".to_string(),
+            ideal: "right".to_string(),
+            truncated: false,
+            created_at: String::new(),
+            trained_into: None,
+            trained_at: None,
+        };
+        store.upsert(row("seed")).unwrap();
+
+        let s1 = store.clone();
+        let mark = std::thread::spawn(move || {
+            for _ in 0..50 {
+                s1.mark_trained_into(&["seed".to_string()], "fixes-v1");
+            }
+        });
+        let s2 = store.clone();
+        let upserts = std::thread::spawn(move || {
+            for i in 0..50 {
+                s2.upsert(row(&format!("new-{i}"))).unwrap();
+            }
+        });
+        mark.join().unwrap();
+        upserts.join().unwrap();
+
+        let rows = store.list();
+        assert_eq!(rows.len(), 51, "no upsert may be lost");
+        let seed = rows.iter().find(|r| r.request_id == "seed").unwrap();
+        assert_eq!(
+            seed.trained_into.as_deref(),
+            Some("fixes-v1"),
+            "the trained marker must survive concurrent upserts"
+        );
     }
 }

--- a/crates/kiln-server/src/eval/queue.rs
+++ b/crates/kiln-server/src/eval/queue.rs
@@ -78,6 +78,14 @@ fn now_instant_default() -> std::time::Instant {
 pub struct PostEvalGate {
     /// Aggregate-accuracy floor from `PostEvalConfig::min_accuracy`.
     pub min_accuracy: f32,
+    /// distill_refresh §6.4: minimum FRACTIONAL recovery vs the baseline
+    /// run (`new/baseline >= x`). `None` for ordinary gates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relative_recovery: Option<f32>,
+    /// distill_refresh §6.4: minimum ABSOLUTE gain vs the baseline run
+    /// (`new - baseline >= x`). `None` for ordinary gates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub absolute_gain: Option<f32>,
     /// The adapter under judgment (the training job's output).
     pub adapter_name: String,
     /// Training job to stamp the verdict on.

--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -322,6 +322,39 @@ async fn apply_post_eval_gate(state: &AppState, snapshot: &crate::eval::queue::E
                 ));
                 return;
             }
+
+            // distill_refresh §6.4 dual thresholds against the SAME
+            // baseline run: fractional recovery (new/baseline) and
+            // absolute gain (new − baseline).
+            let baseline_acc = baseline_run.metrics.accuracy;
+            if let Some(min_recovery) = gate.relative_recovery {
+                let recovery = if baseline_acc > 0.0 {
+                    accuracy / baseline_acc
+                } else {
+                    1.0
+                };
+                if recovery < min_recovery {
+                    stamp_verdict(format!(
+                        "RECOVERY FAILED: `{}` recovered only {recovery:.3} of `{}`'s \
+                         {baseline_acc:.3} (required {min_recovery:.2}) — NOT promoted",
+                        gate.adapter_name,
+                        baseline_run.adapter.as_deref().unwrap_or("base"),
+                    ));
+                    return;
+                }
+            }
+            if let Some(min_gain) = gate.absolute_gain {
+                let gain = accuracy - baseline_acc;
+                if gain < min_gain {
+                    stamp_verdict(format!(
+                        "GAIN TOO SMALL: `{}` gained {gain:+.3} over `{}`'s \
+                         {baseline_acc:.3} (required {min_gain:+.2}) — NOT promoted",
+                        gate.adapter_name,
+                        baseline_run.adapter.as_deref().unwrap_or("base"),
+                    ));
+                    return;
+                }
+            }
         }
     }
 
@@ -731,6 +764,8 @@ mod tests {
             gate_suite("phrase-the-reply-never-contains"),
             crate::eval::queue::PostEvalGate {
                 min_accuracy: 0.9,
+                relative_recovery: None,
+                absolute_gain: None,
                 adapter_name: "gated".into(),
                 training_job_id: "train-1".into(),
                 auto_load_on_pass: false,
@@ -765,6 +800,8 @@ mod tests {
             gate_suite("mock"),
             crate::eval::queue::PostEvalGate {
                 min_accuracy: 0.9,
+                relative_recovery: None,
+                absolute_gain: None,
                 adapter_name: "good".into(),
                 training_job_id: "train-2".into(),
                 auto_load_on_pass: false,
@@ -799,6 +836,8 @@ mod tests {
         );
         info.post_eval_gate = Some(crate::eval::queue::PostEvalGate {
             min_accuracy: 0.5,
+            relative_recovery: None,
+            absolute_gain: None,
             adapter_name: "unmeasured".into(),
             training_job_id: "train-3".into(),
             auto_load_on_pass: true,

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -2455,43 +2455,54 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             // adapter), and `require_internal_qa_gain` is an
             // *absolute* gain threshold; both translate to
             // PostEvalConfig knobs the eval worker already honours.
-            if let Some((if_suite, qa_suite, _frac_recovery, _qa_gain)) =
+            if let Some((if_suite, qa_suite, frac_recovery, qa_gain)) =
                 distill_refresh_dual.as_ref()
             {
-                if let Some(suite) = if_suite {
+                // §6.4 dual gates, ENFORCED (round-5 discovery: these
+                // thresholds were validated then silently discarded — the
+                // recipe advertised a 0.95/0.05 safety net that gated
+                // nothing). Each suite enqueues as a GATED comparison:
+                // min_accuracy 0.0 makes the run a Compare job
+                // [previous-active/base, refreshed] and the gate's new
+                // relative_recovery / absolute_gain thresholds apply
+                // against the baseline run in apply_post_eval_gate.
+                let mut enqueue_gated = |suite: &String,
+                                         relative_recovery: Option<f32>,
+                                         absolute_gain: Option<f32>,
+                                         label: &str| {
                     let cfg = kiln_eval::PostEvalConfig {
                         suite: suite.clone(),
                         generation: None,
-                        min_accuracy: None,
-                        include_baseline: true,
+                        min_accuracy: Some(0.0),
+                        include_baseline: false,
                     };
-                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg, false)
-                    {
-                        tracing::warn!(job_id = %job_id, suite = %suite, error = %e, "distill_refresh IF-eval enqueue failed");
-                    } else {
-                        tracing::info!(job_id = %job_id, suite = %suite, "distill_refresh IF-eval queued");
+                    match enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg, false) {
+                        Err(e) => tracing::warn!(job_id = %job_id, suite = %suite, error = %e, "distill_refresh {label} enqueue failed"),
+                        Ok(()) => {
+                            // Stamp the dual thresholds onto the gate the
+                            // standard enqueue just installed.
+                            let mut jobs = state.eval_jobs.write().unwrap();
+                            if let Some((_, job)) = jobs.iter_mut().find(|(_, j)| {
+                                j.post_eval_gate
+                                    .as_ref()
+                                    .is_some_and(|g| g.training_job_id == job_id)
+                                    && j.suite_name == *suite
+                            }) {
+                                if let Some(gate) = job.post_eval_gate.as_mut() {
+                                    gate.relative_recovery = relative_recovery;
+                                    gate.absolute_gain = absolute_gain;
+                                }
+                            }
+                            tracing::info!(job_id = %job_id, suite = %suite, "distill_refresh {label} queued (gated)");
+                        }
                     }
+                };
+                if let Some(suite) = if_suite {
+                    enqueue_gated(suite, Some(*frac_recovery as f32), None, "IF-eval");
                 }
                 if let Some(suite) = qa_suite {
-                    let cfg = kiln_eval::PostEvalConfig {
-                        suite: suite.clone(),
-                        generation: None,
-                        min_accuracy: None,
-                        include_baseline: true,
-                    };
-                    if let Err(e) = enqueue_post_training_eval(&state, &job_id, &adapter_name, &cfg, false)
-                    {
-                        tracing::warn!(job_id = %job_id, suite = %suite, error = %e, "distill_refresh QA-eval enqueue failed");
-                    } else {
-                        tracing::info!(job_id = %job_id, suite = %suite, "distill_refresh QA-eval queued");
-                    }
+                    enqueue_gated(suite, None, Some(*qa_gain as f32), "QA-eval");
                 }
-                // The §8.7 auto-rollback gate (rename .failed if
-                // refreshed_score / prior_score < require_if_eval_recovery
-                // OR refreshed - prior < require_internal_qa_gain) is
-                // applied by the eval worker once both eval pairs
-                // complete — implemented in a sibling commit alongside
-                // the eval-worker side of the dual-gate.
             }
         }
         Err(e) => {
@@ -2618,6 +2629,8 @@ pub fn enqueue_post_training_eval(
         if let Some(job) = jobs.get_mut(&adapter_eval_id) {
             job.post_eval_gate = Some(crate::eval::queue::PostEvalGate {
                 min_accuracy,
+                relative_recovery: None,
+                absolute_gain: None,
                 adapter_name: adapter_name.to_string(),
                 training_job_id: training_job_id.to_string(),
                 auto_load_on_pass,


### PR DESCRIPTION
## Summary

Round-5 discovery item 2. `require_if_eval_recovery` / `require_internal_qa_gain` were validated at submission then destructured as `_frac_recovery`/`_qa_gain` and discarded — both dual evals enqueued ungated, and the "sibling commit" the comment promised never existed. The shipped recipe advertised a 0.95/0.05 safety net that enforced nothing.

`PostEvalGate` gains `relative_recovery` and `absolute_gain`; the dual enqueues become gated comparisons (riding #1538's Compare machinery); `apply_post_eval_gate` applies the thresholds against the baseline run with `RECOVERY FAILED` / `GAIN TOO SMALL` verdicts.

Note: stacked on #1541 (corrections locking); merge that first.

## Verification

Full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)