### PR TITLE
self_improve scheduler: durable cadence + /health visibility

### DIFF
--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -33,6 +33,9 @@ struct HealthResponse {
     requests: RequestMetrics,
     recent_requests: RecentRequestMetrics,
     scheduler: Option<SchedulerStats>,
+    /// [agent] self_improve scheduler status (None = not armed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    self_improve_scheduler: Option<crate::state::SelfImproveSchedulerStatus>,
     gpu_memory: Option<GpuMemoryInfo>,
     prefix_cache: PrefixCacheInfo,
     prompt_caches: PromptCachesInfo,
@@ -454,6 +457,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         requests,
         recent_requests,
         scheduler: scheduler_stats,
+        self_improve_scheduler: state.self_improve_scheduler.read().unwrap().clone(),
         gpu_memory,
         prefix_cache,
         prompt_caches,

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -618,19 +618,50 @@ async fn main() -> Result<()> {
     // §10.6 flywheel scheduler: [agent] self_improve_interval_hours runs
     // the weekly loop automatically through the SAME submission path as
     // POST /v1/agent/self_improve (validation, teacher gate, queue caps).
-    // First run fires one full interval after startup — never at boot.
+    // DURABLE: next_run_unix_ms persists to
+    // <adapter_dir>/.self_improve_scheduler.json, so frequent restarts
+    // don't reset the timer (a server restarted daily would otherwise
+    // NEVER fire a weekly round). Transient run failures log and retry
+    // next interval; only an invalid [agent.self_improve] config stops
+    // the loop (loudly).
     if let Some(agent_cfg) = config.agent.clone() {
         if let Some(hours) = agent_cfg.self_improve_interval_hours.filter(|&h| h > 0) {
             let scheduler_state = state.clone();
             let req_template = agent_cfg.self_improve.clone();
+            let status_path = state.adapter_dir.join(".self_improve_scheduler.json");
+            let interval_ms = hours.saturating_mul(3_600_000);
+            let now_ms = kiln_server::recent_requests::now_unix_ms();
+            // Resume the persisted cadence; clamp into [now, now+interval]
+            // so a config change or clock jump can't park the loop years out.
+            let mut status: kiln_server::state::SelfImproveSchedulerStatus =
+                std::fs::read_to_string(&status_path)
+                    .ok()
+                    .and_then(|s| serde_json::from_str(&s).ok())
+                    .unwrap_or_default();
+            status.interval_hours = hours;
+            if status.next_run_unix_ms == 0 || status.next_run_unix_ms > now_ms + interval_ms {
+                status.next_run_unix_ms = now_ms + interval_ms;
+            }
+            let persist = {
+                let status_path = status_path.clone();
+                move |s: &kiln_server::state::SelfImproveSchedulerStatus| {
+                    if let Ok(body) = serde_json::to_vec(s) {
+                        let _ = kiln_resource::locked_atomic_write(&status_path, &body);
+                    }
+                }
+            };
+            persist(&status);
+            *scheduler_state.self_improve_scheduler.write().unwrap() = Some(status.clone());
             tracing::info!(
                 interval_hours = hours,
-                "self_improve scheduler armed (first run in one interval)"
+                next_run_unix_ms = status.next_run_unix_ms,
+                "self_improve scheduler armed"
             );
             tokio::spawn(async move {
-                let interval = std::time::Duration::from_secs(hours.saturating_mul(3600));
                 loop {
-                    tokio::time::sleep(interval).await;
+                    let now = kiln_server::recent_requests::now_unix_ms();
+                    let wait_ms = status.next_run_unix_ms.saturating_sub(now).max(1_000);
+                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                     if scheduler_state
                         .shutdown
                         .load(std::sync::atomic::Ordering::Relaxed)
@@ -650,19 +681,34 @@ async fn main() -> Result<()> {
                         },
                         None => Default::default(),
                     };
+                    let ran_at = kiln_server::recent_requests::now_unix_ms();
+                    status.last_run_unix_ms = Some(ran_at);
                     match kiln_server::api::self_improve::submit_self_improve(
                         &scheduler_state,
                         req,
                     ) {
-                        Ok(resp) => tracing::info!(
-                            jobs = resp.job_ids.len(),
-                            "scheduled self_improve round queued"
-                        ),
-                        Err(e) => tracing::warn!(
-                            error = ?e,
-                            "scheduled self_improve round failed to queue; will retry next interval"
-                        ),
+                        Ok(resp) => {
+                            tracing::info!(
+                                jobs = resp.job_ids.len(),
+                                "scheduled self_improve round queued"
+                            );
+                            status.last_result =
+                                Some(format!("queued {} job(s)", resp.job_ids.len()));
+                            status.last_job_ids = resp.job_ids;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = ?e,
+                                "scheduled self_improve round failed to queue; will retry next interval"
+                            );
+                            status.last_result = Some(format!("failed: {e:?}"));
+                            status.last_job_ids = Vec::new();
+                        }
                     }
+                    status.next_run_unix_ms = ran_at + interval_ms;
+                    persist(&status);
+                    *scheduler_state.self_improve_scheduler.write().unwrap() =
+                        Some(status.clone());
                 }
             });
         }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1343,6 +1343,24 @@ pub enum ModelBackend {
 }
 
 /// Shared application state passed to all handlers.
+/// Durable status for the [agent] self_improve scheduler.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct SelfImproveSchedulerStatus {
+    pub interval_hours: u64,
+    /// Unix ms of the last attempted run (success or failure).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_unix_ms: Option<u64>,
+    /// "queued N jobs" or the error string from the last attempt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<String>,
+    /// Job ids the last successful round enqueued.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub last_job_ids: Vec<String>,
+    /// Unix ms when the next round fires (the restart-surviving anchor).
+    pub next_run_unix_ms: u64,
+}
+
+
 #[derive(Clone)]
 pub struct AppState {
     pub model_config: ModelConfig,
@@ -1366,6 +1384,11 @@ pub struct AppState {
     /// KILN_C1_ATTR_PATH CSV.
     pub mtp_acceptance:
         Arc<std::sync::Mutex<std::collections::HashMap<String, (u64, u64)>>>,
+    /// [agent] self_improve scheduler status — None when the scheduler
+    /// isn't armed. Persisted to `<adapter_dir>/.self_improve_scheduler.json`
+    /// so the cadence survives restarts; surfaced via /health.
+    pub self_improve_scheduler:
+        Arc<std::sync::RwLock<Option<SelfImproveSchedulerStatus>>>,
     /// Last adapter load failure by adapter name. Used by the registry so
     /// automation can distinguish "not loaded" from "failed to load".
     pub adapter_load_errors: Arc<std::sync::RwLock<HashMap<String, String>>>,
@@ -1630,6 +1653,7 @@ impl AppState {
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             mtp_acceptance: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            self_improve_scheduler: Arc::new(std::sync::RwLock::new(None)),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
             adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
@@ -2281,6 +2305,7 @@ impl AppState {
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             mtp_acceptance: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            self_improve_scheduler: Arc::new(std::sync::RwLock::new(None)),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
             adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),


### PR DESCRIPTION
## Summary

Round-5 discovery item 4. The scheduler was a bare `tokio::spawn` with sleep-from-boot — a server restarted daily would **never** fire a weekly round — and nothing surfaced last/next run anywhere.

The cadence now persists to `<adapter_dir>/.self_improve_scheduler.json` and resumes at boot (clamped into `[now, now+interval]`); every attempt records `{last_run, last_result, last_job_ids, next_run}` into AppState + the receipt file; `/health` gains `self_improve_scheduler` so `kiln health --json` and the dashboard see the cadence and last outcome.

## Verification

Full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)