### PR TITLE
Gate verdicts persist across restarts: stamp_verdict re-archives the job

### DIFF
--- a/crates/kiln-server/src/eval/worker.rs
+++ b/crates/kiln-server/src/eval/worker.rs
@@ -255,9 +255,25 @@ async fn apply_post_eval_gate(state: &AppState, snapshot: &crate::eval::queue::E
             verdict = %verdict,
             "post-eval gate verdict"
         );
-        let mut jobs = state.training_jobs.write().unwrap();
-        if let Some(job) = jobs.get_mut(&gate.training_job_id) {
-            job.post_eval_verdict = Some(verdict);
+        let snapshot = {
+            let mut jobs = state.training_jobs.write().unwrap();
+            jobs.get_mut(&gate.training_job_id).map(|job| {
+                job.post_eval_verdict = Some(verdict);
+                job.clone()
+            })
+        };
+        // Re-archive: finalize_job persisted the terminal job BEFORE the
+        // gate eval ran, so without this re-save the verdict only lived
+        // in memory and a restart showed the gated job verdict-less
+        // (round-5 quick win).
+        if let Some(job) = snapshot {
+            if let Err(e) = crate::training_history::save(&state.adapter_dir, &job) {
+                tracing::warn!(
+                    error = %e,
+                    training_job = %gate.training_job_id,
+                    "failed to persist gate verdict to training history"
+                );
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

Round-5 quick win. `finalize_job` archives the terminal training job **before** its gate eval runs, so the §8.7 verdict lived only in memory — restarts showed gated jobs verdict-less. `stamp_verdict` now re-saves the job snapshot to `training_history` after stamping.

## Verification

Full `kiln-server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)