### PR TITLE
Failure panels recover: Retry buttons dispatch, dedupe keys invalidate, outages stop hiding the queue

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -1148,7 +1148,11 @@ async function pollDecodePerf() {
       refreshDecodeSparkline();
     }
   } catch (e) {
+    // The failure HTML destroys both sub-hosts, so every dedupe key that
+    // could skip rebuilding them must be invalidated or the panel stays
+    // stuck on this message after the server recovers.
     lastDecodeStatsKey = null;
+    lastTpsRendered = null;
     el.innerHTML = apiFailureHtml('Decode performance', e, 'pollDecodePerf');
   } finally {
     setPanelBusy('decode-perf-panel', false);
@@ -1201,7 +1205,7 @@ function shortId(s) {
 }
 
 function apiFailureHtml(action, e, retryFn) {
-  const retryButton = retryFn ? `<div style="margin-top:var(--space-3);"><button type="button" class="btn btn-primary" onclick="${retryFn}()" aria-label="Retry ${escapeHtml(action)}">Retry ${escapeHtml(action)}</button></div>` : '';
+  const retryButton = retryFn ? `<div style="margin-top:var(--space-3);"><button type="button" class="btn btn-primary" data-retry="${escapeHtml(retryFn)}" aria-label="Retry ${escapeHtml(action)}">Retry ${escapeHtml(action)}</button></div>` : '';
   return `<div class="empty api-failure">
     <div style="font-weight:600;color:var(--text);margin-bottom:6px;">Dashboard is waiting for Kiln server APIs.</div>
     <div>${escapeHtml(action)} could not load yet. If this is a cold start, wait for <code>kiln serve</code> to finish model startup, then retry.</div>
@@ -1210,6 +1214,23 @@ function apiFailureHtml(action, e, retryFn) {
     <div style="margin-top:var(--space-2);font-family:var(--font-mono);font-size:var(--text-xs);">Details: ${escapeHtml(e.message)}</div>
   </div>`;
 }
+
+// The whole app lives inside an IIFE, so the failure panels' Retry buttons
+// can't use inline onclick (the poll functions aren't globals — a click would
+// throw ReferenceError). They dispatch through this delegated listener instead.
+const RETRY_ACTIONS = {
+  pollHealth,
+  pollDecodePerf,
+  pollRecentRequests,
+  pollAdapters,
+  pollTraining,
+};
+document.addEventListener('click', (ev) => {
+  const btn = ev.target.closest('[data-retry]');
+  if (!btn) return;
+  const action = RETRY_ACTIONS[btn.dataset.retry];
+  if (action) action();
+});
 
 let recentRequestsFilter = '';
 let recentAgentFilter = 'all';
@@ -1763,6 +1784,9 @@ async function pollRecentRequests() {
     lastRecentRequestsKey = key;
     renderRecentRequests(recentRequestsCache);
   } catch (e) {
+    // Invalidate the dedupe key: the failure HTML replaced the list, so an
+    // unchanged key after recovery would leave this panel stuck on the error.
+    lastRecentRequestsKey = null;
     el.innerHTML = apiFailureHtml('Recent requests', e, 'pollRecentRequests');
   } finally {
     setPanelBusy('recent-requests-panel', false);
@@ -1788,6 +1812,9 @@ async function pollAdapters() {
     const count = (data.available || []).length;
     setText('adapters-count', String(count));
   } catch (e) {
+    // refreshAdapterCards owns this panel and dedupes on lastAdaptersKey;
+    // reset it so the card list repaints once the server recovers.
+    lastAdaptersKey = null;
     adaptersPanel.innerHTML = apiFailureHtml('Adapters', e, 'pollAdapters');
   } finally {
     setPanelBusy('adapters-panel', false);
@@ -2217,7 +2244,11 @@ const cancellingTrainingJobIds = new Set();
 // Flat snapshot of the latest /v1/train/queue payload so the command
 // palette (and any other consumer) can search training jobs without
 // re-issuing the request. Updated on every pollTraining tick.
-let trainingJobsCache = { running: null, queued: [], completed: [] };
+// null until the first SUCCESSFUL fetch: an unfetched (or failing) queue is
+// unknown, not empty — seeding an empty shape here made selectPage('training')
+// auto-switch to the SFT form during outages, hiding the failure panel and
+// its Retry button.
+let trainingJobsCache = null;
 // Skip the wholesale `tab-queue` innerHTML rewrite when nothing changed
 // (running progress, queued list identity, recent finish-state). Mirrors
 // the `lastAdaptersKey` guard on the adapters tab.
@@ -2278,6 +2309,8 @@ async function pollTraining() {
     setText('training-count', String(liveCount));
     updateFlywheel();
   } catch (e) {
+    // Invalidate the queue's render key — the failure HTML replaced the list.
+    lastTrainingKey = null;
     queuePanel.innerHTML = apiFailureHtml('Training queue', e, 'pollTraining');
   } finally {
     setPanelBusy('tab-queue', false);
@@ -6236,11 +6269,11 @@ function buildCmdkIndex() {
   // Training runs (running + queued + most-recent completed) — same
   // drill-modal jump as clicking a card on the Training tab. Lets
   // power users find a finished run by adapter name without scrolling.
-  const trainingPool = [
+  const trainingPool = trainingJobsCache ? [
     ...(trainingJobsCache.running ? [trainingJobsCache.running] : []),
     ...(trainingJobsCache.queued || []),
     ...(trainingJobsCache.completed || []).slice(0, 30),
-  ];
+  ] : [];
   for (const j of trainingPool) {
     const stateNorm = (j.state || '').toString().toLowerCase() || 'queued';
     const lossLbl = j.current_loss != null ? `loss ${j.current_loss.toFixed(3)}` : 'no loss yet';
@@ -7156,6 +7189,9 @@ async function fetchTrainDrill() {
       trainDrillPollHandle = null;
     }
   } catch (e) {
+    // Reset the drill key so the next successful poll repaints over this
+    // error instead of being deduped away.
+    trainDrillLastKey = null;
     document.getElementById('train-drill-content').innerHTML = `<div class="detail-empty">Failed: ${escapeHtml(e.message)}</div>`;
   }
 }

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -268,6 +268,9 @@ function sse(res, chunks) {
 }
 
 async function startServer({ failDashboardApis = false, availableAdapters = defaultAvailableAdapters } = {}) {
+  // Mutable so the failure scenario can heal/re-break the APIs mid-run and
+  // assert the dashboard recovers (Retry buttons + dedupe-key invalidation).
+  const apiState = { failDashboardApis };
   const uiHtml = await readFile(uiIndexPath, 'utf8');
   const uiStyles = await readFile(uiStylesPath, 'utf8');
   const uiDemoJs = await readFile(uiDemoJsPath, 'utf8');
@@ -320,7 +323,7 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       res.end();
       return;
     }
-    if (failDashboardApis) {
+    if (apiState.failDashboardApis) {
       if (url.pathname === '/health') {
         apiFailure(res, 'Server status', url.pathname);
         return;
@@ -617,7 +620,11 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
   });
   const address = server.address();
   if (!address || typeof address === 'string') fail('Could not bind local smoke server.');
-  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    setFailDashboardApis: (value) => { apiState.failDashboardApis = value; },
+  };
 }
 
 async function expectText(page, selector, pattern, message) {
@@ -1017,7 +1024,7 @@ async function runMobileOnboardingSmoke(baseUrl) {
   }
 }
 
-async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapters = false } = {}) {
+async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapters = false, setFailDashboardApis = null } = {}) {
   const puppeteer = await loadPuppeteer();
   const browser = await puppeteer.launch({
     executablePath: chromiumPath(),
@@ -1057,6 +1064,61 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       await expectApiFailurePanel(page, '#adapters-panel', 'Adapters', 'Adapters smoke failure from /v1/adapters');
       await goToPrimaryTab(page, 'training');
       await expectApiFailurePanel(page, '#tab-queue', 'Training queue', 'Training queue smoke failure from /v1/train/queue');
+
+      // Retry buttons must dispatch through the app's delegated listener.
+      // (The app is IIFE-scoped: the old inline onclick threw ReferenceError
+      // on every click, which the pageErrors assertion below would catch.)
+      await page.click('#tab-queue [data-retry]')
+        .catch((e) => fail(`Training queue failure panel has no clickable Retry button: ${e.message}`));
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      if (pageErrors.length > 0) fail(`Retry click emitted browser errors: ${pageErrors.join('; ')}`);
+
+      if (setFailDashboardApis) {
+        const recoverPanel = async (selector, pattern, message) => {
+          // Click Retry for an instant repaint when the button is still there;
+          // the interval polls (2-5s) cover the already-recovered case.
+          await page.click(`${selector} [data-retry]`).catch(() => {});
+          await waitForPanelText(page, selector, pattern, message);
+        };
+
+        // Heal the APIs: every panel must recover (Retry click or next poll).
+        setFailDashboardApis(false);
+        await goToPrimaryTab(page, 'overview');
+        await recoverPanel('#server-status', /GPU VRAM/, 'Server status did not recover after the APIs healed');
+        await page.waitForSelector('#server-status .vram-donut svg', { timeout: 5000 })
+          .catch(() => fail('VRAM donut missing from recovered server status panel'));
+        await recoverPanel('#decode-perf-panel', /No streaming completions/i, 'Decode panel did not recover after the APIs healed');
+        await recoverPanel('#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not recover after the APIs healed');
+        await goToPrimaryTab(page, 'training');
+        await recoverPanel('#tab-queue', /No training jobs yet\./, 'Training queue did not recover after the APIs healed');
+        await goToPrimaryTab(page, 'adapters');
+        await recoverPanel('#adapters-panel', /adapter-alpha/, 'Adapters did not recover after the APIs healed');
+
+        // Break the APIs again, then heal again. The second recovery is the
+        // real regression test for the stuck-panel class: by now every render
+        // dedupe key holds the pre-failure value, so a failure writer that
+        // forgets to invalidate its key leaves the panel frozen on the error
+        // HTML forever (the data hasn't changed, so the repaint is skipped).
+        setFailDashboardApis(true);
+        await goToPrimaryTab(page, 'overview');
+        await expectApiFailurePanel(page, '#server-status', 'Server status', 'Server status smoke failure from /health');
+        await expectApiFailurePanel(page, '#decode-perf-panel', 'Decode performance', 'Decode performance smoke failure from /v1/stats/decode');
+        await expectApiFailurePanel(page, '#recent-requests-panel', 'Recent requests', 'Recent requests smoke failure from /v1/stats/recent-requests');
+        await goToPrimaryTab(page, 'training');
+        await expectApiFailurePanel(page, '#tab-queue', 'Training queue', 'Training queue smoke failure from /v1/train/queue');
+        await goToPrimaryTab(page, 'adapters');
+        await expectApiFailurePanel(page, '#adapters-panel', 'Adapters', 'Adapters smoke failure from /v1/adapters');
+
+        setFailDashboardApis(false);
+        await recoverPanel('#adapters-panel', /adapter-alpha/, 'Adapters stuck on failure HTML after second recovery (dedupe key not invalidated)');
+        await goToPrimaryTab(page, 'training');
+        await recoverPanel('#tab-queue', /No training jobs yet\./, 'Training queue stuck on failure HTML after second recovery (dedupe key not invalidated)');
+        await goToPrimaryTab(page, 'overview');
+        await recoverPanel('#server-status', /GPU VRAM/, 'Server status stuck on failure HTML after second recovery');
+        await recoverPanel('#decode-perf-panel', /No streaming completions/i, 'Decode panel stuck on failure HTML after second recovery');
+        await recoverPanel('#recent-requests-panel', /No recent requests yet\./, 'Recent requests stuck on failure HTML after second recovery (dedupe key not invalidated)');
+      }
+
       if (pageErrors.length > 0) fail(`Failure state UI emitted browser errors: ${pageErrors.join('; ')}`);
       return;
     }
@@ -1266,7 +1328,10 @@ try {
 const failureScenario = await startServer({ failDashboardApis: true });
 try {
   console.log('[smoke] failure scenario start');
-  await runSmoke(failureScenario.baseUrl, { expectFailureStates: true });
+  await runSmoke(failureScenario.baseUrl, {
+    expectFailureStates: true,
+    setFailDashboardApis: failureScenario.setFailDashboardApis,
+  });
   console.log('[smoke] failure scenario passed');
 } finally {
   await new Promise((accept) => failureScenario.server.close(accept));


### PR DESCRIPTION
Wave 1 of the UI overhaul (roadmap PR 1 of 25, from the 36-agent audit — all findings adversarially verified).

## Three failure-path bugs

1. **Every Retry button threw `ReferenceError` (P0).** The app is IIFE-scoped, so `onclick="pollHealth()"` couldn't resolve. Retry now dispatches through a delegated `[data-retry]` listener mapped to the five panel polls.
2. **Recovered servers left panels frozen on error HTML.** Four failure writers never invalidated their render dedupe keys, so the first successful poll after an outage compared equal to the pre-failure key and skipped the repaint. Recent requests, training queue, adapters, the decode sparkline (`lastTpsRendered` — closing a gap in #1545), and the train-drill modal now reset their keys in the catch path.
3. **Outages hid the Training failure panel.** `trainingJobsCache` initialized to an empty shape, so the Training page's "empty queue → jump to SFT form" convenience fired during failures too, auto-switching away from the queue and hiding the error + Retry button. The cache is now `null` until the first successful fetch — unfetched is unknown, not empty.

## Verification

The smoke failure scenario now drives a full outage lifecycle: failure asserts → Retry click with zero browser errors → heal → all five panels recover → **second outage → second heal**. The second cycle is the true regression shape for stuck keys (by then every dedupe key holds a real pre-failure value). The mock server's failure mode became runtime-togglable to support this.

- Full suite passes (empty / default desktop+mobile / failure-lifecycle).
- **Negative-tested**: the previous `app.js` fails the new scenario immediately.
- `node --check` clean on app.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)