### PR TITLE
Suite cards no longer lie: 'Latest run accuracy' showed the oldest run

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -4881,13 +4881,18 @@ async function refreshSuites() {
       return;
     }
     el.className = '';
-    // Build a per-suite history from the cached job list.
+    // Build a per-suite history from the cached job list. The server returns
+    // jobs NEWEST-first (sorted descending by submitted_at_iso), but the
+    // sparkline draws points left-to-right in array order and the badge takes
+    // the LAST entry — so accumulate each history oldest→newest. Sort a copy
+    // (never mutate the shared evalJobsCache) rather than blindly reversing,
+    // matching the defensive re-sorts in adapterEvalChip/adapterCompareVerdict.
     const suiteHistory = {};
-    for (const j of evalJobsCache) {
-      if (j.state !== 'completed') continue;
-      const acc = j.headline_accuracy;
-      if (acc == null) continue;
-      (suiteHistory[j.suite_name] = suiteHistory[j.suite_name] || []).push(acc);
+    const completedOldestFirst = evalJobsCache
+      .filter(j => j.state === 'completed' && j.headline_accuracy != null)
+      .sort((a, b) => String(a.submitted_at_iso || '').localeCompare(String(b.submitted_at_iso || '')));
+    for (const j of completedOldestFirst) {
+      (suiteHistory[j.suite_name] = suiteHistory[j.suite_name] || []).push(j.headline_accuracy);
     }
     el.innerHTML = suites.map(s => {
       const hist = (suiteHistory[s.name] || []).slice(-10);

--- a/crates/kiln-server/src/ui/demo.js
+++ b/crates/kiln-server/src/ui/demo.js
@@ -52,8 +52,11 @@
     ],
     schema_version: 1,
   });
+  // NOTE: the real server returns jobs sorted NEWEST-first (descending
+  // submitted_at_iso) — keep this array in that order so demo renders match.
   const evalJobs = () => ({
     jobs: [
+      { job_id: 'eval_44e5f607-0000-1111-2222-333344445555', suite_name: 'commit-msg-contains', adapters: ['commit-msg-writer'], submission_kind: 'on_demand', state: 'queued', progress: { examples_completed: 0, examples_total: 96, running_accuracy: 0, running_mean_score: 0 }, finished_runs: [], headline_accuracy: null, error: null, submitted_at_iso: ISO(30_000) },
       { job_id: 'eval_77a1c0de-aa11-bb22-cc33-dd44ee55ff66', suite_name: 'pi-toolcall-eval', adapters: [ACTIVE_ADAPTER], submission_kind: 'on_demand', state: 'running', progress: { examples_completed: 162, examples_total: 240, running_accuracy: 0.913, running_mean_score: 0.91 }, finished_runs: [], headline_accuracy: null, error: null, submitted_at_iso: ISO(180_000) },
       { job_id: 'eval_31b4f0a9-1234-5678-9abc-def012345678', suite_name: 'rust-review-quality', adapters: [null, ACTIVE_ADAPTER], submission_kind: 'compare', state: 'completed', progress: { examples_completed: 128, examples_total: 128, running_accuracy: 0, running_mean_score: 0 }, headline_accuracy: 0.84, error: null, submitted_at_iso: ISO(3 * 3600_000), finished_runs: [
         { suite_name: 'rust-review-quality', adapter: null, metrics: { num_examples: 128, num_pass: 79, accuracy: 0.617, mean_score: 0.62, pass_rate_by_tag: { correctness: 0.71, style: 0.55, security: 0.58 } }, outcomes: [] },
@@ -62,7 +65,6 @@
       { job_id: 'eval_9c2d1e8f-aaaa-bbbb-cccc-dddddddddddd', suite_name: 'sql-exact-match', adapters: [ACTIVE_ADAPTER], submission_kind: 'on_demand', state: 'completed', progress: { examples_completed: 300, examples_total: 300, running_accuracy: 0, running_mean_score: 0 }, headline_accuracy: 0.91, error: null, submitted_at_iso: ISO(8 * 3600_000), finished_runs: [
         { suite_name: 'sql-exact-match', adapter: ACTIVE_ADAPTER, metrics: { num_examples: 300, num_pass: 273, accuracy: 0.91, mean_score: 0.91, pass_rate_by_tag: { select: 0.96, join: 0.88, window: 0.79 } }, outcomes: [] },
       ] },
-      { job_id: 'eval_44e5f607-0000-1111-2222-333344445555', suite_name: 'commit-msg-contains', adapters: ['commit-msg-writer'], submission_kind: 'on_demand', state: 'queued', progress: { examples_completed: 0, examples_total: 96, running_accuracy: 0, running_mean_score: 0 }, finished_runs: [], headline_accuracy: null, error: null, submitted_at_iso: ISO(30_000) },
       { job_id: 'eval_55f6a708-9999-8888-7777-666655554444', suite_name: 'pi-toolcall-eval', adapters: ['tool-call-tuned-v1'], submission_kind: 'on_demand', state: 'failed', progress: { examples_completed: 41, examples_total: 240, running_accuracy: 0, running_mean_score: 0 }, finished_runs: [], headline_accuracy: null, error: 'adapter tool-call-tuned-v1 failed to load: rank mismatch (expected 32, got 16)', submitted_at_iso: ISO(2 * 86400_000) },
     ],
   });


### PR DESCRIPTION
Wave 1 of the UI overhaul (roadmap PR 3 of 25).

`GET /v1/eval/jobs` returns jobs newest-first (`api/eval.rs:294` sorts descending by `submitted_at_iso`), but `refreshSuites` accumulated each suite's history in array order — so the badge labeled **"Latest run accuracy" showed the oldest run**, `.slice(-10)` kept the 10 oldest, and the sparkline rendered an improving adapter as a declining line.

History is now built oldest→newest from a sorted copy (defensive ascending sort matching `adapterEvalChip`/`adapterCompareVerdict`'s existing pattern, never mutating the shared cache). Badge = true latest; truncation keeps the 10 newest; sparkline reads left-to-right chronologically.

Also reordered the demo fixture's `/v1/eval/jobs` to the real server contract (newest-first) with a comment pinning it.

Verified: synthetic newest-first array (with running/failed/null-accuracy jobs interleaved) produces ascending series, newest badge, unmutated cache, newest-10 truncation; `node --check` both files; full UI smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)