### PR TITLE
Merge-sources rows stop stealing focus on every adapters poll

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -2106,6 +2106,11 @@ function updateMergeButtonState() {
   return state;
 }
 
+// Structural signature of the last merge-sources render. This function runs
+// on every 5s adapters poll; rebuilding the rows when nothing changed would
+// steal focus/caret from someone mid-typing a weight and snap open adapter
+// selects shut. Rebuild only when the adapter set or the row count changes.
+let lastMergeSourcesKey = null;
 function renderMergeSources() {
   const list = document.getElementById('merge-sources');
   if (!list) return;
@@ -2113,9 +2118,24 @@ function renderMergeSources() {
   const available = (adapterState && adapterState.available) || [];
   const canMerge = available.length >= 2;
   if (!canMerge) {
-    list.innerHTML = '';
+    lastMergeSourcesKey = null;
+    if (list.firstChild) list.innerHTML = '';
     updateMergeButtonState();
     return;
+  }
+  const structureKey = available.map(a => a.name).join('|') + '::' + mergeSourceCount;
+  if (structureKey === lastMergeSourcesKey && list.querySelector('.merge-source')) {
+    updateMergeButtonState();
+    return;
+  }
+  lastMergeSourcesKey = structureKey;
+  // A structural rebuild is required — if the user is focused in one of our
+  // inputs (e.g. an adapter was saved mid-edit), put them back afterwards.
+  const active = document.activeElement;
+  const restoreFocusId = active && list.contains(active) ? active.id : null;
+  let restoreSelStart = null, restoreSelEnd = null;
+  if (restoreFocusId) {
+    try { restoreSelStart = active.selectionStart; restoreSelEnd = active.selectionEnd; } catch {}
   }
   // Preserve current values across re-renders.
   const existing = Array.from(list.querySelectorAll('.merge-source')).map(row => ({
@@ -2145,6 +2165,14 @@ function renderMergeSources() {
     row.querySelector('.merge-src-name').addEventListener('change', updateMergeButtonState);
     row.querySelector('.merge-src-weight').addEventListener('input', updateMergeButtonState);
   });
+  if (restoreFocusId) {
+    const el = document.getElementById(restoreFocusId);
+    if (el) {
+      el.focus();
+      // setSelectionRange throws on <input type=number> in some browsers.
+      try { if (restoreSelStart != null && el.setSelectionRange) el.setSelectionRange(restoreSelStart, restoreSelEnd); } catch {}
+    }
+  }
   updateMergeButtonState();
 }
 

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -1208,6 +1208,23 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await expectDisabled(page, '#merge-btn', true, 'Adapter merge should stay disabled before source adapters are selected');
     await page.select('#merge-src-name-1', 'adapter-alpha');
     await page.select('#merge-src-name-2', 'uploaded-smoke-adapter');
+
+    // Regression: the 5s adapters poll re-renders merge sources; it must not
+    // steal focus (or wipe selections) from someone mid-edit in a weight input.
+    // (Triple-click doesn't select-all in number inputs — use el.select().)
+    await page.$eval('#merge-src-weight-1', (el) => { el.focus(); el.select(); });
+    await page.keyboard.type('0.75');
+    await new Promise((resolve) => setTimeout(resolve, 5600)); // sit through one adapters poll
+    const mergeFocusState = await page.evaluate(() => ({
+      focusedId: document.activeElement?.id || null,
+      weight: document.getElementById('merge-src-weight-1')?.value,
+      src1: document.getElementById('merge-src-name-1')?.value,
+      src2: document.getElementById('merge-src-name-2')?.value,
+    }));
+    if (mergeFocusState.focusedId !== 'merge-src-weight-1') fail(`Merge weight input lost focus to ${mergeFocusState.focusedId || 'nothing'} during the adapters poll`);
+    if (mergeFocusState.weight !== '0.75') fail(`Merge weight value lost during the adapters poll: "${mergeFocusState.weight}"`);
+    if (mergeFocusState.src1 !== 'adapter-alpha' || mergeFocusState.src2 !== 'uploaded-smoke-adapter') fail(`Merge source selections lost during the adapters poll: ${mergeFocusState.src1}/${mergeFocusState.src2}`);
+
     await page.click('#merge-output-name', { clickCount: 3 });
     await page.type('#merge-output-name', 'merged-smoke-adapter');
     await expectDisabled(page, '#merge-btn', false, 'Adapter merge should enable after two distinct sources and path-safe output are selected');


### PR DESCRIPTION
Wave 1 of the UI overhaul (roadmap PR 7 of 25).

`renderMergeSources` runs on every 5s adapters poll and rebuilt its rows via `innerHTML` unconditionally: typing a merge weight meant losing focus and caret every 5 seconds, and an open adapter `<select>` snapped shut mid-pick.

- Render is now keyed on a structural signature (adapter set + row count) and early-returns when unchanged; add/remove-source still rebuild (count changes).
- If a structural rebuild does land while one of the inputs is focused, focus + selection are snapshotted and restored after the rewrite (`setSelectionRange` guarded — it throws on number inputs in some browsers).

Smoke regression: focus a weight input, type, sit through one full adapters poll, then require focus + value + both source selections intact. **Negative-tested**: previous `app.js` fails with "lost focus to nothing" (the input was destroyed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)