### PR TITLE
Normalize 'btn primary' to .btn-primary: 17 CTA sites were rendering unstyled

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -3522,7 +3522,7 @@ function restorePlaygroundHistoryBanner() {
       <span style="color:var(--text-quiet);"> — ${stash.messages.length} message${stash.messages.length === 1 ? '' : 's'}${ageMin ? `, ${ageMin} min ago` : ''}.</span>
     </div>
     <div style="display:flex; gap:6px;">
-      <button class="btn btn-sm primary" type="button" data-restore="yes">Restore</button>
+      <button class="btn btn-sm btn-primary" type="button" data-restore="yes">Restore</button>
       <button class="btn btn-sm" type="button" data-restore="no">Discard</button>
     </div>`;
   out.parentNode.insertBefore(banner, out);
@@ -3892,7 +3892,7 @@ function renderChat() {
           <textarea class="user-edit-input">${escapeHtml(m.content)}</textarea>
           <div class="user-edit-actions">
             <button class="btn btn-sm" type="button" data-chat-action="edit-cancel" data-chat-id="${escapeHtml(m._id)}">Cancel</button>
-            <button class="btn btn-sm primary" type="button" data-chat-action="edit-save" data-chat-id="${escapeHtml(m._id)}">Save & resend</button>
+            <button class="btn btn-sm btn-primary" type="button" data-chat-action="edit-save" data-chat-id="${escapeHtml(m._id)}">Save & resend</button>
           </div>
         </div>
       </div>`;
@@ -4704,9 +4704,9 @@ async function refreshDatasets() {
         </div>
         <div class="row-sub" style="font-family:var(--font-mono);">${escapeHtml(pattern)}</div>
         <div class="row-actions">
-          ${m.format === 'sft_chat' ? `<button type="button" class="btn primary btn-sm" data-action="train-sft" data-name="${escapeHtml(m.name)}" title="Open Training with this dataset loaded — one click from here to a queued job">Train SFT →</button>` : ''}
-          ${m.format === 'grpo_groups' ? `<button type="button" class="btn primary btn-sm" data-action="train-grpo" data-name="${escapeHtml(m.name)}" title="Open Training with this dataset loaded — one click from here to a queued job">Train GRPO →</button>` : ''}
-          <button type="button" class="btn ${m.format === 'raw' ? 'primary ' : ''}btn-sm" data-action="synth" data-name="${escapeHtml(m.name)}">Synthesize eval</button>
+          ${m.format === 'sft_chat' ? `<button type="button" class="btn btn-primary btn-sm" data-action="train-sft" data-name="${escapeHtml(m.name)}" title="Open Training with this dataset loaded — one click from here to a queued job">Train SFT →</button>` : ''}
+          ${m.format === 'grpo_groups' ? `<button type="button" class="btn btn-primary btn-sm" data-action="train-grpo" data-name="${escapeHtml(m.name)}" title="Open Training with this dataset loaded — one click from here to a queued job">Train GRPO →</button>` : ''}
+          <button type="button" class="btn ${m.format === 'raw' ? 'btn-primary ' : ''}btn-sm" data-action="synth" data-name="${escapeHtml(m.name)}">Synthesize eval</button>
           <button type="button" class="btn btn-sm" data-action="del" data-name="${escapeHtml(m.name)}">Delete</button>
         </div>
       </div>`;
@@ -5014,7 +5014,7 @@ async function refreshSuites() {
         <div class="tabular-nums">${s.num_examples.toLocaleString()} examples · <span class="scorer-badge">${escapeHtml(s.default_scorer_kind)}</span></div>
         <div style="display:flex; gap:6px; align-items:center;">${recentBadge} ${sparkline}</div>
         <div class="row-actions">
-          <button type="button" class="btn primary btn-sm" data-suite="${escapeHtml(s.name)}" data-action="run" ${evalActiveAdapter ? `title="Score ${escapeHtml(evalActiveAdapter)} (the active adapter) on this suite"` : 'title="Score the base model on this suite"'}>Run</button>
+          <button type="button" class="btn btn-primary btn-sm" data-suite="${escapeHtml(s.name)}" data-action="run" ${evalActiveAdapter ? `title="Score ${escapeHtml(evalActiveAdapter)} (the active adapter) on this suite"` : 'title="Score the base model on this suite"'}>Run</button>
           <button type="button" class="btn btn-sm" data-suite="${escapeHtml(s.name)}" data-action="compare" ${evalActiveAdapter ? `title="Compare base vs ${escapeHtml(evalActiveAdapter)} (the active adapter) — to compare a different adapter, use Run eval… on its card under Adapters"` : 'disabled title="No adapter is active — load one on the Adapters page, or use Run eval… on any adapter card"'}>A/B${evalActiveAdapter ? '' : ''}</button>
           <button type="button" class="btn btn-sm" data-suite="${escapeHtml(s.name)}" data-action="preview" title="Show the first few examples without running">Preview</button>
           <button type="button" class="btn btn-sm" data-suite="${escapeHtml(s.name)}" data-action="del">Delete</button>
@@ -5886,7 +5886,7 @@ async function refreshJudgments() {
           <div class="tabular-nums">${m.num_rows} judgments</div>
           <div style="display:flex; gap:8px; align-items:center; font-size:11px;">${winnerBar}<span class="hint">A ${winners.a||0} · T ${winners.tie||0} · B ${winners.b||0}</span></div>
           <div class="row-actions">
-            <button type="button" class="btn primary btn-sm" data-action="judge" data-name="${escapeHtml(m.name)}">${isActive ? 'Continue' : 'Judge →'}</button>
+            <button type="button" class="btn btn-primary btn-sm" data-action="judge" data-name="${escapeHtml(m.name)}">${isActive ? 'Continue' : 'Judge →'}</button>
             <button type="button" class="btn btn-sm" data-action="promote" data-name="${escapeHtml(m.name)}">Promote</button>
             <button type="button" class="btn btn-sm" data-action="del" data-name="${escapeHtml(m.name)}">Delete</button>
           </div>
@@ -6872,7 +6872,7 @@ function renderAdaptersAsCards(data) {
       <div class="adapter-card-actions">
         ${isActive
           ? `<button class="btn btn-sm" type="button" data-adapter-action="unload" title="Stop serving this adapter — requests fall back to the base model">Unload (use base)</button>`
-          : `<button class="btn btn-sm primary" type="button" data-adapter-action="load" title="Hot-swap this adapter in — pi's next request uses it, no restart">Make active</button>`}
+          : `<button class="btn btn-sm btn-primary" type="button" data-adapter-action="load" title="Hot-swap this adapter in — pi's next request uses it, no restart">Make active</button>`}
         <button class="btn btn-sm" type="button" data-adapter-action="eval" title="Grade this adapter on an eval suite — compare it against base">Run eval…</button>
         <button class="btn btn-sm" type="button" data-adapter-action="download">Download</button>
         <button class="btn btn-sm" type="button" data-adapter-action="delete" title="Delete this adapter from disk" style="margin-left:auto;">Delete</button>
@@ -6973,7 +6973,7 @@ async function openAdapterDrillModal(name) {
       `<span class="hint">${d.is_active ? 'ACTIVE · ' : ''}${fmtBytes(d.size_bytes)} · ${d.files.length} file${d.files.length === 1 ? '' : 's'}</span>`;
     const loadBtn = document.getElementById('adapter-drill-load');
     loadBtn.textContent = d.is_active ? 'Unload' : 'Load';
-    loadBtn.classList.toggle('primary', !d.is_active);
+    loadBtn.classList.toggle('btn-primary', !d.is_active);
     const content = document.getElementById('adapter-drill-content');
     content.innerHTML = renderAdapterDrillBody(d);
     content.querySelectorAll('[data-eval-job]').forEach(row => {
@@ -7698,7 +7698,7 @@ document.getElementById('chat-save-judgment')?.addEventListener('click', () => {
       <option value="tie" selected>Tie</option>
       <option value="skip">Skip</option>
     </select>
-    <button class="btn btn-sm primary" id="chat-save-confirm" type="button">Save</button>
+    <button class="btn btn-sm btn-primary" id="chat-save-confirm" type="button">Save</button>
     <button class="btn btn-sm" id="chat-save-cancel" type="button">Cancel</button>`;
   host.parentNode.insertBefore(form, host.nextSibling);
   document.getElementById('chat-save-cancel').addEventListener('click', () => form.remove());

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -688,7 +688,7 @@
             <label for="dataset-file">JSONL file</label>
             <input id="dataset-file" type="file" accept=".jsonl,.json" required>
           </div>
-          <button type="submit" class="btn primary">Upload</button>
+          <button type="submit" class="btn btn-primary">Upload</button>
         </form>
         <div id="datasets-list" class="empty" style="margin-top:12px;">Loading datasets…</div>
 
@@ -744,8 +744,8 @@
           </div>
           <div style="display:flex; gap:8px; margin-top:8px;">
             <button id="synth-preview-btn" class="btn" type="button">Preview 5 examples</button>
-            <button id="synth-save-btn" class="btn primary" type="button">Save suite</button>
-            <button id="synth-save-and-run-btn" class="btn primary" type="button" title="Save the suite and immediately run it against the active adapter">Save &amp; Run vs active</button>
+            <button id="synth-save-btn" class="btn btn-primary" type="button">Save suite</button>
+            <button id="synth-save-and-run-btn" class="btn btn-primary" type="button" title="Save the suite and immediately run it against the active adapter">Save &amp; Run vs active</button>
           </div>
           <div id="synth-preview-output" style="margin-top:12px;"></div>
         </div>
@@ -775,7 +775,7 @@
             <label for="judgment-create-name">New judgment dataset</label>
             <input id="judgment-create-name" type="text" placeholder="my-judgments">
           </div>
-          <button id="judgment-create-btn" type="button" class="btn primary">Create</button>
+          <button id="judgment-create-btn" type="button" class="btn btn-primary">Create</button>
         </div>
         <div id="judgments-list" class="empty" style="margin-top:12px;">Loading judgment datasets…</div>
 
@@ -803,7 +803,7 @@
                 <input id="judgment-autoadvance" type="checkbox" checked> Auto-advance
               </label>
             </div>
-            <button id="judgment-generate-btn" type="button" class="btn primary">
+            <button id="judgment-generate-btn" type="button" class="btn btn-primary">
               Generate pair <span class="judge-kbd">G</span>
             </button>
           </div>
@@ -858,7 +858,7 @@
               <label for="compile-judge-adapter">Validate adapter</label>
               <select id="compile-judge-adapter"><option value="">Base model</option></select>
             </div>
-            <button id="compile-btn" class="btn primary" type="button">Compile to SFT</button>
+            <button id="compile-btn" class="btn btn-primary" type="button">Compile to SFT</button>
             <button id="validate-btn" class="btn" type="button">Validate adapter</button>
           </div>
           <div id="compile-output" style="margin-top:8px;"></div>
@@ -991,7 +991,7 @@
       <div class="modal-head">
         <h2 id="adapter-drill-title">Adapter</h2>
         <span class="modal-meta" id="adapter-drill-meta"></span>
-        <button class="btn btn-sm primary" id="adapter-drill-load" type="button">Load</button>
+        <button class="btn btn-sm btn-primary" id="adapter-drill-load" type="button">Load</button>
         <button class="btn btn-sm" id="adapter-drill-eval" type="button">Run eval…</button>
         <button class="modal-close" id="adapter-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>

--- a/crates/kiln-server/src/ui/styles.css
+++ b/crates/kiln-server/src/ui/styles.css
@@ -187,6 +187,8 @@ code {
 button { font: inherit; color: inherit; }
 button, input, select, textarea { font-family: inherit; }
 .tabular-nums { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum' 1; }
+/* Secondary helper text; many call sites refine via inline style (inline wins). */
+.hint { color: var(--text-muted); font-size: var(--text-xs); }
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
@@ -787,13 +789,16 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   outline-offset: -2px;
 }
 
-.btn-primary {
+/* .btn.primary is a legacy token alias — keep stragglers styled */
+.btn-primary,
+.btn.primary {
   background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600));
   border-color: var(--kiln-700);
   color: white;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 2px 8px rgba(249, 115, 22, 0.18);
 }
-.btn-primary:hover:not(:disabled) {
+.btn-primary:hover:not(:disabled),
+.btn.primary:hover:not(:disabled) {
   background: linear-gradient(180deg, var(--kiln-400), var(--kiln-500));
   border-color: var(--kiln-600);
   color: white;
@@ -1728,7 +1733,6 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   background: var(--ink-850);
 }
 .empty a { font-weight: 500; }
-.empty .api-failure { background: var(--danger-bg); border-color: var(--danger-bd); }
 .empty.api-failure { border-color: var(--danger-bd); background: var(--danger-bg); }
 
 /* =====================================================================


### PR DESCRIPTION
Wave 1 of the UI overhaul (roadmap PR 9 of 25).

17 call-to-action buttons across `index.html` (7) and `app.js` templates (10, including a conditional ternary token and a `classList.toggle('primary', …)` in the adapter drill) used `class="btn primary"` — but only `.btn-primary` exists in the stylesheet, so all of them rendered as plain gray buttons. Among them: "Synthesize eval", "Create judgment", "Compile", and the adapter drill's Load.

- All 17 sites normalized to the canonical token; zero remain (word-boundary scan confirms).
- `.btn.primary` added as a **grouped alias selector** on the same rules as `.btn-primary` (base + hover) so a future straggler still renders — grouped, not duplicated, so it can never drift.
- `.hint` rule added (`--text-muted` / `--text-xs`): 74 usages existed with no backing rule; the 35 with inline refinements still win.
- Deleted the dead `.empty .api-failure` descendant selector — the only emission has both classes on one element, and its declarations were byte-identical to the surviving `.empty.api-failure` compound rule.

Verified with puppeteer computed styles: the broken CTAs go from the plain `.btn` surface (`rgb(29,27,23)`, no gradient) to the accent gradient (`linear-gradient(rgb(249,115,22), rgb(234,88,12))`); a synthetic legacy `btn primary` element renders identically via the alias. Full UI smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)