### PR TITLE
Train-drill modal Stop works for running jobs — same cooperative cancel as the queue card

### DIFF
--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -462,7 +462,7 @@ impl ApiError {
             status: StatusCode::CONFLICT,
             code: "training_job_not_cancellable",
             message: format!("Cannot cancel job '{job_id}': current state is {state}"),
-            hint: "Only jobs in 'queued' state can be cancelled. Running jobs must complete.",
+            hint: "DELETE /v1/train/queue/{job_id} cancels queued jobs immediately and stops running jobs cooperatively (the trainer aborts at the next step boundary). Jobs already in a terminal state can only be deleted via DELETE /v1/train/jobs/{job_id}.",
             retry_after_seconds: None,
         }
     }

--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -7280,8 +7280,11 @@ async function fetchTrainDrill() {
       stopBtn.hidden = false;
       if (deleteBtn) deleteBtn.hidden = true;
     } else if (stateLow === 'running') {
-      stopBtn.disabled = true;
-      stopBtn.title = 'Cancellation of running training jobs is not yet supported.';
+      // Running jobs are stoppable too — DELETE /v1/train/queue/{id} sets
+      // the cooperative cancel flag and the trainer aborts at the next
+      // step boundary. Same path as the queue card's Stop button.
+      stopBtn.disabled = false;
+      stopBtn.title = 'Stop at the next training step';
       stopBtn.hidden = false;
       if (deleteBtn) deleteBtn.hidden = true;
     } else {
@@ -7293,6 +7296,9 @@ async function fetchTrainDrill() {
       }
     }
     stopBtn.dataset.jobId = j.job_id;
+    // The click handler words its confirm() by state (queued = removed
+    // from queue immediately; running = cooperative stop at the next step).
+    stopBtn.dataset.jobState = stateLow;
 
     document.getElementById('train-drill-content').innerHTML = renderTrainDrillBody(j);
     const curveEl = document.getElementById('train-drill-curve-host');
@@ -7391,15 +7397,23 @@ document.getElementById('train-drill-close')?.addEventListener('click', closeTra
 document.getElementById('train-drill-modal')?.addEventListener('click', ev => {
   if (ev.target.id === 'train-drill-modal') closeTrainDrillModal();
 });
-document.getElementById('train-drill-stop')?.addEventListener('click', () => {
-  const jobId = document.getElementById('train-drill-stop').dataset.jobId;
+document.getElementById('train-drill-stop')?.addEventListener('click', async () => {
+  const stopBtn = document.getElementById('train-drill-stop');
+  const jobId = stopBtn.dataset.jobId;
   if (!jobId) return;
-  if (!confirm('Cancel queued job?')) return;
+  const running = stopBtn.dataset.jobState === 'running';
+  const msg = running
+    ? 'Stop this running job at the next training step?'
+    : 'Cancel queued job?';
+  if (!confirm(msg)) return;
   // Reuse the in-flight set + toast + pollTraining refresh that
   // window.cancelJob already implements; calling DELETE directly
-  // would let rapid clicks fire duplicate requests.
-  closeTrainDrillModal();
-  window.cancelJob(jobId);
+  // would let rapid clicks fire duplicate requests. Keep the modal
+  // OPEN until the DELETE resolves — a failure surfaces right here
+  // instead of in a closed modal, and on success the 1.5s drill poll
+  // repaints the state to cancelled on its own.
+  trainDrillLastKey = null; // bypass change-detection so the repaint lands
+  await window.cancelJob(jobId);
 });
 document.getElementById('train-drill-delete')?.addEventListener('click', async () => {
   const jobId = document.getElementById('train-drill-delete').dataset.jobId;

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -942,7 +942,7 @@
       <div class="modal-head">
         <h2 id="train-drill-title">Training job</h2>
         <span class="modal-meta" id="train-drill-meta"></span>
-        <button class="btn btn-sm" id="train-drill-stop" type="button" title="Cancel this training job (queued only)"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Stop</button>
+        <button class="btn btn-sm" id="train-drill-stop" type="button" title="Stop this training job — queued jobs cancel immediately, running jobs stop at the next training step"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Stop</button>
         <button class="btn btn-sm" id="train-drill-delete" type="button" hidden title="Permanently delete this terminal job from memory and from the on-disk archive"><svg class="icn icn-sm"><use href="#i-trash"></use></svg> Delete</button>
         <button class="modal-close" id="train-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
       </div>

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -278,6 +278,12 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
   availableAdapters = availableAdapters.map((adapter) => ({ ...adapter }));
   let activeAdapter = availableAdapters.find((adapter) => adapter.active)?.name || null;
   const completedTrainingJobs = [];
+  // Mirrors the real server's single running slot. SFT submit lands here
+  // (state Running) so the drill-modal Stop flow can exercise the
+  // cooperative running-job cancel; DELETE /v1/train/queue/:id moves it to
+  // `completedTrainingJobs` as Failed("cancelled by user"), exactly like
+  // the trainer aborting at the next step boundary.
+  let runningTrainingJob = null;
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const adapterRoute = parseAdapterRoute(url.pathname);
@@ -496,7 +502,51 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       return;
     }
     if (url.pathname === '/v1/train/queue' || url.pathname === '/v1/train/status') {
-      json(res, { running: null, queued: [], completed: completedTrainingJobs });
+      json(res, { running: runningTrainingJob, queued: [], completed: completedTrainingJobs });
+      return;
+    }
+    // Parameterized training-job routes, mirroring the real API:
+    //   GET    /v1/train/jobs/:id   — drill-modal detail payload
+    //   DELETE /v1/train/queue/:id  — cooperative cancel (running jobs)
+    const trainJobDetailMatch = /^\/v1\/train\/jobs\/([^/]+)$/.exec(url.pathname);
+    if (trainJobDetailMatch && req.method === 'GET') {
+      const jobId = decodeURIComponent(trainJobDetailMatch[1]);
+      const job = (runningTrainingJob && runningTrainingJob.job_id === jobId)
+        ? runningTrainingJob
+        : completedTrainingJobs.find((candidate) => candidate.job_id === jobId);
+      if (!job) {
+        res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: { code: 'training_job_not_found', message: `Training job '${jobId}' not found` } }));
+        return;
+      }
+      json(res, {
+        ...job,
+        progress: job.progress ?? 0,
+        loss_history: job.loss_history || [],
+        linked_eval_job_ids: job.linked_eval_job_ids || [],
+        auto_load: job.auto_load ?? false,
+      });
+      return;
+    }
+    const trainCancelMatch = /^\/v1\/train\/queue\/([^/]+)$/.exec(url.pathname);
+    if (trainCancelMatch && req.method === 'DELETE') {
+      const jobId = decodeURIComponent(trainCancelMatch[1]);
+      if (runningTrainingJob && runningTrainingJob.job_id === jobId) {
+        completedTrainingJobs.unshift({
+          ...runningTrainingJob,
+          state: 'Failed',
+          error: 'cancelled by user',
+        });
+        runningTrainingJob = null;
+        json(res, {
+          job_id: jobId,
+          status: 'cancelling',
+          message: 'stop requested — the trainer aborts at the next step boundary',
+        });
+        return;
+      }
+      res.writeHead(409, { 'content-type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ error: { code: 'training_job_not_cancellable', message: `Cannot cancel job '${jobId}'` } }));
       return;
     }
     if (url.pathname === '/v1/train/sft') {
@@ -511,14 +561,21 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
         apiBadRequest(res, validationError);
         return;
       }
-      completedTrainingJobs.unshift({
+      // SFT lands as the RUNNING job so the drill-modal Stop flow can
+      // assert running-job cooperative cancel against the mock.
+      runningTrainingJob = {
         job_id: 'smoke-sft',
         job_type: 'sft',
-        state: 'Completed',
-        progress: 1,
+        state: 'Running',
+        progress: 0.42,
+        current_loss: 1.234,
+        epoch: 1,
         adapter_name: body.config.output_name,
-        elapsed_secs: 1,
-      });
+        elapsed_secs: 12,
+        loss_history: [],
+        linked_eval_job_ids: [],
+        auto_load: false,
+      };
       setTimeout(() => json(res, { message: 'SFT job submitted', job_id: 'smoke-sft' }), 75);
       return;
     }
@@ -1284,6 +1341,49 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await expectActiveTrainingTab(page, 'queue', 'Submitting SFT should switch back to the training queue tab');
     await waitForPanelText(page, '#tab-queue', /smoke-sf/, 'Training queue should refresh after SFT submit');
     await waitForPanelText(page, '#tab-queue', /Adapter:\s*sft-adapter/, 'Training queue should show the submitted SFT adapter name');
+    await waitForPanelText(page, '#tab-queue', /running/, 'Training queue should show the SFT job as running');
+
+    // Drill modal for the RUNNING job: Stop must be live (running jobs are
+    // cancellable cooperatively — the trainer aborts at the next step
+    // boundary) and must route through the same DELETE /v1/train/queue/:id
+    // path the queue card uses. The modal stays open across the cancel so
+    // failures (and the cancelled repaint) surface in it.
+    await clickAndWait(page, '[data-train-job-id="smoke-sft"]', 'Could not open the train drill modal for the running SFT job');
+    await page.waitForFunction(
+      () => {
+        const modal = document.getElementById('train-drill-modal');
+        const stop = document.getElementById('train-drill-stop');
+        return modal && !modal.hidden && stop && !stop.hidden && !stop.disabled
+          && stop.title === 'Stop at the next training step'
+          && stop.dataset.jobId === 'smoke-sft';
+      },
+      { timeout: 5000 },
+    ).catch(() => fail('Train drill Stop should be enabled for a running job with title "Stop at the next training step"'));
+    page.once('dialog', async (dialog) => {
+      if (!/Stop this running job at the next training step\?/.test(dialog.message())) fail(`Unexpected stop confirmation text: ${dialog.message()}`);
+      await dialog.accept();
+    });
+    const stopRequestPromise = page.waitForRequest(
+      (request) => request.method() === 'DELETE' && request.url().endsWith('/v1/train/queue/smoke-sft'),
+      { timeout: 5000 },
+    );
+    await clickAndWait(page, '#train-drill-stop', 'Could not click the train drill Stop button');
+    await stopRequestPromise.catch(() => fail('Drill-modal Stop did not send DELETE /v1/train/queue/smoke-sft'));
+    await expectTrainingToast(page, 'Cancelled job smoke-sf');
+    const drillStillOpen = await page.$eval('#train-drill-modal', (el) => !el.hidden);
+    if (!drillStillOpen) fail('Train drill modal should stay open across Stop so failures and the cancelled state surface in it');
+    // The 1.5s drill poll repaints the now-terminal job: Stop hides, Delete shows.
+    await page.waitForFunction(
+      () => {
+        const stop = document.getElementById('train-drill-stop');
+        const del = document.getElementById('train-drill-delete');
+        return stop && stop.hidden && del && !del.hidden;
+      },
+      { timeout: 6000 },
+    ).catch(() => fail('Train drill modal did not repaint to the cancelled state after Stop'));
+    await clickAndWait(page, '#train-drill-close', 'Could not close the train drill modal');
+    await page.waitForFunction(() => document.getElementById('train-drill-modal')?.hidden === true, { timeout: 5000 })
+      .catch(() => fail('Train drill modal did not close'));
 
     await clickAndWait(page, '#training-tab-grpo', 'Could not open GRPO tab');
     await waitForVisiblePanel(page, '#tab-grpo', 'GRPO tab did not activate');


### PR DESCRIPTION
Wave 1 of the UI overhaul (roadmap PR 8 of 25).

The train-drill modal disabled Stop for running jobs with "Cancellation of running training jobs is not yet supported" — while the queue card one click away has offered exactly that (cooperative cancel: DELETE sets a flag, trainer aborts at the next step boundary) the whole time. Stale UI contradicting live capability.

- Drill Stop now routes through the same `cancelJob` path as the queue card (`DELETE /v1/train/queue/{job_id}`, in-flight dedupe, toast, repoll) — no duplicated DELETE logic. Confirm copy is state-aware ("Stop this running job at the next training step?" vs the unchanged queued wording), and the modal stays open until the DELETE resolves so failures surface in it; the 1.5s drill poll then swaps Stop→Delete on success.
- Static title in `index.html` fixed ("queued only" claim removed; the eval drill's "(queued only)" is a different endpoint and intentionally untouched).
- `error.rs` `training_job_not_cancellable` hint no longer claims running jobs must complete — documents queued/running/terminal cancel paths.

Smoke: the mock's SFT submit now lands as the running job with matching `GET /v1/train/jobs/:id` + `DELETE /v1/train/queue/:id` routes; the default scenario drills in, asserts Stop enabled with the new title, accepts the asserted confirm, asserts the DELETE fires, the modal stays open, and the poll swaps Stop→Delete. **Negative-tested**: re-disabling the button fails the new assertion. `cargo check` clean; full smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)