### PR TITLE
Evals novice path: sample dataset + corrections→dataset CTAs replace the raw-API dead-ends

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -654,13 +654,21 @@ function updateCorrFoot() {
   const btn = document.getElementById('corr-train');
   if (btn) btn.disabled = ready === 0;
 }
+// The one corrections→SFT transform. Both consumers — the Train button on the
+// Corrections card and "Build a dataset from your corrections" on the Evals
+// Datasets tab — go through here, so a correction always becomes the same
+// (user prompt, ideal answer) chat row whether it trains directly or lands in
+// a dataset first.
+function correctionsToSftExamples(corrections) {
+  return corrections.map(c => ({ messages: [{ role: 'user', content: c.user }, { role: 'assistant', content: c.ideal }] }));
+}
 async function trainFromCorrections() {
   const trainable = correctionsBasket.filter(corrTrainable);
   if (!trainable.length) { toast('Write at least one ideal answer (different from pi’s) before training', 'err'); return; }
   const nameInput = document.getElementById('corr-adapter-name');
   const name = ((nameInput && nameInput.value) || '').trim() || 'codebase-corrections';
   if (!/^[A-Za-z0-9._-]+$/.test(name)) { toast('Adapter name: letters, digits, . _ - only', 'err'); nameInput && nameInput.focus(); return; }
-  const examples = trainable.map(c => ({ messages: [{ role: 'user', content: c.user }, { role: 'assistant', content: c.ideal }] }));
+  const examples = correctionsToSftExamples(trainable);
   const btn = document.getElementById('corr-train');
   if (btn) btn.disabled = true;
   try {
@@ -4779,11 +4787,26 @@ async function refreshDatasets() {
     const el = document.getElementById('datasets-list');
     if (!datasets.length) {
       el.className = 'eval-empty';
-      setListHtml(el, 'empty', `
+      // The corrections CTA tracks the basket: enabled the moment a finished
+      // correction exists. Key on that count so the 1.5s poll repaints the
+      // button state as corrections arrive (or get their ideal answers).
+      const corrReady = (typeof correctionsBasket !== 'undefined' && typeof corrTrainable === 'function')
+        ? correctionsBasket.filter(corrTrainable).length : 0;
+      const corrHint = corrReady > 0
+        ? `Turn your ${corrReady} finished correction${corrReady === 1 ? '' : 's'} into a dataset you can build evals from`
+        : 'Nothing to build yet — when pi gives a wrong answer, add it to Corrections (Overview page) and write the ideal answer first';
+      const wrote = setListHtml(el, 'empty:' + corrReady, `
         <div class="eval-empty-icon"><svg class="icn"><use href="#i-folder"></use></svg></div>
         <div class="eval-empty-title">No datasets yet</div>
-        <div class="eval-empty-body">Upload an SFT JSONL above and Kiln will let you preview, sample, and synthesize an eval suite from it in seconds.</div>
-        <button class="eval-empty-cta" type="button" onclick="document.getElementById('dataset-name').focus()">Upload your first dataset</button>`);
+        <div class="eval-empty-body">A dataset is a list of conversations — the raw material Kiln turns into eval suites and training runs. Upload your own above, or start with one of these:</div>
+        <div style="display:flex; gap:8px; justify-content:center; flex-wrap:wrap;">
+          <button class="eval-empty-cta" type="button" id="use-sample-dataset" title="Adds a small built-in dataset of coding-agent conversations — tool calls, code review, commit messages — so you can try the eval flow without bringing your own data">Try a sample dataset</button>
+          <button class="eval-empty-cta" type="button" id="dataset-from-corrections" ${corrReady > 0 ? '' : 'disabled '}title="${escapeHtml(corrHint)}">Build a dataset from your corrections</button>
+        </div>`);
+      if (wrote) {
+        document.getElementById('use-sample-dataset')?.addEventListener('click', ev => uploadSampleDataset(ev.currentTarget));
+        document.getElementById('dataset-from-corrections')?.addEventListener('click', ev => buildDatasetFromCorrections(ev.currentTarget));
+      }
       return;
     }
     el.className = '';
@@ -5013,6 +5036,25 @@ document.getElementById('synth-save-and-run-btn')?.addEventListener('click', asy
   await doSynthesize([evalActiveAdapter || '']);
 });
 
+// Shared multipart POST for every dataset-upload surface (the form, the
+// sample-dataset CTA, the corrections builder). Matches the server contract:
+// fields `name`, `format`, optional `description`, and `file` (JSONL bytes).
+async function postDatasetUpload(name, format, description, fileOrBlob) {
+  const fd = new FormData();
+  fd.append('name', name);
+  fd.append('format', format);
+  if (description) fd.append('description', description);
+  fd.append('file', fileOrBlob, fileOrBlob.name || name + '.jsonl');
+  const res = await fetch('/v1/eval/datasets/upload', { method: 'POST', body: fd });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    const e = new Error(err.error?.message || `HTTP ${res.status}`);
+    e.code = err.error?.code;
+    throw e;
+  }
+  return res.json();
+}
+
 document.getElementById('dataset-upload-form')?.addEventListener('submit', async ev => {
   ev.preventDefault();
   const name = document.getElementById('dataset-name').value.trim();
@@ -5020,18 +5062,8 @@ document.getElementById('dataset-upload-form')?.addEventListener('submit', async
   const description = document.getElementById('dataset-description').value.trim();
   const file = document.getElementById('dataset-file').files[0];
   if (!name || !file) { toast('Name and file are required', 'err'); return; }
-  const fd = new FormData();
-  fd.append('name', name);
-  fd.append('format', format);
-  if (description) fd.append('description', description);
-  fd.append('file', file);
   try {
-    const res = await fetch('/v1/eval/datasets/upload', { method: 'POST', body: fd });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      throw new Error(err.error?.message || `HTTP ${res.status}`);
-    }
-    const m = await res.json();
+    const m = await postDatasetUpload(name, format, description, file);
     toast(`Uploaded "${m.name}" (${m.num_rows.toLocaleString()} rows)`, 'ok');
     document.getElementById('dataset-upload-form').reset();
     refreshDatasets();
@@ -5045,6 +5077,124 @@ document.getElementById('dataset-upload-form')?.addEventListener('submit', async
     }
   } catch (e) { toast('Upload failed: ' + e.message, 'err'); }
 });
+
+/* ---------- First-run CTAs: sample dataset + corrections → dataset ---------- */
+
+// A small built-in sft_chat dataset themed on realistic coding-agent traffic
+// (what pi actually sends Kiln: tool calls, code review, commit messages,
+// test writing) so "Run an eval" works in the first five minutes without
+// bringing your own data. Every row matches the server's SftConversation
+// contract exactly: messages[] of {role, content}, OpenAI-style tool_calls
+// on assistant turns, and name/tool_call_id on tool replies.
+const SAMPLE_DATASET_NAME = 'sample-coding-agent';
+function sampleDatasetRows() {
+  const call = (id, name, args) => ({ id, type: 'function', function: { name, arguments: JSON.stringify(args) } });
+  return [
+    { messages: [
+      { role: 'user', content: 'What files import the deprecated `legacy_client` module?' },
+      { role: 'assistant', content: '', tool_calls: [call('call_1', 'grep_repo', { pattern: 'legacy_client', glob: '**/*.rs' })] },
+      { role: 'tool', name: 'grep_repo', tool_call_id: 'call_1', content: 'src/api/handlers.rs:12\nsrc/sync/worker.rs:7\ntests/integration/client_test.rs:3' },
+      { role: 'assistant', content: 'Three files still import `legacy_client`: src/api/handlers.rs, src/sync/worker.rs, and tests/integration/client_test.rs. The two src/ call sites need migrating to `TokenStore` before the module can be removed; the test can be deleted with it.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Run the cache tests and tell me if anything fails.' },
+      { role: 'assistant', content: '', tool_calls: [call('call_2', 'run_tests', { package: 'cache', filter: '' })] },
+      { role: 'tool', name: 'run_tests', tool_call_id: 'call_2', content: 'running 14 tests\ntest read_through_hit ... ok\ntest eviction_lru ... FAILED\n13 passed; 1 failed' },
+      { role: 'assistant', content: 'One failure: `eviction_lru`. The test expects the least-recently-used entry to be evicted first, but the current implementation evicts by insertion order. The fix is to touch the entry timestamp on read, not just on write.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'What does the retry helper in src/net/retry.rs actually do?' },
+      { role: 'assistant', content: '', tool_calls: [call('call_3', 'read_file', { path: 'src/net/retry.rs' })] },
+      { role: 'tool', name: 'read_file', tool_call_id: 'call_3', content: 'pub async fn with_retry<F, T>(op: F, max: u32) -> Result<T> { /* exponential backoff, jitter 0-50ms, caps at 5s */ }' },
+      { role: 'assistant', content: '`with_retry` wraps an async operation with exponential backoff: it retries up to `max` times, doubling the delay each attempt with 0-50ms of jitter, capped at 5 seconds per wait. Errors from the final attempt propagate to the caller unchanged.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Generate a conventional-commit message for this change: swapped the blocking Mutex for an async RwLock in cache.rs so reads no longer serialize.' },
+      { role: 'assistant', content: 'fix(cache): replace blocking Mutex with async RwLock so concurrent reads no longer serialize' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Review this diff and flag anything risky: the PR holds a `.read()` guard across an `await` on the network fetch in cache.rs line 88.' },
+      { role: 'assistant', content: 'Risky: holding the RwLock read guard across the awaited network fetch blocks every writer for the full request latency, and can deadlock if the fetch path ever takes the write lock. Scope the guard to the lookup only — clone the value out, drop the guard, then await the fetch.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'How do I store handlers with different concrete types in one Vec in Rust?' },
+      { role: 'assistant', content: 'Use trait objects: define a common trait and store boxed instances — `Vec<Box<dyn Handler>>`. Each handler implements `Handler`, and you push `Box::new(MyHandler)` into the vec. If the handlers are cloned or shared across threads, use `Vec<Arc<dyn Handler + Send + Sync>>` instead.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Write a unit test for the rate limiter covering burst then steady-state.' },
+      { role: 'assistant', content: '#[tokio::test]\nasync fn limiter_allows_burst_then_throttles() {\n    let lim = RateLimiter::new(5, Duration::from_secs(1));\n    for _ in 0..5 {\n        assert!(lim.try_acquire());\n    }\n    assert!(!lim.try_acquire(), "burst budget should be exhausted");\n    tokio::time::sleep(Duration::from_secs(1)).await;\n    assert!(lim.try_acquire(), "tokens should refill after the window");\n}' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Explain what this query does: SELECT user_id, COUNT(*) AS n FROM events WHERE ts > now() - interval \'7 days\' GROUP BY user_id HAVING COUNT(*) > 100;' },
+      { role: 'assistant', content: 'It finds heavy users from the last week: it filters `events` to rows newer than 7 days, groups them by `user_id`, counts each user\'s events, and keeps only users with more than 100 events. The result is one row per heavy user with their event count `n`.' },
+    ] },
+    { messages: [
+      { role: 'user', content: 'Why would the integration test `flaky_reconnect` fail intermittently but pass on retry?' },
+      { role: 'assistant', content: 'The test asserts reconnection within 100ms, but the client\'s backoff adds random jitter that can push the first retry to ~150ms under load. Either widen the assertion window to cover worst-case jitter or inject a deterministic backoff in tests.' },
+    ] },
+    { messages: [
+      { role: 'system', content: 'You are a careful coding agent working in a Rust codebase.' },
+      { role: 'user', content: 'Refactor src/auth/session.rs to use the new TokenStore trait. What is your plan?' },
+      { role: 'assistant', content: 'Plan: 1) add a `store: Arc<dyn TokenStore>` field to `Session` and thread it through `Session::new`; 2) replace the three direct `token_db` calls in handlers/ with `self.store` methods; 3) keep the old constructor behind a deprecated shim for one release; 4) run the auth test suite and fix call sites until green.' },
+    ] },
+  ];
+}
+
+// "Try a sample dataset" — upload the embedded rows through the same endpoint
+// a real JSONL file goes through, then hand off to the eval-suite synthesizer
+// (that is the next step on the eval golden path).
+async function uploadSampleDataset(btn) {
+  if (btn) btn.disabled = true;
+  try {
+    const jsonl = sampleDatasetRows().map(r => JSON.stringify(r)).join('\n') + '\n';
+    const blob = new Blob([jsonl], { type: 'application/jsonl' });
+    const m = await postDatasetUpload(SAMPLE_DATASET_NAME, 'sft_chat',
+      'Built-in sample: coding-agent conversations with tool calls', blob);
+    refreshDatasets();
+    toast(`Sample dataset added (${m.num_rows} rows) — next: synthesize an eval suite from it`, 'ok');
+    openSynthPanel(m.name);
+  } catch (e) {
+    if (e.code === 'dataset_exists' || /already exists/i.test(e.message || '')) {
+      toast('The sample dataset is already here — synthesize an eval suite from it', 'info');
+      refreshDatasets();
+      openSynthPanel(SAMPLE_DATASET_NAME);
+    } else {
+      toast('Could not add the sample dataset: ' + e.message, 'err');
+      if (btn) btn.disabled = false;
+    }
+  }
+}
+
+// "Build a dataset from your corrections" — the durable corrections store
+// (your hand-written ideal answers, including rows already trained into an
+// adapter) becomes an sft_chat dataset via the SAME transform the Corrections
+// card trains with, so you can eval exactly what you taught.
+async function buildDatasetFromCorrections(btn) {
+  if (btn) btn.disabled = true;
+  try {
+    let rows = correctionsBasket;
+    try {
+      const d = await api('/v1/corrections?include_trained=1');
+      if (d && Array.isArray(d.corrections)) rows = d.corrections;
+    } catch (_) { /* server store unreachable — the local basket still works */ }
+    const finished = rows.filter(corrTrainable);
+    if (!finished.length) {
+      toast('Your corrections need ideal answers first — open Corrections on the Overview page and write what pi should have said', 'info');
+      if (btn) btn.disabled = false;
+      return;
+    }
+    const jsonl = correctionsToSftExamples(finished).map(r => JSON.stringify(r)).join('\n') + '\n';
+    const name = 'corrections-' + new Date().toISOString().replace(/[-:T]/g, '').slice(0, 12);
+    const m = await postDatasetUpload(name, 'sft_chat',
+      'Your corrections: each row pairs a prompt with the answer you said pi should have given', new Blob([jsonl], { type: 'application/jsonl' }));
+    refreshDatasets();
+    toast(`Dataset "${m.name}" built from ${finished.length} correction${finished.length === 1 ? '' : 's'} — next: synthesize an eval suite from it`, 'ok');
+    openSynthPanel(m.name);
+  } catch (e) {
+    toast('Could not build the dataset: ' + e.message, 'err');
+    if (btn) btn.disabled = false;
+  }
+}
 
 // Inline "uploaded — what next?" strip on the Datasets tab. Primary action is
 // training (that's why most people upload SFT/GRPO data); synthesizing an eval
@@ -5090,8 +5240,8 @@ async function refreshSuites() {
       setListHtml(el, 'empty', `
         <div class="eval-empty-icon"><svg class="icn"><use href="#i-target"></use></svg></div>
         <div class="eval-empty-title">No eval suites yet</div>
-        <div class="eval-empty-body">A suite is a named collection of (prompt, target, scorer) triplets. Synthesize one from a dataset, or POST an EvalSuite document to <code>/v1/eval/suites</code>.</div>
-        <button class="eval-empty-cta" type="button" onclick="document.getElementById('evals-tab-datasets').click()">Browse datasets</button>`);
+        <div class="eval-empty-body">A suite is a set of prompts with expected answers and a scorer — your model's report card. Create one from a dataset on the Datasets tab; no data yet? The built-in sample dataset works out of the box.</div>
+        <button class="eval-empty-cta" type="button" title="Synthesize a suite from any dataset — power users can also POST an EvalSuite document to /v1/eval/suites" onclick="document.getElementById('evals-tab-datasets').click()">Create a suite from a dataset</button>`);
       return;
     }
     el.className = '';

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -645,7 +645,7 @@
         <div style="font-size: 14px; font-weight: 600; color: var(--text); margin-bottom: 4px;">Welcome to Evals</div>
         <div style="font-size: 12px; color: var(--text-2); line-height: 1.5;">
           Three steps to your first eval result:
-          <strong style="color: var(--kiln-300);">①</strong> upload an SFT JSONL on the Datasets tab,
+          <strong style="color: var(--kiln-300);">①</strong> add a dataset on the Datasets tab — upload a JSONL, or just click "Try a sample dataset",
           <strong style="color: var(--kiln-300);">②</strong> click "Synthesize" to turn it into an eval suite,
           <strong style="color: var(--kiln-300);">③</strong> click "Run" — Kiln will evaluate against the active adapter and show you the per-example breakdown.
           The Judgments tab adds a flywheel where your A/B picks train a local judge LoRA.

--- a/crates/kiln-server/src/ui/styles.css
+++ b/crates/kiln-server/src/ui/styles.css
@@ -2411,6 +2411,10 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-sm);
 }
 .eval-empty .eval-empty-cta:hover { background: var(--accent-hover); }
+/* Disabled CTA (e.g. "Build a dataset from your corrections" with an empty
+   basket) stays visible-but-quiet; the title attribute explains what unlocks it. */
+.eval-empty .eval-empty-cta:disabled { opacity: 0.55; cursor: not-allowed; }
+.eval-empty .eval-empty-cta:disabled:hover { background: var(--accent); }
 
 /* Tag chips */
 .tag-chip {

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -249,6 +249,92 @@ function parseAdapterRoute(pathname) {
   return { name: decodeURIComponent(match[1]), action: match[2] || null };
 }
 
+// Mirrors api/eval.rs upload_dataset: multipart fields `name`, `format`
+// (sft_chat | grpo_groups | raw), optional `description`, and `file` whose
+// every JSONL line must parse into the SftConversation contract — messages[]
+// of { role, content?, tool_calls?, name?, tool_call_id? }.
+function validateEvalDatasetUploadRequest(req, body) {
+  if (req.method !== 'POST') return { status: 405, detail: 'Use POST for dataset upload' };
+  const contentType = req.headers['content-type'] || '';
+  if (!/^multipart\/form-data\b/i.test(contentType)) {
+    return { status: 400, detail: 'Dataset upload should use multipart/form-data' };
+  }
+  const parts = parseMultipartFormData(contentType, body);
+  if (!parts) return { status: 400, detail: 'Dataset upload should include a multipart boundary' };
+  const name = parts.find((part) => part.name === 'name')?.content.toString('utf8').trim();
+  const format = parts.find((part) => part.name === 'format')?.content.toString('utf8').trim() || 'sft_chat';
+  const description = parts.find((part) => part.name === 'description')?.content.toString('utf8') || null;
+  const file = parts.find((part) => part.name === 'file');
+  if (!isPathSafeAdapterDirectoryName(name) || name.includes('..')) return { status: 400, detail: 'Dataset name should be path-safe' };
+  if (!['sft_chat', 'sft', 'grpo_groups', 'grpo', 'raw'].includes(format)) return { status: 400, detail: `unknown format \`${format}\`` };
+  if (!file) return { status: 400, detail: 'Dataset upload should include a file field' };
+  const jsonl = file.content.toString('utf8');
+  const lines = jsonl.split('\n').filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return { status: 400, detail: 'Dataset file should contain at least one JSONL row' };
+  const stats = {
+    num_assistant_turns: 0,
+    num_with_tool_calls: 0,
+    num_tool_messages: 0,
+    max_messages_per_conv: 0,
+    max_content_chars: 0,
+    avg_messages_per_conv: 0,
+    sample_role_patterns: [],
+  };
+  let totalMessages = 0;
+  if (format !== 'raw') {
+    for (const [index, line] of lines.entries()) {
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch (error) {
+        return { status: 400, detail: `line ${index + 1} is not valid JSON: ${error.message}` };
+      }
+      if (!Array.isArray(row.messages) || row.messages.length === 0) {
+        return { status: 400, detail: `line ${index + 1} should have a non-empty messages array` };
+      }
+      for (const message of row.messages) {
+        if (typeof message.role !== 'string' || message.role.length === 0) {
+          return { status: 400, detail: `line ${index + 1} has a message without a string role` };
+        }
+        if (message.content !== undefined && typeof message.content !== 'string') {
+          return { status: 400, detail: `line ${index + 1} has a non-string content field` };
+        }
+        if (message.tool_calls !== undefined && !Array.isArray(message.tool_calls)) {
+          return { status: 400, detail: `line ${index + 1} has a non-array tool_calls field` };
+        }
+        if (message.role === 'tool' && typeof message.tool_call_id !== 'string') {
+          return { status: 400, detail: `line ${index + 1} has a tool reply without tool_call_id` };
+        }
+        if (message.role === 'assistant') {
+          stats.num_assistant_turns += 1;
+          if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) stats.num_with_tool_calls += 1;
+        }
+        if (message.role === 'tool') stats.num_tool_messages += 1;
+        stats.max_content_chars = Math.max(stats.max_content_chars, (message.content || '').length);
+      }
+      totalMessages += row.messages.length;
+      stats.max_messages_per_conv = Math.max(stats.max_messages_per_conv, row.messages.length);
+      if (stats.sample_role_patterns.length < 5) {
+        stats.sample_role_patterns.push(row.messages.map((message) => message.role).join(' '));
+      }
+    }
+    stats.avg_messages_per_conv = totalMessages / lines.length;
+  }
+  const now = new Date().toISOString();
+  return {
+    manifest: {
+      name,
+      format: format === 'sft' ? 'sft_chat' : format === 'grpo' ? 'grpo_groups' : format,
+      description,
+      num_rows: lines.length,
+      size_bytes: file.content.length,
+      created_at: now,
+      updated_at: now,
+      stats,
+    },
+  };
+}
+
 const defaultAvailableAdapters = [
   { name: 'adapter-alpha', active: false, size_bytes: 4096 },
   { name: 'adapter-beta', active: false, size_bytes: 8192 },
@@ -284,6 +370,10 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
   // `completedTrainingJobs` as Failed("cancelled by user"), exactly like
   // the trainer aborting at the next step boundary.
   let runningTrainingJob = null;
+  // Eval datasets created through POST /v1/eval/datasets/upload (the
+  // "Try a sample dataset" golden path) — GET /v1/eval/datasets reflects
+  // them so the Datasets list refresh after upload is observable.
+  const uploadedEvalDatasets = [];
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const adapterRoute = parseAdapterRoute(url.pathname);
@@ -640,7 +730,30 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       return;
     }
     if (url.pathname === '/v1/eval/datasets') {
-      json(res, { datasets: [] });
+      json(res, { datasets: uploadedEvalDatasets });
+      return;
+    }
+    // Mirrors api/eval.rs upload_dataset: multipart in, DatasetManifest out
+    // (the manifest JSON is the entire response body, not an envelope).
+    if (url.pathname === '/v1/eval/datasets/upload') {
+      const body = await readBufferBody(req);
+      const result = validateEvalDatasetUploadRequest(req, body);
+      if (result.detail) {
+        res.writeHead(result.status, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: { code: 'dataset_invalid', message: result.detail, hint: '' } }));
+        return;
+      }
+      if (uploadedEvalDatasets.some((dataset) => dataset.name === result.manifest.name)) {
+        res.writeHead(409, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: {
+          code: 'dataset_exists',
+          message: `Eval dataset '${result.manifest.name}' already exists`,
+          hint: 'Delete or rename the existing dataset, or use a different name.',
+        } }));
+        return;
+      }
+      uploadedEvalDatasets.push(result.manifest);
+      json(res, result.manifest);
       return;
     }
     if (url.pathname === '/v1/judgments') {
@@ -1416,6 +1529,56 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await clickAndWait(page, '#chat-clear', 'Could not click Quick Inference clear');
     await waitForPanelText(page, '#chat-output', /Send a message to test inference\./, 'Quick Inference clear should restore the empty state');
     await expectDisabled(page, '#copy-chat-response', true, 'Copy response should disable after clearing chat');
+
+    // ---- Evals golden path: a first-five-minutes user with no data must not
+    // dead-end. Suites empty state routes to Datasets (no raw-API copy);
+    // Datasets empty state offers a one-click sample upload through the real
+    // endpoint, then hands off to suite synthesis.
+    await goToPrimaryTab(page, 'evals');
+    await clickAndWait(page, '#evals-tab-suites', 'Could not open the Suites sub-tab');
+    await waitForPanelText(page, '#suites-list', /No eval suites yet/, 'Suites empty state missing');
+    await waitForPanelText(page, '#suites-list', /report card/, 'Suites empty state should explain suites in plain language');
+    const suitesEmptyText = await page.$eval('#suites-list', (el) => el.textContent || '');
+    if (/POST|\/v1\/eval\/suites/.test(suitesEmptyText)) fail('Suites empty state should not surface raw API instructions in primary copy');
+    const suitesCtaTitle = await page.$eval('#suites-list .eval-empty-cta', (el) => el.title).catch(() => '');
+    if (!suitesCtaTitle.includes('/v1/eval/suites')) fail('Suites empty-state CTA should keep the API mention as a title for power users');
+    await clickAndWait(page, '#suites-list .eval-empty-cta', 'Could not click the suites empty-state CTA');
+    await waitForVisiblePanel(page, '#tab-evals-datasets', 'Suites empty-state CTA should land on the Datasets sub-tab');
+
+    await waitForPanelText(page, '#datasets-list', /No datasets yet/, 'Datasets empty state missing');
+    await waitForPanelText(page, '#datasets-list', /Try a sample dataset/, 'Datasets empty state should offer the sample dataset CTA');
+    await expectDisabled(page, '#dataset-from-corrections', true, 'Corrections dataset CTA should be disabled while the basket is empty');
+    const corrCtaHint = await page.$eval('#dataset-from-corrections', (el) => el.title);
+    if (!/write the ideal answer/i.test(corrCtaHint)) fail(`Disabled corrections CTA should explain what unlocks it, got: ${JSON.stringify(corrCtaHint)}`);
+
+    const sampleUploadRequestPromise = page.waitForRequest(
+      (request) => request.method() === 'POST' && request.url().endsWith('/v1/eval/datasets/upload'),
+      { timeout: 5000 },
+    );
+    const sampleUploadResponsePromise = page.waitForResponse(
+      (response) => response.url().endsWith('/v1/eval/datasets/upload'),
+      { timeout: 5000 },
+    );
+    await clickAndWait(page, '#use-sample-dataset', 'Could not click Try a sample dataset');
+    await sampleUploadRequestPromise.catch(() => fail('Try a sample dataset did not POST /v1/eval/datasets/upload'));
+    const sampleUploadResponse = await sampleUploadResponsePromise.catch(() => fail('Sample dataset upload got no response'));
+    if (sampleUploadResponse.status() !== 200) {
+      const detail = await sampleUploadResponse.text().catch(() => '');
+      fail(`Sample dataset upload should return 200 (mock validates every JSONL row against the SftConversation contract), got ${sampleUploadResponse.status()}: ${detail}`);
+    }
+    await expectTrainingToast(page, 'Sample dataset added (10 rows) — next: synthesize an eval suite from it');
+    await waitForPanelText(page, '#datasets-list', /sample-coding-agent/, 'Datasets list should refresh with the uploaded sample');
+    // The handoff lands on the next step of the golden path: the synthesize
+    // panel, pre-filled from the sample dataset.
+    await page.waitForFunction(
+      () => {
+        const panel = document.getElementById('synthesize-panel');
+        return panel && !panel.hidden;
+      },
+      { timeout: 5000 },
+    ).catch(() => fail('Sample upload should open the synthesize panel (create a suite is the next step)'));
+    const synthSuiteName = await page.$eval('#synth-suite-name', (el) => el.value);
+    if (synthSuiteName !== 'sample-coding-agent-eval') fail(`Synthesize panel should pre-fill the suite name from the sample dataset, got ${JSON.stringify(synthSuiteName)}`);
 
   } finally {
     await browser.close();


### PR DESCRIPTION
Wave 2 of the UI overhaul (roadmap PR 13 of 25).

The "Run an eval" golden-path step dead-ended for a first-five-minutes user: the Datasets empty state demanded a hand-authored SFT JSONL, and the Suites empty state literally instructed them to POST an EvalSuite document to the API. Training has "Try a sample"; Evals now has the equivalent — plus a bridge from data the dashboard already collected.

- **"Try a sample dataset"**: 10 embedded `sft_chat` rows of realistic coding-agent traffic (tool-calling conversations with `tool_calls`/`tool_call_id` replies, code review, commit messages, flaky-test debugging…), uploaded through the existing `POST /v1/eval/datasets/upload`; on success the list refreshes, the toast names the next step, and the synthesize-suite panel opens pre-filled.
- **"Build a dataset from your corrections"**: the corrections→SFT transform that already fed training is extracted as a shared `correctionsToSftExamples()` and reused — `GET /v1/corrections?include_trained=1`, filter via the existing `corrTrainable`, upload. Disabled with a live count-keyed hint when the basket is empty.
- Suites empty state: plain-language CTA to Datasets; the API mention survives as a `title` for power users.

The sample JSONL was validated against the **actual Rust parser** (`SftConversation` per line, throwaway kiln-eval test), and the smoke mock now multipart-parses and row-validates every upload on each run. The new smoke walk asserts the full flow: CTA → POST → manifest response → toast → list refresh → pre-filled synth panel. Full UI smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)