### PR TITLE
Connect panel tells the truth: dashboard traffic isn't an agent, cold starts don't bake stale model ids

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -478,6 +478,7 @@ fn request_record_from_req(
         thinking_mode: Some(thinking_mode_for_request(req).to_string()),
         prefix_cache: Some("unknown".to_string()),
         user_agent: req.user_agent.clone(),
+        client: req.client.clone(),
         ..RequestRecord::default()
     }
 }
@@ -491,6 +492,19 @@ fn extract_user_agent(headers: &HeaderMap) -> Option<String> {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(|s| s.chars().take(200).collect())
+}
+
+/// Extract the `X-Kiln-Client` self-identification header. The /ui dashboard
+/// sends `dashboard` on its own inference traffic so the journey strip /
+/// Connect panel can tell it apart from a real agent. Bounded like
+/// `extract_user_agent` so a hostile header can't bloat the ring.
+fn extract_client(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-kiln-client")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(64).collect())
 }
 
 const REASONING_OPEN_TAG: &str = "<think>\n";
@@ -1411,6 +1425,7 @@ fn record_failed_chat_completion(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             prompt_tokens: prompt_tokens.min(u32::MAX as usize) as u32,
             completion_tokens: 0,
             duration_ms: request_start.elapsed().as_millis() as u64,
@@ -2726,6 +2741,7 @@ fn response_from_cached_completion(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -2829,6 +2845,7 @@ fn response_from_cached_chat_choices(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: cached.prompt_tokens as u32,
@@ -2913,6 +2930,7 @@ fn streaming_response_from_cached_completion(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -3410,6 +3428,12 @@ pub struct ChatCompletionRequest {
     /// JSON body) so the /ui dashboard can attribute traffic per agent.
     #[serde(skip)]
     pub user_agent: Option<String>,
+    /// First-party self-identification from the `X-Kiln-Client` header,
+    /// injected by the handler (never from the JSON body). The /ui dashboard
+    /// sends `dashboard` on its own traffic (Test connection, Playground,
+    /// Compare) so onboarding milestones don't mistake it for an agent.
+    #[serde(skip)]
+    pub client: Option<String>,
     /// Number of completions to generate for this prompt. Defaults to 1.
     /// Non-streaming `n>1` reuses the same single-output fast paths below.
     #[serde(default)]
@@ -3897,6 +3921,7 @@ async fn chat_completions(
     // so the dashboard can show per-client traffic. Header-only, never trusted
     // from the body.
     req.user_agent = extract_user_agent(&headers);
+    req.client = extract_client(&headers);
     state.metrics.inc_active();
 
     let result = chat_completions_inner(&state, req).await;
@@ -5254,6 +5279,7 @@ async fn generate_real_batched(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -5348,6 +5374,7 @@ async fn generate_real_batched_streaming(
     let prompt_full = truncate_chars(&prompt_text_full, FULL_BODY_MAX_CHARS);
     let req_adapter = req.adapter.request_adapter_name();
     let req_user_agent = req.user_agent.clone();
+    let req_client = req.client.clone();
     let req_temperature = req.temperature;
     let req_top_p = req.top_p;
     let req_max_tokens = Some(chat_request_max_tokens(req).min(u32::MAX as usize) as u32);
@@ -5384,6 +5411,7 @@ async fn generate_real_batched_streaming(
             let record = |finish_reason: String, completion: &str, completion_tokens: u32| {
                 let record = RequestRecord {
                     user_agent: req_user_agent.clone(),
+                    client: req_client.clone(),
                     id: id.clone(),
                     timestamp_unix_ms: now_unix_ms(),
                     model: model.clone(),
@@ -6127,6 +6155,7 @@ async fn generate_real(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(preview_source, COMPLETION_PREVIEW_MAX_CHARS),
             completion_full: Some(truncate_chars(preview_source, FULL_BODY_MAX_CHARS)),
             prompt_tokens: prompt_token_count as u32,
@@ -6251,6 +6280,7 @@ async fn generate_real_streaming(
     let prompt_full = truncate_chars(&prompt_text_full, FULL_BODY_MAX_CHARS);
     let req_adapter = req.adapter.request_adapter_name();
     let req_user_agent = req.user_agent.clone();
+    let req_client = req.client.clone();
     let req_temperature = req.temperature;
     let req_top_p = req.top_p;
     let req_max_tokens = Some(chat_request_max_tokens(req).min(u32::MAX as usize) as u32);
@@ -6283,6 +6313,7 @@ async fn generate_real_streaming(
             let record = |finish_reason: String, completion: &str, completion_tokens: u32| {
                 let record = RequestRecord {
                     user_agent: req_user_agent.clone(),
+                    client: req_client.clone(),
                     id: id.clone(),
                     timestamp_unix_ms: now_unix_ms(),
                     model: model.clone(),
@@ -7048,6 +7079,7 @@ async fn generate_mock(
         state,
         RequestRecord {
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             completion_preview: truncate_chars(
                 assistant_output.preview_source(),
                 COMPLETION_PREVIEW_MAX_CHARS,
@@ -8330,6 +8362,7 @@ async fn batch_completions_inner(
                         model: model.clone(),
                         messages: messages.clone(),
                         user_agent: None,
+                        client: None,
                         n: None,
                         temperature,
                         top_p,
@@ -8580,6 +8613,7 @@ async fn generate_multi_chat_response(
             model: req.model.clone(),
             messages: req.messages.clone(),
             user_agent: req.user_agent.clone(),
+            client: req.client.clone(),
             n: None,
             temperature: req.temperature,
             top_p: req.top_p,

--- a/crates/kiln-server/src/recent_requests.rs
+++ b/crates/kiln-server/src/recent_requests.rs
@@ -62,6 +62,13 @@ pub struct RequestRecord {
     /// OpenAI SDKs, curl, …). The dashboard maps it to a friendly label.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,
+    /// First-party self-identification from the `X-Kiln-Client` request
+    /// header. The /ui dashboard sends `dashboard` on its own traffic
+    /// (Test connection, Playground, Compare) so onboarding milestones like
+    /// "Agent connected" can tell dashboard-originated requests apart from a
+    /// real external agent. Additive: absent for every other caller.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
 }
 
 /// Cap on full prompt / completion body size kept in the ring (chars).
@@ -215,6 +222,20 @@ mod tests {
     fn capacity_is_clamped_to_at_least_one() {
         let ring = RecentRequestsRing::new(0);
         assert_eq!(ring.capacity(), 1);
+    }
+
+    #[test]
+    fn client_field_is_additive_serialized_only_when_present() {
+        // Absent for every normal caller — cold rings / old clients see no
+        // new key. Present verbatim when a first-party caller (the /ui
+        // dashboard) self-identifies via X-Kiln-Client.
+        let mut record = make_record("a");
+        let json = serde_json::to_value(&record).unwrap();
+        assert!(json.get("client").is_none());
+
+        record.client = Some("dashboard".to_owned());
+        let json = serde_json::to_value(&record).unwrap();
+        assert_eq!(json["client"], "dashboard");
     }
 
     #[test]

--- a/crates/kiln-server/src/request_log.rs
+++ b/crates/kiln-server/src/request_log.rs
@@ -134,6 +134,11 @@ pub struct RequestLogEntry {
     pub streamed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,
+    /// First-party self-identification from the `X-Kiln-Client` header (the
+    /// /ui dashboard sends `dashboard` on its own traffic) so the mining
+    /// pipeline can exclude dashboard-originated rows. Absent otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
     /// LoRA adapter that actually served this response (from the
     /// `x-kiln-loaded-adapter` response header); `None` = base model.
     /// Lets the mining pipeline split the corpus per adapter.
@@ -365,6 +370,15 @@ pub async fn tap(State(state): State<AppState>, req: Request<Body>, next: Next) 
         .get(axum::http::header::USER_AGENT)
         .and_then(|v| v.to_str().ok())
         .map(|v| v.chars().take(256).collect::<String>());
+    // `X-Kiln-Client` follows the same path as User-Agent: the /ui dashboard
+    // self-identifies (`dashboard`) so its own traffic is distinguishable.
+    let client = req
+        .headers()
+        .get("x-kiln-client")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|v| v.chars().take(64).collect::<String>());
     let max_capture = state.request_log_max_capture_bytes;
 
     let (parts, body) = req.into_parts();
@@ -408,6 +422,7 @@ pub async fn tap(State(state): State<AppState>, req: Request<Body>, next: Next) 
             duration_ms: started.elapsed().as_millis() as u64,
             streamed: false,
             user_agent,
+            client,
             adapter,
             request: request_value,
             response: response_value,
@@ -427,6 +442,7 @@ pub async fn tap(State(state): State<AppState>, req: Request<Body>, next: Next) 
         status,
         started,
         user_agent,
+        client,
         adapter,
         request_value,
         request_truncated,
@@ -473,6 +489,7 @@ struct SseTapCtx {
     status: u16,
     started: Instant,
     user_agent: Option<String>,
+    client: Option<String>,
     adapter: Option<String>,
     request_value: serde_json::Value,
     request_truncated: bool,
@@ -510,6 +527,7 @@ impl SseTapCtx {
             duration_ms: self.started.elapsed().as_millis() as u64,
             streamed: true,
             user_agent: self.user_agent.take(),
+            client: self.client.take(),
             adapter: self.adapter.take(),
             request: std::mem::take(&mut self.request_value),
             response,
@@ -700,6 +718,7 @@ mod tests {
             duration_ms: 5,
             streamed: false,
             user_agent: Some("test".into()),
+            client: None,
             adapter: None,
             request: serde_json::json!({ "messages": [{"role": "user", "content": "x".repeat(payload_size)}] }),
             response: serde_json::json!({ "choices": [{"message": {"role": "assistant", "content": "y"}}] }),

--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -233,6 +233,20 @@ function renderConnectSnippets(active) {
   }).join('');
 }
 
+// Push a freshly-resolved served-model id into every copyable surface: the
+// model-id field and the pi/opencode/SDK/curl snippets. Cold starts open the
+// dashboard before /v1/models can answer, so the panel initially renders the
+// fallback id — this silently upgrades it the moment the real id arrives.
+// Re-renders only on an actual change, preserving the selected tab.
+function applyServedModelId(id) {
+  if (!id || connectModelId === id) return;
+  connectModelId = id;
+  const modelEl = document.getElementById('connect-model');
+  if (modelEl) { modelEl.textContent = id; modelEl.title = id; }
+  const activeTab = document.querySelector('.connect-tabs .tab.active')?.dataset.connectTab || 'pi';
+  renderConnectSnippets(activeTab);
+}
+
 function selectConnectTab(key) {
   document.querySelectorAll('.connect-tabs .tab').forEach(t => {
     const on = t.dataset.connectTab === key;
@@ -268,13 +282,17 @@ function openConnect() {
   if (panel) panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
-// Auto-collapse to the slim "connected" bar once traffic flows (unless the
-// operator has manually picked a state this session).
+// Auto-collapse to the slim "connected" bar once EXTERNAL traffic flows
+// (unless the operator has manually picked a state this session). The
+// dashboard's own requests (Test connection, Playground — `client:
+// "dashboard"`) don't prove anything connected and must not hide the setup
+// snippets a first-run user still needs.
 function updateConnectSummary(rows) {
-  const n = Array.isArray(rows) ? rows.length : 0;
+  const external = (Array.isArray(rows) ? rows : []).filter(r => !rowIsDashboard(r));
+  const n = external.length;
   const txt = document.getElementById('connect-collapsed-text');
   if (txt && n > 0) {
-    const last = rows[0]?.timestamp_unix_ms;
+    const last = external[0]?.timestamp_unix_ms;
     txt.innerHTML = `<strong>Connected</strong> · <strong>${n}</strong> recent request${n === 1 ? '' : 's'}${last ? ' · last ' + fmtRelTime(last) : ''}`;
   }
   if (connectManualState === null && n > 0) setConnectCollapsed(true);
@@ -508,7 +526,7 @@ function addCorrectionFromRequest(r) {
   if (!r) return false;
   return addCorrectionItem({
     request_id: r.id || ('req-' + Date.now()),
-    agent: (clientFromUA(r.user_agent) || {}).label || 'client',
+    agent: (clientForRow(r) || {}).label || 'client',
     ts: r.timestamp_unix_ms || Date.now(),
     model: r.model || '', adapter: r.adapter || 'base',
     user: r.prompt_full || r.prompt_preview || '',
@@ -729,7 +747,14 @@ function updateJourneyStrip() {
   try { dismissed = localStorage.getItem(JOURNEY_KEY) === '1'; } catch {}
   const serverUp = !!lastHealth;
   const rows = recentRequestsCache || [];
-  const agentSeen = rows.some(r => { const k = clientFromUA(r.user_agent).key; return k && k !== 'unknown' && k !== 'curl'; });
+  // Only EXTERNAL traffic completes "Agent connected": the dashboard's own
+  // requests (Test connection, Playground — `client: "dashboard"`) never
+  // count, while curl DOES — a user who followed the curl tab really did
+  // connect something. When curl is the only client seen, the step carries
+  // an inline nudge to point a coding agent here next.
+  const externalKeys = rows.filter(r => !rowIsDashboard(r)).map(r => clientFromUA(r.user_agent).key);
+  const agentSeen = externalKeys.some(k => k && k !== 'unknown');
+  const curlOnly = agentSeen && externalKeys.every(k => !k || k === 'unknown' || k === 'curl');
   const adapterTrained = nonBaseAdapterCount() > 0;
   const allDone = serverUp && agentSeen && adapterTrained;
   if (dismissed || allDone) {
@@ -749,6 +774,15 @@ function updateJourneyStrip() {
     const isNext = !done && !nextMarked;
     if (isNext) nextMarked = true;
     el.classList.toggle('is-next', isNext);
+  }
+  // Inline (not hover-only) state on the agent step: when curl is the only
+  // external client seen, the milestone is honestly complete but the natural
+  // next move — pointing a real coding agent here — gets said out loud.
+  const agentSub = strip.querySelector('[data-journey="agent"] .journey-sub');
+  if (agentSub) {
+    agentSub.textContent = curlOnly
+      ? 'curl seen — point a coding agent here next'
+      : 'point pi or opencode here';
   }
 }
 document.getElementById('journey-dismiss')?.addEventListener('click', () => {
@@ -773,7 +807,9 @@ document.querySelectorAll('.journey-step').forEach(el => el.addEventListener('cl
 function updateFlywheel() {
   const set = (id, v) => { const e = document.getElementById(id); if (e) e.textContent = v; };
   const rows = recentRequestsCache || [];
-  const agents = new Set(rows.map(r => clientFromUA(r.user_agent).key));
+  // Client count means EXTERNAL clients — the dashboard's own traffic
+  // (`client: "dashboard"`) is not an agent and never inflates this node.
+  const agents = new Set(rows.filter(r => !rowIsDashboard(r)).map(r => clientFromUA(r.user_agent).key));
   set('fw-agents', agents.size || 0);
   set('fw-agents-sub', agents.size ? (agents.size === 1 ? '1 client' : agents.size + ' clients') : 'none yet');
   set('fw-traffic', rows.length || 0);
@@ -903,7 +939,10 @@ function bindFlywheel() {
 async function initConnect() {
   const baseEl = document.getElementById('connect-base-url');
   if (baseEl) { baseEl.textContent = connectBaseUrl(); baseEl.title = connectBaseUrl(); }
-  try { const m = await api('/v1/models'); const id = m?.data?.[0]?.id; if (id) connectModelId = id; } catch {}
+  // One shared resolver with the Playground: if the server is mid-cold-start
+  // this fails harmlessly and pollHealth keeps retrying until a real id
+  // arrives (applyServedModelId then upgrades the rendered snippets in place).
+  await loadServedModelId();
   const modelEl = document.getElementById('connect-model');
   if (modelEl) { modelEl.textContent = connectModelId; modelEl.title = connectModelId; }
   renderConnectSnippets('pi');
@@ -934,7 +973,7 @@ async function testConnection() {
   const t0 = performance.now();
   try {
     const res = await fetch(connectBaseUrl() + '/chat/completions', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Kiln-Client': 'dashboard' },
       body: JSON.stringify({ model: connectModelId, messages: [{ role: 'user', content: 'Reply with the single word: connected' }], max_tokens: 8, temperature: 0 }),
     });
     const ms = Math.round(performance.now() - t0);
@@ -1046,6 +1085,12 @@ async function pollHealth() {
     renderHeader(h);
     renderServerStatus(h);
     updateFlywheel();
+    // Cold-start follow-up: /v1/models may have failed (or listed nothing)
+    // while weights loaded, leaving the fallback model id baked into the
+    // Connect snippets and Playground bodies. Piggyback the retry on this
+    // 2s poll — no extra interval — until a real id resolves, then stop
+    // (the resolved flag short-circuits).
+    if (!servedModelIdResolved) loadServedModelId();
   } catch (e) {
     document.getElementById('status-dot').className = 'status-dot offline';
     document.getElementById('status-text').textContent = 'offline';
@@ -1381,6 +1426,21 @@ function clientFromUA(ua) {
   return { key: 'other', label: (ua.split(/[\/ ]/)[0] || 'client').slice(0, 16) };
 }
 
+// The dashboard's own inference traffic (Test connection, Playground,
+// Compare, judgment generation) self-identifies via the `X-Kiln-Client:
+// dashboard` request header, which the server echoes back as `client` on
+// each recent-requests row. Those rows are labeled honestly and must NEVER
+// count as a connected agent — only external clients prove the
+// "Agent connected" milestone.
+function rowIsDashboard(r) { return !!r && r.client === 'dashboard'; }
+
+// Resolve a row to its client identity: trusted self-identification first,
+// User-Agent sniffing otherwise.
+function clientForRow(r) {
+  if (rowIsDashboard(r)) return { key: 'dashboard', label: 'dashboard' };
+  return clientFromUA(r && r.user_agent);
+}
+
 function renderRecentRequests(rows) {
   const el = document.getElementById('recent-requests-panel');
   if (!el) return;
@@ -1396,12 +1456,15 @@ function renderRecentRequests(rows) {
   // Tag every row with its calling agent so we can both badge it and offer
   // per-client filter chips — the operator confirms "is opencode getting
   // through?" in one click.
-  rows.forEach(r => { r._client = clientFromUA(r.user_agent); });
+  rows.forEach(r => { r._client = clientForRow(r); });
 
   // Build the agent-filter chips from the clients actually present.
+  // pi is the first-class agent integration — it always leads the
+  // enumeration; everything else orders by traffic volume.
   const counts = new Map();
   rows.forEach(r => counts.set(r._client.key, (counts.get(r._client.key) || 0) + 1));
-  const ordered = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const ordered = [...counts.entries()].sort((a, b) =>
+    a[0] === 'pi' ? -1 : b[0] === 'pi' ? 1 : b[1] - a[1]);
   const labelFor = k => (rows.find(r => r._client.key === k)?._client.label) || k;
   if (!counts.has(recentAgentFilter) && recentAgentFilter !== 'all') recentAgentFilter = 'all';
   const chip = (key, label, n) =>
@@ -1562,7 +1625,7 @@ function openRequestDrillModal(id) {
   titleEl.textContent = `Request ${trimmedId.slice(0, 8) || 'unknown'}`;
   const pieces = [];
   pieces.push(escapeHtml(r.model || '—'));
-  if (r.user_agent) pieces.push(`via <strong>${escapeHtml(clientFromUA(r.user_agent).label)}</strong>`);
+  if (r.user_agent || rowIsDashboard(r)) pieces.push(`via <strong>${escapeHtml(clientForRow(r).label)}</strong>`);
   if (r.adapter) pieces.push(`adapter <code>${escapeHtml(r.adapter)}</code>`);
   pieces.push(r.streamed ? 'streamed' : 'unary');
   metaEl.innerHTML = pieces.join(' · ');
@@ -3363,16 +3426,27 @@ const chatMessages = [];
 let chatAbort = null;
 let chatGenerating = false;
 let servedModelId = null;
+// True once the SERVER reported a model id. Until then the Connect panel and
+// Playground run on the fallback id, and every successful health poll retries
+// /v1/models (cold start: the endpoint 503s or lists nothing while weights
+// load). Once resolved, the flag short-circuits — the retry stops for good.
+let servedModelIdResolved = false;
 
 async function loadServedModelId() {
+  if (servedModelIdResolved) return;
   try {
     const res = await fetch('/v1/models');
     if (!res.ok) return;
     const data = await res.json();
-    servedModelId = data?.data?.[0]?.id || null;
+    const id = data?.data?.[0]?.id;
+    if (!id) return;
+    servedModelId = id;
+    servedModelIdResolved = true;
+    // Upgrade the copyable snippets / model-id field that rendered with the
+    // fallback while weights were still loading.
+    applyServedModelId(id);
   } catch {}
 }
-loadServedModelId();
 
 /* ---------------------------------------------------------------------
    Playground settings persistence
@@ -4211,7 +4285,7 @@ async function streamAssistantTurn(temp) {
 
     const res = await fetch('/v1/chat/completions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Kiln-Client': 'dashboard' },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -6287,7 +6361,7 @@ async function streamCompletion(slot, body) {
   try {
     const res = await fetch('/v1/chat/completions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
+      headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream', 'X-Kiln-Client': 'dashboard' },
       body: JSON.stringify({ ...body, stream: true }),
       signal: ctrl.signal,
     });
@@ -6336,7 +6410,7 @@ async function streamCompletion(slot, body) {
 async function nonStreamingCompletion(slot, body, ctrl, target) {
   const res = await fetch('/v1/chat/completions', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-Kiln-Client': 'dashboard' },
     body: JSON.stringify({ ...body, stream: false }),
     signal: ctrl.signal,
   });
@@ -7912,7 +7986,7 @@ async function streamCompareSide(side, adapterName, prompt, temp, signal) {
 
     const res = await fetch('/v1/chat/completions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Kiln-Client': 'dashboard' },
       body: JSON.stringify(body),
       signal,
     });

--- a/crates/kiln-server/src/ui/demo.js
+++ b/crates/kiln-server/src/ui/demo.js
@@ -207,6 +207,36 @@
           prompt_full: 'What files import the deprecated `legacy_client` module?',
           completion_full: 'grep_repo({"pattern":"legacy_client","glob":"**/*.rs"})',
         },
+        // Dashboard-originated rows (`client: 'dashboard'` from the
+        // X-Kiln-Client header): labeled honestly in the list, but they never
+        // count toward "Agent connected", the client tally, or the Connect
+        // panel auto-collapse — only external traffic does.
+        {
+          id: 'chatcmpl-d05b3a92-4c17-4e8b-a6f0-8b2c9d1e7f43',
+          model: 'Qwen3.5-4B', adapter: 'pi-coder-v4', streamed: true,
+          timestamp_unix_ms: now - 14_700, duration_ms: 1_104, ttft_ms: 35,
+          prompt_tokens: 64, completion_tokens: 118, finish_reason: 'stop',
+          temperature: 0.7, top_p: 0.95, max_tokens: 1024,
+          user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36',
+          client: 'dashboard',
+          prompt_preview: 'Compare base vs adapter: explain this regex',
+          completion_preview: 'This regex matches semantic version strings: an optional `v` prefix, then MAJOR.MINOR.PATCH digits…',
+          prompt_full: 'Compare base vs adapter: explain this regex: ^v?(\\d+)\\.(\\d+)\\.(\\d+)$',
+          completion_full: 'This regex matches semantic version strings: an optional `v` prefix, then MAJOR.MINOR.PATCH digit groups anchored to the whole string.',
+        },
+        {
+          id: 'chatcmpl-e1c47b08-9d35-4a62-b7e9-5f0a8c3d2b17',
+          model: 'Qwen3.5-4B', adapter: 'pi-coder-v4', streamed: false,
+          timestamp_unix_ms: now - 16_200, duration_ms: 287, ttft_ms: null,
+          prompt_tokens: 18, completion_tokens: 2, finish_reason: 'stop',
+          temperature: 0, top_p: 1.0, max_tokens: 8,
+          user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36',
+          client: 'dashboard',
+          prompt_preview: 'Reply with the single word: connected',
+          completion_preview: 'connected',
+          prompt_full: 'Reply with the single word: connected',
+          completion_full: 'connected',
+        },
         {
           id: 'chatcmpl-3c8f0a17-7d22-49b6-8c41-0a5e6f2b1d34',
           model: 'Qwen3.5-4B', adapter: 'pi-coder-v4', streamed: true,

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -155,7 +155,7 @@
           <span class="journey-sub">model loaded &amp; healthy</span>
         </button>
         <span class="journey-arrow" aria-hidden="true"><svg class="icn icn-sm"><use href="#i-arrow-right"></use></svg></span>
-        <button type="button" class="journey-step" data-journey="agent" title="Checks itself when a request from pi, opencode, or an OpenAI SDK arrives. Click to open the connection snippets.">
+        <button type="button" class="journey-step" data-journey="agent" title="Checks itself when an external client connects — pi, opencode, an OpenAI SDK, or curl. The dashboard's own Test connection / Playground traffic doesn't count. Click to open the connection snippets.">
           <span class="journey-dot" aria-hidden="true"></span>
           <span class="journey-label">Agent connected</span>
           <span class="journey-sub">point pi or opencode here</span>

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -340,6 +340,42 @@ const defaultAvailableAdapters = [
   { name: 'adapter-beta', active: false, size_bytes: 8192 },
 ];
 
+// Recent-requests row factory for the journey-strip truth assertions. The
+// `client` field mirrors the server echoing the X-Kiln-Client header:
+// dashboard-originated rows carry `client: 'dashboard'` and must never
+// complete the "Agent connected" milestone; external rows (curl, pi) must.
+let smokeRowSeq = 0;
+function smokeRecentRow(overrides = {}) {
+  smokeRowSeq += 1;
+  return {
+    id: `chatcmpl-smoke-row-${smokeRowSeq}`,
+    timestamp_unix_ms: Date.now() - smokeRowSeq * 1000,
+    model: 'Qwen3.5-4B',
+    prompt_preview: 'smoke prompt',
+    completion_preview: 'smoke completion',
+    prompt_tokens: 12,
+    completion_tokens: 8,
+    duration_ms: 120,
+    streamed: false,
+    finish_reason: 'stop',
+    ...overrides,
+  };
+}
+const dashboardRow = () => smokeRecentRow({
+  user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36',
+  client: 'dashboard',
+  prompt_preview: 'Reply with the single word: connected',
+  completion_preview: 'connected',
+});
+const curlRow = () => smokeRecentRow({
+  user_agent: 'curl/8.7.1',
+  prompt_preview: 'hello from the curl tab',
+});
+const piRow = () => smokeRecentRow({
+  user_agent: 'pi/1.2.0',
+  prompt_preview: 'hello from pi',
+});
+
 function sse(res, chunks) {
   res.writeHead(200, {
     'content-type': 'text/event-stream; charset=utf-8',
@@ -353,10 +389,18 @@ function sse(res, chunks) {
   res.end();
 }
 
-async function startServer({ failDashboardApis = false, availableAdapters = defaultAvailableAdapters } = {}) {
+async function startServer({
+  failDashboardApis = false,
+  availableAdapters = defaultAvailableAdapters,
+  // Cold-start fixture: /v1/models 503s until healed via setModelsCold(false),
+  // then serves `servedModelId`. Distinct from the UI fallback ('Qwen3.5-4B')
+  // when the scenario needs to prove the snippets upgraded without reload.
+  modelsCold = false,
+  servedModelId = 'Qwen3.5-4B',
+} = {}) {
   // Mutable so the failure scenario can heal/re-break the APIs mid-run and
   // assert the dashboard recovers (Retry buttons + dedupe-key invalidation).
-  const apiState = { failDashboardApis };
+  const apiState = { failDashboardApis, modelsCold, recentRequests: [], modelsRequests: 0 };
   const uiHtml = await readFile(uiIndexPath, 'utf8');
   const uiStyles = await readFile(uiStylesPath, 'utf8');
   const uiDemoJs = await readFile(uiDemoJsPath, 'utf8');
@@ -693,7 +737,12 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       return;
     }
     if (url.pathname === '/v1/models') {
-      json(res, { object: 'list', data: [{ id: 'Qwen3.5-4B', object: 'model', owned_by: 'kiln' }] });
+      apiState.modelsRequests += 1;
+      if (apiState.modelsCold) {
+        apiFailure(res, 'Models', url.pathname);
+        return;
+      }
+      json(res, { object: 'list', data: [{ id: servedModelId, object: 'model', owned_by: 'kiln' }] });
       return;
     }
     if (url.pathname === '/v1/stats/decode') {
@@ -712,7 +761,7 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
       return;
     }
     if (url.pathname === '/v1/stats/recent-requests') {
-      json(res, []);
+      json(res, apiState.recentRequests);
       return;
     }
     // The UI polls /v1/eval/jobs at startup to keep the Evals badge
@@ -766,6 +815,14 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
         res.end(JSON.stringify({ detail: 'Use POST for chat completions' }));
         return;
       }
+      // Bug-A regression: every dashboard-originated inference request must
+      // self-identify so the server can mark it `client: 'dashboard'` and
+      // onboarding milestones don't count the dashboard as an agent.
+      if (req.headers['x-kiln-client'] !== 'dashboard') {
+        res.writeHead(400, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ detail: 'Dashboard inference request is missing the X-Kiln-Client: dashboard header' }));
+        return;
+      }
       const body = await readJsonBody(req);
       const prompt = body?.messages?.findLast((message) => message.role === 'user')?.content || '';
       if (!body?.stream || !/Explain Kiln in one sentence\./.test(prompt)) {
@@ -794,6 +851,9 @@ async function startServer({ failDashboardApis = false, availableAdapters = defa
     server,
     baseUrl: `http://127.0.0.1:${address.port}`,
     setFailDashboardApis: (value) => { apiState.failDashboardApis = value; },
+    setRecentRequests: (rows) => { apiState.recentRequests = rows; },
+    setModelsCold: (value) => { apiState.modelsCold = value; },
+    getModelsRequests: () => apiState.modelsRequests,
   };
 }
 
@@ -1194,7 +1254,72 @@ async function runMobileOnboardingSmoke(baseUrl) {
   }
 }
 
-async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapters = false, setFailDashboardApis = null } = {}) {
+// ── Bug B: cold-start model-id resolution ──────────────────────────────
+// Open the dashboard while /v1/models still 503s (weights loading): the
+// Connect snippets render the fallback id. Heal the endpoint → the next
+// 2s health poll piggybacks a /v1/models retry, and the copyable model-id
+// field + snippets silently upgrade to the real id without a reload. Once
+// resolved, the retry stops for good.
+async function runModelColdStartSmoke(baseUrl, { setModelsCold, getModelsRequests }) {
+  const puppeteer = await loadPuppeteer();
+  const browser = await puppeteer.launch({
+    executablePath: chromiumPath(),
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage();
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+    page.on('console', (entry) => {
+      if (entry.type() !== 'error') return;
+      const text = entry.text();
+      // The cold phase intentionally 503s /v1/models — that resource noise
+      // is the fixture, not a dashboard defect.
+      if (/Failed to load resource: the server responded with a status of 503/.test(text)) return;
+      pageErrors.push(text);
+    });
+
+    await page.setViewport({ width: 1280, height: 900, deviceScaleFactor: 1 });
+    await page.goto(`${baseUrl}/ui`, { waitUntil: 'networkidle0', timeout: 10000 });
+
+    // Cold: the panel runs on the fallback id.
+    await page.waitForFunction(
+      () => document.getElementById('connect-model')?.textContent === 'Qwen3.5-4B',
+      { timeout: 8000 },
+    ).catch(() => fail('Connect model id should show the fallback while /v1/models is cold'));
+    const coldSnippets = await page.$eval('#connect-snippets', (el) => el.textContent || '');
+    if (!coldSnippets.includes('Qwen3.5-4B')) fail('Connect snippets should render the fallback model id during cold start');
+    if (coldSnippets.includes('Qwen3.5-4B-resolved')) fail('Connect snippets must not know the real model id before /v1/models answers');
+
+    // Heal. The piggybacked retry on the 2s health poll must upgrade the
+    // copyable model-id field and the rendered snippets without a reload.
+    setModelsCold(false);
+    await page.waitForFunction(
+      () => document.getElementById('connect-model')?.textContent === 'Qwen3.5-4B-resolved',
+      { timeout: 10000 },
+    ).catch(() => fail('Connect model id did not upgrade to the served id after /v1/models recovered (no-reload retry broken)'));
+    const warmSnippets = await page.$eval('#connect-snippets', (el) => el.textContent || '');
+    if (!warmSnippets.includes('Qwen3.5-4B-resolved')) fail('Connect snippets did not re-render with the served model id after cold start');
+    // The fallback id is a PREFIX of the resolved one — assert no snippet
+    // still carries a bare fallback (every occurrence must be the resolved id).
+    const bareFallbacks = warmSnippets.split('Qwen3.5-4B').slice(1).filter((tail) => !tail.startsWith('-resolved')).length;
+    if (bareFallbacks > 0) fail(`Connect snippets still contain ${bareFallbacks} stale fallback model id(s) after resolution`);
+
+    // Resolved → the retry stops: no further /v1/models hits across >2 polls.
+    const settled = getModelsRequests();
+    await new Promise((resolve) => setTimeout(resolve, 5200));
+    const after = getModelsRequests();
+    if (after !== settled) fail(`/v1/models retry did not stop after resolution (${settled} → ${after} requests)`);
+
+    if (pageErrors.length > 0) fail(`Cold-start UI emitted browser errors: ${pageErrors.join('; ')}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapters = false, setFailDashboardApis = null, setRecentRequests = null } = {}) {
   const puppeteer = await loadPuppeteer();
   const browser = await puppeteer.launch({
     executablePath: chromiumPath(),
@@ -1299,8 +1424,98 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       await expectPanelLink(page, '#adapters-panel .empty', 'Quickstart', 'https://ericflo.github.io/kiln/quickstart.html');
       await expectPanelLink(page, '#adapters-panel .empty', 'Troubleshooting', 'https://ericflo.github.io/kiln/troubleshooting.html');
       await expectDisabled(page, '#merge-btn', true, 'Adapter merge should stay disabled when fewer than two adapters exist');
+
+      // ── Journey-strip truth (Bug A), novice golden path ────────────────
+      // No adapters trained yet → the strip stays on screen, so the agent
+      // step's honesty is directly observable through every transition.
+      if (setRecentRequests) {
+        await goToPrimaryTab(page, 'overview');
+        await page.waitForFunction(
+          () => { const strip = document.getElementById('journey-strip'); return strip && !strip.hidden; },
+          { timeout: 8000 },
+        ).catch(() => fail('Journey strip should be visible on a fresh server with no adapters'));
+
+        // Dashboard-only traffic (Test connection / Playground) must NOT
+        // complete "Agent connected" nor collapse the Connect panel.
+        setRecentRequests([dashboardRow()]);
+        await waitForPanelText(page, '#recent-requests-panel', /Reply with the single word: connected/, 'Dashboard-client row did not render in recent requests');
+        const dashOnly = await page.evaluate(() => ({
+          agentDone: !!document.querySelector('#journey-strip [data-journey="agent"]')?.classList.contains('is-done'),
+          sub: document.querySelector('#journey-strip [data-journey="agent"] .journey-sub')?.textContent || '',
+          connectExpandedHidden: !!document.getElementById('connect-expanded')?.hidden,
+          fwAgents: document.getElementById('fw-agents')?.textContent || '',
+        }));
+        if (dashOnly.agentDone) fail('Dashboard-only rows must NOT complete the "Agent connected" milestone');
+        if (dashOnly.sub !== 'point pi or opencode here') fail(`Agent step sub-text should stay default on dashboard-only rows, got "${dashOnly.sub}"`);
+        if (dashOnly.connectExpandedHidden) fail('Connect panel must not auto-collapse on dashboard-only traffic');
+        if (dashOnly.fwAgents !== '0') fail(`Flywheel client count should ignore dashboard rows, got "${dashOnly.fwAgents}"`);
+
+        // A curl row IS an external connection: the milestone completes,
+        // with the inline (not hover-only) "next move" hint.
+        setRecentRequests([dashboardRow(), curlRow()]);
+        await page.waitForFunction(
+          () => {
+            const strip = document.getElementById('journey-strip');
+            const step = strip?.querySelector('[data-journey="agent"]');
+            const sub = step?.querySelector('.journey-sub')?.textContent || '';
+            return strip && !strip.hidden && !!step?.classList.contains('is-done')
+              && sub === 'curl seen — point a coding agent here next';
+          },
+          { timeout: 8000 },
+        ).catch(() => fail('A curl row should complete "Agent connected" with the inline coding-agent hint'));
+        const collapsedAfterCurl = await page.evaluate(() => !document.getElementById('connect-collapsed')?.hidden);
+        if (!collapsedAfterCurl) fail('Connect panel should auto-collapse once external (curl) traffic flows');
+
+        // A recognized coding agent arrives → the curl hint clears, and pi
+        // leads the client-chip enumeration (hard preference).
+        setRecentRequests([dashboardRow(), curlRow(), piRow()]);
+        await page.waitForFunction(
+          () => {
+            const step = document.querySelector('#journey-strip [data-journey="agent"]');
+            const sub = step?.querySelector('.journey-sub')?.textContent || '';
+            return !!step?.classList.contains('is-done') && sub === 'point pi or opencode here';
+          },
+          { timeout: 8000 },
+        ).catch(() => fail('The curl hint should clear once a recognized coding agent connects'));
+        const chips = await page.$$eval('#recent-requests-panel .agent-chip', (els) => els.map((el) => el.textContent.trim()));
+        if (chips.length === 0) fail('Client filter chips should render when multiple clients are present');
+        if (!(chips[1] || '').startsWith('pi')) fail(`pi should lead the client chips after "All agents", got ${JSON.stringify(chips)}`);
+        if (!chips.some((chip) => chip.startsWith('dashboard'))) fail(`Dashboard rows should be labeled honestly in the client chips, got ${JSON.stringify(chips)}`);
+      }
+
       if (pageErrors.length > 0) fail(`Empty adapter UI emitted browser errors: ${pageErrors.join('; ')}`);
       return;
+    }
+
+    // ── Journey-strip truth (Bug A), default scenario ───────────────────
+    // Dashboard-client rows must not complete "Agent connected"; a curl row
+    // must. With smoke adapters already present, the curl row completes all
+    // three milestones, so the strip retires itself — that retirement IS the
+    // milestone assertion here (the empty-adapter scenario watches the step
+    // classes directly while the strip stays visible).
+    if (setRecentRequests) {
+      setRecentRequests([dashboardRow()]);
+      await waitForPanelText(page, '#recent-requests-panel', /Reply with the single word: connected/, 'Dashboard-client row did not render in recent requests');
+      const dashOnly = await page.evaluate(() => ({
+        stripHidden: !document.getElementById('journey-strip') || document.getElementById('journey-strip').hidden,
+        agentDone: !!document.querySelector('#journey-strip [data-journey="agent"]')?.classList.contains('is-done'),
+        connectExpandedHidden: !!document.getElementById('connect-expanded')?.hidden,
+      }));
+      if (dashOnly.stripHidden) fail('Journey strip should stay visible while only dashboard-client rows exist');
+      if (dashOnly.agentDone) fail('Dashboard-only rows must NOT complete the "Agent connected" milestone');
+      if (dashOnly.connectExpandedHidden) fail('Connect panel must not auto-collapse on dashboard-only traffic');
+
+      setRecentRequests([dashboardRow(), curlRow()]);
+      await page.waitForFunction(
+        () => document.getElementById('journey-strip')?.hidden === true,
+        { timeout: 8000 },
+      ).catch(() => fail('A curl row should complete "Agent connected" (all milestones done → journey strip retires)'));
+      const collapsedAfterCurl = await page.evaluate(() => !document.getElementById('connect-collapsed')?.hidden);
+      if (!collapsedAfterCurl) fail('Connect panel should auto-collapse once external (curl) traffic flows');
+
+      // Drain the fixture rows so the later empty-state assertions hold.
+      setRecentRequests([]);
+      await waitForPanelText(page, '#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not drain after the journey-strip truth checks');
     }
 
     await goToPrimaryTab(page, 'adapters');
@@ -1588,21 +1803,36 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
 const emptyAdapterScenario = await startServer({ availableAdapters: [] });
 try {
   console.log('[smoke] empty adapter scenario start');
-  await runSmoke(emptyAdapterScenario.baseUrl, { expectEmptyAdapters: true });
+  await runSmoke(emptyAdapterScenario.baseUrl, {
+    expectEmptyAdapters: true,
+    setRecentRequests: emptyAdapterScenario.setRecentRequests,
+  });
   console.log('[smoke] empty adapter scenario passed');
 } finally {
   await new Promise((accept) => emptyAdapterScenario.server.close(accept));
 }
 
-const { server, baseUrl } = await startServer();
+const { server, baseUrl, setRecentRequests } = await startServer();
 try {
   console.log('[smoke] default scenario desktop start');
-  await runSmoke(baseUrl);
+  await runSmoke(baseUrl, { setRecentRequests });
   console.log('[smoke] default scenario desktop passed; mobile start');
   await runMobileOnboardingSmoke(baseUrl);
   console.log('[smoke] default scenario mobile passed');
 } finally {
   await new Promise((accept) => server.close(accept));
+}
+
+const coldStartScenario = await startServer({ modelsCold: true, servedModelId: 'Qwen3.5-4B-resolved' });
+try {
+  console.log('[smoke] model cold-start scenario start');
+  await runModelColdStartSmoke(coldStartScenario.baseUrl, {
+    setModelsCold: coldStartScenario.setModelsCold,
+    getModelsRequests: coldStartScenario.getModelsRequests,
+  });
+  console.log('[smoke] model cold-start scenario passed');
+} finally {
+  await new Promise((accept) => coldStartScenario.server.close(accept));
 }
 
 const failureScenario = await startServer({ failDashboardApis: true });


### PR DESCRIPTION
Wave 2 of the UI overhaul (roadmap PRs 12+14 of 25 — both Connect-panel honesty). Completes wave 2.

**Bug A — the dashboard's own traffic completed "Agent connected".** Clicking Test connection (or one Playground message) falsely completed the golden path's first milestone and auto-collapsed the Connect panel, hiding the pi setup snippets before any agent existed — while a user following the dashboard's own curl tab never completed it.

- All 5 dashboard inference fetches send `X-Kiln-Client: dashboard`; the server records it (`extract_client()` — header-only, bounded; additive `client` field on `RequestRecord`, serialized only when present, mirrored onto the JSONL mining log) through all 11 record-construction sites.
- Journey strip, Connect auto-collapse, and flywheel client count exclude dashboard rows (labeled honestly as "dashboard" in the requests list). **curl now counts as connected**, with an inline "curl seen — point a coding agent here next" hint that clears when a real agent appears. pi stays first in client enumerations.

**Bug B — cold starts baked the fallback model id into copyable config snippets** until manual reload. `loadServedModelId()` is now the single resolver; the retry piggybacks on the existing 2s health poll (no new interval), silently upgrades the snippets/model-id field on first real id (preserving the selected tab), then stops.

Verification: 567 lib tests (incl. new additive-serialization test); full smoke now **5 scenarios** — including a new model-cold-start scenario (`/v1/models` 503 → heal → snippets upgrade without reload → retry provably stops) and journey-truth assertions. **Mutation-checked**: pre-fix app.js fails at "Dashboard-only rows must NOT complete the Agent connected milestone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)