### PR TITLE
Dashboard hash navigation is real history: Back/Forward walk the tabs, live hash edits route

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -4,7 +4,18 @@
 /* =====================================================================
    Page switcher (Overview / Adapters / Training / Playground)
    ===================================================================== */
-function selectPage(name) {
+// The 7 primary pages — single source of truth shared by boot-time hash
+// resolution and the hashchange handler below.
+const PRIMARY_PAGES = ['overview', 'adapters', 'training', 'evals', 'distill', 'playground', 'terminal'];
+
+// opts (optional):
+//   fromHash: true  — the call ORIGINATED from the hashchange handler
+//                     (browser Back/Forward or a live hash edit). The URL is
+//                     already correct; pushing here would bury the entry the
+//                     user just traveled to, breaking Forward.
+//   replace:  true  — boot-time landing: repair the URL in place instead of
+//                     minting an entry, so Back still exits the dashboard.
+function selectPage(name, opts) {
   document.querySelectorAll('.primary-tab').forEach(t => {
     const active = t.dataset.page === name;
     t.classList.toggle('active', active);
@@ -16,10 +27,14 @@ function selectPage(name) {
     p.hidden = !active;
     if (active) p.removeAttribute('inert'); else p.setAttribute('inert', '');
   });
-  if (history.replaceState) {
-    const u = new URL(window.location.href);
-    u.hash = name;
-    history.replaceState(null, '', u);
+  // Real history entries (pushState) so browser Back/Forward walks the tab
+  // trail. Same-page guard: re-selecting the page already in the hash (tab
+  // re-click, polling re-entry) must not stack duplicate entries. Note that
+  // pushState itself fires neither hashchange nor popstate, so writing here
+  // cannot re-trigger the hashchange handler.
+  if (!(opts && opts.fromHash) && history.pushState && location.hash !== '#' + name) {
+    if (opts && opts.replace) history.replaceState(null, '', '#' + name);
+    else history.pushState(null, '', '#' + name);
   }
   // Remember the user's last tab so a fresh visit (no hash, no bookmark)
   // lands them back where they were instead of always on Overview.
@@ -65,10 +80,39 @@ let initialPage = (location.hash || '').slice(1);
 if (!initialPage) {
   try { initialPage = localStorage.getItem('kiln.lastPage') || ''; } catch {}
 }
-if (!['overview', 'adapters', 'training', 'evals', 'distill', 'playground', 'terminal'].includes(initialPage)) {
+if (!PRIMARY_PAGES.includes(initialPage)) {
   initialPage = 'overview';
 }
-selectPage(initialPage);
+selectPage(initialPage, { replace: true });
+
+// Browser Back/Forward + live hash edits re-resolve through the same
+// whitelist as boot. ONE hashchange listener suffices — no separate
+// popstate handler. Evidence (probed in headless Chrome 148, the same
+// binary the smoke suite drives):
+//   - history.pushState('#x') fires NEITHER hashchange nor popstate;
+//   - Back/Forward across pushState'd entries fires BOTH (the entries
+//     differ only by fragment, and fragment-differing same-document
+//     traversals fire hashchange per spec);
+//   - location.hash = '#x' assignment fires BOTH.
+// Every entry selectPage creates differs by fragment (same-page guard
+// above), so hashchange covers every traversal we can produce, and it is
+// the spec-guaranteed event for address-bar hash edits. Listening to both
+// events would double-invoke this handler on every Back/Forward.
+window.addEventListener('hashchange', () => {
+  const name = (location.hash || '').slice(1);
+  if (PRIMARY_PAGES.includes(name)) {
+    selectPage(name, { fromHash: true });
+    return;
+  }
+  // In-page anchor (e.g. the "Skip to content" link targets #content):
+  // leave the browser's native scroll/focus behavior alone.
+  if (name && document.getElementById(name)) return;
+  // Unknown/garbage hash: land on Overview and repair the URL in place —
+  // replaceState, NOT pushState, so the junk never survives as its own
+  // history entry for Back to trip over.
+  if (history.replaceState) history.replaceState(null, '', '#overview');
+  selectPage('overview', { fromHash: true });
+});
 
 // --- Toast Notifications ---
 function toast(msg, type) {

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -914,6 +914,30 @@ async function goToPrimaryTab(page, name) {
   ).catch(() => fail(`Primary tab ${name} did not activate (${pageId})`));
 }
 
+// Asserts BOTH halves of hash navigation: the page section is active AND
+// location.hash agrees. Used by the Back/Forward history assertions, where
+// either half regressing (page without hash, hash without page) is a bug.
+async function expectActivePageAndHash(page, name, message) {
+  await page.waitForFunction(
+    (targetName) => {
+      const section = document.querySelector(`#page-${targetName}`);
+      return section
+        && section.classList.contains('active')
+        && !section.hidden
+        && !section.hasAttribute('inert')
+        && window.location.hash === `#${targetName}`;
+    },
+    { timeout: 5000 },
+    name,
+  ).catch(async () => {
+    const actual = await page.evaluate(() => ({
+      hash: window.location.hash,
+      page: document.querySelector('.page.active')?.id || 'none',
+    })).catch(() => ({ hash: 'unknown', page: 'unknown' }));
+    fail(`${message}: expected page-${name} active with hash #${name}, got page=${actual.page} hash=${actual.hash}`);
+  });
+}
+
 async function waitForVisiblePanel(page, selector, message) {
   await page.waitForFunction(
     (panelSelector) => {
@@ -1517,6 +1541,30 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       setRecentRequests([]);
       await waitForPanelText(page, '#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not drain after the journey-strip truth checks');
     }
+
+    // --- Hash navigation: tab clicks mint history entries, browser
+    // Back/Forward walks them, and live hash edits route through the
+    // page whitelist (roadmap PR 16). ---
+    await expectActivePageAndHash(page, 'overview', 'Landing on /ui (no fragment) should repair the URL to #overview in place');
+    await goToPrimaryTab(page, 'adapters');
+    await expectActivePageAndHash(page, 'adapters', 'Clicking the Adapters tab should push #adapters');
+    await goToPrimaryTab(page, 'training');
+    await expectActivePageAndHash(page, 'training', 'Clicking the Training tab should push #training');
+    await page.goBack();
+    await expectActivePageAndHash(page, 'adapters', 'Browser Back from Training should return to Adapters');
+    await page.goBack();
+    await expectActivePageAndHash(page, 'overview', 'Second browser Back should return to Overview');
+    await page.goForward();
+    await expectActivePageAndHash(page, 'adapters', 'Browser Forward should re-land on Adapters');
+    // A live hash edit (address bar / location.hash) must activate the page.
+    await page.evaluate(() => { window.location.hash = '#evals'; });
+    await expectActivePageAndHash(page, 'evals', 'Setting location.hash = #evals should activate the Evals page');
+    // A junk hash falls back to Overview and is repaired via replaceState —
+    // the junk entry must NOT survive in history for Back to trip over.
+    await page.evaluate(() => { window.location.hash = '#nonsense'; });
+    await expectActivePageAndHash(page, 'overview', 'A junk hash should fall back to Overview with the URL repaired');
+    await page.goBack();
+    await expectActivePageAndHash(page, 'evals', 'Back after a junk hash should land on Evals — #nonsense must not pollute history');
 
     await goToPrimaryTab(page, 'adapters');
     await waitForPanelText(page, '#adapters-panel', /adapter-alpha/, 'Adapter list should show the first smoke adapter');


### PR DESCRIPTION
Wave 3 of the UI overhaul (roadmap PR 16 of 25) — the navigation foundation deep links build on.

Browser Back/Forward exited the dashboard entirely, and editing the hash did nothing. Now `selectPage` mints one history entry per page change (`pushState`, with a same-page guard against duplicates and a boot-time `replaceState` so Back still exits the dashboard from the landing entry), and one `hashchange` listener re-resolves through the shared 7-page whitelist without re-pushing. Junk hashes route to overview via `replaceState` — they never survive in history. The `#content` skip-link keeps native anchor behavior (it would otherwise have been hijacked).

**The listener choice is empirically grounded**: probed in the suite's exact Chrome build — Back/Forward across pushState'd *fragment-differing* entries fires both `popstate` and `hashchange`, so a single `hashchange` listener covers every traversal we can produce and a popstate listener would double-invoke. Probe evidence documented in the code.

All ~30 `selectPage` callers audited (tabs, cmdk palette + search results, quick actions, journey strip, flywheel nodes, toasts, keyboard shortcuts, distill jumps): one entry each, no doubles. Screenshot deep-link path verified live (`file://…#training` lands with `history.length` 2 — no boot pollution).

New smoke block: clicks track the hash; two Backs walk training→adapters→overview; Forward re-lands; live `#evals` edit routes; `#nonsense` → overview with Back landing on evals. **Negative-tested**: on the previous app.js it fails at the first Back assertion ("got page=none hash=" — Back exited the app). Full smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)