### PR TITLE
Judgment Undo: POST /rows returns judgment_id, wiring the orphaned DELETE endpoint

### DIFF
--- a/crates/kiln-server/src/api/eval.rs
+++ b/crates/kiln-server/src/api/eval.rs
@@ -801,11 +801,23 @@ struct AppendJudgmentBody {
     tags: Vec<String>,
 }
 
+/// Response for `POST /v1/judgments/{name}/rows`. Additive over the bare
+/// manifest the endpoint used to return: `judgment_id` is the id assigned
+/// to the row that was just appended, so the UI can offer Undo via
+/// `DELETE /v1/judgments/{name}/rows/{judgment_id}` without re-reading the
+/// dataset. Every pre-existing manifest field stays at the top level.
+#[derive(Debug, Serialize)]
+struct AppendJudgmentResponse {
+    judgment_id: String,
+    #[serde(flatten)]
+    manifest: JudgmentManifest,
+}
+
 async fn append_judgment(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
     Json(body): Json<AppendJudgmentBody>,
-) -> Result<Json<JudgmentManifest>, ApiError> {
+) -> Result<Json<AppendJudgmentResponse>, ApiError> {
     let store = state
         .judgment_store
         .as_ref()
@@ -827,7 +839,10 @@ async fn append_judgment(
         crate::eval::JudgmentError::InvalidName(n) => ApiError::dataset_invalid(n),
         other => ApiError::judgment_invalid(format!("{other}")),
     })?;
-    Ok(Json(m))
+    Ok(Json(AppendJudgmentResponse {
+        judgment_id: row.id,
+        manifest: m,
+    }))
 }
 
 async fn remove_judgment_row(

--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -6510,6 +6510,36 @@ async function generateJudgmentPair() {
 
 document.getElementById('judgment-generate-btn')?.addEventListener('click', () => generateJudgmentPair());
 
+// One toast with an Undo action for a just-recorded judgment. The rows POST
+// returns `judgment_id` (the appended row's stable id) — Undo DELETEs that
+// exact row, refreshes the visible counts, and confirms. A misclicked vote
+// no longer poisons the dataset permanently. `fired` guards double-fires:
+// actionToast removes the toast on click, but a queued second click must
+// not double-DELETE (the second DELETE would 404 and toast a scary error).
+function recordedJudgmentToast(message, datasetName, judgmentId) {
+  if (!judgmentId) { toast(message, 'ok'); return; }  // no id, no Undo
+  let fired = false;
+  actionToast(message, 'ok', [{
+    label: 'Undo',
+    onClick: async () => {
+      if (fired) return;
+      fired = true;
+      try {
+        const m = await api('/v1/judgments/' + encodeURIComponent(datasetName) + '/rows/' + encodeURIComponent(judgmentId), { method: 'DELETE' });
+        if (activeJudgmentDataset === datasetName) {
+          document.getElementById('judgment-rows-count').textContent =
+            `${m.num_rows} judgments in "${datasetName}". Press G to generate the next pair (A/B/T/S to vote).`;
+        }
+        refreshJudgments();
+        toast(`Undone — judgment removed from "${datasetName}"`, 'ok');
+      } catch (e) {
+        // Leave the counts as they are — the row may still exist server-side.
+        toast('Undo failed: ' + e.message, 'err');
+      }
+    },
+  }]);
+}
+
 async function recordJudgment(winner) {
   if (!activeJudgmentDataset || !pendingJudgmentPair) return;
   // If a stream is still going, capture whatever has been emitted so far so
@@ -6529,13 +6559,14 @@ async function recordJudgment(winner) {
     note: note || null,
     tags,
   };
+  const dataset = activeJudgmentDataset;
   try {
-    const m = await api('/v1/judgments/' + encodeURIComponent(activeJudgmentDataset) + '/rows', {
+    const m = await api('/v1/judgments/' + encodeURIComponent(dataset) + '/rows', {
       method: 'POST', headers: {'Content-Type':'application/json'},
       body: JSON.stringify(body),
     });
     document.getElementById('judgment-rows-count').textContent =
-      `${m.num_rows} judgments in "${activeJudgmentDataset}". Press G to generate the next pair (A/B/T/S to vote).`;
+      `${m.num_rows} judgments in "${dataset}". Press G to generate the next pair (A/B/T/S to vote).`;
     document.getElementById('judgment-note').value = '';
     pendingJudgmentPair = null;
     document.getElementById('judgment-actions').hidden = true;
@@ -6544,6 +6575,8 @@ async function recordJudgment(winner) {
     document.getElementById('judgment-b-text').textContent = '';
     document.getElementById('judgment-pair').hidden = true;
     refreshJudgments();
+    const winnerLabel = { a: 'A wins', b: 'B wins', tie: 'Tie', skip: 'Skip' }[winner] || winner;
+    recordedJudgmentToast(`Recorded ${winnerLabel} in "${dataset}"`, dataset, m.judgment_id);
     if (judgmentAutoAdvance) {
       // Re-focus the prompt for the next round.
       setTimeout(() => document.getElementById('judgment-prompt').focus(), 50);
@@ -8196,11 +8229,11 @@ document.getElementById('chat-save-judgment')?.addEventListener('click', () => {
     try {
       // 409 (already-exists) is fine — we just append a row below.
       try { await api('/v1/judgments', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ name: datasetName }) }); } catch (_) { /* already exists is fine */ }
-      await api('/v1/judgments/' + encodeURIComponent(datasetName) + '/rows', {
+      const m = await api('/v1/judgments/' + encodeURIComponent(datasetName) + '/rows', {
         method: 'POST', headers: {'Content-Type':'application/json'},
         body: JSON.stringify({ ...chatComparePair, winner, note: 'from playground', tags: ['playground'] }),
       });
-      toast('Saved into ' + datasetName, 'ok');
+      recordedJudgmentToast('Saved into ' + datasetName, datasetName, m.judgment_id);
       form.remove();
     } catch (e) { toast('Save failed: ' + e.message, 'err'); }
   });

--- a/crates/kiln-server/tests/eval_dataset_pipeline.rs
+++ b/crates/kiln-server/tests/eval_dataset_pipeline.rs
@@ -229,8 +229,13 @@ async fn judgment_flywheel_create_append_compile() {
             "note": "test",
             "tags": ["prose"],
         });
-        let (status, _) = json_call(&router, "POST", "/v1/judgments/prose-judge/rows", &body).await;
+        let (status, appended) = json_call(&router, "POST", "/v1/judgments/prose-judge/rows", &body).await;
         assert_eq!(status, StatusCode::OK, "winner={} {}", winner.0, body);
+        // The POST response carries the appended row's id (the UI's Undo
+        // DELETEs by it) alongside the pre-existing manifest fields.
+        assert_eq!(appended["judgment_id"].as_str().unwrap(), format!("j{i}"), "{appended}");
+        assert_eq!(appended["name"], "prose-judge");
+        assert_eq!(appended["num_rows"].as_u64().unwrap(), (i + 1) as u64);
     }
 
     // 3. List judgments — should see prose-judge with 3 rows.
@@ -280,6 +285,42 @@ async fn judgment_flywheel_create_append_compile() {
     .await;
     assert_eq!(status, StatusCode::OK, "body={after}");
     assert_eq!(after["num_rows"].as_u64().unwrap(), 2);
+
+    // 6. Undo round-trip: append WITHOUT a client-supplied id — the server
+    // assigns a uuid and returns it as `judgment_id` — then DELETE with
+    // exactly that id removes the row again.
+    let body = serde_json::json!({
+        "prompt": [{"role":"user", "content":"Pick one"}],
+        "response_a": "alpha",
+        "response_b": "beta",
+        "winner": "a",
+    });
+    let (status, appended) = json_call(&router, "POST", "/v1/judgments/prose-judge/rows", &body).await;
+    assert_eq!(status, StatusCode::OK, "body={appended}");
+    let judgment_id = appended["judgment_id"]
+        .as_str()
+        .expect("POST response carries the server-assigned judgment_id")
+        .to_string();
+    assert!(!judgment_id.is_empty());
+    assert_eq!(appended["num_rows"].as_u64().unwrap(), 3);
+    let (status, undone) = json_call(
+        &router,
+        "DELETE",
+        &format!("/v1/judgments/prose-judge/rows/{judgment_id}"),
+        &serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={undone}");
+    assert_eq!(undone["num_rows"].as_u64().unwrap(), 2);
+    // A double-fired Undo can't corrupt counts: the second DELETE is a 404.
+    let (status, _) = json_call(
+        &router,
+        "DELETE",
+        &format!("/v1/judgments/prose-judge/rows/{judgment_id}"),
+        &serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -418,6 +418,28 @@ async function startServer({
   // "Try a sample dataset" golden path) — GET /v1/eval/datasets reflects
   // them so the Datasets list refresh after upload is observable.
   const uploadedEvalDatasets = [];
+  // Judgment datasets created/judged through the A/B walk. The rows POST
+  // mirrors api/eval.rs append_judgment: it returns `judgment_id` plus the
+  // flattened manifest, so the smoke can assert the record → Undo → DELETE
+  // round-trip restores the visible counts.
+  const judgmentDatasets = [];
+  let judgmentRowCounter = 0;
+  const judgmentManifest = (dataset) => ({
+    name: dataset.name,
+    description: dataset.description,
+    num_rows: dataset.rows.length,
+    created_at: dataset.created_at,
+    updated_at: dataset.updated_at,
+    winner_histogram: { ...dataset.winner_histogram },
+  });
+  const judgmentNotFound = (res, detail) => {
+    res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ error: {
+      code: 'judgment_not_found',
+      message: `Judgment dataset '${detail}' not found`,
+      hint: 'List judgments with GET /v1/judgments.',
+    } }));
+  };
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const adapterRoute = parseAdapterRoute(url.pathname);
@@ -806,7 +828,86 @@ async function startServer({
       return;
     }
     if (url.pathname === '/v1/judgments') {
-      json(res, { judgments: [] });
+      if (req.method === 'POST') {
+        const body = await readJsonBody(req);
+        const name = (body?.name || '').trim();
+        if (!isPathSafeAdapterDirectoryName(name)) {
+          apiBadRequest(res, 'Judgment dataset name should be path-safe');
+          return;
+        }
+        if (judgmentDatasets.some((dataset) => dataset.name === name)) {
+          res.writeHead(409, { 'content-type': 'application/json; charset=utf-8' });
+          res.end(JSON.stringify({ error: {
+            code: 'dataset_exists',
+            message: `Judgment dataset '${name}' already exists`,
+            hint: 'Append rows to the existing dataset or pick a new name.',
+          } }));
+          return;
+        }
+        const now = new Date().toISOString();
+        const dataset = {
+          name,
+          description: body?.description || null,
+          created_at: now,
+          updated_at: now,
+          winner_histogram: {},
+          rows: [],
+        };
+        judgmentDatasets.push(dataset);
+        json(res, judgmentManifest(dataset));
+        return;
+      }
+      json(res, { judgments: judgmentDatasets.map(judgmentManifest) });
+      return;
+    }
+    // POST /v1/judgments/:name/rows — append a judgment. Mirrors the real
+    // handler's response shape: `judgment_id` for the appended row plus the
+    // flattened manifest (the UI's Undo DELETEs by that id).
+    const judgmentRowsMatch = /^\/v1\/judgments\/([^/]+)\/rows$/.exec(url.pathname);
+    if (judgmentRowsMatch && req.method === 'POST') {
+      const name = decodeURIComponent(judgmentRowsMatch[1]);
+      const dataset = judgmentDatasets.find((candidate) => candidate.name === name);
+      if (!dataset) {
+        judgmentNotFound(res, name);
+        return;
+      }
+      const body = await readJsonBody(req);
+      if (!Array.isArray(body?.prompt) || body.prompt.length === 0) {
+        apiBadRequest(res, 'Judgment rows should carry the prompt messages');
+        return;
+      }
+      if (!['a', 'b', 'tie', 'skip'].includes(body?.winner)) {
+        apiBadRequest(res, 'Judgment winner should be one of a|b|tie|skip');
+        return;
+      }
+      if (typeof body?.response_a !== 'string' || typeof body?.response_b !== 'string') {
+        apiBadRequest(res, 'Judgment rows should carry both responses');
+        return;
+      }
+      judgmentRowCounter += 1;
+      const id = body.id || `smoke-judgment-${judgmentRowCounter}`;
+      dataset.rows.push({ id, winner: body.winner });
+      dataset.winner_histogram[body.winner] = (dataset.winner_histogram[body.winner] || 0) + 1;
+      dataset.updated_at = new Date().toISOString();
+      json(res, { judgment_id: id, ...judgmentManifest(dataset) });
+      return;
+    }
+    // DELETE /v1/judgments/:name/rows/:id — the Undo path. Unknown ids 404
+    // (a double-fired Undo must not silently "succeed").
+    const judgmentRowDeleteMatch = /^\/v1\/judgments\/([^/]+)\/rows\/([^/]+)$/.exec(url.pathname);
+    if (judgmentRowDeleteMatch && req.method === 'DELETE') {
+      const name = decodeURIComponent(judgmentRowDeleteMatch[1]);
+      const id = decodeURIComponent(judgmentRowDeleteMatch[2]);
+      const dataset = judgmentDatasets.find((candidate) => candidate.name === name);
+      const rowIndex = dataset ? dataset.rows.findIndex((row) => row.id === id) : -1;
+      if (!dataset || rowIndex === -1) {
+        judgmentNotFound(res, `${name}/${id}`);
+        return;
+      }
+      const [removed] = dataset.rows.splice(rowIndex, 1);
+      dataset.winner_histogram[removed.winner] = Math.max(0, (dataset.winner_histogram[removed.winner] || 1) - 1);
+      dataset.updated_at = new Date().toISOString();
+      json(res, judgmentManifest(dataset));
       return;
     }
     if (url.pathname === '/v1/chat/completions') {
@@ -825,6 +926,14 @@ async function startServer({
       }
       const body = await readJsonBody(req);
       const prompt = body?.messages?.findLast((message) => message.role === 'user')?.content || '';
+      // The judgment viewer streams the same prompt twice (slots A and B).
+      if (body?.stream && /Judge this smoke pair\./.test(prompt)) {
+        sse(res, [
+          { choices: [{ delta: { role: 'assistant' } }] },
+          { choices: [{ delta: { content: 'smoke reply for judging' } }] },
+        ]);
+        return;
+      }
       if (!body?.stream || !/Explain Kiln in one sentence\./.test(prompt)) {
         res.writeHead(400, { 'content-type': 'application/json; charset=utf-8' });
         res.end(JSON.stringify({ detail: 'Unexpected Quick Inference smoke request' }));
@@ -1842,6 +1951,59 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     ).catch(() => fail('Sample upload should open the synthesize panel (create a suite is the next step)'));
     const synthSuiteName = await page.$eval('#synth-suite-name', (el) => el.value);
     if (synthSuiteName !== 'sample-coding-agent-eval') fail(`Synthesize panel should pre-fill the suite name from the sample dataset, got ${JSON.stringify(synthSuiteName)}`);
+
+    // ---- Judgment Undo: record an A/B pick, then the toast's Undo must
+    // DELETE exactly the row the POST response identified (judgment_id)
+    // and restore the visible counts.
+    await clickAndWait(page, '#evals-tab-judgments', 'Could not open the Judgments sub-tab');
+    await waitForVisiblePanel(page, '#tab-evals-judgments', 'Judgments sub-tab did not activate');
+    await page.type('#judgment-create-name', 'smoke-judgments');
+    await clickAndWait(page, '#judgment-create-btn', 'Could not create the smoke judgment dataset');
+    await waitForPanelText(page, '#judgment-rows-count', /Judging into "smoke-judgments"/, 'Judgment viewer should open on the new dataset');
+    await page.type('#judgment-prompt', 'Judge this smoke pair.');
+    await clickAndWait(page, '#judgment-generate-btn', 'Could not generate the judgment pair');
+    await page.waitForFunction(
+      () => !document.getElementById('judgment-actions')?.hidden
+        && /smoke reply for judging/.test(document.getElementById('judgment-a-text')?.textContent || '')
+        && /smoke reply for judging/.test(document.getElementById('judgment-b-text')?.textContent || ''),
+      { timeout: 5000 },
+    ).catch(() => fail('Judgment pair did not stream into both compare cards'));
+    const judgmentRecordResponsePromise = page.waitForResponse(
+      (response) => response.url().endsWith('/v1/judgments/smoke-judgments/rows')
+        && response.request().method() === 'POST',
+      { timeout: 5000 },
+    );
+    await clickAndWait(page, '#judgment-pick-a', 'Could not record the A vote');
+    const judgmentRecordResponse = await judgmentRecordResponsePromise
+      .catch(() => fail('Recording a judgment did not POST /v1/judgments/smoke-judgments/rows'));
+    const judgmentRecordBody = await judgmentRecordResponse.json().catch(() => ({}));
+    if (judgmentRecordBody.judgment_id !== 'smoke-judgment-1') {
+      fail(`Judgment POST response should carry the new row's judgment_id, got ${JSON.stringify(judgmentRecordBody.judgment_id)}`);
+    }
+    if (judgmentRecordBody.num_rows !== 1) {
+      fail(`Judgment POST response should keep the manifest fields (num_rows), got ${JSON.stringify(judgmentRecordBody.num_rows)}`);
+    }
+    await waitForPanelText(page, '#judgment-rows-count', /1 judgments in "smoke-judgments"/, 'Row count should reflect the recorded judgment');
+    const undoDeleteRequestPromise = page.waitForRequest(
+      (request) => request.method() === 'DELETE'
+        && request.url().endsWith('/v1/judgments/smoke-judgments/rows/smoke-judgment-1'),
+      { timeout: 5000 },
+    );
+    const undoClicked = await page.evaluate(() => {
+      const toastEl = Array.from(document.querySelectorAll('#toasts .toast-action'))
+        .find((candidate) => /Recorded A wins in "smoke-judgments"/.test(candidate.textContent || ''));
+      const undoBtn = Array.from(toastEl?.querySelectorAll('.toast-action-btn') || [])
+        .find((button) => button.textContent?.trim() === 'Undo');
+      if (!undoBtn) return false;
+      undoBtn.click();
+      return true;
+    });
+    if (!undoClicked) fail('Recorded-judgment toast should offer an Undo action');
+    await undoDeleteRequestPromise
+      .catch(() => fail('Undo did not DELETE /v1/judgments/smoke-judgments/rows/smoke-judgment-1'));
+    await expectTrainingToast(page, 'Undone — judgment removed from "smoke-judgments"');
+    await waitForPanelText(page, '#judgment-rows-count', /0 judgments in "smoke-judgments"/, 'Undo should restore the judgment viewer count');
+    await waitForPanelText(page, '#judgments-list', /0 judgments/, 'Judgments list should refresh to zero rows after Undo');
 
   } finally {
     await browser.close();


### PR DESCRIPTION
Wave 4 of the UI overhaul (roadmap PR 21 of 25).

A/B judging had no undo — one misclick permanently recorded a wrong preference, while `DELETE /v1/judgments/{name}/rows/{judgment_id}` sat server-side never called by any UI.

- **Additive API**: `POST /v1/judgments/{name}/rows` now returns `AppendJudgmentResponse { judgment_id, #[serde(flatten)] manifest }` — every existing field stays top-level; clients that ignored the body see no change. (Row ids were already stable: client-supplied or uuid v4, `api/eval.rs:827`.)
- **UI**: shared `recordedJudgmentToast()` gives both the A/B judging viewer ("Recorded A wins / B wins / Tie / Skip") and the Playground Save-A/B flow an **Undo** action — DELETE by returned id, live rows-count update, list refresh, confirmation. Double-fire guarded; failed DELETE → error toast with counts untouched; old servers without `judgment_id` → plain toast, no broken Undo.

Tests: `judgment_flywheel_create_append_compile` extended — client-id echo, server-uuid round-trip (append → DELETE → `num_rows` restored), second DELETE → 404. Full `cargo test -p kiln-server` green. The smoke harness gained a judgment flow (create → generate pair via SSE mock → vote → Undo → DELETE fires to the exact path → count back to 0). Full smoke passes post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)