### PR TITLE
Dashboard surfaces hidden server diagnostics: /v1/config, /metrics, adapter receipts

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -291,6 +291,17 @@ function applyServedModelId(id) {
   renderConnectSnippets(activeTab);
 }
 
+// Prometheus scrape config for this server's /metrics endpoint, built from
+// the live origin. Rendered once at init (the origin can't change without a
+// reload); the Copy button reuses the same delegated data-copy-code handler
+// as the client snippets above.
+function renderConnectMetricsSnippet() {
+  const pre = document.getElementById('connect-metrics-snippet');
+  if (!pre) return;
+  const code = `# prometheus.yml — scrape this Kiln server\nscrape_configs:\n  - job_name: "kiln"\n    metrics_path: "/metrics"\n    static_configs:\n      - targets: ["${window.location.host}"]`;
+  pre.innerHTML = renderHighlighted(code, 'sh');
+}
+
 function selectConnectTab(key) {
   document.querySelectorAll('.connect-tabs .tab').forEach(t => {
     const on = t.dataset.connectTab === key;
@@ -990,6 +1001,7 @@ async function initConnect() {
   const modelEl = document.getElementById('connect-model');
   if (modelEl) { modelEl.textContent = connectModelId; modelEl.title = connectModelId; }
   renderConnectSnippets('pi');
+  renderConnectMetricsSnippet();
   const tr = document.getElementById('connect-test-result');
   if (tr && !tr.textContent.trim()) tr.innerHTML = 'Once connected, your agent&rsquo;s calls stream into <strong>Recent requests</strong> below.';
   document.querySelectorAll('.connect-tabs .tab').forEach(t => t.addEventListener('click', () => selectConnectTab(t.dataset.connectTab)));
@@ -1251,6 +1263,107 @@ function renderServerStatus(h) {
 
   el.innerHTML = (vramHtml + schedHtml + checksHtml + donutHtml) || '<div class="empty">No data</div>';
 }
+
+/* =====================================================================
+   Runtime config expander — GET /v1/config (detected VRAM + detection
+   source, KV cache geometry, training checkpointing, memory budgets).
+   The <details> shell is static in index.html as a SIBLING of the keyed
+   #server-status region: renderServerStatus innerHTML-swaps that element
+   whenever its content key changes (and pollHealth's failure path
+   overwrites it wholesale), so anything rendered inside it is destroyed
+   by the 2s poll — exactly how the VRAM donut used to vanish. Out here
+   the open state and the rendered content survive repaints by
+   construction. Fetched once per open (no poll loop); Refresh re-fetches;
+   failures render a quiet retry line and never throw.
+   ===================================================================== */
+let runtimeConfigLoaded = false;
+let runtimeConfigFetchSeq = 0;
+
+function runtimeConfigRow(label, valueHtml, title) {
+  return `<div class="rc-row"${title ? ` title="${escapeHtml(title)}"` : ''}>
+    <span class="rc-label">${escapeHtml(label)}</span>
+    <span class="rc-value">${valueHtml}</span>
+  </div>`;
+}
+
+// Renders the genuinely useful subset of /v1/config (shape: api/config.rs
+// ConfigResponse — vram / kv_cache / training / memory_budget) plus a raw
+// pretty-printed JSON toggle so nothing the server reports is hidden.
+function renderRuntimeConfigBody(cfg) {
+  const vram = cfg.vram || {};
+  const kv = cfg.kv_cache || {};
+  const train = cfg.training || {};
+  const b = cfg.memory_budget || {};
+  const srcChip = s => s == null ? '' : ` <span class="rc-source" title="Where this value came from">${escapeHtml(String(s))}</span>`;
+  const onOff = v => v ? 'on' : 'off';
+  const num = v => (typeof v === 'number' && isFinite(v)) ? v.toLocaleString() : '—';
+  const gb = v => (typeof v === 'number' && isFinite(v)) ? v.toFixed(1) + ' GB' : '—';
+  return `
+    <div class="rc-groups">
+      <div class="rc-group">
+        <div class="rc-group-title">VRAM detection</div>
+        ${runtimeConfigRow('Detected', `<strong>${gb(vram.detected_gb)}</strong>${srcChip(vram.source)}`, 'GPU memory detected at startup, plus the detector that reported it (nvidia-smi, linux-drm-sysfs, KILN_GPU_MEMORY_GB, …).')}
+      </div>
+      <div class="rc-group">
+        <div class="rc-group-title">KV cache</div>
+        ${runtimeConfigRow('Blocks', `<strong>${num(kv.num_blocks)}</strong>${srcChip(kv.num_blocks_source)}`, 'Paged-attention blocks allocated by the running backend (auto-sized, or pinned via KILN_NUM_BLOCKS).')}
+        ${runtimeConfigRow('FP8 cache', `<strong>${onOff(kv.fp8_enabled)}</strong>`, 'Whether the KV cache stores keys/values in FP8 (halves cache memory per token).')}
+      </div>
+      <div class="rc-group">
+        <div class="rc-group-title">Training</div>
+        ${runtimeConfigRow('Grad checkpointing', `<strong>${onOff(train.checkpointing_enabled)}</strong>`, 'Gradient checkpointing trades recompute for activation memory during LoRA training.')}
+        ${runtimeConfigRow('Segments', `<strong>${num(train.checkpoint_segments)}</strong>${srcChip(train.checkpoint_segments_source)}`, 'Checkpoint segment count (auto-sized, or pinned via KILN_GRAD_CHECKPOINT_SEGMENTS).')}
+      </div>
+      <div class="rc-group">
+        <div class="rc-group-title">Memory budget</div>
+        ${runtimeConfigRow('Total VRAM', `<strong>${gb(b.total_vram_gb)}</strong>`)}
+        ${runtimeConfigRow('Model weights', `<strong>${gb(b.model_gb)}</strong>`)}
+        ${runtimeConfigRow('KV cache', `<strong>${gb(b.kv_cache_gb)}</strong>`)}
+        ${runtimeConfigRow('Training reserve', `<strong>${gb(b.training_budget_gb)}</strong>`)}
+        ${runtimeConfigRow('Inference fraction', `<strong>${(typeof b.inference_memory_fraction === 'number' && isFinite(b.inference_memory_fraction)) ? (b.inference_memory_fraction * 100).toFixed(0) + '%' : '—'}</strong>`, 'Fraction of usable VRAM reserved for inference (model + KV cache); the remainder is the training budget.')}
+      </div>
+    </div>
+    <div class="rc-actions">
+      <button class="btn btn-sm" type="button" data-rc-refresh>Refresh</button>
+      <button class="btn btn-sm btn-ghost" type="button" data-rc-raw aria-expanded="false">Raw JSON</button>
+    </div>
+    <pre class="rc-raw" data-rc-raw-pre hidden>${escapeHtml(JSON.stringify(cfg, null, 2))}</pre>`;
+}
+
+async function loadRuntimeConfig(force = false) {
+  const body = document.getElementById('runtime-config-body');
+  if (!body) return;
+  if (runtimeConfigLoaded && !force) return;
+  const seq = ++runtimeConfigFetchSeq;
+  body.innerHTML = '<div class="hint">Loading GET /v1/config…</div>';
+  try {
+    const cfg = await api('/v1/config');
+    if (seq !== runtimeConfigFetchSeq) return; // superseded by a newer refresh
+    runtimeConfigLoaded = true;
+    body.innerHTML = renderRuntimeConfigBody(cfg);
+  } catch (e) {
+    if (seq !== runtimeConfigFetchSeq) return;
+    runtimeConfigLoaded = false; // the next open retries automatically
+    body.innerHTML = `<div class="hint">Couldn't load /v1/config — ${escapeHtml((e && e.message) || 'request failed')}</div>
+      <div class="rc-actions"><button class="btn btn-sm" type="button" data-rc-refresh>Retry</button></div>`;
+  }
+}
+
+// Static shell: wire once at startup. `toggle` fires on open and close;
+// fetch on open only (and only the first time, unless Refresh forces it).
+(function initRuntimeConfig() {
+  const details = document.getElementById('runtime-config');
+  if (!details) return;
+  details.addEventListener('toggle', () => { if (details.open) loadRuntimeConfig(); });
+  details.addEventListener('click', e => {
+    if (e.target.closest('[data-rc-refresh]')) { loadRuntimeConfig(true); return; }
+    const raw = e.target.closest('[data-rc-raw]');
+    if (raw) {
+      const pre = details.querySelector('[data-rc-raw-pre]');
+      if (pre) { pre.hidden = !pre.hidden; raw.setAttribute('aria-expanded', String(!pre.hidden)); }
+    }
+  });
+})();
 
 
 // --- Decode Performance ---
@@ -7488,9 +7601,103 @@ async function openAdapterDrillModal(name) {
     content.querySelectorAll('[data-train-job]').forEach(row => {
       row.addEventListener('click', () => openTrainDrillModal(row.dataset.trainJob));
     });
+    // Provenance receipt loads after the detail body renders — its failure
+    // (404 is the normal case for uploaded/legacy adapters) must never take
+    // the rest of the modal down, so it's a separate fire-and-forget fetch.
+    loadAdapterReceipt(name);
   } catch (e) {
     document.getElementById('adapter-drill-content').innerHTML = `<div class="detail-empty">Failed to load: ${escapeHtml(e.message)}</div>`;
   }
+}
+
+/* ---- Adapter receipt (GET /v1/adapters/:name/receipt) -----------------
+   The §8.11 reproducibility receipt (kiln-train/src/receipt.rs
+   AdapterReceipt): training provenance — source kind, seed, teacher,
+   prompt corpus, hyperparameters, run diagnostics, post-train eval
+   scores. Fetched when the drill modal opens; 404 means no receipt.json
+   on disk (uploaded or pre-receipt adapters) and renders as a quiet
+   explanation; any other failure renders a one-line hint. */
+async function loadAdapterReceipt(name) {
+  // Re-resolve on every write: the modal may have switched to another
+  // adapter (or been repainted) while this fetch was in flight.
+  const section = () => (adapterDrillName === name
+    ? document.getElementById('adapter-receipt-section')
+    : null);
+  let receipt;
+  try {
+    receipt = await api('/v1/adapters/' + encodeURIComponent(name) + '/receipt');
+  } catch (e) {
+    const el = section();
+    if (!el) return;
+    el.innerHTML = (e && e.status === 404)
+      ? '<h4>Receipt</h4><div class="hint">No receipt — uploaded or legacy adapter. Adapters trained on this server ship a reproducibility receipt (<code>receipt.json</code>).</div>'
+      : `<h4>Receipt</h4><div class="hint">Couldn't load receipt — ${escapeHtml((e && e.message) || 'request failed')}</div>`;
+    return;
+  }
+  const el = section();
+  if (!el) return;
+  el.innerHTML = renderAdapterReceipt(receipt);
+  el.querySelectorAll('[data-train-job]').forEach(row => {
+    row.addEventListener('click', () => openTrainDrillModal(row.dataset.trainJob));
+  });
+  const rawBtn = el.querySelector('[data-receipt-raw]');
+  const rawPre = el.querySelector('[data-receipt-raw-pre]');
+  if (rawBtn && rawPre) {
+    rawBtn.addEventListener('click', () => {
+      rawPre.hidden = !rawPre.hidden;
+      rawBtn.setAttribute('aria-expanded', String(!rawPre.hidden));
+    });
+  }
+}
+
+function renderAdapterReceipt(r) {
+  const rows = [];
+  const line = (label, html) => rows.push(`<div><span class="hint">${escapeHtml(label)}:</span> ${html}</div>`);
+  if (r.source_kind) line('Trained via', `<code>${escapeHtml(String(r.source_kind))}</code>`);
+  if (r.produced_at) {
+    const t = Date.parse(r.produced_at);
+    line('Produced', escapeHtml(isFinite(t) ? fmtSmartTime(t) : String(r.produced_at)));
+  }
+  if (r.kiln_version) line('Kiln version', `<code>${escapeHtml(String(r.kiln_version))}</code>`);
+  if (r.seed != null) line('Seed', `<code>${escapeHtml(String(r.seed))}</code>`);
+  // The receipt schema has no dedicated job-id field today, but when a
+  // producer recorded one (top-level or inside the free-form
+  // hyperparameters object) link it through to the train drill.
+  const hp = (r.hyperparameters && typeof r.hyperparameters === 'object' && !Array.isArray(r.hyperparameters)) ? r.hyperparameters : null;
+  const jobId = r.job_id || r.training_job_id || (hp && (hp.job_id || hp.training_job_id)) || null;
+  if (jobId) line('Training job', `<a data-train-job="${escapeHtml(String(jobId))}" style="font-family:var(--font-mono); cursor:pointer;">${escapeHtml(String(jobId))}</a>`);
+  if (r.teacher && r.teacher.alias) {
+    const tid = r.teacher.model_id && r.teacher.model_id !== r.teacher.alias
+      ? ` <span class="hint">(${escapeHtml(String(r.teacher.model_id))})</span>` : '';
+    line('Teacher', `<code>${escapeHtml(String(r.teacher.alias))}</code>${tid}`);
+  }
+  if (r.prompts && r.prompts.source) {
+    const count = typeof r.prompts.count === 'number' ? ` <span class="hint">· ${r.prompts.count} prompts</span>` : '';
+    line('Dataset', `<code>${escapeHtml(String(r.prompts.source))}</code>${count}`);
+  }
+  const diag = r.diagnostic_summary || {};
+  if (typeof diag.final_loss === 'number') line('Final loss', `<code>${diag.final_loss.toFixed(4)}</code>`);
+  if (Array.isArray(diag.guardrail_triggers) && diag.guardrail_triggers.length) {
+    line('Guardrails fired', escapeHtml(diag.guardrail_triggers.join(', ')));
+  }
+  if (r.post_eval && typeof r.post_eval === 'object') {
+    const evals = Object.entries(r.post_eval).slice(0, 6)
+      .map(([suite, score]) => `${escapeHtml(suite)} <code>${typeof score === 'number' ? score.toFixed(3) : escapeHtml(String(score))}</code>`);
+    if (evals.length) line('Post-train evals', evals.join(' · '));
+  }
+  let hyperHtml = '';
+  if (hp) {
+    const chips = Object.entries(hp)
+      .filter(([, v]) => v === null || ['number', 'string', 'boolean'].includes(typeof v))
+      .slice(0, 12)
+      .map(([k, v]) => `<span class="receipt-chip"><span class="hint">${escapeHtml(k)}</span> ${escapeHtml(v === null ? 'default' : String(v))}</span>`);
+    if (chips.length) hyperHtml = `<div class="receipt-chips">${chips.join('')}</div>`;
+  }
+  return `<h4>Receipt</h4>
+    <div style="display:flex; flex-direction:column; gap:4px; font-size:13px;">${rows.join('') || '<div class="hint">Receipt present, but it carries no provenance fields.</div>'}</div>
+    ${hyperHtml}
+    <div style="margin-top:8px;"><button class="btn btn-sm btn-ghost" type="button" data-receipt-raw aria-expanded="false">Raw JSON</button></div>
+    <pre class="rc-raw" data-receipt-raw-pre hidden>${escapeHtml(JSON.stringify(r, null, 2))}</pre>`;
 }
 
 function renderAdapterDrillBody(d) {
@@ -7568,6 +7775,10 @@ function renderAdapterDrillBody(d) {
     </div>
   </div>
   ${lineageHtml}
+  <div class="detail-section" id="adapter-receipt-section">
+    <h4>Receipt</h4>
+    <div class="hint">Loading receipt…</div>
+  </div>
   <div class="detail-section">
     <h4>Eval history</h4>
     ${evalHtml}

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -237,6 +237,17 @@
             <div class="connect-snippets" id="connect-snippets"><!-- rendered by initConnect() --></div>
           </div>
         </div>
+        <!-- Observability footer: the server has always exported Prometheus
+             metrics at /metrics — surface it where operators wire things up.
+             The scrape-config snippet (live origin) is rendered by
+             initConnect() and reuses the delegated data-copy-code handler. -->
+        <div class="connect-metrics" id="connect-metrics">
+          <span class="connect-metrics-line">
+            <svg class="icn icn-sm" aria-hidden="true"><use href="#i-activity"></use></svg>
+            Prometheus metrics at <a href="/metrics" target="_blank" rel="noopener"><code>/metrics</code></a> — scrape config:
+          </span>
+          <div class="code-block connect-metrics-snippet"><button class="copy-btn" type="button" data-copy-code aria-label="Copy Prometheus scrape config"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button><pre id="connect-metrics-snippet"><!-- rendered by initConnect() --></pre></div>
+        </div>
       </div>
     </section>
 
@@ -366,6 +377,25 @@
         <div class="card-body" id="server-status" data-panel-id="server-status-panel" role="status" aria-live="polite" aria-atomic="false" aria-busy="true">
           <div class="empty">Loading server diagnostics…</div>
         </div>
+        <!-- Runtime config expander — deliberately a SIBLING of the keyed
+             #server-status region. renderServerStatus repaints
+             #server-status.innerHTML on a content key every 2s health poll
+             (and pollHealth's failure path overwrites that element wholesale),
+             so anything rendered inside it gets destroyed on the next poll —
+             that is exactly how the VRAM donut used to vanish. This static
+             shell is never touched by the poll, so its open state and content
+             survive repaints by construction. Content fetches GET /v1/config
+             on first open only — no poll loop. -->
+        <details class="runtime-config" id="runtime-config">
+          <summary>
+            <svg class="icn icn-sm" aria-hidden="true"><use href="#i-gear"></use></svg>
+            Runtime config
+            <span class="runtime-config-hint">detected VRAM · KV cache · memory budget — GET /v1/config</span>
+          </summary>
+          <div class="runtime-config-body" id="runtime-config-body">
+            <div class="hint">Loading…</div>
+          </div>
+        </details>
       </div>
 
       <!-- Decode Performance card with live tok/s sparkline -->

--- a/crates/kiln-server/src/ui/styles.css
+++ b/crates/kiln-server/src/ui/styles.css
@@ -3297,3 +3297,76 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
     .flywheel-node { flex-basis: 40%; }
     .flywheel-arrow { display: none; }
   }
+
+/* =====================================================================
+   Hidden server diagnostics — runtime-config expander (Server status
+   card footer), Prometheus /metrics line (Connect panel footer), and
+   adapter receipt chips (adapter drill modal).
+   ===================================================================== */
+
+/* Runtime config: a <details> footer that is a SIBLING of the keyed
+   #server-status region, so the 2s health-poll repaint never touches it. */
+.runtime-config { border-top: 1px solid var(--border); }
+.runtime-config > summary {
+  display: flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-3) var(--space-5); cursor: pointer; list-style: none;
+  font-size: var(--text-xs); font-weight: 600; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: var(--tracking-caps);
+  user-select: none;
+}
+.runtime-config > summary::-webkit-details-marker { display: none; }
+.runtime-config > summary::before {
+  content: ''; width: 0; height: 0; flex-shrink: 0;
+  border-left: 5px solid currentColor; border-top: 4px solid transparent; border-bottom: 4px solid transparent;
+  transition: transform 0.15s ease;
+}
+.runtime-config[open] > summary::before { transform: rotate(90deg); }
+.runtime-config > summary:hover { color: var(--text); }
+.runtime-config .runtime-config-hint {
+  margin-left: auto; font-weight: 400; text-transform: none; letter-spacing: 0;
+  color: var(--text-quiet); font-family: var(--font-mono); font-size: 10px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.runtime-config-body { padding: 0 var(--space-5) var(--space-4); }
+.rc-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--space-4); }
+.rc-group-title {
+  font-size: 10px; font-weight: 600; color: var(--text-quiet);
+  text-transform: uppercase; letter-spacing: var(--tracking-caps); margin-bottom: var(--space-2);
+}
+.rc-row { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); padding: 2px 0; font-size: var(--text-xs); }
+.rc-label { color: var(--text-muted); }
+.rc-value { text-align: right; font-variant-numeric: tabular-nums; }
+.rc-source {
+  display: inline-block; padding: 0 5px; border-radius: var(--radius-pill);
+  background: var(--surface-2); border: 1px solid var(--border);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-quiet);
+}
+.rc-actions { display: flex; gap: var(--space-2); margin-top: var(--space-3); }
+.rc-raw {
+  margin: var(--space-3) 0 0; padding: var(--space-3);
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  font-family: var(--font-mono); font-size: 11px; line-height: 1.45;
+  overflow: auto; max-height: 320px; white-space: pre;
+}
+
+/* Connect panel footer: Prometheus metrics line + scrape-config snippet. */
+.connect-metrics {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  padding: var(--space-3) var(--space-5) var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.connect-metrics-line {
+  display: flex; align-items: center; gap: var(--space-2);
+  font-size: var(--text-xs); color: var(--text-muted);
+}
+.connect-metrics-line .icn { color: var(--text-quiet); }
+.connect-metrics-line a { color: var(--text-2); }
+.connect-metrics-snippet pre { font-size: 11px; }
+
+/* Adapter receipt hyperparameter chips (drill modal Receipt section). */
+.receipt-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3); }
+.receipt-chip {
+  display: inline-flex; align-items: baseline; gap: 4px; padding: 2px 7px;
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-pill);
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-2);
+}

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -243,11 +243,55 @@ function validateExistingAdapterName(name, availableAdapters, action) {
 }
 
 function parseAdapterRoute(pathname) {
-  const match = /^\/v1\/adapters\/([^/]+)(?:\/(download))?$/.exec(pathname);
+  const match = /^\/v1\/adapters\/([^/]+)(?:\/(download|detail|receipt))?$/.exec(pathname);
   if (!match) return null;
   if (['load', 'unload', 'upload', 'merge'].includes(match[1])) return null;
   return { name: decodeURIComponent(match[1]), action: match[2] || null };
 }
+
+function adapterNotFound(res, name) {
+  // Mirrors error.rs ApiError::adapter_not_found.
+  res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify({
+    error: {
+      code: 'adapter_not_found',
+      message: `Adapter '${name}' does not exist`,
+      hint: 'List available adapters with GET /v1/adapters.',
+    },
+  }));
+}
+
+// §8.11 reproducibility receipt for adapter-alpha — field-for-field the
+// kiln-train/src/receipt.rs AdapterReceipt shape (the /receipt endpoint
+// serializes that struct directly). Other adapters 404, exactly like
+// AdapterReceipt::read_from_adapter_dir returning Ok(None) for uploaded
+// or pre-receipt adapters.
+const smokeAdapterReceipt = {
+  schema_version: 1,
+  adapter: 'adapter-alpha',
+  produced_at: '2026-06-10T18:30:00Z',
+  kiln_version: '0.1.0',
+  kernel_versions: { 'kiln-opd-loss-kernel': '0.1.0' },
+  seed: 4218,
+  source_kind: 'opd',
+  teacher: { alias: 'qwen3.6-27b@openrouter', model_id: 'qwen/qwen-3.6-27b' },
+  prompts: {
+    source: 'kiln-canonical:math_reasoning:v3',
+    manifest_hash: 'f00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeed',
+    count: 128,
+  },
+  hyperparameters: {
+    learning_rate: 0.0001,
+    lora_rank: 16,
+    lora_alpha: 32,
+    epochs: 2,
+    temperature: 0.7,
+    top_k: 64,
+    top_p: 0.95,
+  },
+  diagnostic_summary: { overlap_ratio_final: 0.91, rep_rate_max: 0.0, final_loss: 0.0421 },
+  post_eval: { 'math-reasoning-suite': 0.84 },
+};
 
 // Mirrors api/eval.rs upload_dataset: multipart fields `name`, `format`
 // (sft_chat | grpo_groups | raw), optional `description`, and `file` whose
@@ -414,6 +458,8 @@ async function startServer({
   // `completedTrainingJobs` as Failed("cancelled by user"), exactly like
   // the trainer aborting at the next step boundary.
   let runningTrainingJob = null;
+  // Health-poll counter — see the /health handler.
+  let healthTick = 0;
   // Eval datasets created through POST /v1/eval/datasets/upload (the
   // "Try a sample dataset" golden path) — GET /v1/eval/datasets reflects
   // them so the Datasets list refresh after upload is observable.
@@ -494,6 +540,10 @@ async function startServer({
         apiFailure(res, 'Decode performance', url.pathname);
         return;
       }
+      if (url.pathname === '/v1/config') {
+        apiFailure(res, 'Runtime config', url.pathname);
+        return;
+      }
       if (url.pathname === '/v1/stats/recent-requests') {
         apiFailure(res, 'Recent requests', url.pathname);
         return;
@@ -520,15 +570,38 @@ async function startServer({
       }
     }
     if (url.pathname === '/health') {
+      // blocks_used cycles so renderServerStatus's content key changes on
+      // every poll — each 2s tick genuinely innerHTML-swaps #server-status,
+      // which is what the runtime-config-expander survival assertion (and
+      // the VRAM-donut regression assertion) must hold against.
+      healthTick += 1;
       json(res, {
         status: 'ok',
         model: 'Qwen3.5-4B',
         backend: 'mock',
         uptime_seconds: 42,
         active_adapter: activeAdapter,
-        scheduler: { waiting: 0, running: 0, blocks_used: 0, blocks_free: 1024 },
+        scheduler: { waiting: 0, running: 0, blocks_used: healthTick % 2, blocks_free: 1024 },
         gpu_memory: { total_vram_gb: 24, model_gb: 8, kv_cache_gb: 2, training_budget_gb: 4 },
         checks: [{ name: 'mock smoke server', pass: true }],
+      });
+      return;
+    }
+    // Mirrors api/config.rs ConfigResponse (vram / kv_cache / training /
+    // memory_budget) — the runtime-config expander fetches this once per
+    // open, never on a poll loop.
+    if (url.pathname === '/v1/config') {
+      json(res, {
+        vram: { detected_gb: 25.8, source: 'nvidia-smi' },
+        kv_cache: { num_blocks: 1024, num_blocks_source: 'auto', fp8_enabled: true },
+        training: { checkpoint_segments: 4, checkpoint_segments_source: 'auto', checkpointing_enabled: true },
+        memory_budget: {
+          total_vram_gb: 25.8,
+          model_gb: 8.2,
+          kv_cache_gb: 2.1,
+          training_budget_gb: 4.0,
+          inference_memory_fraction: 0.55,
+        },
       });
       return;
     }
@@ -580,6 +653,40 @@ async function startServer({
       }
       activeAdapter = null;
       setTimeout(() => json(res, { active: null }), 75);
+      return;
+    }
+    // Mirrors api/adapters.rs AdapterDetail — the drill modal's main body.
+    if (adapterRoute?.action === 'detail') {
+      const adapter = availableAdapters.find((candidate) => candidate.name === adapterRoute.name);
+      if (!adapter) {
+        adapterNotFound(res, adapterRoute.name);
+        return;
+      }
+      json(res, {
+        name: adapter.name,
+        is_active: activeAdapter === adapter.name,
+        has_config: true,
+        has_weights: true,
+        size_bytes: adapter.size_bytes,
+        files: [
+          { name: 'adapter_config.json', size_bytes: 512 },
+          { name: 'adapter_model.safetensors', size_bytes: adapter.size_bytes },
+        ],
+        training_jobs: [],
+        eval_jobs: [],
+      });
+      return;
+    }
+    // GET /v1/adapters/:name/receipt — adapter-alpha ships the smoke
+    // receipt; everything else 404s with the adapter_not_found envelope
+    // (api/adapters.rs adapter_receipt's Ok(None) branch).
+    if (adapterRoute?.action === 'receipt') {
+      const adapterExists = availableAdapters.some((candidate) => candidate.name === adapterRoute.name);
+      if (!adapterExists || adapterRoute.name !== 'adapter-alpha') {
+        adapterNotFound(res, `${adapterRoute.name}/receipt.json`);
+        return;
+      }
+      json(res, smokeAdapterReceipt);
       return;
     }
     if (adapterRoute?.action === 'download') {
@@ -1488,6 +1595,16 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       await expectApiFailurePanel(page, '#server-status', 'Server status', 'Server status smoke failure from /health');
       await expectApiFailurePanel(page, '#decode-perf-panel', 'Decode performance', 'Decode performance smoke failure from /v1/stats/decode');
       await expectApiFailurePanel(page, '#recent-requests-panel', 'Recent requests', 'Recent requests smoke failure from /v1/stats/recent-requests');
+
+      // Opening the runtime-config expander while /v1/config 503s must
+      // render a quiet retry line INSIDE the expander — the Server-status
+      // card keeps its own failure state, nothing throws (the pageErrors
+      // assertion at the end of this scenario backs that up).
+      await clickAndWait(page, '#runtime-config > summary', 'Could not open the runtime config expander in the failure scenario');
+      await waitForPanelText(page, '#runtime-config-body', /Couldn't load \/v1\/config/, 'Runtime config should render its graceful failure copy');
+      await page.$('#runtime-config [data-rc-refresh]')
+        .then((handle) => { if (!handle) fail('Runtime config failure copy should offer a Retry button'); });
+
       await goToPrimaryTab(page, 'adapters');
       await expectApiFailurePanel(page, '#adapters-panel', 'Adapters', 'Adapters smoke failure from /v1/adapters');
       await goToPrimaryTab(page, 'training');
@@ -1515,6 +1632,10 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
         await recoverPanel('#server-status', /GPU VRAM/, 'Server status did not recover after the APIs healed');
         await page.waitForSelector('#server-status .vram-donut svg', { timeout: 5000 })
           .catch(() => fail('VRAM donut missing from recovered server status panel'));
+        // The expander's Retry refetches /v1/config (no poll loop covers it).
+        await page.click('#runtime-config [data-rc-refresh]')
+          .catch(() => fail('Could not click the runtime config Retry button after the APIs healed'));
+        await waitForPanelText(page, '#runtime-config-body', /nvidia-smi/, 'Runtime config did not recover after Retry');
         await recoverPanel('#decode-perf-panel', /No streaming completions/i, 'Decode panel did not recover after the APIs healed');
         await recoverPanel('#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not recover after the APIs healed');
         await goToPrimaryTab(page, 'training');
@@ -1732,6 +1853,47 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       await rm(uploadFixtureDir, { recursive: true, force: true });
     }
 
+    // ---- Adapter receipt viewer in the drill modal: adapter-alpha carries
+    // a §8.11 receipt.json → provenance fields + raw-JSON toggle render; the
+    // just-uploaded adapter 404s → the graceful no-receipt copy renders and
+    // the rest of the modal is unaffected.
+    const openAdapterDrill = async (name) => {
+      const clicked = await page.evaluate((target) => {
+        const card = document.querySelector(`#adapters-panel .adapter-card[data-adapter-name="${target}"]`);
+        if (!card) return false;
+        card.click();
+        return true;
+      }, name);
+      if (!clicked) fail(`Could not find the adapter card for ${name}`);
+      await page.waitForFunction(() => document.getElementById('adapter-drill-modal')?.hidden === false, { timeout: 5000 })
+        .catch(() => fail(`Adapter drill modal did not open for ${name}`));
+    };
+    const closeAdapterDrill = async () => {
+      await clickAndWait(page, '#adapter-drill-close', 'Could not close the adapter drill modal');
+      await page.waitForFunction(() => document.getElementById('adapter-drill-modal')?.hidden === true, { timeout: 5000 })
+        .catch(() => fail('Adapter drill modal did not close'));
+    };
+
+    await openAdapterDrill('adapter-alpha');
+    await waitForPanelText(page, '#adapter-receipt-section', /Trained via/, 'Receipt section should render provenance for adapter-alpha');
+    await waitForPanelText(page, '#adapter-receipt-section', /opd/, 'Receipt should render the source kind');
+    await waitForPanelText(page, '#adapter-receipt-section', /kiln-canonical:math_reasoning:v3/, 'Receipt should render the dataset source');
+    await waitForPanelText(page, '#adapter-receipt-section', /128 prompts/, 'Receipt should render the prompt count');
+    await waitForPanelText(page, '#adapter-receipt-section', /qwen3\.6-27b@openrouter/, 'Receipt should render the teacher alias');
+    await waitForPanelText(page, '#adapter-receipt-section', /lora_rank/, 'Receipt should render key hyperparameters');
+    await clickAndWait(page, '#adapter-receipt-section [data-receipt-raw]', 'Could not toggle the receipt raw JSON');
+    const receiptRawShown = await page.$eval(
+      '#adapter-receipt-section [data-receipt-raw-pre]',
+      (el) => !el.hidden && /"schema_version"/.test(el.textContent || ''),
+    );
+    if (!receiptRawShown) fail('Receipt raw JSON toggle should reveal the pretty-printed receipt payload');
+    await closeAdapterDrill();
+
+    await openAdapterDrill('uploaded-smoke-adapter');
+    await waitForPanelText(page, '#adapter-receipt-section', /No receipt — uploaded or legacy adapter/, 'A 404 receipt should render the graceful no-receipt copy');
+    await waitForPanelText(page, '#adapter-drill-content', /Files on disk/, 'The drill modal body should render fine alongside a 404 receipt');
+    await closeAdapterDrill();
+
     page.once('dialog', async (dialog) => {
       if (!/Delete adapter "adapter-beta"\?/.test(dialog.message())) fail(`Unexpected delete confirmation text: ${dialog.message()}`);
       await dialog.accept();
@@ -1786,10 +1948,38 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await waitForPanelText(page, '#decode-perf-panel', /No streaming completions/i, 'Empty decode performance state missing');
     await expectPanelLink(page, '#decode-perf-panel', '/health', '/health');
 
+    // ---- Hidden diagnostics: Prometheus /metrics line in the Connect panel
+    // with a live-origin scrape config behind the standard copy button.
+    await waitForPanelText(page, '#connect-metrics', /Prometheus metrics at/, 'Connect panel missing the /metrics line');
+    await expectPanelLink(page, '#connect-metrics', '/metrics', '/metrics');
+    const scrapeSnippet = await page.$eval('#connect-metrics-snippet', (el) => el.innerText || '');
+    if (!scrapeSnippet.includes(`targets: ["${new URL(baseUrl).host}"]`)) {
+      fail(`Prometheus scrape config should target the live origin, got: ${JSON.stringify(scrapeSnippet)}`);
+    }
+    if (!(await page.$('#connect-metrics [data-copy-code]'))) fail('Prometheus scrape config snippet missing its copy button');
+
+    // ---- Hidden diagnostics: the runtime-config expander on the Server
+    // status card fetches GET /v1/config on first open and renders the real
+    // ConfigResponse fields (VRAM detection, KV cache geometry, budgets).
+    await clickAndWait(page, '#runtime-config > summary', 'Could not open the runtime config expander');
+    await waitForPanelText(page, '#runtime-config-body', /nvidia-smi/, 'Runtime config should render the VRAM detection source');
+    await waitForPanelText(page, '#runtime-config-body', /25\.8 GB/, 'Runtime config should render detected VRAM');
+    await waitForPanelText(page, '#runtime-config-body', /1,024/, 'Runtime config should render the KV cache block count');
+    await waitForPanelText(page, '#runtime-config-body', /FP8 cache/, 'Runtime config should render the fp8 cache mode');
+    await waitForPanelText(page, '#runtime-config-body', /Training reserve/, 'Runtime config should render the memory budget rows');
+    await clickAndWait(page, '#runtime-config [data-rc-raw]', 'Could not toggle the runtime config raw JSON');
+    const configRawShown = await page.$eval(
+      '#runtime-config [data-rc-raw-pre]',
+      (el) => !el.hidden && /"memory_budget"/.test(el.textContent || ''),
+    );
+    if (!configRawShown) fail('Runtime config raw JSON toggle should reveal the pretty-printed /v1/config payload');
+
     // Regression (the "pie chart disappears" bug): the VRAM donut and header
     // stats must survive subsequent 2s health polls. The donut used to render
     // once, then renderServerStatus clobbered the panel while the donut
     // refresher's dedupe key skipped re-appending it — gone until reload.
+    // The mock /health cycles scheduler.blocks_used, so every poll below is
+    // a REAL innerHTML repaint of #server-status, not a deduped no-op.
     await page.waitForSelector('#server-status .vram-donut svg', { timeout: 5000 })
       .catch(() => fail('VRAM donut should render in the server status panel'));
     await new Promise((resolve) => setTimeout(resolve, 5200)); // sit through ≥2 health polls
@@ -1798,11 +1988,17 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       svg: Boolean(document.querySelector('#server-status .vram-donut svg')),
       model: document.getElementById('header-model')?.textContent || '',
       uptime: document.getElementById('header-uptime')?.textContent || '',
+      configOpen: document.getElementById('runtime-config')?.open === true,
+      configIntact: /nvidia-smi/.test(document.getElementById('runtime-config-body')?.textContent || ''),
     }));
     if (!overviewSteadyState.svg) fail('VRAM donut disappeared after subsequent health polls');
     if (overviewSteadyState.donuts !== 1) fail(`Expected exactly one VRAM donut, found ${overviewSteadyState.donuts}`);
     if (overviewSteadyState.model !== 'Qwen3.5-4B') fail(`Header model stat should render from /health, got "${overviewSteadyState.model}"`);
     if (!/^\d+[sm]/.test(overviewSteadyState.uptime)) fail(`Header uptime stat should render, got "${overviewSteadyState.uptime}"`);
+    // The expander is a static SIBLING of the keyed #server-status region —
+    // the ≥2 genuine repaints above must not close it or destroy its content.
+    if (!overviewSteadyState.configOpen) fail('Runtime config expander lost its open state across server-status repaints');
+    if (!overviewSteadyState.configIntact) fail('Runtime config content was destroyed by the server-status repaint');
 
     await goToPrimaryTab(page, 'playground');
     await waitForPanelText(page, '#chat-output', /Send a message to test inference\./, 'Quick Inference empty state missing');


### PR DESCRIPTION
Wave 4 of the UI overhaul (roadmap PR 22 of 25).

Three diagnostics surfaces existed server-side with zero UI exposure — power users discovered them only by reading source:

- **Runtime config expander** on the Server-status card: detected VRAM + detection source (`nvidia-smi`, `linux-drm-sysfs`, env override…), KV cache geometry + FP8 mode, memory budgets — fetched from `GET /v1/config` on first open, with manual Refresh and a raw-JSON toggle. The shell is a **static sibling** of the poll-repainted `#server-status` region, so the 2s content-keyed repaint can't destroy it by construction (the donut lesson, applied). The smoke proves it: the mock now cycles `scheduler.blocks_used` to force genuine repaints every tick, and asserts the expander stays open with content intact across ≥2 of them.
- **Adapter receipts** in the adapter drill: provenance (source kind, teacher, dataset + prompt counts, hyperparameter chips, diagnostic summary) from `GET /v1/adapters/{name}/receipt`, raw-JSON toggle, graceful 404 → "No receipt — uploaded or legacy adapter". Training-job link rendered only when a producer recorded an id (the receipt schema has no job-id field today).
- **Prometheus**: the Connect panel links `/metrics` with a copyable live-origin `prometheus.yml` scrape snippet via the existing copy machinery.

All fetches are on-open only (no new poll loops) and failure-tolerant — the failure scenario opens the expander against a 503 and recovers it via Retry after heal, zero page errors. Every rendered field traced to the actual Rust structs (`api/config.rs:6-41`, `kiln-train/src/receipt.rs:63-103`). Full smoke passes post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)