### PR TITLE
Dashboard contrast pass: dark ink on orange primaries, --text-quiet demoted to graphics-only at small sizes

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -3849,7 +3849,7 @@ function restorePlaygroundHistoryBanner() {
   banner.innerHTML = `
     <div>
       <strong>Restore previous chat?</strong>
-      <span style="color:var(--text-quiet);"> — ${stash.messages.length} message${stash.messages.length === 1 ? '' : 's'}${ageMin ? `, ${ageMin} min ago` : ''}.</span>
+      <span style="color:var(--text-muted);"> — ${stash.messages.length} message${stash.messages.length === 1 ? '' : 's'}${ageMin ? `, ${ageMin} min ago` : ''}.</span>
     </div>
     <div style="display:flex; gap:6px;">
       <button class="btn btn-sm btn-primary" type="button" data-restore="yes">Restore</button>
@@ -4069,9 +4069,9 @@ function renderAssistantBubble(m) {
       body = `<pre>Generating…</pre>`;
     }
   } else if (m.pending && hasReasoning && !hasContent) {
-    body = `<pre style="color:var(--text-quiet);font-style:italic;">Drafting answer…</pre>`;
+    body = `<pre style="color:var(--text-muted);font-style:italic;">Drafting answer…</pre>`;
   } else if (!hasContent && !hasReasoning) {
-    body = `<pre style="color:var(--text-quiet);">(empty response)</pre>`;
+    body = `<pre style="color:var(--text-muted);">(empty response)</pre>`;
   }
   parts.push(body);
 
@@ -5212,9 +5212,9 @@ function renderSynthPreview(container, preview) {
         <div class="eyebrow">Example ${i+1}</div>
         <span class="scorer-badge">${escapeHtml(scorerKind)}</span>
       </div>
-      <div style="font-size:11px; color:var(--text-quiet); margin-bottom:2px;">prompt</div>
+      <div style="font-size:11px; color:var(--text-muted); margin-bottom:2px;">prompt</div>
       <div style="font-family:var(--font-mono); font-size:12px; max-height:60px; overflow:auto; margin-bottom:6px;">${escapeHtml(truncate(userText, 240))}</div>
-      <div style="font-size:11px; color:var(--text-quiet); margin-bottom:2px;">target</div>
+      <div style="font-size:11px; color:var(--text-muted); margin-bottom:2px;">target</div>
       <div style="font-family:var(--font-mono); font-size:12px; max-height:80px; overflow:auto;">${escapeHtml(truncate(ex.target || '', 320))}</div>
       <div style="margin-top:6px;">${tags}</div>
     </div>`;
@@ -5222,15 +5222,15 @@ function renderSynthPreview(container, preview) {
   container.innerHTML = `
     <div style="margin-bottom:8px; padding:10px; background:var(--surface-2); border-radius:6px; display:flex; gap:16px; align-items:center; flex-wrap:wrap;">
       <div>
-        <div class="hint" style="font-size:11px; color:var(--text-quiet);">examples generated</div>
+        <div class="hint" style="font-size:11px; color:var(--text-muted);">examples generated</div>
         <div style="font-size:18px; font-weight:700; font-variant-numeric:tabular-nums;">${(s.examples_generated || 0).toLocaleString()}</div>
       </div>
       <div>
-        <div class="hint" style="font-size:11px; color:var(--text-quiet);">trajectories used</div>
+        <div class="hint" style="font-size:11px; color:var(--text-muted);">trajectories used</div>
         <div style="font-size:18px; font-weight:700; font-variant-numeric:tabular-nums;">${(s.trajectories_used || 0).toLocaleString()}</div>
       </div>
       <div style="flex:1; min-width:200px;">
-        <div class="hint" style="font-size:11px; color:var(--text-quiet); margin-bottom:4px;">auto-detected scorers</div>
+        <div class="hint" style="font-size:11px; color:var(--text-muted); margin-bottom:4px;">auto-detected scorers</div>
         <div>${histStr || '<span class="hint">n/a</span>'}</div>
       </div>
     </div>
@@ -5621,7 +5621,7 @@ async function openSuitePreview(name) {
         : '';
       const tags = (ex.tags || []).map(t => `<span class="tag-chip">${escapeHtml(t)}</span>`).join('');
       return `<div style="border:1px solid var(--border); border-radius:var(--radius-md); padding:var(--space-3); margin-bottom:var(--space-3); background:var(--surface-2);">
-        <div style="font-size:11px; color:var(--text-quiet); font-family:var(--font-mono); margin-bottom:6px;">#${i + 1}${ex.id ? ' · ' + escapeHtml(ex.id) : ''}</div>
+        <div style="font-size:11px; color:var(--text-muted); font-family:var(--font-mono); margin-bottom:6px;">#${i + 1}${ex.id ? ' · ' + escapeHtml(ex.id) : ''}</div>
         ${msgs}
         ${target}
         ${tags ? `<div style="margin-top:6px;">${tags}</div>` : ''}
@@ -7226,7 +7226,7 @@ function donutChartSvg(slices, opts = {}) {
   }).join('');
   const center = opts.centerLabel
     ? `<text x="${c}" y="${c - 2}" text-anchor="middle" style="fill:var(--text); font-weight:700; font-size:14px; font-variant-numeric:tabular-nums;">${escapeHtml(opts.centerLabel)}</text>
-       <text x="${c}" y="${c + 12}" text-anchor="middle" style="fill:var(--text-quiet); font-size:9px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">${escapeHtml(opts.centerSub || '')}</text>`
+       <text x="${c}" y="${c + 12}" text-anchor="middle" style="fill:var(--text-muted); font-size:9px; text-transform:uppercase; letter-spacing: var(--tracking-caps);">${escapeHtml(opts.centerSub || '')}</text>`
     : '';
   return `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
     <circle cx="${c}" cy="${c}" r="${r}" fill="none" stroke="var(--surface-3)" stroke-width="${stroke}"/>
@@ -8024,7 +8024,7 @@ function renderTrainDrillBody(j) {
     durationSecs = Math.max(0, (Date.now() - j.submitted_unix_ms) / 1000);
   }
   const timeRow = (j.submitted_unix_ms || j.finished_unix_ms)
-    ? `<div style="margin-top:6px; font-size:11px; color:var(--text-quiet);">
+    ? `<div style="margin-top:6px; font-size:11px; color:var(--text-muted);">
         ${j.submitted_unix_ms ? `submitted ${escapeHtml(fmtSmartTime(j.submitted_unix_ms))}` : ''}
         ${j.finished_unix_ms ? ` · finished ${escapeHtml(fmtSmartTime(j.finished_unix_ms))}` : ''}
       </div>`
@@ -8161,7 +8161,7 @@ if (playgroundCard) {
   comparePair.className = 'compare-pair';
   comparePair.style.display = 'none';
   comparePair.style.padding = '0 var(--space-5) var(--space-4)';
-  const sidePlaceholder = `<div style="color:var(--text-quiet); font-style:italic; font-size:12px; padding:8px 0;">Pick adapters above and send a prompt to fan it out side-by-side.</div>`;
+  const sidePlaceholder = `<div style="color:var(--text-muted); font-style:italic; font-size:12px; padding:8px 0;">Pick adapters above and send a prompt to fan it out side-by-side.</div>`;
   comparePair.innerHTML = `
     <div class="compare-side"><div class="compare-side-head">A · <span id="chat-compare-a-name">base</span></div><div class="compare-side-body" id="chat-compare-a-body">${sidePlaceholder}</div></div>
     <div class="compare-side"><div class="compare-side-head">B · <span id="chat-compare-b-name">base</span></div><div class="compare-side-body" id="chat-compare-b-body">${sidePlaceholder}</div></div>`;
@@ -8231,7 +8231,7 @@ function _renderCompareSide(side, m) {
       ? `<pre style="white-space:pre-wrap; margin:0;">${escapeHtml(m.content)}</pre>`
       : `<div class="md-body">${renderMarkdown(m.content)}</div>`;
   } else if (m.pending) {
-    html += `<div style="color:var(--text-quiet); font-style:italic; font-size:11px;">Generating…</div>`;
+    html += `<div style="color:var(--text-muted); font-style:italic; font-size:11px;">Generating…</div>`;
   }
   if (m.ttftMs != null || m.durationMs != null) {
     const stats = [];
@@ -8847,7 +8847,7 @@ async function refreshRecipesList() {
       <div style="flex:1; min-width:0;">
         <div style="font-weight:600;">${escapeHtml(r.name)}</div>
         <div style="font-size:var(--text-xs); color:var(--text-muted);">${escapeHtml(r.description || '')}</div>
-        <div style="font-size:var(--text-2xs); color:var(--text-quiet); margin-top:var(--space-1);">${r.num_steps || 0} step${(r.num_steps || 0) === 1 ? '' : 's'}</div>
+        <div style="font-size:var(--text-2xs); color:var(--text-muted); margin-top:var(--space-1);">${r.num_steps || 0} step${(r.num_steps || 0) === 1 ? '' : 's'}</div>
       </div>
       <button class="btn btn-sm" data-recipe-run="${escapeHtml(r.name)}">Run</button>
     </div>`).join('');
@@ -9167,7 +9167,7 @@ document.getElementById('agent-traces-refresh')?.addEventListener('click', async
         return `<div class="adapter-card" style="margin-bottom:var(--space-2);">
           <div style="font-weight:600; font-family:var(--font-mono); font-size:var(--text-xs);">${escapeHtml(t.id || '?')}</div>
           <div style="font-size:var(--text-xs); color:var(--text-muted);">${t.num_turns || 0} turns · ${t.num_tool_calls || 0} tool calls · ${escapeHtml(t.working_dir || '')}</div>
-          ${outcomeBits.length ? `<div style="font-size:var(--text-2xs); color:var(--text-quiet); margin-top:var(--space-1);">${outcomeBits.map(b => escapeHtml(b)).join(' · ')}</div>` : ''}
+          ${outcomeBits.length ? `<div style="font-size:var(--text-2xs); color:var(--text-muted); margin-top:var(--space-1);">${outcomeBits.map(b => escapeHtml(b)).join(' · ')}</div>` : ''}
         </div>`;
       }).join('');
   } catch (e) {
@@ -9214,7 +9214,7 @@ async function refreshPreflightSurfaces() {
           </div>
           <div style="font-size:var(--text-xs); color:var(--text-muted); margin-top:var(--space-1);">rank ${t.lora_rank} · top-K ${t.default_top_k} · loss ${escapeHtml(t.default_loss || '')} · batch ${t.batch_size}</div>
           <div style="font-size:var(--text-xs); color:var(--text-muted);">cost cap ${t.cost_cap_default_usd == null ? '—' : '$' + t.cost_cap_default_usd.toFixed(0)} · max rollout ${(t.max_rollout_tokens || 0).toLocaleString()} tok · checkpoint every ${t.auto_checkpoint_cadence_steps} steps</div>
-          <div style="font-size:var(--text-2xs); color:var(--text-quiet); margin-top:var(--space-1);">samples/prompt: ${t.samples_per_prompt_default} (data-multiplier: ${t.samples_per_prompt_data_multiplier}) · cold-start ≥ ${t.cold_start_overlap_threshold} · goldens ${(t.mixture_distillation_golden_fraction * 100).toFixed(0)}%</div>
+          <div style="font-size:var(--text-2xs); color:var(--text-muted); margin-top:var(--space-1);">samples/prompt: ${t.samples_per_prompt_default} (data-multiplier: ${t.samples_per_prompt_data_multiplier}) · cold-start ≥ ${t.cold_start_overlap_threshold} · goldens ${(t.mixture_distillation_golden_fraction * 100).toFixed(0)}%</div>
         </div>`).join('');
   } catch (e) {
     tierNode.innerHTML = `<div class="empty">Failed: ${escapeHtml(e.message)}</div>`;

--- a/crates/kiln-server/src/ui/styles.css
+++ b/crates/kiln-server/src/ui/styles.css
@@ -30,9 +30,9 @@
   --ink-650: #2b2720;
   --ink-600: #342f26;
   --ink-500: #443c31;
-  /* Text-bearing steps are tuned for WCAG AA on the --surface (ink-800):
-     ink-300 (text-muted) ≈ 4.6:1, ink-200 (text-3) ≈ 7:1, ink-400
-     (text-quiet) ≈ 3:1 → large/bold only. */
+  /* Text-bearing steps, measured (WCAG relative luminance) on the --surface
+     (ink-800): ink-300 (text-muted) 5.34:1, ink-200 (text-3) 7.64:1, ink-400
+     (text-quiet) 3.45:1. */
   --ink-400: #756b5b;
   --ink-300: #938b79;
   --ink-200: #b0a895;
@@ -66,6 +66,11 @@
   --text-2:     var(--ink-100);
   --text-3:     var(--ink-200);
   --text-muted: var(--ink-300);
+  /* CONTRACT: --text-quiet is ~3.1–3.8:1 on our surfaces, which only meets
+     WCAG AA for large text (≥24px regular / ≥18.66px bold) and non-text
+     graphics (icons, dots, bar segments — 1.4.11 needs 3:1). Small text
+     (anything below that — labels, hints, placeholders, metadata) must use
+     --text-muted (≥4.5:1 on every surface up to --surface-3). */
   --text-quiet: var(--ink-400);
   --accent:     var(--kiln-500);
   --accent-hover: var(--kiln-400);
@@ -709,7 +714,7 @@ input:disabled, select:disabled, textarea:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
-input::placeholder, textarea::placeholder { color: var(--text-quiet); }
+input::placeholder, textarea::placeholder { color: var(--text-muted); }
 
 input[type="checkbox"] {
   width: 16px; height: 16px;
@@ -790,18 +795,33 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 
 /* .btn.primary is a legacy token alias — keep stragglers styled */
+/* Dark ink on the kiln gradient: ink-950 measures 7.10:1 on kiln-500 and
+   5.59:1 on kiln-600 (white was 2.80/3.56 — below AA). */
 .btn-primary,
 .btn.primary {
   background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600));
   border-color: var(--kiln-700);
-  color: white;
+  color: var(--ink-950);
+  font-weight: 600;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14), 0 2px 8px rgba(249, 115, 22, 0.18);
 }
 .btn-primary:hover:not(:disabled),
 .btn.primary:hover:not(:disabled) {
+  /* ink-950 on kiln-400/kiln-500: 8.79:1 / 7.10:1 */
   background: linear-gradient(180deg, var(--kiln-400), var(--kiln-500));
   border-color: var(--kiln-600);
-  color: white;
+  color: var(--ink-950);
+}
+.btn-primary:disabled,
+.btn.primary:disabled {
+  /* The base .btn:disabled opacity (0.45) drops the orange button below 3:1
+     once composited; a flat dimmed ember keeps the disabled label readable
+     (ink-950 on kiln-700 = 3.84:1). */
+  opacity: 1;
+  background: var(--kiln-700);
+  border-color: var(--kiln-800);
+  color: var(--ink-950);
+  box-shadow: none;
 }
 
 .btn-danger {
@@ -882,7 +902,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .recent-correct.is-added { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
 /* Non-flagged rows get the same one-click capture, just quieter — any answer
    can be worth correcting, not only the ones we auto-flagged. */
-.recent-correct.quiet { border-color: var(--border); color: var(--text-quiet); }
+.recent-correct.quiet { border-color: var(--border); color: var(--text-muted); }
 .recent-correct.quiet:hover { border-color: var(--warning-fg); color: var(--warning-fg); background: transparent; }
 .recent-time {
   font-family: var(--font-mono);
@@ -1021,7 +1041,10 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .badge-active {
   background: linear-gradient(180deg, var(--kiln-500), var(--kiln-600));
-  color: white;
+  /* Same gradient as .btn-primary, same dark ink: 7.10:1 / 5.59:1 on the
+     two stops (white was 2.80/3.56). The dot is a graphic — 1.4.11 wants
+     3:1, which ink-950 also clears. */
+  color: var(--ink-950);
   border-color: var(--kiln-700);
   box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);
 }
@@ -1030,7 +1053,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   display: inline-block;
   width: 6px; height: 6px;
   border-radius: 50%;
-  background: white;
+  background: var(--ink-950);
   box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.6);
   animation: pulse-active 1.6s var(--ease-out) infinite;
 }
@@ -1066,7 +1089,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .tab-group-label {
   align-self: center; flex: 0 0 auto; white-space: nowrap;
   font-size: 10px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: var(--tracking-caps); color: var(--text-quiet);
+  letter-spacing: var(--tracking-caps); color: var(--text-muted);
   padding: 0 var(--space-2) 0 0;
 }
 .tab-group-label:not(:first-child) { padding-left: var(--space-3); }
@@ -1391,7 +1414,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .chat-msg .think-block[open] > summary::before { transform: rotate(90deg); }
 .chat-msg .think-block .think-label { color: var(--text); }
-.chat-msg .think-block .think-meta { color: var(--text-quiet); font-weight: 500; text-transform: none; letter-spacing: 0; }
+.chat-msg .think-block .think-meta { color: var(--text-muted); font-weight: 500; text-transform: none; letter-spacing: 0; }
 .chat-msg .think-block.live > summary { color: var(--accent); }
 .chat-msg .think-block.live > summary::after {
   content: '';
@@ -1414,7 +1437,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .chat-msg .think-body:empty::before {
   content: 'Thinking…';
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -1427,7 +1450,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   gap: 8px;
   margin-top: 6px;
   font-size: var(--text-2xs);
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .chat-msg .turn-foot .stat { display: inline-flex; align-items: center; gap: 4px; }
 .chat-msg .turn-foot .stat strong { color: var(--text-muted); font-weight: 600; }
@@ -1436,7 +1459,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .chat-msg .turn-foot .turn-btn {
   background: transparent;
   border: 1px solid transparent;
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-size: var(--text-2xs);
   padding: 2px 6px;
   border-radius: 4px;
@@ -1540,7 +1563,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   right: 8px;
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--text-quiet);
+  color: var(--text-muted);
   text-transform: lowercase;
   letter-spacing: var(--tracking-caps);
 }
@@ -1619,7 +1642,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: var(--tracking-caps);
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .chat-output-actions .chat-turn-count[hidden] { display: none; }
 .chat-starter-prompts {
@@ -1821,7 +1844,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .evals-toolbar .filter-pill .pill-count {
   margin-left: 6px;
   font-variant-numeric: tabular-nums;
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .evals-toolbar .filter-pill.active .pill-count { color: var(--kiln-300); }
 
@@ -1838,7 +1861,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .eval-row.eval-row-clickable { cursor: pointer; }
 .eval-row .row-title { font-weight: 500; color: var(--text); }
 /* row-sub carries the description/stats/pattern — real content, so it uses the
-   AA-passing muted grey (text-quiet is 3.96:1 on the card surface, below AA). */
+   AA-passing muted grey (text-quiet is 3.45:1 on the card surface, below AA). */
 .eval-row .row-sub { color: var(--text-muted); font-size: var(--text-xs); margin-top: 2px; }
 .eval-row .row-actions { display: flex; gap: var(--space-1); justify-content: flex-end; }
 
@@ -1900,7 +1923,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .job-state-pill.completed::before { background: var(--success-fg); }
 .job-state-pill.failed    { color: var(--danger-fg); background: var(--danger-bg); border-color: var(--danger-bd); }
 .job-state-pill.failed::before    { background: var(--danger-fg); }
-.job-state-pill.cancelled { color: var(--text-quiet); background: var(--surface-2); }
+.job-state-pill.cancelled { color: var(--text-muted); background: var(--surface-2); }
 .job-state-pill.cancelled::before { background: var(--text-quiet); }
 
 @keyframes pulseDot {
@@ -1973,7 +1996,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-weight: 600; color: var(--text); font-size: var(--text-md);
 }
 .job-card .job-card-sub {
-  color: var(--text-quiet); font-size: var(--text-xs);
+  color: var(--text-muted); font-size: var(--text-xs);
   display: flex; gap: 8px; flex-wrap: wrap; align-items: center;
 }
 .job-card .job-card-progress {
@@ -2025,7 +2048,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   margin: 0; font-size: var(--text-lg); font-weight: 600;
   flex: 1; min-width: 0;
 }
-.modal-head .modal-meta { color: var(--text-quiet); font-size: var(--text-xs); }
+.modal-head .modal-meta { color: var(--text-muted); font-size: var(--text-xs); }
 .modal-close {
   background: transparent;
   border: 1px solid var(--border);
@@ -2077,7 +2100,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-md); font-weight: 600; font-variant-numeric: tabular-nums;
 }
 .drill-counts .count-cell .count-label {
-  text-transform: uppercase; font-size: 10px; letter-spacing: var(--tracking-caps); color: var(--text-quiet);
+  text-transform: uppercase; font-size: 10px; letter-spacing: var(--tracking-caps); color: var(--text-muted);
 }
 
 /* Recent-request inspect modal */
@@ -2097,13 +2120,13 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   padding: var(--space-3);
 }
 .req-stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.req-stat-k { font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-quiet); }
+.req-stat-k { font-size: 10px; text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); }
 .req-stat-v { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text); overflow-wrap: anywhere; }
 .req-section { display: flex; flex-direction: column; gap: var(--space-2); min-width: 0; }
 .req-section-head {
   display: flex; align-items: center; justify-content: space-between;
   font-size: 11px; text-transform: uppercase; letter-spacing: var(--tracking-caps);
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .req-pre {
   background: var(--surface-2);
@@ -2167,7 +2190,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .outcome-item .outcome-meta {
   display: flex; gap: 8px; align-items: center;
-  font-size: 11px; color: var(--text-quiet);
+  font-size: 11px; color: var(--text-muted);
 }
 
 /* Outcome detail panel */
@@ -2181,7 +2204,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .outcome-detail .detail-empty {
   padding: var(--space-10);
   text-align: center;
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .outcome-detail .detail-section {
   padding: var(--space-4) var(--space-5);
@@ -2193,7 +2216,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: var(--tracking-caps);
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 .outcome-detail .messages-list { display: flex; flex-direction: column; gap: var(--space-2); }
 .outcome-detail .chat-msg {
@@ -2207,7 +2230,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: var(--tracking-caps);
-  color: var(--text-quiet);
+  color: var(--text-muted);
   margin-bottom: 4px;
 }
 .outcome-detail .chat-msg .role.user      { color: var(--info-fg); }
@@ -2232,7 +2255,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .detail-tg .tg-cell.tg-fail { border-color: var(--danger-bd); background: var(--danger-bg); }
 .detail-tg .tg-cell .tg-label {
   font-size: var(--text-2xs); font-weight: 700; text-transform: uppercase;
-  letter-spacing: var(--tracking-caps); color: var(--text-quiet); margin-bottom: 6px;
+  letter-spacing: var(--tracking-caps); color: var(--text-muted); margin-bottom: 6px;
 }
 .detail-tg .tg-cell pre {
   margin: 0; font-family: var(--font-mono); font-size: 12px; line-height: 1.55;
@@ -2285,7 +2308,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   display: flex; gap: var(--space-2); align-items: center;
   font-family: var(--font-mono); font-size: 11px;
 }
-.live-ticker .live-ticker-row .lt-time { color: var(--text-quiet); }
+.live-ticker .live-ticker-row .lt-time { color: var(--text-muted); }
 
 /* Judgment view styling */
 .judgment-pair-grid {
@@ -2310,7 +2333,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .judgment-reply.judgment-reply-b:hover { border-color: var(--kiln-400); }
 .judgment-reply .judgment-tag {
   font-size: var(--text-2xs); font-weight: 700; text-transform: uppercase;
-  letter-spacing: var(--tracking-caps); color: var(--text-quiet); margin-bottom: 6px;
+  letter-spacing: var(--tracking-caps); color: var(--text-muted); margin-bottom: 6px;
   display: flex; gap: var(--space-2); align-items: center;
 }
 .judgment-reply.judgment-reply-a .judgment-tag::before {
@@ -2366,7 +2389,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .judgment-actions .judge-meta {
   display: flex; flex-direction: column; gap: 2px; align-items: flex-start;
-  font-size: var(--text-xs); color: var(--text-quiet); padding: 0 var(--space-3);
+  font-size: var(--text-xs); color: var(--text-muted); padding: 0 var(--space-3);
 }
 .judgment-actions .judge-meta-fields {
   display: flex; gap: var(--space-2); align-items: center;
@@ -2396,13 +2419,15 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-size: var(--text-md); font-weight: 600; color: var(--text); margin-bottom: var(--space-2);
 }
 .eval-empty .eval-empty-body {
-  color: var(--text-quiet); font-size: var(--text-xs); max-width: 420px; margin: 0 auto var(--space-3); line-height: 1.6;
+  color: var(--text-muted); font-size: var(--text-xs); max-width: 420px; margin: 0 auto var(--space-3); line-height: 1.6;
 }
 .eval-empty .eval-empty-cta {
   display: inline-flex; gap: var(--space-2); align-items: center;
   padding: 8px 16px;
   background: var(--accent);
-  color: white;
+  /* Dark ink on accent, like .btn-primary: 7.10:1 on kiln-500, 8.79:1 on
+     the kiln-400 hover (white was 2.80:1). */
+  color: var(--ink-950);
   border: none;
   border-radius: var(--radius-md);
   font-weight: 600;
@@ -2412,8 +2437,9 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .eval-empty .eval-empty-cta:hover { background: var(--accent-hover); }
 /* Disabled CTA (e.g. "Build a dataset from your corrections" with an empty
-   basket) stays visible-but-quiet; the title attribute explains what unlocks it. */
-.eval-empty .eval-empty-cta:disabled { opacity: 0.55; cursor: not-allowed; }
+   basket) stays visible-but-quiet; the title attribute explains what unlocks
+   it. 0.65 keeps the composited label ≥3:1 on our surfaces (0.55 fell to 2.9). */
+.eval-empty .eval-empty-cta:disabled { opacity: 0.65; cursor: not-allowed; }
 .eval-empty .eval-empty-cta:disabled:hover { background: var(--accent); }
 
 /* Tag chips */
@@ -2439,7 +2465,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .delta-badge.delta-up   { background: var(--success-bg); color: var(--success-fg); border: 1px solid var(--success-bd); }
 .delta-badge.delta-down { background: var(--danger-bg);  color: var(--danger-fg);  border: 1px solid var(--danger-bd); }
-.delta-badge.delta-flat { background: var(--surface-2); color: var(--text-quiet); border: 1px solid var(--border); }
+.delta-badge.delta-flat { background: var(--surface-2); color: var(--text-muted); border: 1px solid var(--border); }
 
 /* Sparkline (suite history) */
 .spark {
@@ -2472,7 +2498,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   background: var(--surface-2);
   font-size: var(--text-xs); font-weight: 600;
   text-transform: uppercase; letter-spacing: var(--tracking-caps);
-  color: var(--text-quiet);
+  color: var(--text-muted);
 }
 
 /* Token streaming cursor */
@@ -2535,10 +2561,10 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   outline: none;
   padding: 4px 0;
 }
-.cmdk-input::placeholder { color: var(--text-quiet); }
+.cmdk-input::placeholder { color: var(--text-muted); }
 .cmdk-hint {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 10px; color: var(--text-quiet); padding: 4px 8px;
+  font-size: 10px; color: var(--text-muted); padding: 4px 8px;
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--surface-2);
@@ -2552,7 +2578,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .cmdk-section-label {
   padding: 8px 14px 4px;
   font-size: 10px; font-weight: 700; letter-spacing: var(--tracking-caps);
-  text-transform: uppercase; color: var(--text-quiet);
+  text-transform: uppercase; color: var(--text-muted);
 }
 .cmdk-item {
   display: flex; gap: var(--space-3); align-items: center;
@@ -2582,7 +2608,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   text-overflow: ellipsis;
 }
 .cmdk-item .cmdk-item-sub {
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-size: 11px;
   white-space: nowrap;
   overflow: hidden;
@@ -2590,20 +2616,20 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .cmdk-item .cmdk-item-action {
   font-size: 10px;
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-family: var(--font-mono);
 }
 .cmdk-empty {
   padding: var(--space-6);
   text-align: center;
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-size: var(--text-sm);
 }
 .cmdk-footer {
   border-top: 1px solid var(--border);
   padding: 8px 14px;
   display: flex; gap: var(--space-3); align-items: center;
-  font-size: 11px; color: var(--text-quiet);
+  font-size: 11px; color: var(--text-muted);
 }
 .cmdk-footer .cmdk-foot-key {
   display: inline-flex; align-items: center; gap: 4px;
@@ -2617,7 +2643,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--surface-2);
-  color: var(--text-quiet);
+  color: var(--text-muted);
   font-size: 11px;
   font-family: inherit;
   cursor: pointer;
@@ -2663,7 +2689,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   display: block;
 }
 .line-chart .axis { stroke: var(--border); stroke-width: 0.5; }
-.line-chart .axis-label { fill: var(--text-quiet); font-size: 10px; font-family: var(--font-sans); }
+.line-chart .axis-label { fill: var(--text-muted); font-size: 10px; font-family: var(--font-sans); }
 .line-chart .grid { stroke: var(--surface-3); stroke-width: 0.5; stroke-dasharray: 2,2; }
 .line-chart .data-line { fill: none; stroke: var(--accent); stroke-width: 1.5; }
 .line-chart .data-area { fill: var(--accent-soft); stroke: none; }
@@ -2700,7 +2726,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .training-card-head .training-card-type {
   font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: var(--tracking-caps);
   padding: 1px 6px; border-radius: 3px;
-  background: var(--surface-2); color: var(--text-quiet); border: 1px solid var(--border);
+  background: var(--surface-2); color: var(--text-muted); border: 1px solid var(--border);
   font-family: var(--font-mono);
 }
 /* SFT / GRPO / OPD are peer job-type tags — neutral (amber is reserved for the
@@ -2741,7 +2767,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   font-variant-numeric: tabular-nums; font-size: var(--text-md); font-weight: 600; color: var(--text);
 }
 .training-card-progress .training-stat-label {
-  font-size: 10px; color: var(--text-quiet); text-transform: uppercase; letter-spacing: var(--tracking-caps);
+  font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: var(--tracking-caps);
 }
 
 .training-card-curve {
@@ -2775,7 +2801,8 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .adapter-card .adapter-card-active-pill {
   position: absolute; top: 8px; right: 8px;
-  background: var(--accent); color: white;
+  /* ink-950 on kiln-500 = 7.10:1 (white was 2.80:1) */
+  background: var(--accent); color: var(--ink-950);
   font-size: 9px; font-weight: 700; text-transform: uppercase;
   padding: 2px 7px; border-radius: 999px; letter-spacing: var(--tracking-caps);
 }
@@ -2784,7 +2811,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .adapter-card .adapter-card-meta {
   display: flex; gap: 12px; flex-wrap: wrap;
-  font-size: 11px; color: var(--text-quiet);
+  font-size: 11px; color: var(--text-muted);
 }
 .adapter-card .adapter-card-meta .tabular-nums {
   color: var(--text-2); font-weight: 500;
@@ -2797,7 +2824,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   border: 1px solid var(--border); color: var(--text-muted); font-size: 11px;
 }
 .adapter-card .adapter-eval-chip strong { color: var(--text); font-variant-numeric: tabular-nums; }
-.adapter-card .adapter-eval-chip.none { background: transparent; border-style: dashed; color: var(--text-quiet); }
+.adapter-card .adapter-eval-chip.none { background: transparent; border-style: dashed; color: var(--text-muted); }
 .adapter-card .adapter-card-actions {
   display: flex; gap: 4px; margin-top: 4px; flex-wrap: wrap;
 }
@@ -2840,7 +2867,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   flex-shrink: 0;
 }
 .quick-action-btn .quick-action-title { font-weight: 600; font-size: var(--text-sm); }
-.quick-action-btn .quick-action-sub { font-size: 11px; color: var(--text-quiet); margin-top: 2px; }
+.quick-action-btn .quick-action-sub { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
 
 /* =====================================================================
    Playground compare mode
@@ -2861,7 +2888,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 }
 .compare-side .compare-side-head {
   font-size: 11px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: var(--tracking-caps); color: var(--text-quiet);
+  letter-spacing: var(--tracking-caps); color: var(--text-muted);
   margin-bottom: 6px;
   display: flex; gap: 8px; align-items: center;
 }
@@ -2950,14 +2977,14 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .connect-snippet.active { display: block; }
   .connect-snippet-note { font-size: var(--text-xs); color: var(--text-muted); margin-bottom: var(--space-2); line-height: 1.5; }
   .code-block { position: relative; background: var(--ink-950); border: 1px solid var(--border); border-radius: var(--radius-md); overflow: hidden; }
-  .code-block-path { font-family: var(--font-mono); font-size: 11px; color: var(--text-quiet);
+  .code-block-path { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted);
     padding: 6px var(--space-4); border-bottom: 1px solid var(--border); background: var(--ink-900); }
   .code-block pre { margin: 0; padding: var(--space-3) 44px var(--space-3) var(--space-4); overflow-x: auto;
     font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-2); white-space: pre; }
   .code-block .copy-btn { position: absolute; top: 8px; right: 8px; }
   .code-block .tok-key { color: var(--kiln-300); }
   .code-block .tok-str { color: var(--success-fg); }
-  .code-block .tok-com { color: var(--text-quiet); font-style: italic; }
+  .code-block .tok-com { color: var(--text-muted); font-style: italic; }
 
   /* Collapsed "connected" bar (auto-shown once traffic is flowing) */
   .connect-collapsed { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-5); cursor: pointer; }
@@ -2986,7 +3013,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .agent-chip.active { color: var(--text); background: var(--accent-soft); border-color: var(--accent-ring); }
   .agent-chip .icn { width: 13px; height: 13px; color: var(--text-quiet); }
   .agent-chip.active .icn { color: var(--accent-hover); }
-  .agent-chip .count { font-variant-numeric: tabular-nums; color: var(--text-quiet); font-family: var(--font-mono); font-size: 11px; }
+  .agent-chip .count { font-variant-numeric: tabular-nums; color: var(--text-muted); font-family: var(--font-mono); font-size: 11px; }
   .agent-chip.active .count { color: var(--kiln-200); }
   /* "Needs attention" filter — warning-tinted, visually separated from the
      agent (client) chips by an auto left margin so it reads as a status toggle.
@@ -3019,7 +3046,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
     background: var(--surface-3); border: 1px solid var(--border); color: var(--text-3); white-space: nowrap; }
   .recent-served.is-base { color: var(--warning-fg); border-color: var(--warning-bd); background: var(--warning-bg); }
   .recent-served .icn { width: 10px; height: 10px; }
-  .recent-ttft { margin-left: 8px; color: var(--text-quiet); }
+  .recent-ttft { margin-left: 8px; color: var(--text-muted); }
 
   /* Corrections basket — the flywheel hinge. "Use as correction" in the drill
      modal drops a bad answer here; the operator edits the ideal reply and trains
@@ -3071,7 +3098,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .corr-ideal { width: 100%; min-height: 120px; flex: 1; resize: vertical; padding: var(--space-2) var(--space-3);
     background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm);
     font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.5; color: var(--text); }
-  .corr-ideal::placeholder { color: var(--text-quiet); }
+  .corr-ideal::placeholder { color: var(--text-muted); }
   .corr-ideal:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft, rgba(249,115,22,0.18)); }
   .corrections-foot { display: flex; align-items: flex-end; gap: var(--space-3); flex-wrap: wrap;
     border-top: 1px solid var(--border); }
@@ -3088,7 +3115,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .corr-receipt-icon .icn { width: 15px; height: 15px; }
   .corr-receipt-text { flex: 1; min-width: 0; font-size: var(--text-sm); color: var(--text-2); }
   .corr-receipt-text strong { color: var(--text); }
-  .corr-receipt-dismiss { flex-shrink: 0; padding: 2px; line-height: 0; color: var(--text-quiet); }
+  .corr-receipt-dismiss { flex-shrink: 0; padding: 2px; line-height: 0; color: var(--text-muted); }
   .corr-receipt-dismiss:hover { color: var(--text); }
   .input-invalid { border-color: var(--danger-fg) !important; box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18) !important; }
   #request-drill-correct.is-added { background: var(--success-bg); border-color: var(--success-bd); color: var(--success-fg); }
@@ -3215,7 +3242,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 
   /* Advanced hyperparameters — collapsed, summary narrates the values */
   .adv-row { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }
-  .adv-summary { font-size: var(--text-xs); color: var(--text-quiet); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .adv-summary { font-size: var(--text-xs); color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .adv-body { padding: var(--space-3); margin-bottom: var(--space-3);
     background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); }
   .adv-body .form-row { margin-bottom: 0; }
@@ -3259,7 +3286,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .shortcuts-body kbd { font-family: var(--font-mono); font-size: 11px; line-height: 1; color: var(--text);
     background: var(--surface-3); border: 1px solid var(--border-strong); border-bottom-width: 2px;
     border-radius: var(--radius-sm); padding: 3px 6px; white-space: nowrap; }
-  .kbd-or { font-size: 10px; color: var(--text-quiet); margin: 0 2px; }
+  .kbd-or { font-size: 10px; color: var(--text-muted); margin: 0 2px; }
   @media (max-width: 560px) { .shortcuts-body { grid-template-columns: 1fr; } }
 
   /* The loop — flywheel ribbon */
@@ -3267,7 +3294,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .flywheel-title { display: flex; align-items: center; gap: 7px; font-size: var(--text-2xs);
     text-transform: uppercase; letter-spacing: var(--tracking-caps); color: var(--text-muted); font-weight: 600; padding-left: 2px; }
   .flywheel-title .icn { color: var(--accent-hover); }
-  .flywheel-tagline { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--text-quiet); }
+  .flywheel-tagline { text-transform: none; letter-spacing: 0; font-weight: 400; color: var(--text-muted); }
   .flywheel { display: flex; align-items: stretch;
     background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
     border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; }
@@ -3282,7 +3309,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
   .flywheel-node .fw-value { font-family: var(--font-display); font-size: var(--text-2xl); font-weight: 700;
     letter-spacing: var(--tracking-tight); font-variant-numeric: tabular-nums; line-height: 1.1;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .flywheel-node .fw-sub { font-size: 11px; color: var(--text-quiet); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .flywheel-node .fw-sub { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   /* The active adapter's win verdict on the Hot-swap node — green when the swap
      is proven better than base, so the flywheel's payoff pops on the Overview. */
   .flywheel-node .fw-sub.fw-win { color: var(--success-fg); font-weight: 600; }
@@ -3324,13 +3351,13 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .runtime-config > summary:hover { color: var(--text); }
 .runtime-config .runtime-config-hint {
   margin-left: auto; font-weight: 400; text-transform: none; letter-spacing: 0;
-  color: var(--text-quiet); font-family: var(--font-mono); font-size: 10px;
+  color: var(--text-muted); font-family: var(--font-mono); font-size: 10px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .runtime-config-body { padding: 0 var(--space-5) var(--space-4); }
 .rc-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--space-4); }
 .rc-group-title {
-  font-size: 10px; font-weight: 600; color: var(--text-quiet);
+  font-size: 10px; font-weight: 600; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: var(--tracking-caps); margin-bottom: var(--space-2);
 }
 .rc-row { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); padding: 2px 0; font-size: var(--text-xs); }
@@ -3339,7 +3366,7 @@ input:focus-visible, select:focus-visible, textarea:focus-visible,
 .rc-source {
   display: inline-block; padding: 0 5px; border-radius: var(--radius-pill);
   background: var(--surface-2); border: 1px solid var(--border);
-  font-family: var(--font-mono); font-size: 10px; color: var(--text-quiet);
+  font-family: var(--font-mono); font-size: 10px; color: var(--text-muted);
 }
 .rc-actions { display: flex; gap: var(--space-2); margin-top: var(--space-3); }
 .rc-raw {


### PR DESCRIPTION
Wave 5 of the UI overhaul (roadmap PR 25 of 25 by number — measured, not guessed).

**Primary buttons failed WCAG on both gradient stops** (white on kiln-500/600: 2.80/3.56 vs the 4.5:1 requirement; hover as low as 2.26; the playground's disabled Send composited to ~2.0). They now use `--ink-950` on the gradient: **7.10/5.59 base, 8.79 hover, 3.84 disabled** (≥3:1 inactive threshold), with `.badge-active`, `.eval-empty-cta`, and the adapter active pill fixed the same way. One claimed site (`.chat-msg.user pre`) actually measured 5.18+ and was left alone.

**`--text-quiet` measured 3.10–3.80:1 on our surfaces** — fine for large text and graphics, failing for the small labels it was used on. 55 styles.css sites + 16 inline app.js sites moved to `--text-muted` (4.80–5.88:1); the 13 genuine graphics uses (dots, bar segments, icon glyphs, the accuracy-ring zero state — all ≥3:1 per 1.4.11) stay quiet. Token **values untouched**; the contract is now documented at the definition and two stale ratio comments were corrected.

Verified: WCAG relative-luminance computation for every changed site (full table in the agent run), puppeteer computed-style assertion (`.btn-primary` resolves to `rgb(10,9,8)`, in-page ratios ≥4.5 on both stops), before/after screenshots on all 4 pages (zero layout shift; tracked PNGs restored — commit is styles+app.js only), full UI smoke green. Judgment call included: `.btn-primary` gains `font-weight: 600` since dark-on-orange reads thin at 500 — trivially revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)