### PR TITLE
Eval + train drills grow power-user exits: raw JSON, outcomes JSONL, loss CSV

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -5895,6 +5895,9 @@ async function openDrillModal(jobId) {
   drillSelectedOutcome = null;
   document.getElementById('drill-search').value = '';
   document.querySelectorAll('[data-drill-filter]').forEach(b => b.classList.toggle('active', b.dataset.drillFilter === 'all'));
+  // A leftover raw-JSON block from a previously drilled job would show the
+  // wrong payload until the user re-toggles — drop it on every open.
+  document.getElementById('drill-raw-block')?.remove();
   document.getElementById('eval-drill-modal').hidden = false;
   document.body.style.overflow = 'hidden';
   await fetchDrillJob(jobId);
@@ -5910,6 +5913,7 @@ async function openDrillModal(jobId) {
 function closeDrillModal() {
   document.getElementById('eval-drill-modal').hidden = true;
   document.body.style.overflow = '';
+  document.getElementById('drill-raw-block')?.remove();
   drillJob = null;
   drillSelectedOutcome = null;
   drillSuiteCacheKey = null;
@@ -6011,6 +6015,17 @@ function renderDrillModal(preserveSelection) {
     const failingInAnyRun = (j.runs || []).some(r =>
       (r.outcomes || []).some(o => o.kind !== 'pass'));
     rerunBtn.hidden = isActive || !failingInAnyRun;
+  }
+  // Download outcomes (.jsonl): live across every run of the job (compare
+  // jobs export all adapters, one line per outcome). Disabled until the
+  // first outcome lands so the click never produces an empty file.
+  const exportBtn = document.getElementById('drill-download-outcomes');
+  if (exportBtn) {
+    const outcomeCount = (j.runs || []).reduce((n, r) => n + (r.outcomes || []).length, 0);
+    exportBtn.disabled = outcomeCount === 0;
+    exportBtn.title = outcomeCount
+      ? `Download all ${outcomeCount} per-example outcomes across ${(j.runs || []).length} run(s) as JSON Lines`
+      : 'No outcomes yet — the download unlocks as examples finish';
   }
 
   const runs = j.runs || [];
@@ -6298,6 +6313,75 @@ function renderOutcomeDetail(o) {
 document.getElementById('drill-close')?.addEventListener('click', closeDrillModal);
 document.getElementById('eval-drill-modal')?.addEventListener('click', ev => {
   if (ev.target.id === 'eval-drill-modal') closeDrillModal();
+});
+// Raw JSON toggle — same pattern as the request drill modal's `raw` button:
+// click appends a pretty-printed <pre> of the cached job to the modal
+// content, click again removes it.
+document.getElementById('drill-raw')?.addEventListener('click', () => {
+  if (!drillJob) return;
+  const content = document.getElementById('drill-content');
+  if (!content) return;
+  const existing = content.querySelector('#drill-raw-block');
+  if (existing) { existing.remove(); return; }
+  const pre = document.createElement('pre');
+  pre.id = 'drill-raw-block';
+  pre.className = 'req-pre';
+  pre.style.cssText = 'max-height:50vh; margin:var(--space-4) var(--space-5);';
+  pre.textContent = JSON.stringify(drillJob, null, 2);
+  content.appendChild(pre);
+  pre.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+});
+/// Trigger a browser download via a temporary object URL. The URL is
+/// revoked right after the click so repeated downloads don't pin every
+/// blob in memory for the lifetime of the page.
+function downloadBlobAsFile(filename, blob) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+/// One JSON line per outcome, across every finished run of the job. Each
+/// line is standalone: suite/job/adapter context first, then the outcome's
+/// verdict and (when present) its optional diagnostics, completion last.
+function buildDrillOutcomesJsonl(j) {
+  const lines = [];
+  for (const run of (j.runs || [])) {
+    (run.outcomes || []).forEach((o, i) => {
+      const line = {
+        suite: run.suite_name || j.suite_name || 'eval',
+        job_id: j.job_id,
+        adapter: run.adapter || 'base',
+        example_index: i,
+        example_id: o.example_id,
+        completion_index: o.completion_index,
+        kind: o.kind,
+        score: o.score,
+      };
+      if (o.detail != null) line.detail = o.detail;
+      if (o.latency_ms != null) line.latency_ms = o.latency_ms;
+      if (o.prompt_tokens != null) line.prompt_tokens = o.prompt_tokens;
+      if (o.completion_tokens != null) line.completion_tokens = o.completion_tokens;
+      if (o.tags && o.tags.length) line.tags = o.tags;
+      if (o.metadata != null) line.metadata = o.metadata;
+      if (o.reasoning_text != null) line.reasoning_text = o.reasoning_text;
+      line.completion_text = o.completion_text || '';
+      lines.push(JSON.stringify(line));
+    });
+  }
+  return lines;
+}
+document.getElementById('drill-download-outcomes')?.addEventListener('click', () => {
+  if (!drillJob) return;
+  const lines = buildDrillOutcomesJsonl(drillJob);
+  if (!lines.length) return; // button is disabled in this state; belt and braces
+  const suiteSlug = String(drillJob.suite_name || 'eval').replace(/[^A-Za-z0-9._-]+/g, '-');
+  const filename = `${suiteSlug}-${drillJob.job_id.slice(0, 8)}.outcomes.jsonl`;
+  downloadBlobAsFile(filename, new Blob([lines.join('\n') + '\n'], { type: 'application/jsonl' }));
+  toast(`Downloaded ${lines.length} outcome${lines.length === 1 ? '' : 's'} as ${filename}`, 'ok');
 });
 document.getElementById('drill-search')?.addEventListener('input', ev => {
   drillSearch = ev.target.value;
@@ -7903,6 +7987,9 @@ let trainDrillPollHandle = null;
 // modal polls every 1.5s; for a finished job that's a 1024-sample
 // loss_history shipping every poll otherwise.
 let trainDrillLastKey = null;
+// Loss samples of the currently drilled job, refreshed on every poll —
+// the header's "Copy loss CSV" button reads this instead of re-fetching.
+let trainDrillLossHistory = [];
 
 const TRAIN_TERMINAL_STATES = new Set(['completed', 'failed', 'cancelled']);
 
@@ -7923,6 +8010,12 @@ async function openTrainDrillModal(jobId) {
 function closeTrainDrillModal() {
   trainDrillJobId = null;
   trainDrillLastKey = null;
+  trainDrillLossHistory = [];
+  const copyLossBtn = document.getElementById('train-drill-copy-loss');
+  if (copyLossBtn) {
+    copyLossBtn.disabled = true;
+    copyLossBtn.title = 'No loss samples recorded yet — the CSV unlocks once training reports its first loss';
+  }
   document.getElementById('train-drill-modal').hidden = true;
   document.body.style.overflow = '';
   if (trainDrillPollHandle) { clearInterval(trainDrillPollHandle); trainDrillPollHandle = null; }
@@ -7980,6 +8073,18 @@ async function fetchTrainDrill() {
     // The click handler words its confirm() by state (queued = removed
     // from queue immediately; running = cooperative stop at the next step).
     stopBtn.dataset.jobState = stateLow;
+
+    // Copy loss CSV: enabled the moment the first loss sample lands.
+    // Samples may be downsampled past TRAINING_LOSS_HISTORY_CAP, so the
+    // CSV column is `sample` (recorded order), not a training step.
+    trainDrillLossHistory = Array.isArray(j.loss_history) ? j.loss_history : [];
+    const copyLossBtn = document.getElementById('train-drill-copy-loss');
+    if (copyLossBtn) {
+      copyLossBtn.disabled = trainDrillLossHistory.length === 0;
+      copyLossBtn.title = trainDrillLossHistory.length
+        ? `Copy ${trainDrillLossHistory.length} loss sample${trainDrillLossHistory.length === 1 ? '' : 's'} as CSV (sample,epoch,progress,loss,elapsed_secs)`
+        : 'No loss samples recorded yet — the CSV unlocks once training reports its first loss';
+    }
 
     document.getElementById('train-drill-content').innerHTML = renderTrainDrillBody(j);
     const curveEl = document.getElementById('train-drill-curve-host');
@@ -8109,6 +8214,26 @@ document.getElementById('train-drill-delete')?.addEventListener('click', async (
   } catch (e) {
     toast('Delete failed: ' + e.message, 'err');
   }
+});
+// Copy loss history (CSV) — `sample` is the recorded order (the in-memory
+// history downsamples past 512 points, so it is NOT the optimizer step).
+// Loss samples carry no wall-clock timestamps; elapsed_secs is the offset
+// from job start.
+document.getElementById('train-drill-copy-loss')?.addEventListener('click', () => {
+  if (!trainDrillLossHistory.length) return;
+  const csv = ['sample,epoch,progress,loss,elapsed_secs']
+    .concat(trainDrillLossHistory.map((s, i) => `${i + 1},${s.epoch},${s.progress},${s.loss},${s.elapsed_secs}`))
+    .join('\n');
+  const writeText = navigator.clipboard?.writeText
+    ? navigator.clipboard.writeText.bind(navigator.clipboard)
+    : (t) => { fallbackCopyText(t); return Promise.resolve(); };
+  writeText(csv).then(() => {
+    if (Object.prototype.hasOwnProperty.call(window, '__copiedText')) window.__copiedText = csv;
+    toast('Loss history copied as CSV', 'ok');
+  }).catch(() => {
+    try { fallbackCopyText(csv); toast('Loss history copied as CSV', 'ok'); }
+    catch { toast('Copy failed', 'err'); }
+  });
 });
 
 /* =====================================================================

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -905,6 +905,8 @@
       <div class="modal-head">
         <h2 id="drill-title">Eval results</h2>
         <span class="modal-meta" id="drill-meta"></span>
+        <button class="btn btn-sm btn-ghost" id="drill-raw" type="button" title="Toggle the raw JSON view of this eval job"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-terminal"></use></svg> raw</button>
+        <button class="btn btn-sm" id="drill-download-outcomes" type="button" disabled title="No outcomes yet — the download unlocks as examples finish"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-download"></use></svg> Download outcomes (.jsonl)</button>
         <button class="btn btn-sm" id="drill-cancel" type="button" hidden title="Cancel this eval job (queued only)"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Cancel</button>
         <button class="btn btn-sm" id="drill-rerun" type="button" title="Queue a new eval job that runs only the failing examples again"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-refresh"></use></svg> Re-run failures</button>
         <button class="modal-close" id="drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
@@ -932,7 +934,7 @@
             <!-- outcome list rows injected here -->
           </div>
         </aside>
-        <main class="modal-content">
+        <main class="modal-content" id="drill-content">
           <div id="drill-detail" class="outcome-detail">
             <div class="detail-empty">
               <div style="font-size:32px; opacity:0.5; margin-bottom:12px;">←</div>
@@ -972,6 +974,7 @@
       <div class="modal-head">
         <h2 id="train-drill-title">Training job</h2>
         <span class="modal-meta" id="train-drill-meta"></span>
+        <button class="btn btn-sm" id="train-drill-copy-loss" type="button" disabled title="No loss samples recorded yet — the CSV unlocks once training reports its first loss"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg> Copy loss CSV</button>
         <button class="btn btn-sm" id="train-drill-stop" type="button" title="Stop this training job — queued jobs cancel immediately, running jobs stop at the next training step"><svg class="icn icn-sm"><use href="#i-stop"></use></svg> Stop</button>
         <button class="btn btn-sm" id="train-drill-delete" type="button" hidden title="Permanently delete this terminal job from memory and from the on-disk archive"><svg class="icn icn-sm"><use href="#i-trash"></use></svg> Delete</button>
         <button class="modal-close" id="train-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -486,6 +486,93 @@ async function startServer({
       hint: 'List judgments with GET /v1/judgments.',
     } }));
   };
+  // Eval drill fixtures, mirroring kiln-eval's ExampleOutcome / SuiteResult
+  // and the queue's EvalJobInfo: one completed compare job with real
+  // outcomes (the raw-JSON toggle + outcomes-JSONL export walk reads these)
+  // and one queued job with no runs yet (the export must disable on it).
+  const smokeEvalOutcome = (exampleId, kind, text, detail) => ({
+    example_id: exampleId,
+    completion_index: 0,
+    completion_text: text,
+    kind,
+    score: kind === 'pass' ? 1 : 0,
+    ...(detail ? { detail } : {}),
+    latency_ms: 42,
+    prompt_tokens: 12,
+    completion_tokens: 4,
+    tags: ['math'],
+  });
+  const smokeEvalRun = (adapter, outcomes) => {
+    const numPass = outcomes.filter((outcome) => outcome.kind === 'pass').length;
+    const accuracy = numPass / outcomes.length;
+    return {
+      suite_name: 'smoke-suite',
+      adapter,
+      metrics: {
+        num_examples: outcomes.length,
+        num_pass: numPass,
+        num_fail: outcomes.length - numPass,
+        num_invalid: 0,
+        num_error: 0,
+        accuracy,
+        mean_score: accuracy,
+        weighted_mean_score: accuracy,
+        latency: { p50_ms: 42, p90_ms: 55, p99_ms: 61 },
+        total_prompt_tokens: 36,
+        total_completion_tokens: 12,
+        elapsed_secs: 1.5,
+        pass_rate_by_tag: { math: accuracy },
+        by_scorer: [{ scorer_kind: 'exact_match', num_examples: outcomes.length, num_pass: numPass, accuracy }],
+      },
+      outcomes,
+      started_at: '2026-06-11T00:00:00Z',
+      finished_at: '2026-06-11T00:00:02Z',
+      suite_hash: 'smoke-suite-hash',
+    };
+  };
+  const smokeEvalJobs = [
+    {
+      job_id: 'smoke-eval-full',
+      suite_name: 'smoke-suite',
+      adapters: [null, 'smoke-tuned'],
+      submission_kind: 'compare',
+      state: 'completed',
+      progress: { examples_completed: 3, examples_total: 3, running_accuracy: 2 / 3, running_mean_score: 2 / 3 },
+      finished_runs: [
+        smokeEvalRun(null, [
+          smokeEvalOutcome('ex-1', 'pass', '4'),
+          smokeEvalOutcome('ex-2', 'fail', '41', 'expected 42, got 41'),
+          smokeEvalOutcome('ex-3', 'fail', '7', 'expected 9, got 7'),
+        ]),
+        smokeEvalRun('smoke-tuned', [
+          smokeEvalOutcome('ex-1', 'pass', '4'),
+          smokeEvalOutcome('ex-2', 'fail', '41', 'expected 42, got 41'),
+          smokeEvalOutcome('ex-3', 'pass', '9'),
+        ]),
+      ],
+      headline_accuracy: 2 / 3,
+      error: null,
+      source_training_job_id: null,
+      submitted_at_iso: '2026-06-11T00:00:00Z',
+      started_at_iso: '2026-06-11T00:00:00Z',
+      finished_at_iso: '2026-06-11T00:00:02Z',
+    },
+    {
+      job_id: 'smoke-eval-empty',
+      suite_name: 'smoke-suite',
+      adapters: [null],
+      submission_kind: 'on_demand',
+      state: 'queued',
+      progress: { examples_completed: 0, examples_total: 0, running_accuracy: 0, running_mean_score: 0 },
+      finished_runs: [],
+      headline_accuracy: null,
+      error: null,
+      source_training_job_id: null,
+      submitted_at_iso: '2026-06-11T00:00:01Z',
+      started_at_iso: null,
+      finished_at_iso: null,
+    },
+  ];
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const adapterRoute = parseAdapterRoute(url.pathname);
@@ -825,7 +912,10 @@ async function startServer({
         return;
       }
       // SFT lands as the RUNNING job so the drill-modal Stop flow can
-      // assert running-job cooperative cancel against the mock.
+      // assert running-job cooperative cancel against the mock. The loss
+      // samples mirror state.rs TrainingLossSample (epoch/progress/loss/
+      // elapsed_secs — no step, no wall-clock) and feed the drill modal's
+      // "Copy loss CSV" assertion.
       runningTrainingJob = {
         job_id: 'smoke-sft',
         job_type: 'sft',
@@ -835,7 +925,11 @@ async function startServer({
         epoch: 1,
         adapter_name: body.config.output_name,
         elapsed_secs: 12,
-        loss_history: [],
+        loss_history: [
+          { epoch: 1, progress: 0.1, loss: 2.5, elapsed_secs: 2 },
+          { epoch: 1, progress: 0.25, loss: 1.9, elapsed_secs: 5 },
+          { epoch: 1, progress: 0.42, loss: 1.234, elapsed_secs: 12 },
+        ],
         linked_eval_job_ids: [],
         auto_load: false,
       };
@@ -894,10 +988,32 @@ async function startServer({
       return;
     }
     // The UI polls /v1/eval/jobs at startup to keep the Evals badge
-    // accurate before the user has visited the tab. Stub an empty list
-    // so the empty-adapter smoke run doesn't see a 404 in the console.
+    // accurate before the user has visited the tab. The fixture jobs feed
+    // the eval drill walk (raw JSON toggle + outcomes JSONL export); their
+    // adapters reference no real adapter card, so the rest of the
+    // dashboard is unaffected.
     if (url.pathname === '/v1/eval/jobs') {
-      json(res, { jobs: [] });
+      json(res, { jobs: smokeEvalJobs });
+      return;
+    }
+    // GET /v1/eval/jobs/:id — mirrors EvalJobInfo::to_result: the public
+    // detail payload renames finished_runs to `runs` and only ships
+    // `progress` while the job is still active.
+    const evalJobDetailMatch = /^\/v1\/eval\/jobs\/([^/]+)$/.exec(url.pathname);
+    if (evalJobDetailMatch && req.method === 'GET') {
+      const jobId = decodeURIComponent(evalJobDetailMatch[1]);
+      const job = smokeEvalJobs.find((candidate) => candidate.job_id === jobId);
+      if (!job) {
+        res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: { code: 'eval_job_not_found', message: `Eval job '${jobId}' not found` } }));
+        return;
+      }
+      json(res, {
+        job_id: job.job_id,
+        state: job.state,
+        runs: job.finished_runs,
+        ...(job.state === 'queued' || job.state === 'running' ? { progress: job.progress } : {}),
+      });
       return;
     }
     // Same shape as the production endpoints — only the empty cases
@@ -905,6 +1021,20 @@ async function startServer({
     // background polls don't surprise the mock.
     if (url.pathname === '/v1/eval/suites') {
       json(res, { suites: [] });
+      return;
+    }
+    // The drill modal lazily fetches the suite content so it can show the
+    // prompt next to each outcome. Serve the fixture suite (kept OUT of
+    // the suites list so the Suites empty-state assertions still hold).
+    if (url.pathname === '/v1/eval/suites/smoke-suite' && req.method === 'GET') {
+      json(res, {
+        name: 'smoke-suite',
+        examples: [
+          { id: 'ex-1', messages: [{ role: 'user', content: 'What is 2 + 2?' }], target: '4', tags: ['math'] },
+          { id: 'ex-2', messages: [{ role: 'user', content: 'What is 6 x 7?' }], target: '42', tags: ['math'] },
+          { id: 'ex-3', messages: [{ role: 'user', content: 'What is 3 squared?' }], target: '9', tags: ['math'] },
+        ],
+      });
       return;
     }
     if (url.pathname === '/v1/eval/datasets') {
@@ -2040,6 +2170,23 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       },
       { timeout: 5000 },
     ).catch(() => fail('Train drill Stop should be enabled for a running job with title "Stop at the next training step"'));
+    // Copy loss CSV: the running SFT job carries three TrainingLossSample
+    // rows (epoch/progress/loss/elapsed_secs — no step, no timestamps), so
+    // the header button must be live and put exactly that CSV on the
+    // clipboard via the shared __copiedText test hook.
+    await expectDisabled(page, '#train-drill-copy-loss', false, 'Copy loss CSV should enable once the job has loss samples');
+    await page.evaluate(() => { window.__copiedText = ''; });
+    await clickAndWait(page, '#train-drill-copy-loss', 'Could not click Copy loss CSV');
+    const expectedLossCsv = 'sample,epoch,progress,loss,elapsed_secs\n1,1,0.1,2.5,2\n2,1,0.25,1.9,5\n3,1,0.42,1.234,12';
+    await page.waitForFunction(
+      (expected) => window.__copiedText === expected,
+      { timeout: 5000 },
+      expectedLossCsv,
+    ).catch(async () => {
+      const copiedText = await page.evaluate(() => window.__copiedText).catch(() => undefined);
+      fail(`Copy loss CSV should copy the loss history rows, got ${JSON.stringify(copiedText)}`);
+    });
+    await expectTrainingToast(page, 'Loss history copied as CSV');
     page.once('dialog', async (dialog) => {
       if (!/Stop this running job at the next training step\?/.test(dialog.message())) fail(`Unexpected stop confirmation text: ${dialog.message()}`);
       await dialog.accept();
@@ -2077,6 +2224,18 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await expectActiveTrainingTab(page, 'queue', 'Submitting GRPO should switch back to the training queue tab');
     await waitForPanelText(page, '#tab-queue', /smoke-gr/, 'Training queue should refresh after GRPO submit');
     await waitForPanelText(page, '#tab-queue', /Adapter:\s*grpo-adapter/, 'Training queue should show the submitted GRPO adapter name');
+
+    // The completed GRPO job recorded no loss samples — Copy loss CSV must
+    // disable with a title that explains what unlocks it.
+    await clickAndWait(page, '[data-train-job-id="smoke-grpo"]', 'Could not open the train drill modal for the completed GRPO job');
+    await page.waitForFunction(() => document.getElementById('train-drill-modal')?.hidden === false, { timeout: 5000 })
+      .catch(() => fail('Train drill modal did not open for the GRPO job'));
+    await expectDisabled(page, '#train-drill-copy-loss', true, 'Copy loss CSV should disable when the job has no loss samples');
+    const copyLossTitle = await page.$eval('#train-drill-copy-loss', (el) => el.title);
+    if (!/No loss samples recorded yet/.test(copyLossTitle)) fail(`Disabled Copy loss CSV should explain what unlocks it, got: ${JSON.stringify(copyLossTitle)}`);
+    await clickAndWait(page, '#train-drill-close', 'Could not close the GRPO train drill modal');
+    await page.waitForFunction(() => document.getElementById('train-drill-modal')?.hidden === true, { timeout: 5000 })
+      .catch(() => fail('GRPO train drill modal did not close'));
 
     await goToPrimaryTab(page, 'playground');
     await expectDisabled(page, '#chat-send', true, 'Quick Inference send should start disabled until text is entered');
@@ -2200,6 +2359,109 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await expectTrainingToast(page, 'Undone — judgment removed from "smoke-judgments"');
     await waitForPanelText(page, '#judgment-rows-count', /0 judgments in "smoke-judgments"/, 'Undo should restore the judgment viewer count');
     await waitForPanelText(page, '#judgments-list', /0 judgments/, 'Judgments list should refresh to zero rows after Undo');
+
+    // ---- Eval drill power-user depth: the raw-JSON toggle mirrors the
+    // request drill modal's `raw` button; the outcomes export downloads one
+    // JSON line per outcome across every run of the job.
+    await clickAndWait(page, '#evals-tab-jobs', 'Could not open the Jobs sub-tab');
+    await waitForVisiblePanel(page, '#tab-evals-jobs', 'Jobs sub-tab did not activate');
+    await clickAndWait(page, '[data-job-id="smoke-eval-full"]', 'Could not open the eval drill modal for the completed compare job');
+    await page.waitForFunction(
+      () => document.getElementById('eval-drill-modal')?.hidden === false
+        && document.getElementById('drill-title')?.textContent === 'smoke-suite',
+      { timeout: 5000 },
+    ).catch(() => fail('Eval drill modal did not open on the completed compare job'));
+
+    // Raw JSON toggle: first click appends the pretty-printed cached job
+    // payload, second click removes it.
+    await clickAndWait(page, '#drill-raw', 'Could not click the eval drill raw JSON toggle');
+    await page.waitForSelector('#drill-raw-block', { timeout: 5000 })
+      .catch(() => fail('Raw JSON toggle did not render #drill-raw-block'));
+    const rawPayload = await page.$eval('#drill-raw-block', (el) => el.textContent || '');
+    let parsedRaw = null;
+    try { parsedRaw = JSON.parse(rawPayload); } catch { fail('Eval drill raw JSON block should contain valid JSON'); }
+    if (parsedRaw.job_id !== 'smoke-eval-full') fail(`Raw JSON should show the drilled job, got job_id ${JSON.stringify(parsedRaw.job_id)}`);
+    if (!Array.isArray(parsedRaw.runs) || parsedRaw.runs.length !== 2) fail('Raw JSON should carry both runs of the compare job');
+    if (!rawPayload.includes('\n  "runs"')) fail('Raw JSON should be pretty-printed with 2-space indentation');
+    if (!rawPayload.includes('"detail": "expected 42, got 41"')) fail('Raw JSON should surface per-outcome fields like detail');
+    await clickAndWait(page, '#drill-raw', 'Could not click the raw JSON toggle a second time');
+    await page.waitForFunction(() => !document.getElementById('drill-raw-block'), { timeout: 5000 })
+      .catch(() => fail('Second raw JSON click should remove the block'));
+
+    // Outcomes JSONL download: stub object URLs and anchor clicks so the
+    // blob is inspectable in-page, then assert the line schema and that
+    // every created URL is revoked (no leak across repeated downloads).
+    await expectDisabled(page, '#drill-download-outcomes', false, 'Download outcomes should enable when the job has outcomes');
+    await page.evaluate(() => {
+      window.__smokeDownloads = { created: 0, revoked: 0, name: '', blob: null };
+      URL.createObjectURL = (blob) => {
+        window.__smokeDownloads.created += 1;
+        window.__smokeDownloads.blob = blob;
+        return `blob:smoke-${window.__smokeDownloads.created}`;
+      };
+      URL.revokeObjectURL = () => { window.__smokeDownloads.revoked += 1; };
+      // Keep headless Chrome from navigating to the fake blob URL; buttons
+      // are unaffected (they use HTMLElement.prototype.click).
+      HTMLAnchorElement.prototype.click = function () { window.__smokeDownloads.name = this.download; };
+    });
+    await clickAndWait(page, '#drill-download-outcomes', 'Could not click Download outcomes (.jsonl)');
+    await page.waitForFunction(
+      () => window.__smokeDownloads?.created === 1 && window.__smokeDownloads?.revoked === 1,
+      { timeout: 5000 },
+    ).catch(async () => {
+      const counts = await page.evaluate(() => window.__smokeDownloads).catch(() => undefined);
+      fail(`Download should create then revoke exactly one object URL, got ${JSON.stringify(counts)}`);
+    });
+    // Toast asserted on the FIRST download — a repeat within 4s dedupes
+    // into the same toast with an appended ×2 counter, which exact-match
+    // would miss.
+    await expectTrainingToast(page, 'Downloaded 6 outcomes as smoke-suite-smoke-ev.outcomes.jsonl');
+    const download = await page.evaluate(async () => ({
+      name: window.__smokeDownloads.name,
+      text: window.__smokeDownloads.blob ? await window.__smokeDownloads.blob.text() : null,
+    }));
+    if (download.name !== 'smoke-suite-smoke-ev.outcomes.jsonl') {
+      fail(`Outcomes download filename should be <suite>-<job8>.outcomes.jsonl, got ${JSON.stringify(download.name)}`);
+    }
+    const jsonlLines = (download.text || '').split('\n').filter((line) => line.length > 0);
+    if (jsonlLines.length !== 6) fail(`Outcomes JSONL should carry 6 lines (2 runs x 3 outcomes), got ${jsonlLines.length}`);
+    const parsedLines = jsonlLines.map((line, index) => {
+      try { return JSON.parse(line); } catch { fail(`Outcomes JSONL line ${index + 1} is not valid JSON: ${line}`); }
+      return null;
+    });
+    const firstLine = parsedLines[0];
+    if (firstLine.suite !== 'smoke-suite' || firstLine.job_id !== 'smoke-eval-full' || firstLine.adapter !== 'base') {
+      fail(`First JSONL line should carry standalone context (suite/job_id/adapter), got ${JSON.stringify(firstLine)}`);
+    }
+    if (firstLine.example_id !== 'ex-1' || firstLine.example_index !== 0 || firstLine.kind !== 'pass' || firstLine.score !== 1 || firstLine.completion_text !== '4') {
+      fail(`First JSONL line should carry the outcome verdict fields, got ${JSON.stringify(firstLine)}`);
+    }
+    if (!parsedLines.some((line) => line.adapter === 'smoke-tuned')) fail('Outcomes JSONL should include the second run, tagged with its adapter');
+    const failLine = parsedLines.find((line) => line.adapter === 'base' && line.example_id === 'ex-2');
+    if (!failLine || failLine.kind !== 'fail' || failLine.detail !== 'expected 42, got 41' || failLine.latency_ms !== 42) {
+      fail(`Failing JSONL line should carry kind/detail/latency, got ${JSON.stringify(failLine)}`);
+    }
+    // A second download must mint and revoke a fresh URL (no leak on repeats).
+    await clickAndWait(page, '#drill-download-outcomes', 'Could not click Download outcomes a second time');
+    await page.waitForFunction(
+      () => window.__smokeDownloads?.created === 2 && window.__smokeDownloads?.revoked === 2,
+      { timeout: 5000 },
+    ).catch(() => fail('Repeated downloads should revoke every object URL they create'));
+    await clickAndWait(page, '#drill-close', 'Could not close the eval drill modal');
+    await page.waitForFunction(() => document.getElementById('eval-drill-modal')?.hidden === true, { timeout: 5000 })
+      .catch(() => fail('Eval drill modal did not close'));
+
+    // No-outcomes job: the export button must disable with an explanatory
+    // title (the raw toggle stays live — the job JSON itself exists).
+    await clickAndWait(page, '[data-job-id="smoke-eval-empty"]', 'Could not open the eval drill modal for the queued job');
+    await page.waitForFunction(() => document.getElementById('eval-drill-modal')?.hidden === false, { timeout: 5000 })
+      .catch(() => fail('Eval drill modal did not open on the queued job'));
+    await expectDisabled(page, '#drill-download-outcomes', true, 'Download outcomes should disable on a job with no outcomes');
+    const emptyDownloadTitle = await page.$eval('#drill-download-outcomes', (el) => el.title);
+    if (!/No outcomes yet/.test(emptyDownloadTitle)) fail(`Disabled outcomes download should explain what unlocks it, got: ${JSON.stringify(emptyDownloadTitle)}`);
+    await clickAndWait(page, '#drill-close', 'Could not close the queued-job eval drill modal');
+    await page.waitForFunction(() => document.getElementById('eval-drill-modal')?.hidden === true, { timeout: 5000 })
+      .catch(() => fail('Queued-job eval drill modal did not close'));
 
   } finally {
     await browser.close();


### PR DESCRIPTION
Wave 4 of the UI overhaul (roadmap PR 20 of 25).

Results lived behind rendered cards with no way out. Now:

- **Eval drill**: a "Raw JSON" toggle (exact same pattern/markup as the request drill's) and **"Download outcomes (.jsonl)"** — one standalone line per outcome, context-first (`suite, job_id, adapter, example_index, example_id, completion_index, kind, score`, present-only optionals like `detail`/`latency_ms`/token counts, `completion_text` last). Compare jobs export **all** runs, each line adapter-tagged. Filename `<suite>-<job_id8>.outcomes.jsonl`; object URLs revoked after click.
- **Train drill**: "Copy loss history (CSV)" — `sample,epoch,progress,loss,elapsed_secs` (named `sample`, not `step`: the server downsamples past 512 points, so it's recorded order — documented in place). Both affordances disable with explanatory titles when there's nothing to export.

Schema grounded in the actual structs: the API renames internal `finished_runs` → public `runs` (`eval/queue.rs:172`), outcomes are `ExampleOutcome` (`kiln-eval/src/result.rs:40`), loss samples carry no step/timestamps (`state.rs:357`).

Smoke: new completed-compare and queued fixtures; assertions cover raw-JSON toggle on/off, download interception via stubbed `URL.createObjectURL` (6 lines, field-level checks, **created === revoked after repeated downloads** — leak check), disabled states on empty jobs, and byte-exact CSV via the clipboard hook. Full suite passes post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)