### PR TITLE
aria-live hygiene: screen readers hear transitions, not 2-second panel firehoses

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -1044,10 +1044,33 @@ async function testConnection() {
   } finally { if (btn) btn.disabled = false; }
 }
 
+// aria-busy may flip only during a panel's FIRST load. The pollers call this
+// on every tick (2-3s), and once content has rendered, busy/idle thrash is
+// pure screen-reader noise. The `false` arm — every poller's `finally`, which
+// runs after both the success render and the failure HTML — marks the panel
+// loaded, so the guard is central and call sites stay untouched.
 function setPanelBusy(id, busy) {
   const el = document.getElementById(id);
-  if (el) el.setAttribute('aria-busy', String(busy));
+  if (!el) return null;
+  if (busy) {
+    if (!el.dataset.loaded) el.setAttribute('aria-busy', 'true');
+  } else {
+    el.setAttribute('aria-busy', 'false');
+    el.dataset.loaded = '1';
+  }
   return el;
+}
+
+// Write a terse one-line transition announcement into a visually-hidden
+// role="status" node. The polled data panels are deliberately NOT aria-live
+// (a content-keyed repaint of a 30-row list would be re-read in full); these
+// nodes are the screen-reader channel for the few transitions a sighted user
+// would actually notice. Re-setting identical text fires no live-region
+// mutation, so repeats get a non-breaking-space nudge to still announce.
+function announceStatus(id, msg) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = (el.textContent === msg) ? msg + '\u00a0' : msg;
 }
 
 // --- Training Tabs ---
@@ -2046,15 +2069,14 @@ document.addEventListener('DOMContentLoaded', () => {
 function refreshRecentTimes() {
   const el = document.getElementById('recent-requests-panel');
   if (!el) return;
-  const liveMode = el.getAttribute('aria-live');
-  el.setAttribute('aria-live', 'off');
+  // No aria-live suppression dance needed: the panel is deliberately not a
+  // live region (see index.html), so in-place timestamp ticks are silent.
   el.querySelectorAll('.recent-row').forEach(row => {
     const ts = Number(row.dataset.ts || 0);
     if (!ts) return;
     const tcell = row.querySelector('.recent-time');
     if (tcell) tcell.textContent = fmtRelTime(ts);
   });
-  if (liveMode) el.setAttribute('aria-live', liveMode);
 }
 
 // Wire the filter input. Re-render on every input event using the
@@ -2102,6 +2124,35 @@ document.addEventListener('click', (ev) => {
 // position on idle servers (`refreshRecentTimes` already updates the
 // relative timestamps in place every second).
 let lastRecentRequestsKey = null;
+
+// One-line screen-reader summary for the Recent requests card, spoken ONLY
+// when the needs-attention count changes — the moment the warning tint
+// appears or clears for a sighted user. Routine traffic never narrates (the
+// panel is not a live region), and "new" counts arrivals since the last
+// announcement so the line carries scale without ticking every poll.
+let lastAnnouncedAttentionCount = null;
+let lastAnnouncedRequestIds = new Set();
+function announceRecentAttention(rows) {
+  const ids = new Set(rows.map(r => `${r.timestamp_unix_ms || ''}:${r.id || ''}`));
+  const attn = rows.filter(requestNeedsAttention).length;
+  if (lastAnnouncedAttentionCount === null) {
+    // First poll is baseline — page load must not announce history.
+    lastAnnouncedAttentionCount = attn;
+    lastAnnouncedRequestIds = ids;
+    return;
+  }
+  if (attn === lastAnnouncedAttentionCount) return;
+  let fresh = 0;
+  ids.forEach(id => { if (!lastAnnouncedRequestIds.has(id)) fresh++; });
+  const newPart = fresh > 0 ? `${fresh} new request${fresh === 1 ? '' : 's'}, ` : '';
+  const attnPart = attn === 0
+    ? 'no requests need attention'
+    : `${attn} request${attn === 1 ? '' : 's'} need${attn === 1 ? 's' : ''} attention`;
+  announceStatus('recent-requests-status', `${newPart}${attnPart}.`);
+  lastAnnouncedAttentionCount = attn;
+  lastAnnouncedRequestIds = ids;
+}
+
 async function pollRecentRequests() {
   const el = setPanelBusy('recent-requests-panel', true);
   if (!el) return;
@@ -2111,6 +2162,7 @@ async function pollRecentRequests() {
     updateConnectSummary(recentRequestsCache);
     updateFlywheel();
     refreshRequestHealth();
+    announceRecentAttention(recentRequestsCache);
     const key = recentRequestsCache
       .map(r => `${r.timestamp_unix_ms || r.id || ''}:${r.completion_tokens || 0}`)
       .join('|');
@@ -2631,16 +2683,27 @@ function detectTrainingTransitions(data) {
   if (prevTrainingStates) {
     for (const [id, state] of now) {
       const prev = prevTrainingStates.get(id);
+      if (prev === state) continue;
+      // Start is an announce-only event (no toast — the submit flow already
+      // confirms visually): a job begins running that wasn't running before,
+      // whether it stepped queued→running or appeared mid-poll already running.
+      if (state === 'running') {
+        const adapter = (data.running && data.running.adapter_name) || 'adapter';
+        announceStatus('training-queue-status', `Training started: ${adapter}.`);
+        continue;
+      }
       // Only announce jobs we watched run/queue in THIS session — never history.
-      if (!prev || prev === state || (prev !== 'running' && prev !== 'queued')) continue;
+      if (!prev || (prev !== 'running' && prev !== 'queued')) continue;
       const j = (data.completed || []).find(x => x.job_id === id) || {};
       const adapter = j.adapter_name || 'adapter';
       if (state === 'completed') {
+        announceStatus('training-queue-status', `Training completed: ${adapter} is ready.`);
         actionToast(`${adapter} finished training — it's ready${j.job_type ? ' (' + j.job_type + ')' : ''}.`, 'ok', [
           { label: 'Prove it vs base', onClick: () => openAdapterEvalModal(adapter) },
           { label: 'View job', onClick: () => { selectPage('training'); document.querySelector('#page-training [data-tab="queue"]')?.click(); } },
         ]);
       } else if (state === 'failed' || state === 'error') {
+        announceStatus('training-queue-status', `Training failed: ${adapter}.`);
         actionToast(`Training ${adapter} failed.`, 'err', [
           { label: 'View job', onClick: () => { selectPage('training'); document.querySelector('#page-training [data-tab="queue"]')?.click(); } },
         ]);
@@ -5773,10 +5836,12 @@ function detectEvalTransitions(jobs) {
         } else if (typeof j.headline_accuracy === 'number') {
           verdict = ` Accuracy: ${(j.headline_accuracy * 100).toFixed(0)}%.`;
         }
+        announceStatus('eval-jobs-status', `Eval ${suite} finished.${verdict}`);
         actionToast(`Eval ${suite} finished.${verdict}`, 'ok', [
           { label: 'View result', onClick: () => { selectPage('evals'); document.getElementById('evals-tab-jobs')?.click(); setTimeout(() => openDrillModal(id), 250); } },
         ]);
       } else if (state === 'failed') {
+        announceStatus('eval-jobs-status', `Eval ${suite} failed.`);
         actionToast(`Eval ${suite} failed${j.error ? ': ' + String(j.error).slice(0, 80) : ''}.`, 'err', [
           { label: 'View job', onClick: () => { selectPage('evals'); document.getElementById('evals-tab-jobs')?.click(); } },
         ]);

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -331,11 +331,19 @@
     <div class="card">
       <div class="card-head">
         <h2>Recent requests</h2>
-        <span class="heartbeat" id="recent-heartbeat" aria-live="polite"><span class="hb-dot"></span><span class="hb-text">Connecting…</span></span>
+        <!-- No aria-live here: the label embeds relative times / TTFT that
+             churn on every 2s poll, so a live region narrates routine traffic.
+             Attention transitions speak via #recent-requests-status below. -->
+        <span class="heartbeat" id="recent-heartbeat"><span class="hb-dot"></span><span class="hb-text">Connecting…</span></span>
         <span style="flex:1;"></span>
         <input class="search-input" id="recent-requests-filter" type="search" placeholder="Filter by prompt, completion, id…" aria-label="Filter recent requests" style="max-width:280px;">
       </div>
-      <div class="card-body" id="recent-requests-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
+      <!-- Screen-reader channel for this card: one terse line, written only
+           when the needs-attention count CHANGES (announceRecentAttention in
+           app.js). The list itself is deliberately NOT aria-live — every
+           content-keyed repaint of a 30-row list would be re-read in full. -->
+      <div class="sr-only" role="status" id="recent-requests-status"></div>
+      <div class="card-body" id="recent-requests-panel" aria-busy="true">
         <div class="empty">Loading recent requests…</div>
       </div>
     </div>
@@ -374,7 +382,11 @@
           <h2>Server status</h2>
           <span class="eyebrow" id="server-status-eyebrow">VRAM &amp; scheduler</span>
         </div>
-        <div class="card-body" id="server-status" data-panel-id="server-status-panel" role="status" aria-live="polite" aria-atomic="false" aria-busy="true">
+        <!-- Deliberately NOT a live region: blocks_used/uptime churn repaints
+             this panel every 2s health poll, and a live region would re-read
+             the whole diagnostics block each time. Online/offline transitions
+             are announced by the scoped aria-live status chip in the header. -->
+        <div class="card-body" id="server-status" data-panel-id="server-status-panel" aria-busy="true">
           <div class="empty">Loading server diagnostics…</div>
         </div>
         <!-- Runtime config expander — deliberately a SIBLING of the keyed
@@ -404,7 +416,10 @@
           <h2>Decode performance</h2>
           <span class="eyebrow">live · 60s rolling window</span>
         </div>
-        <div class="card-body" id="decode-perf-panel" data-panel-id="decode-stats-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
+        <!-- Deliberately NOT a live region: tok/s + latency stats churn with
+             traffic, and announcing continuous metrics every repaint is a
+             screen-reader firehose with no transition to anchor on. -->
+        <div class="card-body" id="decode-perf-panel" data-panel-id="decode-stats-panel" aria-busy="true">
           <div class="empty">Loading live metrics…</div>
         </div>
       </div>
@@ -422,7 +437,11 @@
         <span style="flex:1;"></span>
         <input class="search-input" id="adapters-filter" type="search" placeholder="Filter adapters by name…" aria-label="Filter adapters" style="max-width:240px;">
       </div>
-      <div class="card-body" id="adapters-panel" aria-live="polite" aria-atomic="false" aria-busy="true" style="padding: var(--space-4);">
+      <!-- Deliberately NOT a live region: this is a full card grid rebuilt on
+           content-key changes. Every meaningful adapter transition (load,
+           unload, upload, delete, merge, training completion) already speaks
+           through the toast channel. -->
+      <div class="card-body" id="adapters-panel" aria-busy="true" style="padding: var(--space-4);">
         <div class="empty">Loading adapter list…</div>
       </div>
     </div>
@@ -508,7 +527,14 @@
         <button class="tab" id="training-tab-grpo" data-tab="grpo" type="button" role="tab" aria-selected="false" aria-controls="tab-grpo" tabindex="-1">Train · GRPO</button>
       </div>
 
-      <div class="tab-content active" id="tab-queue" role="tabpanel" aria-labelledby="training-tab-queue" aria-live="polite" aria-atomic="false" aria-busy="true" data-panel-id="training-queue-panel">
+      <!-- Screen-reader channel for training transitions (started / completed
+           / failed), written by detectTrainingTransitions in app.js. Lives
+           OUTSIDE the tabpanels so sub-tab switches never hide it. The queue
+           list itself is deliberately NOT aria-live: progress/loss churn
+           repaints it every 3s poll and a live region would re-read it all. -->
+      <div class="sr-only" role="status" id="training-queue-status"></div>
+
+      <div class="tab-content active" id="tab-queue" role="tabpanel" aria-labelledby="training-tab-queue" aria-busy="true" data-panel-id="training-queue-panel">
         <div class="empty">Loading queued training jobs…</div>
       </div>
 
@@ -694,6 +720,12 @@
         <button class="tab"        id="evals-tab-jobs"      data-tab="jobs"      type="button" role="tab" aria-selected="false" aria-controls="tab-evals-jobs"      tabindex="-1">Jobs</button>
         <button class="tab"        id="evals-tab-judgments" data-tab="judgments" type="button" role="tab" aria-selected="false" aria-controls="tab-evals-judgments" tabindex="-1">Judgments</button>
       </div>
+
+      <!-- Screen-reader channel for eval-job transitions (finished + verdict /
+           failed), written by detectEvalTransitions in app.js. Lives OUTSIDE
+           the tabpanels so sub-tab switches never hide it; the jobs list is
+           deliberately not a live region. -->
+      <div class="sr-only" role="status" id="eval-jobs-status"></div>
 
       <!-- Datasets sub-tab -->
       <div class="tab-content active" id="tab-evals-datasets" role="tabpanel" aria-labelledby="evals-tab-datasets" data-panel-id="evals-datasets-panel">

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -1577,6 +1577,102 @@ async function expectApiFailurePanel(page, selector, action, detail) {
   }
 }
 
+// ── aria-live hygiene (roadmap PR 24) ───────────────────────────────────────
+// Polled data panels must NOT be live regions: every content-keyed repaint
+// would be re-read wholesale by screen readers every 2-3s. Each affected card
+// owns a visually-hidden role="status" node instead, written only on genuine
+// transitions; aria-busy flips only during a panel's FIRST load.
+const polledDataPanelIds = [
+  'tab-queue',
+  'server-status',
+  'decode-perf-panel',
+  'recent-requests-panel',
+  'adapters-panel',
+  'recent-heartbeat',
+];
+const transitionStatusNodeIds = ['training-queue-status', 'eval-jobs-status', 'recent-requests-status'];
+
+async function expectAriaLiveHygieneAtBoot(page) {
+  // Static markup: the polled panels ship aria-busy="true" in index.html
+  // itself, so "busy at boot" holds before app.js ever runs (the live DOM is
+  // already past the first poll by the time puppeteer can look).
+  const staticHtml = await readFile(uiIndexPath, 'utf8');
+  for (const id of polledDataPanelIds) {
+    const tag = staticHtml.match(new RegExp(`<[a-z][^>]*\\bid="${id}"[^>]*>`))?.[0];
+    if (!tag) fail(`index.html is missing #${id}`);
+    if (/aria-live/.test(tag)) fail(`#${id} is a polled data panel and must not be aria-live in static markup: ${tag}`);
+    if (id !== 'recent-heartbeat' && !/aria-busy="true"/.test(tag)) {
+      fail(`#${id} must boot with aria-busy="true" in static markup, got: ${tag}`);
+    }
+  }
+
+  const state = await page.evaluate((panelIds, statusIds) => ({
+    missingPanels: panelIds.filter((id) => !document.getElementById(id)),
+    livePanels: panelIds.filter((id) => document.getElementById(id)?.hasAttribute('aria-live')),
+    serverStatusBusy: document.getElementById('server-status')?.getAttribute('aria-busy'),
+    statusNodes: statusIds.map((id) => {
+      const el = document.getElementById(id);
+      return { id, exists: Boolean(el), role: el?.getAttribute('role') || '', text: (el?.textContent || '').trim() };
+    }),
+    toastsRole: document.getElementById('toasts')?.getAttribute('role') || '',
+    toastsLive: document.getElementById('toasts')?.getAttribute('aria-live') || '',
+  }), polledDataPanelIds, transitionStatusNodeIds);
+  if (state.missingPanels.length > 0) fail(`Polled panels missing from the DOM: ${state.missingPanels.join(', ')}`);
+  if (state.livePanels.length > 0) fail(`Polled data panels must not be aria-live: ${state.livePanels.join(', ')}`);
+  // First load finished before networkidle0 resolved, so the live DOM must
+  // already be past busy — and (asserted later) it must never flip back.
+  if (state.serverStatusBusy !== 'false') {
+    fail(`#server-status aria-busy should be "false" after the first render, got "${state.serverStatusBusy}"`);
+  }
+  for (const node of state.statusNodes) {
+    if (!node.exists) fail(`Missing visually-hidden status node #${node.id}`);
+    if (node.role !== 'status') fail(`#${node.id} must have role="status", got "${node.role}"`);
+    if (node.text !== '') fail(`#${node.id} must be empty at boot (no announcement before a real transition), got ${JSON.stringify(node.text)}`);
+  }
+  // Toasts are the intentional announcement channel — they must stay live.
+  if (state.toastsRole !== 'status' || state.toastsLive !== 'polite') {
+    fail(`#toasts must keep role="status" aria-live="polite", got role="${state.toastsRole}" aria-live="${state.toastsLive}"`);
+  }
+
+  await installServerStatusBusyObserver(page);
+}
+
+// Record every aria-busy value change on #server-status from install time on.
+// The mock /health cycles blocks_used, so each 2s poll is a REAL repaint —
+// aria-busy must still never return to "true" (first-load-only guard). Wiped
+// by full page navigations; re-install after any page.goto/reload that
+// precedes reading window.__serverStatusBusyFlips.
+async function installServerStatusBusyObserver(page) {
+  // Arm only after the first load completed — the boot true→false flip is
+  // legitimate and must not pollute the "never flips again" record.
+  await page.waitForFunction(
+    () => document.getElementById('server-status')?.getAttribute('aria-busy') === 'false',
+    { timeout: 5000 },
+  ).catch(() => fail('#server-status never reached aria-busy="false" before arming the busy observer'));
+  await page.evaluate(() => {
+    const el = document.getElementById('server-status');
+    window.__serverStatusBusyFlips = [];
+    new MutationObserver((records) => {
+      for (let i = 0; i < records.length; i += 1) {
+        const next = i + 1 < records.length ? records[i + 1].oldValue : el.getAttribute('aria-busy');
+        if (records[i].oldValue !== next) window.__serverStatusBusyFlips.push(`${records[i].oldValue}→${next}`);
+      }
+    }).observe(el, { attributes: true, attributeFilter: ['aria-busy'], attributeOldValue: true });
+  });
+}
+
+async function expectStatusAnnouncement(page, nodeId, pattern, message) {
+  await page.waitForFunction(
+    (id, source) => new RegExp(source).test(document.getElementById(id)?.textContent || ''),
+    { timeout: 6000 },
+    nodeId,
+    pattern.source,
+  ).catch(async () => {
+    const text = await page.$eval(`#${nodeId}`, (el) => el.textContent).catch(() => '<missing>');
+    fail(`${message}: #${nodeId} should match ${pattern}, got ${JSON.stringify(text)}`);
+  });
+}
+
 async function runMobileOnboardingSmoke(baseUrl) {
   const puppeteer = await loadPuppeteer();
   const browser = await puppeteer.launch({
@@ -1719,6 +1815,7 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await expectText(page, '.header h1', /^\s*kiln\s*$/i, 'Header did not render');
     await expectHeaderHelpLinks(page);
     await expectNoForbiddenPublicityCopy(page, 'Server dashboard');
+    await expectAriaLiveHygieneAtBoot(page);
 
     if (expectFailureStates) {
       await goToPrimaryTab(page, 'overview');
@@ -1900,6 +1997,29 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       // Drain the fixture rows so the later empty-state assertions hold.
       setRecentRequests([]);
       await waitForPanelText(page, '#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not drain after the journey-strip truth checks');
+
+      // ── Recent-requests status line: announce only on attention CHANGES ──
+      // Routine traffic first: a clean row arrives, the needs-attention count
+      // stays 0 → the status node must stay silent across the next poll tick.
+      const cleanRow = piRow();
+      setRecentRequests([cleanRow]);
+      await waitForPanelText(page, '#recent-requests-panel', /hello from pi/, 'Clean pi row did not render before the attention-announcement checks');
+      await new Promise((resolve) => setTimeout(resolve, 2500)); // ≥1 recent-requests poll
+      const routineText = await page.$eval('#recent-requests-status', (el) => el.textContent || '');
+      if (routineText.trim() !== '') fail(`Routine traffic must not announce; #recent-requests-status got ${JSON.stringify(routineText)}`);
+
+      // An errored row flips the count 0→1: exactly one terse line, counting
+      // arrivals since the last announcement plus the attention total.
+      setRecentRequests([smokeRecentRow({ user_agent: 'pi/1.2.0', prompt_preview: 'attention row', finish_reason: 'error' }), cleanRow]);
+      await expectStatusAnnouncement(page, 'recent-requests-status', /needs attention\./, 'Attention-count increase was not announced');
+
+      // Clearing the errored row flips 1→0: the recovery is announced too.
+      setRecentRequests([cleanRow]);
+      await expectStatusAnnouncement(page, 'recent-requests-status', /no requests need attention\./, 'Attention-count recovery was not announced');
+
+      // Re-drain so the later empty-state assertions hold.
+      setRecentRequests([]);
+      await waitForPanelText(page, '#recent-requests-panel', /No recent requests yet\./, 'Recent requests did not drain after the attention-announcement checks');
     }
 
     // --- Hash navigation: tab clicks mint history entries, browser
@@ -1950,6 +2070,9 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     if (!/^application\/gzip\b/i.test(downloadHeaders['content-type'] || '')) fail('Adapter download should return an archive content-type header');
     if (Number(downloadHeaders['content-length'] || 0) <= 0) fail('Adapter download should return non-empty archive bytes');
     await page.goto(`${baseUrl}/ui`, { waitUntil: 'domcontentloaded' });
+    // The reload wiped the boot-time aria-busy observer — re-arm it so the
+    // overview steady-state assertions below can read it.
+    await installServerStatusBusyObserver(page);
     await goToPrimaryTab(page, 'adapters');
     await waitForPanelText(page, '#adapters-panel', /adapter-alpha/, 'Adapter list should reload after adapter download');
     await waitForPanelText(page, '#adapters-panel', /adapter-beta/, 'Adapter list should still include adapter-beta after download');
@@ -2120,6 +2243,8 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       uptime: document.getElementById('header-uptime')?.textContent || '',
       configOpen: document.getElementById('runtime-config')?.open === true,
       configIntact: /nvidia-smi/.test(document.getElementById('runtime-config-body')?.textContent || ''),
+      serverStatusBusy: document.getElementById('server-status')?.getAttribute('aria-busy'),
+      busyFlips: window.__serverStatusBusyFlips || null,
     }));
     if (!overviewSteadyState.svg) fail('VRAM donut disappeared after subsequent health polls');
     if (overviewSteadyState.donuts !== 1) fail(`Expected exactly one VRAM donut, found ${overviewSteadyState.donuts}`);
@@ -2129,6 +2254,16 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     // the ≥2 genuine repaints above must not close it or destroy its content.
     if (!overviewSteadyState.configOpen) fail('Runtime config expander lost its open state across server-status repaints');
     if (!overviewSteadyState.configIntact) fail('Runtime config content was destroyed by the server-status repaint');
+    // aria-busy hygiene: the ≥2 genuine repaints above (blocks_used cycles, so
+    // content really changed) must not flip aria-busy — it toggles only on the
+    // FIRST load, then stays false for the life of the page.
+    if (overviewSteadyState.serverStatusBusy !== 'false') {
+      fail(`#server-status aria-busy should stay "false" across poll ticks, got "${overviewSteadyState.serverStatusBusy}"`);
+    }
+    if (overviewSteadyState.busyFlips === null) fail('aria-busy mutation observer was not installed on #server-status');
+    if (overviewSteadyState.busyFlips.length > 0) {
+      fail(`aria-busy on #server-status flipped on poll ticks after the first render: ${overviewSteadyState.busyFlips.join(', ')}`);
+    }
 
     await goToPrimaryTab(page, 'playground');
     await waitForPanelText(page, '#chat-output', /Send a message to test inference\./, 'Quick Inference empty state missing');
@@ -2153,6 +2288,9 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await waitForPanelText(page, '#tab-queue', /smoke-sf/, 'Training queue should refresh after SFT submit');
     await waitForPanelText(page, '#tab-queue', /Adapter:\s*sft-adapter/, 'Training queue should show the submitted SFT adapter name');
     await waitForPanelText(page, '#tab-queue', /running/, 'Training queue should show the SFT job as running');
+    // The queue panel is no longer aria-live; the card's visually-hidden
+    // status node must carry the start transition instead.
+    await expectStatusAnnouncement(page, 'training-queue-status', /Training started: sft-adapter\./, 'Training start was not announced');
 
     // Drill modal for the RUNNING job: Stop must be live (running jobs are
     // cancellable cooperatively — the trainer aborts at the next step
@@ -2209,6 +2347,9 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
       },
       { timeout: 6000 },
     ).catch(() => fail('Train drill modal did not repaint to the cancelled state after Stop'));
+    // The running→failed transition (cancel lands as Failed) must also speak
+    // through the status node — same channel as completed/failed jobs.
+    await expectStatusAnnouncement(page, 'training-queue-status', /Training failed: sft-adapter\./, 'Training cancel (failed) was not announced');
     await clickAndWait(page, '#train-drill-close', 'Could not close the train drill modal');
     await page.waitForFunction(() => document.getElementById('train-drill-modal')?.hidden === true, { timeout: 5000 })
       .catch(() => fail('Train drill modal did not close'));


### PR DESCRIPTION
Wave 5 of the UI overhaul (roadmap PR 24 of 25).

Six polled data panels were marked `aria-live="polite"` — every content repaint re-announced big list subtrees to screen readers, and `aria-busy` flipped on every poll tick. Full before/after inventory in the agent run; the short version:

- **Removed aria-live from the data panels** (`#tab-queue`, `#server-status`, `#decode-perf-panel`, `#recent-requests-panel`, `#adapters-panel`, and the relative-time-churning heartbeat label). Correctly-scoped status regions (header chip from #1545, unreachable banner, form-readiness one-liners, the toast channel — already `role=status` + assertive on errors) stay.
- **Added per-card `.sr-only` status nodes** fed by the code that already detects transitions: "Training started/completed/failed: ⟨adapter⟩", "Eval ⟨suite⟩ finished. Verdict: …" (the sign-test-gated string), and "N new requests, 1 request needs attention" — spoken only when the attention count *changes*; routine traffic is silent. The bar applied: announce what a sighted user would notice, not a firehose.
- **`aria-busy` flips exactly once per page lifetime**: `setPanelBusy`'s false-arm stamps `data-loaded`, the true-arm skips stamped panels — central guard, zero call-site changes, holds across failure→recovery cycles.

Smoke: no-aria-live assertions on all six surfaces, boot-empty status nodes, real transition announcements after the existing submit/cancel walks, and a MutationObserver proving `#server-status` aria-busy goes true→false once with **zero flips across ≥2 genuine repaints** (the mock cycles `blocks_used`). **Negative-tested**: origin/main fails immediately at "#tab-queue must not be aria-live". Full suite passes post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)