### PR TITLE
Dashboard tablists share one keyboard contract: Distill's 11 sub-tabs become reachable

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -153,6 +153,10 @@ function selectPage(name, opts) {
     const active = t.dataset.page === name;
     t.classList.toggle('active', active);
     t.setAttribute('aria-selected', String(active));
+    // Roving tabindex lives here (not only in the wireTablist wrapper) so
+    // the MANY direct selectPage callers — boot, hashchange, quick actions,
+    // window.selectPage — keep exactly one nav tab in the Tab order.
+    t.tabIndex = active ? 0 : -1;
   });
   document.querySelectorAll('.page').forEach(p => {
     const active = p.id === 'page-' + name;
@@ -214,8 +218,11 @@ function refreshActiveEvalSubTab() {
   else if (active === 'judgments') refreshJudgments();
   else                             refreshDatasets(); // default sub-tab
 }
-document.querySelectorAll('.primary-tab').forEach(tab => {
-  tab.addEventListener('click', () => selectPage(tab.dataset.page));
+// Primary nav is a tablist too: clicks AND arrow/Home/End keys route
+// through selectPage (the existing nav click path), so history entries and
+// canonical #page/subtab hashes stay exactly as the click path mints them.
+wireTablist(document.querySelector('.primary-nav'), {
+  onSelect: tab => selectPage(tab.dataset.page),
 });
 // Prefer the URL hash (bookmarkable; first segment = page), then the user's
 // last tab from localStorage, then Overview. Sub-tab and drill-id segments
@@ -536,7 +543,9 @@ function renderConnectSnippets(active) {
   const snips = connectSnippets();
   host.innerHTML = Object.entries(snips).map(([key, s]) => {
     const pathLine = s.path ? `<div class="code-block-path">${escapeHtml(s.path)}</div>` : '';
-    return `<div class="connect-snippet${key === active ? ' active' : ''}" data-connect-pane="${key}">
+    // Tabpanel pairing mirrors the training tabs: the static tab buttons in
+    // index.html carry id="connect-tab-{key}" + aria-controls back at these.
+    return `<div class="connect-snippet${key === active ? ' active' : ''}" data-connect-pane="${key}" role="tabpanel" id="connect-snippet-${key}" aria-labelledby="connect-tab-${key}">
       <div class="connect-snippet-note">${s.note}</div>
       <div class="code-block">${pathLine}<button class="copy-btn" type="button" data-copy-code aria-label="Copy code"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-copy"></use></svg>Copy</button><pre>${renderHighlighted(s.code, s.lang)}</pre></div>
     </div>`;
@@ -573,6 +582,7 @@ function selectConnectTab(key) {
     const on = t.dataset.connectTab === key;
     t.classList.toggle('active', on);
     t.setAttribute('aria-selected', String(on));
+    t.tabIndex = on ? 0 : -1;
   });
   document.querySelectorAll('.connect-snippet').forEach(p => p.classList.toggle('active', p.dataset.connectPane === key));
 }
@@ -1270,7 +1280,9 @@ async function initConnect() {
   renderConnectMetricsSnippet();
   const tr = document.getElementById('connect-test-result');
   if (tr && !tr.textContent.trim()) tr.innerHTML = 'Once connected, your agent&rsquo;s calls stream into <strong>Recent requests</strong> below.';
-  document.querySelectorAll('.connect-tabs .tab').forEach(t => t.addEventListener('click', () => selectConnectTab(t.dataset.connectTab)));
+  wireTablist(document.querySelector('.connect-tabs'), {
+    onSelect: tab => selectConnectTab(tab.dataset.connectTab),
+  });
   document.getElementById('connect-panel')?.addEventListener('click', (e) => {
     const f = e.target.closest('[data-copy-target]');
     if (f) { copyText(document.getElementById(f.dataset.copyTarget)?.textContent || '', f); return; }
@@ -1339,6 +1351,59 @@ function announceStatus(id, msg) {
   el.textContent = (el.textContent === msg) ? msg + '\u00a0' : msg;
 }
 
+// --- Shared tablist wiring (roadmap PR 19) ---
+// One keyboard + click contract for every [role=tablist] in the dashboard:
+// ArrowRight/ArrowLeft wrap around, Home/End jump to the edges, and
+// selection FOLLOWS focus on arrow keys (automatic activation — matching
+// the original training-tabs behavior). Only [role=tab] descendants
+// participate: decorative children (the Distill group labels/separators)
+// are skipped by construction.
+//
+// The helper owns NO selection logic. onSelect(tab, { focus }) must route
+// to the tablist's existing select path (selectTrainingTab, selectEvalsTab,
+// the distill select fn, selectConnectTab, selectPage) so localStorage
+// restores, lazy refreshes, and the deep-link hash writes at the END of
+// those functions keep working unchanged. After onSelect runs, the roving
+// tabindex is re-asserted from aria-selected so tablists whose select fn
+// predates roving focus still end up with exactly one Tab stop.
+function wireTablist(root, { onSelect }) {
+  if (!root) return;
+  const tabsOf = () => Array.from(root.querySelectorAll('[role="tab"]'));
+  const applyRovingTabindex = () => {
+    tabsOf().forEach(t => { t.tabIndex = t.getAttribute('aria-selected') === 'true' ? 0 : -1; });
+  };
+  const select = (tab, focus) => {
+    onSelect(tab, { focus });
+    applyRovingTabindex();
+    if (focus) tab.focus();
+  };
+  root.addEventListener('click', event => {
+    const tab = event.target.closest('[role="tab"]');
+    if (!tab || !root.contains(tab)) return;
+    select(tab, false);
+  });
+  root.addEventListener('keydown', event => {
+    const tab = event.target.closest('[role="tab"]');
+    if (!tab) return;
+    const tabs = tabsOf();
+    const index = tabs.indexOf(tab);
+    if (index === -1) return;
+    let nextTab = null;
+    if (event.key === 'ArrowRight') nextTab = tabs[(index + 1) % tabs.length];
+    if (event.key === 'ArrowLeft') nextTab = tabs[(index - 1 + tabs.length) % tabs.length];
+    if (event.key === 'Home') nextTab = tabs[0];
+    if (event.key === 'End') nextTab = tabs[tabs.length - 1];
+    if (nextTab) {
+      event.preventDefault();
+      select(nextTab, true);
+    }
+  });
+  // Normalize the initial state: static markup without explicit tabindex
+  // attributes (Connect tabs, primary nav) starts with every tab in the
+  // Tab order — collapse that to the selected tab only.
+  applyRovingTabindex();
+}
+
 // --- Training Tabs ---
 function selectTrainingTab(tab, focus = false) {
   const panel = tab.closest('.card');
@@ -1363,21 +1428,8 @@ function selectTrainingTab(tab, focus = false) {
   pushSubTabHash('training');
 }
 
-document.querySelectorAll('[data-training-tabs] [role="tab"]').forEach(tab => {
-  tab.addEventListener('click', () => selectTrainingTab(tab));
-  tab.addEventListener('keydown', event => {
-    const tabs = Array.from(tab.closest('[role="tablist"]').querySelectorAll('[role="tab"]'));
-    const index = tabs.indexOf(tab);
-    let nextTab = null;
-    if (event.key === 'ArrowRight') nextTab = tabs[(index + 1) % tabs.length];
-    if (event.key === 'ArrowLeft') nextTab = tabs[(index - 1 + tabs.length) % tabs.length];
-    if (event.key === 'Home') nextTab = tabs[0];
-    if (event.key === 'End') nextTab = tabs[tabs.length - 1];
-    if (nextTab) {
-      event.preventDefault();
-      selectTrainingTab(nextTab, true);
-    }
-  });
+wireTablist(document.querySelector('[data-training-tabs]'), {
+  onSelect: (tab, { focus }) => selectTrainingTab(tab, focus),
 });
 
 // Restore last visited training sub-tab so users return to Submit SFT
@@ -5275,18 +5327,8 @@ function selectEvalsTab(tab, focus = false) {
   else if (which === 'jobs') refreshEvalJobs();
   else if (which === 'judgments') refreshJudgments();
 }
-document.querySelectorAll('[data-evals-tabs] [role="tab"]').forEach(tab => {
-  tab.addEventListener('click', () => selectEvalsTab(tab));
-  tab.addEventListener('keydown', event => {
-    const tabs = Array.from(tab.closest('[role="tablist"]').querySelectorAll('[role="tab"]'));
-    const index = tabs.indexOf(tab);
-    let nextTab = null;
-    if (event.key === 'ArrowRight') nextTab = tabs[(index + 1) % tabs.length];
-    if (event.key === 'ArrowLeft') nextTab = tabs[(index - 1 + tabs.length) % tabs.length];
-    if (event.key === 'Home') nextTab = tabs[0];
-    if (event.key === 'End') nextTab = tabs[tabs.length - 1];
-    if (nextTab) { event.preventDefault(); selectEvalsTab(nextTab, true); }
-  });
+wireTablist(document.querySelector('[data-evals-tabs]'), {
+  onSelect: (tab, { focus }) => selectEvalsTab(tab, focus),
 });
 
 // Restore the last visited eval sub-tab so users return to Jobs (or
@@ -9199,15 +9241,15 @@ setInterval(() => {
    ===================================================================== */
 
 // Sub-tab activation for the Distill page mirrors the evals/training
-// pattern: clicking a `.tab[data-tab="X"]` inside `[data-distill-tabs]`
+// pattern: selecting a `.tab[data-tab="X"]` inside `[data-distill-tabs]`
 // hides every `.tab-content` and shows the one with id
-// `distill-tab-X-pane`.
+// `distill-tab-X-pane`. Click + keyboard (arrow/Home/End) wiring comes
+// from the shared wireTablist helper, which skips the decorative
+// group-label/separator spans (they carry no role=tab).
 (function wireDistillTabs() {
   const root = document.querySelector('[data-distill-tabs]');
   if (!root) return;
-  root.addEventListener('click', (ev) => {
-    const btn = ev.target.closest('button.tab[data-tab]');
-    if (!btn) return;
+  function selectDistillTab(btn) {
     const wanted = btn.dataset.tab;
     root.querySelectorAll('.tab').forEach(t => {
       const active = t.dataset.tab === wanted;
@@ -9226,7 +9268,8 @@ setInterval(() => {
     // Deep-link hash for the sub-tab (no-op for hash-driven activation and
     // for the suppressed localStorage restore below).
     pushSubTabHash('distill');
-  });
+  }
+  wireTablist(root, { onSelect: selectDistillTab });
   // Restore the last-used sub-tab. Hash-suppressed: the no-hash fallback —
   // an explicit hash sub-tab is applied after this in the boot route pass.
   try {

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -98,28 +98,28 @@
 </header>
 
 <nav class="primary-nav" role="tablist" aria-label="Dashboard sections">
-  <button type="button" class="primary-tab active" data-page="overview" role="tab" aria-selected="true" aria-controls="page-overview" id="primary-tab-overview">
+  <button type="button" class="primary-tab active" data-page="overview" role="tab" aria-selected="true" aria-controls="page-overview" id="primary-tab-overview" tabindex="0">
     Overview
   </button>
-  <button type="button" class="primary-tab" data-page="adapters" role="tab" aria-selected="false" aria-controls="page-adapters" id="primary-tab-adapters">
+  <button type="button" class="primary-tab" data-page="adapters" role="tab" aria-selected="false" aria-controls="page-adapters" id="primary-tab-adapters" tabindex="-1">
     Adapters
     <span class="count" data-count="adapters" id="adapters-count">0</span>
   </button>
-  <button type="button" class="primary-tab" data-page="training" role="tab" aria-selected="false" aria-controls="page-training" id="primary-tab-training">
+  <button type="button" class="primary-tab" data-page="training" role="tab" aria-selected="false" aria-controls="page-training" id="primary-tab-training" tabindex="-1">
     Training
     <span class="count" data-count="training" id="training-count">0</span>
   </button>
-  <button type="button" class="primary-tab" data-page="evals" role="tab" aria-selected="false" aria-controls="page-evals" id="primary-tab-evals">
+  <button type="button" class="primary-tab" data-page="evals" role="tab" aria-selected="false" aria-controls="page-evals" id="primary-tab-evals" tabindex="-1">
     Evals
     <span class="count" data-count="evals" id="evals-count" title="Eval jobs queued or running">0</span>
   </button>
-  <button type="button" class="primary-tab" data-page="distill" role="tab" aria-selected="false" aria-controls="page-distill" id="primary-tab-distill">
+  <button type="button" class="primary-tab" data-page="distill" role="tab" aria-selected="false" aria-controls="page-distill" id="primary-tab-distill" tabindex="-1">
     Distill
   </button>
-  <button type="button" class="primary-tab" data-page="playground" role="tab" aria-selected="false" aria-controls="page-playground" id="primary-tab-playground">
+  <button type="button" class="primary-tab" data-page="playground" role="tab" aria-selected="false" aria-controls="page-playground" id="primary-tab-playground" tabindex="-1">
     Playground
   </button>
-  <button type="button" class="primary-tab" data-page="terminal" role="tab" aria-selected="false" aria-controls="page-terminal" id="primary-tab-terminal">
+  <button type="button" class="primary-tab" data-page="terminal" role="tab" aria-selected="false" aria-controls="page-terminal" id="primary-tab-terminal" tabindex="-1">
     pi Terminal
   </button>
 </nav>
@@ -228,11 +228,11 @@
           <div class="connect-clients">
             <span class="connect-clients-label">Set up your client</span>
             <div class="tabs connect-tabs" role="tablist" aria-label="Client setup">
-              <button class="tab active" type="button" role="tab" data-connect-tab="pi" aria-selected="true">pi</button>
-              <button class="tab" type="button" role="tab" data-connect-tab="opencode" aria-selected="false">opencode</button>
-              <button class="tab" type="button" role="tab" data-connect-tab="python" aria-selected="false">OpenAI Python</button>
-              <button class="tab" type="button" role="tab" data-connect-tab="js" aria-selected="false">OpenAI JS</button>
-              <button class="tab" type="button" role="tab" data-connect-tab="curl" aria-selected="false">curl</button>
+              <button class="tab active" type="button" role="tab" id="connect-tab-pi" data-connect-tab="pi" aria-selected="true" aria-controls="connect-snippet-pi" tabindex="0">pi</button>
+              <button class="tab" type="button" role="tab" id="connect-tab-opencode" data-connect-tab="opencode" aria-selected="false" aria-controls="connect-snippet-opencode" tabindex="-1">opencode</button>
+              <button class="tab" type="button" role="tab" id="connect-tab-python" data-connect-tab="python" aria-selected="false" aria-controls="connect-snippet-python" tabindex="-1">OpenAI Python</button>
+              <button class="tab" type="button" role="tab" id="connect-tab-js" data-connect-tab="js" aria-selected="false" aria-controls="connect-snippet-js" tabindex="-1">OpenAI JS</button>
+              <button class="tab" type="button" role="tab" id="connect-tab-curl" data-connect-tab="curl" aria-selected="false" aria-controls="connect-snippet-curl" tabindex="-1">curl</button>
             </div>
             <div class="connect-snippets" id="connect-snippets"><!-- rendered by initConnect() --></div>
           </div>
@@ -1118,28 +1118,42 @@
            them; every data-tab/aria-controls is preserved. -->
       <div class="tabs distill-tabs" role="tablist" aria-label="Distill views" data-distill-tabs>
         <span class="tab-group-label" aria-hidden="true">Methods</span>
-        <button class="tab active" id="distill-tab-opd" data-tab="opd" type="button" role="tab" aria-selected="true" aria-controls="distill-tab-opd-pane" tabindex="0" title="Train your model on a teacher model&rsquo;s token-by-token feedback">Distill</button>
-        <button class="tab" id="distill-tab-refresh" data-tab="refresh" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-refresh-pane" tabindex="-1" title="Refresh an adapter on new data (continual learning)">Refresh</button>
-        <button class="tab" id="distill-tab-pump" data-tab="pump" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-pump-pane" tabindex="-1" title="Boost a domain — distill a bigger teacher&rsquo;s knowledge into your model">Boost</button>
-        <button class="tab" id="distill-tab-self" data-tab="self" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-self-pane" tabindex="-1" title="Self-improve via self-distillation">Self-improve</button>
-        <button class="tab" id="distill-tab-merge" data-tab="merge" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-merge-pane" tabindex="-1" title="Behaviour-space LoRA merge">Merge</button>
+        <button class="tab active" id="distill-tab-opd" data-tab="opd" type="button" role="tab" aria-selected="true" aria-controls="distill-tab-opd-pane" aria-describedby="distill-tab-opd-intro" tabindex="0" title="Train your model on a teacher model&rsquo;s token-by-token feedback">Distill</button>
+        <button class="tab" id="distill-tab-refresh" data-tab="refresh" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-refresh-pane" aria-describedby="distill-tab-refresh-desc" tabindex="-1" title="Refresh an adapter on new data (continual learning)">Refresh</button>
+        <button class="tab" id="distill-tab-pump" data-tab="pump" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-pump-pane" aria-describedby="distill-tab-pump-intro" tabindex="-1" title="Boost a domain — distill a bigger teacher&rsquo;s knowledge into your model">Boost</button>
+        <button class="tab" id="distill-tab-self" data-tab="self" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-self-pane" aria-describedby="distill-tab-self-desc" tabindex="-1" title="Self-improve via self-distillation">Self-improve</button>
+        <button class="tab" id="distill-tab-merge" data-tab="merge" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-merge-pane" aria-describedby="distill-tab-merge-desc" tabindex="-1" title="Behaviour-space LoRA merge">Merge</button>
         <span class="tab-group-sep" aria-hidden="true"></span>
         <span class="tab-group-label" aria-hidden="true">Setup</span>
-        <button class="tab" id="distill-tab-teachers" data-tab="teachers" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-teachers-pane" tabindex="-1" title="Registered teacher models">Teachers</button>
-        <button class="tab" id="distill-tab-recipes" data-tab="recipes" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-recipes-pane" tabindex="-1" title="One-click recipes — Kiln picks the hyperparameters">Recipes</button>
-        <button class="tab" id="distill-tab-preflight" data-tab="preflight" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-preflight-pane" tabindex="-1" title="Capacity & compatibility checks before you run">Preflight</button>
+        <button class="tab" id="distill-tab-teachers" data-tab="teachers" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-teachers-pane" aria-describedby="distill-tab-teachers-desc" tabindex="-1" title="Registered teacher models">Teachers</button>
+        <button class="tab" id="distill-tab-recipes" data-tab="recipes" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-recipes-pane" aria-describedby="distill-tab-recipes-desc" tabindex="-1" title="One-click recipes — Kiln picks the hyperparameters">Recipes</button>
+        <button class="tab" id="distill-tab-preflight" data-tab="preflight" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-preflight-pane" aria-describedby="distill-tab-preflight-desc" tabindex="-1" title="Capacity & compatibility checks before you run">Preflight</button>
         <span class="tab-group-sep" aria-hidden="true"></span>
         <span class="tab-group-label" aria-hidden="true">Assets</span>
-        <button class="tab" id="distill-tab-cache" data-tab="cache" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-cache-pane" tabindex="-1" title="On-disk logit cache">Cache</button>
-        <button class="tab" id="distill-tab-library" data-tab="library" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-library-pane" tabindex="-1" title="Browse, install & publish adapters">Library</button>
-        <button class="tab" id="distill-tab-traces" data-tab="traces" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-traces-pane" tabindex="-1" title="Import pi agent sessions for distillation">Agent traces</button>
+        <button class="tab" id="distill-tab-cache" data-tab="cache" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-cache-pane" aria-describedby="distill-tab-cache-desc" tabindex="-1" title="On-disk logit cache">Cache</button>
+        <button class="tab" id="distill-tab-library" data-tab="library" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-library-pane" aria-describedby="distill-tab-library-desc" tabindex="-1" title="Browse, install & publish adapters">Library</button>
+        <button class="tab" id="distill-tab-traces" data-tab="traces" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-traces-pane" aria-describedby="distill-tab-traces-desc" tabindex="-1" title="Import pi agent sessions for distillation">Agent traces</button>
+      </div>
+
+      <!-- Accessible descriptions for the tabs whose only explanation was a
+           hover title= (useless to keyboard / screen-reader users). Where a
+           pane carries a visible intro line, aria-describedby points AT that
+           line instead (distill-tab-opd-intro / distill-tab-pump-intro and
+           the per-pane eyebrow ids below) — no duplicated text. The three
+           panes with no intro get description-only spans here: hidden, so
+           they are never read in document order but still resolve for the
+           tabs' accessible descriptions. -->
+      <div hidden>
+        <span id="distill-tab-refresh-desc">Refresh an adapter on new data (continual learning).</span>
+        <span id="distill-tab-self-desc">Self-improve via self-distillation.</span>
+        <span id="distill-tab-merge-desc">Behaviour-space LoRA merge.</span>
       </div>
 
       <!-- =================================================================
            Submit OPD — POST /v1/train/opd
            ================================================================= -->
       <div class="tab-content active" id="distill-tab-opd-pane" role="tabpanel" aria-labelledby="distill-tab-opd">
-        <div class="form-help" style="margin: 0 0 var(--space-4);">On-policy distillation (OPD): your model writes the answers, a bigger teacher model grades every token, and the gap becomes the training signal. This form queues one distillation job.</div>
+        <div class="form-help" id="distill-tab-opd-intro" style="margin: 0 0 var(--space-4);">On-policy distillation (OPD): your model writes the answers, a bigger teacher model grades every token, and the gap becomes the training signal. This form queues one distillation job.</div>
         <div class="corr-receipt" id="distill-recipes-hint" hidden role="note" style="margin-bottom: var(--space-4);">
           <span class="corr-receipt-icon"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-book"></use></svg></span>
           <span class="corr-receipt-text">New to distillation? <strong>Recipes</strong> pick the teacher, rank, and cost cap for you — one click instead of this whole form.</span>
@@ -1235,7 +1249,7 @@
       <div class="tab-content" id="distill-tab-teachers-pane" role="tabpanel" aria-labelledby="distill-tab-teachers" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Registered teachers</h3>
-          <span class="eyebrow">Registered teacher models</span>
+          <span class="eyebrow" id="distill-tab-teachers-desc">Registered teacher models</span>
         </div>
         <div id="teachers-list">
           <div class="empty">Loading…</div>
@@ -1297,7 +1311,7 @@
       <div class="tab-content" id="distill-tab-recipes-pane" role="tabpanel" aria-labelledby="distill-tab-recipes" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Bundled recipes</h3>
-          <span class="eyebrow">One-click — Kiln picks the hyperparameters</span>
+          <span class="eyebrow" id="distill-tab-recipes-desc">One-click — Kiln picks the hyperparameters</span>
         </div>
         <div id="recipes-list">
           <div class="empty">Loading…</div>
@@ -1361,7 +1375,7 @@
            Pump — 27B → 4B knowledge pump
            ================================================================= -->
       <div class="tab-content" id="distill-tab-pump-pane" role="tabpanel" aria-labelledby="distill-tab-pump" hidden inert>
-        <div class="form-help" style="margin: 0 0 var(--space-4);">Boost (the &ldquo;knowledge pump&rdquo;): distill one domain &mdash; math, code, writing &mdash; from a bigger teacher into your model.</div>
+        <div class="form-help" id="distill-tab-pump-intro" style="margin: 0 0 var(--space-4);">Boost (the &ldquo;knowledge pump&rdquo;): distill one domain &mdash; math, code, writing &mdash; from a bigger teacher into your model.</div>
         <form id="distill-pump-form">
           <div class="form-row">
             <div class="form-group">
@@ -1491,7 +1505,7 @@
       <div class="tab-content" id="distill-tab-cache-pane" role="tabpanel" aria-labelledby="distill-tab-cache" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Logit cache</h3>
-          <span class="eyebrow">Prefix-keyed logit cache on disk</span>
+          <span class="eyebrow" id="distill-tab-cache-desc">Prefix-keyed logit cache on disk</span>
         </div>
         <div id="cache-stats">
           <div class="empty">Loading…</div>
@@ -1509,7 +1523,7 @@
       <div class="tab-content" id="distill-tab-library-pane" role="tabpanel" aria-labelledby="distill-tab-library" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Adapter library</h3>
-          <span class="eyebrow">Browse, install &amp; publish adapters</span>
+          <span class="eyebrow" id="distill-tab-library-desc">Browse, install &amp; publish adapters</span>
         </div>
         <div id="library-list">
           <div class="empty">Loading…</div>
@@ -1545,7 +1559,7 @@
       <div class="tab-content" id="distill-tab-traces-pane" role="tabpanel" aria-labelledby="distill-tab-traces" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">pi session traces</h3>
-          <span class="eyebrow">Import pi agent sessions for distillation</span>
+          <span class="eyebrow" id="distill-tab-traces-desc">Import pi agent sessions for distillation</span>
         </div>
         <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-3);">
           <button type="button" class="btn btn-sm" id="agent-traces-refresh">Rescan ~/.pi/agent/sessions/</button>
@@ -1561,7 +1575,7 @@
       <div class="tab-content" id="distill-tab-preflight-pane" role="tabpanel" aria-labelledby="distill-tab-preflight" hidden inert>
         <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
           <h3 style="font-size: var(--text-lg);">Compatibility table</h3>
-          <span class="eyebrow">Validated teacher × student × domain combos</span>
+          <span class="eyebrow" id="distill-tab-preflight-desc">Validated teacher × student × domain combos</span>
         </div>
         <div id="preflight-compat-list">
           <div class="empty">Loading…</div>

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -2173,6 +2173,130 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await page.goBack();
     await expectActivePageAndHash(page, 'evals', 'Back after a junk hash should land on Evals — #nonsense must not pollute history', '#evals/datasets');
 
+    // --- Shared tablist keyboard contract (roadmap PR 19): every
+    // [role=tablist] — primary nav, training (asserted separately via
+    // expectTrainingTabKeyboardNavigation), evals, distill, Connect —
+    // answers ArrowLeft/ArrowRight/Home/End with automatic activation
+    // (selection follows focus) and a roving tabindex. ---
+
+    // Primary nav: arrows walk the pages through the same selectPage click
+    // path, so pages activate AND the canonical hashes get minted.
+    await goToPrimaryTab(page, 'overview');
+    await expectActivePageAndHash(page, 'overview', 'Primary-nav keyboard checks should start from Overview');
+    await page.focus('#primary-tab-overview');
+    await page.keyboard.press('ArrowRight');
+    await expectActivePageAndHash(page, 'adapters', 'ArrowRight on the primary nav should activate the Adapters page with its hash');
+    const navArrowState = await page.evaluate(() => ({
+      focused: document.activeElement?.id || null,
+      adaptersTabIndex: document.getElementById('primary-tab-adapters')?.tabIndex,
+      overviewTabIndex: document.getElementById('primary-tab-overview')?.tabIndex,
+    }));
+    if (navArrowState.focused !== 'primary-tab-adapters') fail(`ArrowRight should move focus to the Adapters nav tab, got ${navArrowState.focused}`);
+    if (navArrowState.adaptersTabIndex !== 0 || navArrowState.overviewTabIndex !== -1) {
+      fail(`Primary-nav roving tabindex should follow selection, got adapters=${navArrowState.adaptersTabIndex} overview=${navArrowState.overviewTabIndex}`);
+    }
+    await page.keyboard.press('ArrowLeft');
+    await expectActivePageAndHash(page, 'overview', 'ArrowLeft on the primary nav should return to Overview');
+    await page.keyboard.press('End');
+    await expectActivePageAndHash(page, 'terminal', 'End on the primary nav should jump to the last page (pi Terminal)');
+    await page.keyboard.press('Home');
+    await expectActivePageAndHash(page, 'overview', 'Home on the primary nav should jump back to Overview');
+
+    // Connect panel tabs: the JS-rendered snippet panes carry real tabpanel
+    // semantics paired to the tab button ids, and arrows walk the clients.
+    // (Earlier journey-strip traffic auto-collapsed the panel — re-expand.)
+    await page.evaluate(() => window.openConnect());
+    await page.waitForFunction(() => document.getElementById('connect-expanded')?.hidden === false, { timeout: 5000 })
+      .catch(() => fail('Connect panel did not expand for the tablist keyboard checks'));
+    const connectPaneAria = await page.evaluate(() => Array.from(document.querySelectorAll('.connect-snippet')).map((pane) => ({
+      key: pane.dataset.connectPane,
+      role: pane.getAttribute('role'),
+      id: pane.id,
+      labelledby: pane.getAttribute('aria-labelledby'),
+      tabControls: document.getElementById(`connect-tab-${pane.dataset.connectPane}`)?.getAttribute('aria-controls'),
+    })));
+    if (connectPaneAria.length === 0) fail('Connect snippet panes did not render');
+    for (const pane of connectPaneAria) {
+      if (pane.role !== 'tabpanel') fail(`Connect pane ${pane.key} should carry role=tabpanel, got ${JSON.stringify(pane.role)}`);
+      if (pane.labelledby !== `connect-tab-${pane.key}`) fail(`Connect pane ${pane.key} aria-labelledby should point at its tab, got ${JSON.stringify(pane.labelledby)}`);
+      if (pane.tabControls !== pane.id) fail(`Connect tab ${pane.key} aria-controls should point at its pane id ${pane.id}, got ${JSON.stringify(pane.tabControls)}`);
+    }
+    await clickAndWait(page, '#connect-tab-pi', 'Could not activate the pi connect tab before keyboard checks');
+    await page.focus('#connect-tab-pi');
+    await page.keyboard.press('ArrowRight');
+    const connectArrowState = await page.evaluate(() => ({
+      selected: document.getElementById('connect-tab-opencode')?.getAttribute('aria-selected'),
+      focused: document.activeElement?.id || null,
+      tabIndex: document.getElementById('connect-tab-opencode')?.tabIndex,
+      piTabIndex: document.getElementById('connect-tab-pi')?.tabIndex,
+      paneActive: !!document.getElementById('connect-snippet-opencode')?.classList.contains('active'),
+      paneVisible: (() => {
+        const rect = document.getElementById('connect-snippet-opencode')?.getBoundingClientRect();
+        return Boolean(rect && rect.width > 0 && rect.height > 0);
+      })(),
+    }));
+    if (connectArrowState.selected !== 'true') fail(`ArrowRight should select the opencode connect tab, aria-selected=${connectArrowState.selected}`);
+    if (connectArrowState.focused !== 'connect-tab-opencode') fail(`ArrowRight should focus the opencode connect tab, got ${connectArrowState.focused}`);
+    if (connectArrowState.tabIndex !== 0 || connectArrowState.piTabIndex !== -1) {
+      fail(`Connect-tabs roving tabindex should follow selection, got opencode=${connectArrowState.tabIndex} pi=${connectArrowState.piTabIndex}`);
+    }
+    if (!connectArrowState.paneActive || !connectArrowState.paneVisible) fail('ArrowRight should reveal the opencode snippet pane');
+    await page.keyboard.press('Home');
+    const connectHomeState = await page.evaluate(() => ({
+      selected: document.getElementById('connect-tab-pi')?.getAttribute('aria-selected'),
+      paneActive: !!document.getElementById('connect-snippet-pi')?.classList.contains('active'),
+    }));
+    if (connectHomeState.selected !== 'true' || !connectHomeState.paneActive) fail('Home should return the connect tabs to pi with its pane visible');
+
+    // Distill: the headline fix. Its 11 sub-tabs were completely
+    // unreachable by keyboard (roving tabindex=-1 with no arrow-key
+    // handler). Arrows now activate them, the decorative group
+    // labels/separators inside the tablist are skipped, and — per the
+    // deep-link wiring — every keyboard activation mints #distill/<tab>.
+    await goToPrimaryTab(page, 'distill');
+    await clickAndWait(page, '#distill-tab-opd', 'Could not activate the Distill (OPD) tab before keyboard checks');
+    await page.focus('#distill-tab-opd');
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await expectActivePageAndHash(page, 'distill', 'ArrowRight x2 from Distill should select the third tab (Boost) and mint its deep-link hash', '#distill/pump');
+    const distillBoostState = await page.evaluate(() => {
+      const tab = document.getElementById('distill-tab-pump');
+      const pane = document.getElementById('distill-tab-pump-pane');
+      const rect = pane?.getBoundingClientRect();
+      return {
+        selected: tab?.getAttribute('aria-selected'),
+        focused: document.activeElement === tab,
+        tabIndex: tab?.tabIndex,
+        opdSelected: document.getElementById('distill-tab-opd')?.getAttribute('aria-selected'),
+        opdTabIndex: document.getElementById('distill-tab-opd')?.tabIndex,
+        paneHidden: Boolean(pane?.hidden),
+        paneVisible: Boolean(rect && rect.width > 0 && rect.height > 0),
+      };
+    });
+    if (distillBoostState.selected !== 'true') fail(`ArrowRight x2 should select the Boost tab, aria-selected=${distillBoostState.selected}`);
+    if (!distillBoostState.focused) fail('Boost tab should hold keyboard focus after arrow navigation');
+    if (distillBoostState.tabIndex !== 0 || distillBoostState.opdTabIndex !== -1) {
+      fail(`Distill roving tabindex should follow selection, got pump=${distillBoostState.tabIndex} opd=${distillBoostState.opdTabIndex}`);
+    }
+    if (distillBoostState.opdSelected !== 'false') fail('OPD tab should deselect when Boost activates');
+    if (distillBoostState.paneHidden || !distillBoostState.paneVisible) fail('Boost pane should be visible after arrow-key activation');
+    // Crossing a group boundary: Merge → Teachers skips the decorative
+    // label/separator spans inside the tablist.
+    await clickAndWait(page, '#distill-tab-merge', 'Could not activate the Merge distill tab');
+    await page.focus('#distill-tab-merge');
+    await page.keyboard.press('ArrowRight');
+    await expectActivePageAndHash(page, 'distill', 'ArrowRight from Merge should skip the group label/separator spans and land on Teachers', '#distill/teachers');
+    await page.keyboard.press('End');
+    await expectActivePageAndHash(page, 'distill', 'End should jump to the last distill tab (Agent traces)', '#distill/traces');
+    const tracesPaneVisible = await page.evaluate(() => {
+      const pane = document.getElementById('distill-tab-traces-pane');
+      const rect = pane?.getBoundingClientRect();
+      return Boolean(pane && !pane.hidden && rect && rect.width > 0 && rect.height > 0);
+    });
+    if (!tracesPaneVisible) fail('End should reveal the Agent traces pane');
+    await page.keyboard.press('Home');
+    await expectActivePageAndHash(page, 'distill', 'Home should jump back to the first distill tab', '#distill/opd');
+
     await goToPrimaryTab(page, 'adapters');
     await waitForPanelText(page, '#adapters-panel', /adapter-alpha/, 'Adapter list should show the first smoke adapter');
     await waitForPanelText(page, '#adapters-panel', /adapter-beta/, 'Adapter list should show the second smoke adapter');


### PR DESCRIPTION
Wave 4 of the UI overhaul (roadmap PR 19 of 25).

Distill's 11 sub-tabs were **completely unreachable by keyboard** — roving `tabindex="-1"` with no arrow-key handler, so Tab skipped past them and arrows did nothing. Meanwhile training and evals each carried their own near-identical 13–16-line keydown blocks.

One `wireTablist(root, { onSelect })` helper now owns click + keydown (Arrow wrap, Home/End, automatic activation matching prior training behavior) and roving tabindex across **five tablists**: training, evals, distill (the fix — label/separator spans correctly skipped), the Connect panel tabs, and the primary nav (arrow keys across all 7 pages). It owns no selection logic — `onSelect` routes to each existing select path, so the #1567 hash writes are preserved exactly; new tablists cost ~3 lines instead of ~16.

ARIA completion: connect tabs/panes get full `aria-controls`/`role=tabpanel`/`aria-labelledby` pairing; distill's load-bearing `title=` descriptions now also resolve via `aria-describedby` pointing at the visible pane intros (no duplicated text; hidden spans only where no intro exists).

Smoke: distill arrow-walk asserts selection + visible pane + `#distill/pump` deep-link hash, separator crossing, Home/End, primary-nav arrows with correct hashes, connect pairing — and the pre-existing training keyboard assertion stays green through the refactor. **Negative-tested**: origin/main fails at the distill ArrowRight assertion. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)