### PR TITLE
Agent traces drill in: pi sessions open, filter, and deep-link at #distill/traces/{id}

### DIFF
--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -117,7 +117,7 @@ function pushSubTabHash(pageName) {
 // --- Drill-modal hash bookkeeping (see the state machine above) --------
 // Whether WE minted the history entry for the currently-open modal of each
 // kind; decides between history.back() and replaceState on user close.
-const modalHashPushed = { eval: false, train: false, adapter: false, request: false };
+const modalHashPushed = { eval: false, train: false, adapter: false, request: false, trace: false };
 
 function modalHashOnOpen(kind, hash, alreadyOpen = false) {
   if (hashWriteDepth > 0 || !history.pushState) { modalHashPushed[kind] = false; return; }
@@ -425,9 +425,10 @@ function applyHashRoute(opts = {}) {
         sub = activeSubTab(name);
         id = null;
       }
-      // Drill ids only ride on training/queue and evals/jobs.
+      // Drill ids ride on training/queue, evals/jobs, and distill/traces.
       if (name === 'training' && sub === 'queue' && id) drill = { kind: 'train', id };
       else if (name === 'evals' && sub === 'jobs' && id) drill = { kind: 'eval', id };
+      else if (name === 'distill' && sub === 'traces' && id) drill = { kind: 'trace', id };
       else id = null;
     } else if (name === 'adapters' && sub) {
       // #adapters/{name} — the second segment is a drill id, not a sub-tab.
@@ -451,7 +452,7 @@ function applyHashRoute(opts = {}) {
   if (history.replaceState && location.hash !== canonical) history.replaceState(null, '', canonical);
 }
 
-// Open/close the four drill modals so they match the route. Closes here are
+// Open/close the five drill modals so they match the route. Closes here are
 // direct (never history.back()): this runs FROM a traversal or boot, where
 // the URL is already where it should be. Opens run hash-suppressed by the
 // caller, so the open fns' own pushState helpers stay quiet. Each modal's
@@ -505,6 +506,16 @@ function syncDrillModalsToRoute(drill) {
         modalHashPushed.request = false;
         closeRequestDrillModal();
       }
+    }
+  }
+  const traceModal = document.getElementById('trace-drill-modal');
+  if (traceModal) {
+    const openId = traceModal.hidden ? null : (traceDrillId || null);
+    if (want.kind === 'trace') {
+      if (openId !== want.id) openTraceDrillModal(want.id);
+    } else if (openId !== null) {
+      modalHashPushed.trace = false;
+      closeTraceDrillModal();
     }
   }
 }
@@ -9457,7 +9468,7 @@ function refreshActiveDistillSubTab() {
   } else if (active === 'library') {
     refreshLibraryList();
   } else if (active === 'traces') {
-    /* user-triggered via rescan button */
+    refreshAgentTraces();
   } else if (active === 'preflight') {
     refreshPreflightSurfaces();
   }
@@ -9852,42 +9863,347 @@ document.getElementById('library-publish-form')?.addEventListener('submit', asyn
   } catch (err) { toast('Publish failed: ' + err.message, 'err'); }
 });
 
-// --- Agent traces (/v1/agent/traces) --------------------------------
+// --- Agent traces (pi sessions → distillation source) ----------------
+// The Distill → Agent traces tab: every pi session saved on this machine,
+// browsable before you distill from it. Entering the tab lists the
+// existing index; the scan button rebuilds it (optionally from a custom
+// sessions folder, persisted in localStorage). Outcome chips and a
+// working-dir filter narrow the list client-side — the index rows carry
+// the full §10.3 outcome heuristics — and every card drills into the
+// recorded conversation at #distill/traces/{id}.
+const TRACES_SCAN_PATH_KEY = 'kiln.traces.scanPath';
+let agentTracesCache = null;   // last fetched index; null = never loaded
+let agentTracesScanNote = '';  // headline HTML after an explicit scan
+let agentTraceOutcomeFilter = 'all';
+
+// Outcome buckets for the filter chips, derived from the heuristics the
+// index actually carries: last bash exit code, /tree forks, follow-up
+// attempts, and user-edited agent files. A trace can land in several.
+function agentTraceOutcomeBuckets(t) {
+  const buckets = [];
+  if (t.outcome?.ended_with_exit_0 === true) buckets.push('exit0');
+  if (t.outcome?.ended_with_exit_0 === false) buckets.push('exitnz');
+  if (t.forked || t.outcome?.has_followup_attempt === true || (t.outcome?.user_edited_agent_files || []).length > 0) buckets.push('sideways');
+  if (buckets.length === 0) buckets.push('nosignal');
+  return buckets;
+}
+
+// Human-readable outcome summary shared by the cards and the drill modal.
+function agentTraceOutcomeBits(t) {
+  const bits = [];
+  if (t.outcome?.ended_with_exit_0 === true) bits.push('exit 0');
+  if (t.outcome?.ended_with_exit_0 === false) bits.push('exit ≠ 0');
+  const edited = (t.outcome?.user_edited_agent_files || []).length;
+  if (edited) bits.push(`${edited} user-edited file${edited === 1 ? '' : 's'}`);
+  if (t.outcome?.has_followup_attempt === true) bits.push('has follow-up');
+  if (t.forked) bits.push('forked');
+  return bits;
+}
+
+// List the existing index (no rescan) — fired on tab entry so the tab is
+// useful without touching the scan button.
+async function refreshAgentTraces() {
+  const node = document.getElementById('agent-traces-list');
+  if (!node) return;
+  try {
+    const list = await api('/v1/agent/traces');
+    agentTracesCache = list.traces || [];
+    renderAgentTracesList();
+  } catch (e) {
+    setListHtml(node, 'err:' + e.message, `<div class="empty">Couldn't load pi sessions: ${escapeHtml(e.message)}</div>`);
+    setListHtml(document.getElementById('agent-traces-chips'), 'err', '');
+  }
+}
+
 document.getElementById('agent-traces-refresh')?.addEventListener('click', async () => {
   const node = document.getElementById('agent-traces-list');
-  node.innerHTML = '<div class="empty">Scanning…</div>';
+  if (!node) return;
+  const customPath = (document.getElementById('agent-traces-path')?.value || '').trim();
+  // Remember the last-used folder (empty = pi's default) for next visit.
+  try { localStorage.setItem(TRACES_SCAN_PATH_KEY, customPath); } catch {}
+  setListHtml(node, 'scanning', '<div class="empty">Scanning for pi sessions…</div>');
   try {
-    // First POST /v1/agent/traces/discover to rescan ~/.pi/agent/sessions/
-    // and write the index; then GET /v1/agent/traces to list it.
+    // Rescan first (rebuilds the index), then list what it indexed. An
+    // omitted path means the server scans pi's default sessions folder.
     const discover = await api('/v1/agent/traces/discover', {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({}),
+      body: JSON.stringify(customPath ? { path: customPath } : {}),
     });
+    agentTracesScanNote = `Indexed ${discover.indexed} pi session${discover.indexed === 1 ? '' : 's'} from <code>${escapeHtml(discover.path || '')}</code>.`;
     const list = await api('/v1/agent/traces');
-    const traces = list.traces || [];
-    if (traces.length === 0) {
-      node.innerHTML = `<div class="empty">No pi sessions found under <code>${escapeHtml(discover.path || '~/.pi/agent/sessions/')}</code>.</div>`;
-      return;
-    }
-    node.innerHTML = `<div class="form-help" style="margin-bottom: var(--space-3);">Indexed ${discover.indexed} pi session${discover.indexed === 1 ? '' : 's'} from <code>${escapeHtml(discover.path)}</code>.</div>` +
-      traces.map(t => {
-        const outcomeBits = [];
-        if (t.outcome?.ended_with_exit_0 === true) outcomeBits.push('exit 0');
-        if (t.outcome?.ended_with_exit_0 === false) outcomeBits.push('exit ≠ 0');
-        if (t.outcome?.user_edited_agent_files?.length) outcomeBits.push(`${t.outcome.user_edited_agent_files.length} user-edited`);
-        if (t.outcome?.has_followup_attempt === true) outcomeBits.push('has follow-up');
-        if (t.forked) outcomeBits.push('forked');
-        return `<div class="adapter-card" style="margin-bottom:var(--space-2);">
-          <div style="font-weight:600; font-family:var(--font-mono); font-size:var(--text-xs);">${escapeHtml(t.id || '?')}</div>
-          <div style="font-size:var(--text-xs); color:var(--text-muted);">${t.num_turns || 0} turns · ${t.num_tool_calls || 0} tool calls · ${escapeHtml(t.working_dir || '')}</div>
-          ${outcomeBits.length ? `<div style="font-size:var(--text-2xs); color:var(--text-muted); margin-top:var(--space-1);">${outcomeBits.map(b => escapeHtml(b)).join(' · ')}</div>` : ''}
-        </div>`;
-      }).join('');
+    agentTracesCache = list.traces || [];
+    renderAgentTracesList();
   } catch (e) {
-    node.innerHTML = `<div class="empty">Failed: ${escapeHtml(e.message)}</div>`;
+    agentTracesScanNote = '';
+    setListHtml(node, 'scanerr:' + e.message, `<div class="empty">Scan failed: ${escapeHtml(e.message)}</div>`);
   }
 });
+
+// Restore the last-used scan path (empty = server default).
+try {
+  const savedScanPath = localStorage.getItem(TRACES_SCAN_PATH_KEY);
+  const scanPathInput = document.getElementById('agent-traces-path');
+  if (savedScanPath && scanPathInput) scanPathInput.value = savedScanPath;
+} catch {}
+
+document.getElementById('agent-traces-dir')?.addEventListener('input', () => renderAgentTracesList());
+
+function renderAgentTracesList() {
+  const node = document.getElementById('agent-traces-list');
+  const chipsNode = document.getElementById('agent-traces-chips');
+  if (!node) return;
+  const all = agentTracesCache || [];
+  const dirNeedle = (document.getElementById('agent-traces-dir')?.value || '').trim().toLowerCase();
+
+  const counts = { all: all.length, exit0: 0, exitnz: 0, sideways: 0, nosignal: 0 };
+  for (const t of all) for (const b of agentTraceOutcomeBuckets(t)) counts[b] += 1;
+  // A rescan can empty the active bucket; degrade to All instead of
+  // pinning the list on a filter that now matches nothing.
+  if (agentTraceOutcomeFilter !== 'all' && counts[agentTraceOutcomeFilter] === 0) agentTraceOutcomeFilter = 'all';
+
+  // Outcome chips — same pattern as the recent-requests client chips.
+  const chip = (key, label, n, title) =>
+    `<button type="button" class="agent-chip${agentTraceOutcomeFilter === key ? ' active' : ''}" data-trace-chip="${key}" title="${escapeHtml(title)}">${escapeHtml(label)}<span class="count">${n}</span></button>`;
+  const chipsHtml = all.length === 0 ? '' : `<div class="agent-chips" role="group" aria-label="Filter pi sessions by outcome" style="margin-bottom:0;">`
+    + chip('all', 'All sessions', counts.all, 'Every indexed pi session')
+    + chip('exit0', 'exit 0', counts.exit0, 'Sessions whose last shell command exited 0 — the likely successes worth distilling')
+    + chip('exitnz', 'exit ≠ 0', counts.exitnz, 'Sessions whose last shell command failed')
+    + chip('sideways', 'went sideways', counts.sideways, 'Forked with /tree, retried in a follow-up session, or hand-edited afterwards — signs the original branch went wrong')
+    + chip('nosignal', 'no signal', counts.nosignal, 'Sessions with no outcome heuristics extracted')
+    + '</div>';
+  if (chipsNode && setListHtml(chipsNode, 'chips:' + JSON.stringify([agentTraceOutcomeFilter, counts]), chipsHtml)) {
+    chipsNode.querySelectorAll('[data-trace-chip]').forEach(c => c.addEventListener('click', () => {
+      agentTraceOutcomeFilter = c.dataset.traceChip;
+      renderAgentTracesList();
+    }));
+  }
+
+  if (agentTracesCache === null) return; // first load pending — keep the static hint
+  const noteHtml = agentTracesScanNote ? `<div class="form-help" style="margin-bottom: var(--space-3);">${agentTracesScanNote}</div>` : '';
+  if (all.length === 0) {
+    setListHtml(node, 'empty:' + agentTracesScanNote,
+      noteHtml + '<div class="empty">No pi sessions found yet. Use pi against this server, then scan again — every session it saves becomes distillable here.</div>');
+    return;
+  }
+
+  const filtered = all.filter(t => {
+    if (agentTraceOutcomeFilter !== 'all' && !agentTraceOutcomeBuckets(t).includes(agentTraceOutcomeFilter)) return false;
+    if (dirNeedle && !String(t.working_dir || '').toLowerCase().includes(dirNeedle)) return false;
+    return true;
+  });
+  if (filtered.length === 0) {
+    setListHtml(node, 'nomatch:' + JSON.stringify([agentTraceOutcomeFilter, dirNeedle, agentTracesScanNote]),
+      noteHtml + '<div class="empty">No pi sessions match the current filters.</div>');
+    return;
+  }
+
+  const listKey = 'list:' + JSON.stringify([agentTraceOutcomeFilter, dirNeedle, agentTracesScanNote,
+    filtered.map(t => [t.id, t.num_turns, t.num_tool_calls, t.last_event_at])]);
+  const cards = filtered.map(t => {
+    const bits = agentTraceOutcomeBits(t);
+    const when = t.last_event_at || t.first_event_at || '';
+    return `<button type="button" class="adapter-card" data-trace-open="${escapeHtml(t.id || '')}" style="display:block; width:100%; text-align:left; font:inherit; color:inherit; margin-bottom:var(--space-2);" title="Open this pi session — read the conversation and tool calls before distilling from it">
+      <div style="display:flex; justify-content:space-between; gap:var(--space-3); align-items:baseline; flex-wrap:wrap;">
+        <span style="font-weight:600; font-family:var(--font-mono); font-size:var(--text-xs);">${escapeHtml(t.id || '?')}</span>
+        ${when ? `<span style="font-size:var(--text-2xs); color:var(--text-muted);">${escapeHtml(when)}</span>` : ''}
+      </div>
+      <div style="font-size:var(--text-xs); color:var(--text-muted);">${t.num_turns || 0} turns · ${t.num_tool_calls || 0} tool calls · ${escapeHtml(t.working_dir || '')}</div>
+      ${bits.length ? `<div style="font-size:var(--text-2xs); color:var(--text-muted); margin-top:var(--space-1);">${bits.map(b => escapeHtml(b)).join(' · ')}</div>` : ''}
+    </button>`;
+  }).join('');
+  if (setListHtml(node, listKey, noteHtml + cards)) {
+    node.querySelectorAll('[data-trace-open]').forEach(btn => {
+      btn.addEventListener('click', () => openTraceDrillModal(btn.dataset.traceOpen));
+    });
+  }
+}
+
+/* =====================================================================
+   pi session trace drill-in modal — the recorded conversation: turns,
+   tool calls, outcome heuristics. Read it before you distill from it.
+   ===================================================================== */
+let traceDrillId = null;
+let traceDrillData = null;
+// Full text per clamped block in the current drill render, keyed by the
+// data-trace-clamp attribute; the Show-all buttons swap it in on demand.
+let traceDrillTexts = new Map();
+const TRACE_CLAMP_CHARS = 700;
+
+// Trace ids are pi session ids — stable UUID-like file stems — so they
+// ride the #distill/traces/{id} deep-link grammar like the other drills.
+async function openTraceDrillModal(id) {
+  traceDrillId = id;
+  modalHashOnOpen('trace', '#distill/traces/' + encodeURIComponent(id));
+  const modal = document.getElementById('trace-drill-modal');
+  if (!modal) return;
+  modal.hidden = false;
+  openModal(modal, { onClose: userCloseTraceDrillModal });
+  document.getElementById('trace-drill-title').textContent = 'pi session';
+  document.getElementById('trace-drill-meta').textContent = id;
+  const content = document.getElementById('trace-drill-content');
+  content.innerHTML = '<div class="detail-empty">Loading…</div>';
+  traceDrillData = null;
+  try {
+    const t = await api('/v1/agent/traces/' + encodeURIComponent(id));
+    if (traceDrillId !== id) return; // closed or re-targeted while fetching
+    traceDrillData = t;
+    document.getElementById('trace-drill-title').textContent = `pi session ${String(t.id || id).slice(0, 8)}`;
+    const metaBits = [`${t.num_turns || 0} turns`, `${t.num_tool_calls || 0} tool calls`];
+    const outcomeBits = agentTraceOutcomeBits(t);
+    if (outcomeBits.length) metaBits.push(outcomeBits.join(' · '));
+    document.getElementById('trace-drill-meta').textContent = metaBits.join(' · ');
+    content.innerHTML = renderTraceDrillBody(t);
+    content.querySelectorAll('[data-trace-expand]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const pre = content.querySelector(`pre[data-trace-clamp="${btn.dataset.traceExpand}"]`);
+        const full = traceDrillTexts.get(btn.dataset.traceExpand);
+        if (pre && full != null) { pre.textContent = full; btn.remove(); }
+      });
+    });
+  } catch (e) {
+    if (traceDrillId !== id) return;
+    content.innerHTML = `<div class="detail-empty">Couldn't load this pi session: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
+function closeTraceDrillModal() {
+  traceDrillId = null;
+  traceDrillData = null;
+  traceDrillTexts = new Map();
+  const modal = document.getElementById('trace-drill-modal');
+  if (!modal) return;
+  modal.hidden = true;
+  closeModal(modal);
+}
+// User-initiated close (X / backdrop / Esc): walk history per the
+// deep-link state machine, exactly like the other drills.
+function userCloseTraceDrillModal() {
+  modalHashOnUserClose('trace', '#distill/traces', closeTraceDrillModal);
+}
+document.getElementById('trace-drill-close')?.addEventListener('click', userCloseTraceDrillModal);
+document.getElementById('trace-drill-modal')?.addEventListener('click', ev => {
+  if (ev.target.id === 'trace-drill-modal') userCloseTraceDrillModal();
+});
+// Raw JSON toggle — same pattern as the other drill modals' `raw` buttons.
+document.getElementById('trace-drill-raw')?.addEventListener('click', () => {
+  if (!traceDrillData) return;
+  const content = document.getElementById('trace-drill-content');
+  if (!content) return;
+  const existing = content.querySelector('#trace-drill-raw-block');
+  if (existing) { existing.remove(); return; }
+  const pre = document.createElement('pre');
+  pre.id = 'trace-drill-raw-block';
+  pre.className = 'req-pre';
+  pre.style.cssText = 'max-height:50vh; margin:var(--space-4) var(--space-5);';
+  pre.textContent = JSON.stringify(traceDrillData, null, 2);
+  content.appendChild(pre);
+  pre.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+});
+
+// Split an assistant action segment into displayable pieces: <think>
+// blocks, <tool_call>{json}</tool_call> blocks (the form the trace
+// normalizer emits), and the plain-text runs between them.
+function traceSegmentPieces(content) {
+  const pieces = [];
+  const re = /<think>([\s\S]*?)<\/think>|<tool_call>([\s\S]*?)<\/tool_call>/g;
+  let last = 0;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    if (m.index > last) pieces.push({ kind: 'text', text: content.slice(last, m.index) });
+    if (m[1] !== undefined) pieces.push({ kind: 'think', text: m[1] });
+    else pieces.push({ kind: 'tool_call', text: m[2] });
+    last = re.lastIndex;
+  }
+  if (last < content.length) pieces.push({ kind: 'text', text: content.slice(last) });
+  return pieces.filter(p => p.kind === 'tool_call' || p.text.trim().length > 0);
+}
+
+function renderTraceDrillBody(t) {
+  traceDrillTexts = new Map();
+  let clampSeq = 0;
+  // Long content is clamped with a Show-all expander so a 200-line tool
+  // result doesn't bury the conversation.
+  const clamped = (text) => {
+    const full = String(text ?? '');
+    if (full.length <= TRACE_CLAMP_CHARS) return `<pre class="req-pre">${escapeHtml(full)}</pre>`;
+    const key = 'seg' + (clampSeq++);
+    traceDrillTexts.set(key, full);
+    return `<pre class="req-pre" data-trace-clamp="${key}">${escapeHtml(full.slice(0, TRACE_CLAMP_CHARS))}…</pre>
+      <button type="button" class="btn btn-sm btn-ghost" data-trace-expand="${key}">Show all ${full.length.toLocaleString()} characters</button>`;
+  };
+
+  // Metadata header: where it ran, when, how big, how it ended.
+  const stats = [
+    ['Working dir', t.working_dir || '—'],
+    ['Turns', String(t.num_turns || 0)],
+    ['Tool calls', String(t.num_tool_calls || 0)],
+    ['Started', t.first_event_at || '—'],
+    ['Last event', t.last_event_at || '—'],
+  ];
+  if (t.parent_id) stats.push(['Forked from', t.parent_id]);
+  const outcomeBits = agentTraceOutcomeBits(t);
+  stats.push(['Outcome', outcomeBits.length ? outcomeBits.join(' · ') : 'no signal extracted']);
+  const statRow = stats
+    .map(([k, v]) => `<div class="req-stat"><span class="req-stat-k">${escapeHtml(k)}</span><span class="req-stat-v">${escapeHtml(v)}</span></div>`)
+    .join('');
+
+  const turnHtml = (role, kindLabel, bodyHtml) => `
+    <div class="req-section">
+      <div class="req-section-head">${escapeHtml(role)}${kindLabel ? ` <span class="hint" style="text-transform:none; letter-spacing:normal;">${escapeHtml(kindLabel)}</span>` : ''}</div>
+      ${bodyHtml}
+    </div>`;
+
+  // Leading system/user context — the task the session started from.
+  const promptHtml = (t.prompt_messages || [])
+    .map(m => turnHtml(m.role || '?', 'task scaffold', clamped(m.content)))
+    .join('');
+
+  // The trajectory proper: actions (with tool calls broken out by name),
+  // observations (tool results), and mid-session user/system context.
+  const segHtml = (t.trajectory || []).map(seg => {
+    const kind = seg.kind || 'context';
+    const content = seg.content || '';
+    if (seg.role === 'assistant' && /<tool_call>|<think>/.test(content)) {
+      const piecesHtml = traceSegmentPieces(content).map(p => {
+        if (p.kind === 'tool_call') {
+          let name = '?';
+          let argsText = p.text.trim();
+          try {
+            const parsed = JSON.parse(p.text);
+            if (parsed && typeof parsed === 'object') {
+              name = parsed.name || '?';
+              argsText = JSON.stringify(parsed.arguments ?? {});
+            }
+          } catch { /* malformed call JSON — show it verbatim */ }
+          return `<div style="border:1px solid var(--border); border-radius:var(--radius-sm); padding:var(--space-2) var(--space-3); margin:var(--space-1) 0; background:var(--surface);">
+            <div style="font-size:var(--text-xs); color:var(--text-muted); margin-bottom:4px;">tool call · <strong style="font-family:var(--font-mono); color:var(--text);">${escapeHtml(name)}</strong></div>
+            ${clamped(argsText)}
+          </div>`;
+        }
+        if (p.kind === 'think') {
+          return `<div style="margin:var(--space-1) 0;"><div style="font-size:var(--text-2xs); color:var(--text-muted); text-transform:uppercase; letter-spacing:var(--tracking-caps); margin-bottom:4px;">thinking</div>${clamped(p.text.trim())}</div>`;
+        }
+        return clamped(p.text.trim());
+      }).join('');
+      return turnHtml('assistant', null, piecesHtml);
+    }
+    const role = seg.role || '?';
+    const label = kind === 'observation'
+      ? `tool result${seg.tool_call_id ? ' · ' + seg.tool_call_id : ''}`
+      : (kind === 'action' ? null : 'context');
+    return turnHtml(role, label, clamped(content));
+  }).join('');
+
+  const conversationHtml = (promptHtml || segHtml)
+    ? promptHtml + segHtml
+    : '<div class="empty">This index entry predates turn-level capture — scan again to re-read the session with the current parser.</div>';
+
+  return `<div class="req-detail">
+    <div class="req-stats">${statRow}</div>
+    ${conversationHtml}
+  </div>`;
+}
 
 // --- Preflight (/v1/preflight/*) ------------------------------------
 async function refreshPreflightSurfaces() {

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -1049,6 +1049,25 @@
   </div>
 
   <!-- =================================================================
+       pi session trace drill-in modal — opens when a trace card is clicked
+       ================================================================= -->
+  <div id="trace-drill-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="trace-drill-title">
+    <div class="modal-shell" tabindex="-1">
+      <div class="modal-head">
+        <h2 id="trace-drill-title">pi session</h2>
+        <span class="modal-meta" id="trace-drill-meta"></span>
+        <button class="btn btn-sm btn-ghost" id="trace-drill-raw" type="button" title="Toggle the raw JSON view of this pi session trace"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-terminal"></use></svg> raw</button>
+        <button class="modal-close" id="trace-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
+      </div>
+      <div class="modal-body" style="grid-template-columns: 1fr;">
+        <div class="modal-content" id="trace-drill-content">
+          <div class="detail-empty">Loading…</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =================================================================
        Adapter drill-in modal
        ================================================================= -->
   <div id="adapter-drill-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="adapter-drill-title">
@@ -1561,11 +1580,23 @@
           <h3 style="font-size: var(--text-lg);">pi session traces</h3>
           <span class="eyebrow" id="distill-tab-traces-desc">Import pi agent sessions for distillation</span>
         </div>
-        <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-3);">
-          <button type="button" class="btn btn-sm" id="agent-traces-refresh">Rescan ~/.pi/agent/sessions/</button>
+        <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-2); flex-wrap: wrap; align-items: center;">
+          <input type="text" id="agent-traces-path" style="flex: 1 1 280px;"
+                 placeholder="Sessions folder — empty scans pi's default (~/.pi/agent/sessions/)"
+                 title="Folder to scan for pi session files. Leave empty to scan pi's default sessions folder."
+                 aria-label="Sessions folder to scan">
+          <button type="button" class="btn btn-sm" id="agent-traces-refresh" title="Scan the folder for pi sessions and rebuild the index">Scan for pi sessions</button>
+        </div>
+        <div class="form-help" style="margin-bottom: var(--space-3);">Every session pi saved on this machine becomes a browsable trace — open one to read the conversation and tool calls before distilling from it.</div>
+        <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-3); flex-wrap: wrap; align-items: center;">
+          <div id="agent-traces-chips" style="flex: 1 1 auto; min-width: 0;"></div>
+          <input type="search" id="agent-traces-dir" style="flex: 0 1 240px;"
+                 placeholder="Filter by working directory…"
+                 title="Show only sessions whose working directory contains this text"
+                 aria-label="Filter sessions by working directory">
         </div>
         <div id="agent-traces-list">
-          <div class="empty">Click rescan to discover pi sessions.</div>
+          <div class="empty">No pi sessions discovered yet. Use pi against this server, then scan to find the sessions it saved.</div>
         </div>
       </div>
 

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -574,6 +574,54 @@ async function startServer({
       finished_at_iso: null,
     },
   ];
+  // Agent-trace fixtures, mirroring api/agent_traces.rs `AgentTrace` /
+  // `TraceOutcome` (trajectory segments are kiln-train `TurnSegment`s with
+  // snake_case `kind`; assistant actions embed <think>/<tool_call> blocks
+  // exactly as the pi trace normalizer renders them). One exit-0 session
+  // and one failed+forked session so the outcome chips have something to
+  // split.
+  const smokeAgentTraces = [
+    {
+      id: 'trace-good-1111',
+      working_dir: '/home/smoke/projects/widget',
+      num_turns: 3,
+      num_tool_calls: 1,
+      outcome: { ended_with_exit_0: true, user_edited_agent_files: [], has_followup_attempt: false },
+      first_event_at: '2026-06-10T10:00:00Z',
+      last_event_at: '2026-06-10T10:05:00Z',
+      forked: false,
+      parent_id: null,
+      tool_manifest_sha: 'sha256:smoke-manifest',
+      prompt_messages: [
+        { role: 'system', content: 'You are pi.' },
+        { role: 'user', content: 'Fix the widget test' },
+      ],
+      trajectory: [
+        { role: 'assistant', content: '<think>run the tests first</think><tool_call>{"name": "bash", "arguments": {"cmd": "cargo test -p widget"}}</tool_call>', kind: 'action' },
+        { role: 'tool', content: 'test result: ok. 12 passed; 0 failed', kind: 'observation', tool_call_id: 'call-1' },
+        { role: 'assistant', content: 'All 12 widget tests pass.', kind: 'action' },
+      ],
+    },
+    {
+      id: 'trace-fail-2222',
+      working_dir: '/home/smoke/projects/gadget',
+      num_turns: 2,
+      num_tool_calls: 1,
+      outcome: { ended_with_exit_0: false, user_edited_agent_files: ['src/main.rs'], has_followup_attempt: true },
+      first_event_at: '2026-06-09T09:00:00Z',
+      last_event_at: '2026-06-09T09:30:00Z',
+      forked: true,
+      parent_id: 'trace-parent-0000',
+      tool_manifest_sha: null,
+      prompt_messages: [
+        { role: 'user', content: 'Refactor the gadget pipeline' },
+      ],
+      trajectory: [
+        { role: 'assistant', content: '<tool_call>{"name": "bash", "arguments": {"cmd": "cargo build -p gadget"}}</tool_call>', kind: 'action' },
+        { role: 'tool', content: 'error[E0308]: mismatched types', kind: 'observation', tool_call_id: 'call-2' },
+      ],
+    },
+  ];
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const adapterRoute = parseAdapterRoute(url.pathname);
@@ -1147,6 +1195,41 @@ async function startServer({
       dataset.winner_histogram[removed.winner] = Math.max(0, (dataset.winner_histogram[removed.winner] || 1) - 1);
       dataset.updated_at = new Date().toISOString();
       json(res, judgmentManifest(dataset));
+      return;
+    }
+    // Agent traces (api/agent_traces.rs): discover rescans a sessions dir
+    // (optional `path` in the POST body), the index GET lists every trace,
+    // and the per-trace GET returns one full record by id.
+    if (url.pathname === '/v1/agent/traces/discover' && req.method === 'POST') {
+      const body = await readJsonBody(req);
+      if ('path' in body && typeof body.path !== 'string') {
+        apiBadRequest(res, 'discover `path` must be a string when present');
+        return;
+      }
+      json(res, {
+        indexed: smokeAgentTraces.length,
+        path: body.path || '/home/smoke/.pi/agent/sessions',
+      });
+      return;
+    }
+    if (url.pathname === '/v1/agent/traces' && req.method === 'GET') {
+      json(res, { traces: smokeAgentTraces });
+      return;
+    }
+    const traceDetailMatch = /^\/v1\/agent\/traces\/([^/]+)$/.exec(url.pathname);
+    if (traceDetailMatch && req.method === 'GET') {
+      const traceId = decodeURIComponent(traceDetailMatch[1]);
+      const trace = smokeAgentTraces.find((candidate) => candidate.id === traceId);
+      if (!trace) {
+        res.writeHead(400, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: {
+          code: 'training_invalid_request',
+          message: `trace ${traceId} not indexed`,
+          hint: 'Rescan with POST /v1/agent/traces/discover.',
+        } }));
+        return;
+      }
+      json(res, trace);
       return;
     }
     if (url.pathname === '/v1/chat/completions') {
@@ -2960,6 +3043,142 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await clickAndWait(page, '#drill-close', 'Could not close the queued-job eval drill modal');
     await page.waitForFunction(() => document.getElementById('eval-drill-modal')?.hidden === true, { timeout: 5000 })
       .catch(() => fail('Queued-job eval drill modal did not close'));
+
+    // ---- Agent traces (roadmap PR 23): the Distill → Agent traces tab is
+    // actionable — entering it lists the existing index, outcome chips and
+    // a working-dir filter narrow the list client-side, the scan path
+    // round-trips into the discover POST body (persisted in localStorage),
+    // and each card drills into the recorded conversation at
+    // #distill/traces/{id} through the shared modal manager.
+    await goToPrimaryTab(page, 'distill');
+    await clickAndWait(page, '#distill-tab-traces', 'Could not open the Agent traces distill tab');
+    await waitForPanelText(page, '#agent-traces-list', /trace-good-1111/, 'Traces tab should list the first mock pi session on entry (no manual scan needed)');
+    await waitForPanelText(page, '#agent-traces-list', /trace-fail-2222/, 'Traces tab should list the second mock pi session');
+    const tracesPaneCopy = await page.$eval('#distill-tab-traces-pane', (el) => el.innerText || '');
+    if (/\/v1\/agent\/traces/.test(tracesPaneCopy)) fail('Traces tab primary copy should not name raw API routes');
+
+    // Outcome chips: exit ≠ 0 narrows to the failing session.
+    const traceChips = await page.$$eval('#agent-traces-chips .agent-chip', (els) => els.map((el) => el.textContent.trim()));
+    if (traceChips.length < 5) fail(`Traces tab should render the outcome filter chips, got ${JSON.stringify(traceChips)}`);
+    if (!traceChips[0].startsWith('All sessions')) fail(`The first outcome chip should be "All sessions", got ${JSON.stringify(traceChips[0])}`);
+    await clickAndWait(page, '[data-trace-chip="exitnz"]', 'Could not click the exit ≠ 0 outcome chip');
+    await page.waitForFunction(() => {
+      const text = document.getElementById('agent-traces-list')?.textContent || '';
+      return text.includes('trace-fail-2222') && !text.includes('trace-good-1111');
+    }, { timeout: 5000 }).catch(() => fail('exit ≠ 0 chip should narrow the list to the failing session'));
+    await clickAndWait(page, '[data-trace-chip="all"]', 'Could not reset the outcome chip filter');
+    await waitForPanelText(page, '#agent-traces-list', /trace-good-1111/, 'All-sessions chip should restore the full list');
+
+    // working_dir filter narrows client-side over the fetched index.
+    await page.type('#agent-traces-dir', 'widget');
+    await page.waitForFunction(() => {
+      const text = document.getElementById('agent-traces-list')?.textContent || '';
+      return text.includes('trace-good-1111') && !text.includes('trace-fail-2222');
+    }, { timeout: 5000 }).catch(() => fail('Working-dir filter should narrow the list to sessions under …/widget'));
+    await page.$eval('#agent-traces-dir', (el) => {
+      el.value = '';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await waitForPanelText(page, '#agent-traces-list', /trace-fail-2222/, 'Clearing the working-dir filter should restore the list');
+
+    // Custom scan path: rides the discover POST body and persists.
+    await page.$eval('#agent-traces-path', (el) => { el.value = ''; });
+    await page.type('#agent-traces-path', '/tmp/smoke-pi-sessions');
+    const discoverResponsePromise = page.waitForResponse(
+      (response) => response.url().endsWith('/v1/agent/traces/discover'),
+      { timeout: 5000 },
+    );
+    await clickAndWait(page, '#agent-traces-refresh', 'Could not click the pi session scan button');
+    const discoverResponse = await discoverResponsePromise.catch(() => fail('Scanning should POST the discover endpoint'));
+    let discoverBody = null;
+    try { discoverBody = JSON.parse(discoverResponse.request().postData() || '{}'); } catch { fail('Discover POST body should be JSON'); }
+    if (discoverBody.path !== '/tmp/smoke-pi-sessions') fail(`Custom scan path should ride the discover body, got ${JSON.stringify(discoverBody)}`);
+    await waitForPanelText(page, '#agent-traces-list', /Indexed 2 pi sessions from/, 'Scan headline should report the indexed count and folder');
+    const persistedScanPath = await page.evaluate(() => localStorage.getItem('kiln.traces.scanPath'));
+    if (persistedScanPath !== '/tmp/smoke-pi-sessions') fail(`Scan path should persist to localStorage, got ${JSON.stringify(persistedScanPath)}`);
+    // Empty input = server default: the path key is omitted entirely.
+    await page.$eval('#agent-traces-path', (el) => { el.value = ''; });
+    const defaultDiscoverPromise = page.waitForResponse(
+      (response) => response.url().endsWith('/v1/agent/traces/discover'),
+      { timeout: 5000 },
+    );
+    await clickAndWait(page, '#agent-traces-refresh', 'Could not rescan with the default sessions folder');
+    const defaultDiscover = await defaultDiscoverPromise.catch(() => fail('Default rescan should POST the discover endpoint'));
+    let defaultDiscoverBody = null;
+    try { defaultDiscoverBody = JSON.parse(defaultDiscover.request().postData() || '{}'); } catch { fail('Default discover POST body should be JSON'); }
+    if ('path' in defaultDiscoverBody) fail(`Empty scan path should omit the path field (server default), got ${JSON.stringify(defaultDiscoverBody)}`);
+    await waitForPanelText(page, '#agent-traces-list', /trace-good-1111/, 'Rescan should re-render the session list');
+
+    // Drill-in: focus the card, open it, and the shared modal manager
+    // moves focus into the dialog while the hash gains the id segment.
+    await page.focus('[data-trace-open="trace-good-1111"]');
+    await clickAndWait(page, '[data-trace-open="trace-good-1111"]', 'Could not open the pi session drill');
+    await page.waitForFunction(
+      () => document.getElementById('trace-drill-modal')?.hidden === false
+        && window.location.hash === '#distill/traces/trace-good-1111',
+      { timeout: 5000 },
+    ).catch(async () => {
+      const actual = await page.evaluate(() => ({
+        hidden: document.getElementById('trace-drill-modal')?.hidden,
+        hash: window.location.hash,
+      })).catch(() => ({ hidden: 'unknown', hash: 'unknown' }));
+      fail(`Trace drill should open with its id in the hash, got ${JSON.stringify(actual)}`);
+    });
+    const traceFocus = await page.evaluate(() => ({
+      inModal: document.getElementById('trace-drill-modal').contains(document.activeElement),
+      active: document.activeElement?.id || document.activeElement?.tagName || 'none',
+    }));
+    if (!traceFocus.inModal) fail(`Opening the trace drill should move focus into the dialog, got activeElement=${traceFocus.active}`);
+    await waitForPanelText(page, '#trace-drill-content', /\/home\/smoke\/projects\/widget/, 'Trace drill should show the session working directory');
+    await waitForPanelText(page, '#trace-drill-content', /Fix the widget test/, 'Trace drill should render the user task turn');
+    await waitForPanelText(page, '#trace-drill-content', /cargo test -p widget/, 'Trace drill should render the tool-call arguments');
+    await waitForPanelText(page, '#trace-drill-content', /test result: ok\. 12 passed/, 'Trace drill should render the tool-result turn');
+    const traceDrillText = await page.$eval('#trace-drill-content', (el) => el.textContent || '');
+    for (const expected of ['system', 'user', 'assistant', 'tool result', 'bash', 'run the tests first']) {
+      if (!traceDrillText.includes(expected)) fail(`Trace drill should role-label turns and name tool calls; missing ${JSON.stringify(expected)}`);
+    }
+
+    // Raw JSON toggle mirrors the other drills' raw buttons.
+    await clickAndWait(page, '#trace-drill-raw', 'Could not toggle the trace raw JSON view');
+    await page.waitForSelector('#trace-drill-raw-block', { timeout: 5000 })
+      .catch(() => fail('Trace raw JSON toggle did not render its block'));
+    const traceRawPayload = await page.$eval('#trace-drill-raw-block', (el) => el.textContent || '');
+    let parsedTraceRaw = null;
+    try { parsedTraceRaw = JSON.parse(traceRawPayload); } catch { fail('Trace raw JSON block should contain valid JSON'); }
+    if (parsedTraceRaw.id !== 'trace-good-1111') fail(`Trace raw JSON should show the drilled session, got id ${JSON.stringify(parsedTraceRaw.id)}`);
+    if (!Array.isArray(parsedTraceRaw.trajectory) || parsedTraceRaw.trajectory.length !== 3) fail('Trace raw JSON should carry the full trajectory');
+    await clickAndWait(page, '#trace-drill-raw', 'Could not untoggle the trace raw JSON view');
+    await page.waitForFunction(() => !document.getElementById('trace-drill-raw-block'), { timeout: 5000 })
+      .catch(() => fail('Second trace raw JSON click should remove the block'));
+
+    // Escape closes through the modal manager: the hash entry the open
+    // minted is consumed, and focus returns to the card that opened it.
+    await page.keyboard.press('Escape');
+    await page.waitForFunction(
+      () => document.getElementById('trace-drill-modal')?.hidden === true
+        && window.location.hash === '#distill/traces',
+      { timeout: 5000 },
+    ).catch(async () => {
+      const actual = await page.evaluate(() => ({
+        hidden: document.getElementById('trace-drill-modal')?.hidden,
+        hash: window.location.hash,
+      })).catch(() => ({ hidden: 'unknown', hash: 'unknown' }));
+      fail(`Escape should close the trace drill and consume its hash entry, got ${JSON.stringify(actual)}`);
+    });
+    const traceRestoredFocus = await page.evaluate(() => document.activeElement?.getAttribute('data-trace-open') || 'none');
+    if (traceRestoredFocus !== 'trace-good-1111') fail(`Closing the trace drill should restore focus to its card, got ${traceRestoredFocus}`);
+
+    // Deep link: a fresh boot on #distill/traces/{id} opens the drill on
+    // that session (the per-trace GET feeds it; no list fetch required).
+    // Via about:blank so the hash change is a real navigation, not a
+    // same-document fragment jump.
+    await page.goto('about:blank');
+    await page.goto(`${baseUrl}/ui#distill/traces/trace-fail-2222`, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(
+      () => document.getElementById('trace-drill-modal')?.hidden === false
+        && (document.getElementById('trace-drill-content')?.textContent || '').includes('/home/smoke/projects/gadget'),
+      { timeout: 5000 },
+    ).catch(() => fail('Booting on #distill/traces/{id} should deep-link into the trace drill'));
 
   } finally {
     await browser.close();


### PR DESCRIPTION
Wave 4 of the UI overhaul — **roadmap PR 25 of 25, completing the audit's full roadmap.**

The agent-traces tab listed discovered pi sessions as inert cards: no way to see inside a trace before distilling from it, no filtering, no custom scan path. Everything needed already existed server-side (`GET /v1/agent/traces/{id}` returns the full trace; discover accepts a `path` body field) — zero server changes.

- **Per-session drill**: cards open a modal rendering prompt messages and the trajectory (role-labeled turns; `<tool_call>` blocks parsed out of action content and rendered as name + args; long content clamped with expand), metadata header (working dir, timestamps, turn/tool-call counts, outcome), raw-JSON toggle. Routed through the shared modal manager and the deep-link grammar — trace ids are stable session UUIDs/file stems, so `#distill/traces/{id}` round-trips including fresh-boot deep links.
- **Filters**: outcome chips with counts — exit 0 / exit ≠ 0 / **"went sideways"** (forked ∨ followup-attempt ∨ user-edited-agent-files, the §10.3 wrong-branch signals) / no signal — plus a working-dir substring filter, client-side over the index.
- **Custom scan path**: POSTs `path` in the discover body, persisted in localStorage; tab entry now lists the existing index via GET instead of re-discovering.

All renders content-keyed via `setListHtml`; fetches fail soft. Smoke covers list-on-entry, chip/dir narrowing, discover-body round-trip + persistence, drill-in with focus management, raw JSON, Escape (hash consumed, focus restored), and a fresh-boot deep link — mocks shaped from the Rust structs. **Negative-tested** against origin/main (fails at the first traces assertion; the modal doesn't exist there). Full suite passes post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)