### PR TITLE
Embed pi in the server: /v1/agent/runs drives on-policy rollouts end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A 4B model continuously tuned to your specific workload — and continuously *me
 
 - **OpenAI-compatible API** — drop in as a local replacement. SSE streaming, chat completions, tool use formatting.
 - **pi integration** — `kiln pi-setup` backs up and merges `~/.pi/agent/models.json` + `settings.json`, then points pi at Kiln as an OpenAI-compatible tool-calling backend.
+- **Embedded agent runs** — the server drives pi itself (`POST /v1/agent/runs`): spawns `pi --mode rpc` against its own model, streams the trajectory live with steer/abort, and auto-indexes finished sessions into the trace layer the self-improvement flywheel trains on.
 - **SFT training** over HTTP — submit examples, model updates in seconds via LoRA hot-swap.
 - **GRPO training** over HTTP — submit scored completions for reinforcement learning. You control the reward function.
 - **First-class evals** over HTTP — register suites, run them against any adapter, drill into per-example outcomes. Auto-detect picks the right scorer per example (`numeric_tolerance`, `multiple_choice`, `json_validity`, `regex`, `contains`, `tool_call`, `code`, `llm_judge`, `all`/`any` composites).
@@ -330,6 +331,22 @@ pi -p "Use the bash tool to run: pwd"
 
 Kiln accepts Qwen3.5's native XML tool-call generations internally, but OpenAI-compatible clients receive normal `tool_calls` in both streaming and non-streaming responses. pi should execute the tool call instead of printing raw `<tool_call>` XML.
 
+**Embedded agent runs: kiln drives pi itself.** Beyond serving pi as a model backend, the server can spawn `pi --mode rpc` as a managed child, hand it a task, stream the trajectory live, and merge the finished session straight into the agent-trace layer the self-improvement flywheel reads — on-policy rollouts on demand, no human at the keyboard:
+
+```bash
+# Start a run (the spawned pi talks back to this same server)
+curl http://localhost:8420/v1/agent/runs \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Run the test suite and fix the first failure", "cwd": "/path/to/project"}'
+
+# Watch it live (poll cursor), steer it, or abort it
+curl "http://localhost:8420/v1/agent/runs/<id>/events?after=0"
+curl http://localhost:8420/v1/agent/runs/<id>/steer -d '{"message": "Prefer a minimal fix"}' -H "Content-Type: application/json"
+curl -X POST http://localhost:8420/v1/agent/runs/<id>/abort
+```
+
+Runs queue FIFO (`[agent].max_concurrent_runs`, default 2; `run_timeout_secs`, default 900), persist across restarts, and auto-index into `GET /v1/agent/traces` when they finish — so `kiln self-improve` trains on them in the same cycle. Because embedded runs execute code on the server, they are enabled only on loopback binds by default (`KILN_AGENT_RUNS=1` opts in elsewhere, `=0` force-disables). The dashboard's **Distill → Agent runs** tab provides a launch form and a live trajectory view.
+
 See [QUICKSTART.md](QUICKSTART.md) for the full walkthrough including Desktop App setup, source builds, GRPO, adapter management, Docker, and systemd setup. If setup stalls on binary downloads, CUDA/ROCm/Vulkan/Metal, model paths, `/health`, mock mode, training endpoints, or adapter directories, start with the [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html). For tools-bearing workloads on older pinned releases, see [QUICKSTART.md §9.2](QUICKSTART.md#92-troubleshooting-older-release-long-prefill-timeouts) for the legacy `workers=1` / request-timeout troubleshooting note ([#664](https://github.com/ericflo/kiln/issues/664)).
 
 ## See it in action
@@ -396,6 +413,13 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | GET | `/v1/agent/traces` | List discovered agent session traces |
 | POST | `/v1/agent/self_improve` | One-call agentic self-improvement (traces → OPD + judge distill) |
 | POST | `/v1/agent/judge_distill` | Distill a judge LoRA from agent traces |
+| GET / POST | `/v1/agent/runs` | Embedded pi runs — the server spawns `pi --mode rpc`, streams the trajectory, auto-indexes the session as a trace |
+| GET | `/v1/agent/runs/status` | Embedded-run gate state, pi availability, capacity |
+| GET | `/v1/agent/runs/{id}` | One run record (status, counters, session link) |
+| GET | `/v1/agent/runs/{id}/events` | Live event feed for a run (`?after=<seq>` poll cursor) |
+| POST | `/v1/agent/runs/{id}/steer` | Queue a steering message into a live run |
+| POST | `/v1/agent/runs/{id}/follow_up` | Queue a follow-up task into a live run |
+| POST | `/v1/agent/runs/{id}/abort` | Abort a queued or running run |
 | GET | `/v1/adapters` | List saved/available LoRA adapters and identify the active adapter |
 | GET | `/v1/adapters/{name}/detail` | Files + training history + eval history for one adapter |
 | POST | `/v1/adapters/load` | Load adapter from disk |

--- a/crates/kiln-server/src/agent_runs.rs
+++ b/crates/kiln-server/src/agent_runs.rs
@@ -36,6 +36,11 @@ const PI_PROVIDER_ID: &str = "kiln-local";
 const EVENT_BUFFER_CAP: usize = 2000;
 /// Terminal run records kept before pruning oldest.
 const TERMINAL_RUNS_CAP: usize = 200;
+/// Active (queued + running) runs allowed before new submissions are
+/// turned away — a backstop against a runaway submitter, not a tuning
+/// knob (concurrency is `[agent].max_concurrent_runs`). Enforced
+/// atomically inside `start_run` under the runs lock.
+pub const ACTIVE_RUNS_BACKSTOP: usize = 32;
 /// last_assistant_text is a summary, not a transcript.
 const LAST_TEXT_CAP: usize = 4000;
 
@@ -43,13 +48,20 @@ static SELF_URL: OnceLock<String> = OnceLock::new();
 
 /// Record the URL this server is reachable at locally, for the pi
 /// config merge before each embedded run. A wildcard bind is rewritten
-/// to loopback — the child runs on the same host.
+/// to loopback — the child runs on the same host. Bare IPv6 literals
+/// get bracketed (`::1` → `http://[::1]:port`); unbracketed they parse
+/// as host `:` port soup and pi can't reach the server.
 pub fn set_self_url(host: &str, port: u16) {
-    let host = match host {
-        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
-        other => other,
+    let _ = SELF_URL.set(format_self_url(host, port));
+}
+
+fn format_self_url(host: &str, port: u16) -> String {
+    let host: std::borrow::Cow<'_, str> = match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1".into(),
+        other if other.parse::<std::net::Ipv6Addr>().is_ok() => format!("[{other}]").into(),
+        other => other.into(),
     };
-    let _ = SELF_URL.set(format!("http://{host}:{port}"));
+    format!("http://{host}:{port}")
 }
 
 pub fn self_url() -> String {
@@ -206,10 +218,20 @@ pub struct AgentRunRegistry {
     /// Pinged whenever a slot may have freed (run finished/started).
     slot_notify: tokio::sync::Notify,
     next_queue_seq: std::sync::atomic::AtomicU64,
+    /// Held across snapshot+write in `persist` so file-write order
+    /// matches snapshot order — without it a stale snapshot taken
+    /// before a finish() could land after it and resurrect the run as
+    /// non-terminal on the next restart.
+    persist_lock: std::sync::Mutex<()>,
 }
 
 impl AgentRunRegistry {
     pub fn new(adapter_dir: PathBuf) -> Self {
+        // The sessions dir is handed to pi as `--session-dir`, and pi
+        // runs with the RUN's cwd — a relative adapter_dir (mock mode
+        // uses bare "adapters") would resolve against the wrong
+        // directory and the finalizer would never find the session.
+        let adapter_dir = std::path::absolute(&adapter_dir).unwrap_or(adapter_dir);
         let persist_path = runs_json_path(&adapter_dir);
         let mut runs: BTreeMap<String, AgentRunRecord> = match std::fs::read(&persist_path) {
             Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
@@ -236,6 +258,7 @@ impl AgentRunRegistry {
             settings: std::sync::RwLock::new(RunSettings::default()),
             slot_notify: tokio::sync::Notify::new(),
             next_queue_seq: std::sync::atomic::AtomicU64::new(next_seq),
+            persist_lock: std::sync::Mutex::new(()),
         }
     }
 
@@ -273,18 +296,33 @@ impl AgentRunRegistry {
             .count()
     }
 
-    /// Events with seq >= `after`, plus the run's current status — one
-    /// poll drives the live drill view.
-    pub fn events_after(&self, id: &str, after: u64) -> Option<(Vec<(u64, serde_json::Value)>, RunStatus)> {
+    /// Events with seq >= `after` (inclusive — pass the previous
+    /// response's `next_after` back to poll incrementally), plus the
+    /// run's current status and truncation metadata so a replay from 0
+    /// can tell when the head of the feed is gone (ring-buffer prune,
+    /// or the buffer not surviving a server restart).
+    pub fn events_after(&self, id: &str, after: u64) -> Option<EventsPage> {
         let status = self.get(id)?.status;
-        let events = self
-            .events
-            .lock()
-            .unwrap()
-            .get(id)
-            .map(|buf| buf.after(after))
-            .unwrap_or_default();
-        Some((events, status))
+        let guard = self.events.lock().unwrap();
+        match guard.get(id) {
+            Some(buf) => {
+                let first_available_seq = buf.items.front().map(|(seq, _)| *seq);
+                let truncated = first_available_seq.is_some_and(|first| after < first && first > 0);
+                Some(EventsPage {
+                    events: buf.after(after),
+                    status,
+                    first_available_seq,
+                    truncated,
+                })
+            }
+            // Run record survived a restart; its event buffer did not.
+            None => Some(EventsPage {
+                events: Vec::new(),
+                status,
+                first_available_seq: None,
+                truncated: true,
+            }),
+        }
     }
 
     /// Queue a steer message into a live run.
@@ -319,8 +357,13 @@ impl AgentRunRegistry {
     }
 
     /// Create the record and spawn the driver task. Returns a snapshot
-    /// of the queued record.
-    pub fn start_run(self: &Arc<Self>, params: NewRunParams) -> AgentRunRecord {
+    /// of the queued record, or `AtCapacity` — checked atomically with
+    /// the insert so concurrent submissions can't overshoot the
+    /// backstop.
+    pub fn start_run(
+        self: &Arc<Self>,
+        params: NewRunParams,
+    ) -> Result<AgentRunRecord, StartRunError> {
         let id = uuid::Uuid::new_v4().to_string();
         let record = AgentRunRecord {
             id: id.clone(),
@@ -342,10 +385,14 @@ impl AgentRunRegistry {
             last_assistant_text: None,
             error: None,
         };
-        self.runs
-            .write()
-            .unwrap()
-            .insert(id.clone(), record.clone());
+        {
+            let mut runs = self.runs.write().unwrap();
+            let active = runs.values().filter(|r| !r.status.is_terminal()).count();
+            if active >= ACTIVE_RUNS_BACKSTOP {
+                return Err(StartRunError::AtCapacity(ACTIVE_RUNS_BACKSTOP));
+            }
+            runs.insert(id.clone(), record.clone());
+        }
         self.events
             .lock()
             .unwrap()
@@ -359,7 +406,7 @@ impl AgentRunRegistry {
         tokio::spawn(async move {
             drive_run(reg, id, params, ctl_rx).await;
         });
-        record
+        Ok(record)
     }
 
     // ── internals ───────────────────────────────────────────────────
@@ -390,6 +437,9 @@ impl AgentRunRegistry {
     }
 
     fn persist(&self) {
+        // Snapshot and write under one mutex so writes land in
+        // snapshot order (see persist_lock field doc).
+        let _guard = self.persist_lock.lock().unwrap_or_else(|p| p.into_inner());
         let path = runs_json_path(&self.adapter_dir);
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -436,8 +486,15 @@ impl AgentRunRegistry {
 
     /// Wait until this run is first in the queued FIFO and a slot is
     /// free, then mark it running. Returns false when aborted while
-    /// queued.
-    async fn claim_slot(&self, id: &str, ctl_rx: &mut mpsc::Receiver<ControlMsg>) -> bool {
+    /// queued. Steer/follow-up messages arriving before the start are
+    /// buffered into `pending` — the API told the caller "queued", so
+    /// they must be delivered once the run starts, not dropped.
+    async fn claim_slot(
+        &self,
+        id: &str,
+        ctl_rx: &mut mpsc::Receiver<ControlMsg>,
+        pending: &mut Vec<ControlMsg>,
+    ) -> bool {
         loop {
             let claimed = {
                 let mut runs = self.runs.write().unwrap();
@@ -473,15 +530,16 @@ impl AgentRunRegistry {
                 // registration.
                 _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
                 msg = ctl_rx.recv() => {
-                    if matches!(msg, Some(ControlMsg::Abort) | None) {
-                        return false;
+                    match msg {
+                        Some(ControlMsg::Abort) | None => return false,
+                        Some(msg) => {
+                            self.push_event(id, serde_json::json!({
+                                "type": "kiln_note",
+                                "note": "message queued — delivered when the run starts"
+                            }));
+                            pending.push(msg);
+                        }
                     }
-                    // Steer/follow-up before start: drop with a note in
-                    // the event feed.
-                    self.push_event(id, serde_json::json!({
-                        "type": "kiln_note",
-                        "note": "steer/follow_up ignored — run has not started yet"
-                    }));
                 }
             }
         }
@@ -492,6 +550,24 @@ impl AgentRunRegistry {
 pub enum ControlError {
     NotFound,
     NotActive(RunStatus),
+}
+
+#[derive(Debug)]
+pub enum StartRunError {
+    /// queued + running runs already at the backstop.
+    AtCapacity(usize),
+}
+
+/// One page of the event feed (see [`AgentRunRegistry::events_after`]).
+#[derive(Debug)]
+pub struct EventsPage {
+    pub events: Vec<(u64, serde_json::Value)>,
+    pub status: RunStatus,
+    /// Earliest seq still retained (None when no events were buffered).
+    pub first_available_seq: Option<u64>,
+    /// True when events before the requested cursor are gone — ring
+    /// prune on a long run, or a server restart dropping the buffer.
+    pub truncated: bool,
 }
 
 fn runs_json_path(adapter_dir: &Path) -> PathBuf {
@@ -506,7 +582,8 @@ async fn drive_run(
     params: NewRunParams,
     mut ctl_rx: mpsc::Receiver<ControlMsg>,
 ) {
-    if !reg.claim_slot(&id, &mut ctl_rx).await {
+    let mut pending_control: Vec<ControlMsg> = Vec::new();
+    if !reg.claim_slot(&id, &mut ctl_rx, &mut pending_control).await {
         reg.finish(&id, RunStatus::Aborted, Some("aborted while queued".into()));
         return;
     }
@@ -519,7 +596,11 @@ async fn drive_run(
         }
     }
 
-    let sessions_dir = reg.sessions_dir();
+    // Per-run session dir: runs never share a directory, so the
+    // session-file fallback below can only ever see this run's own
+    // file — a shared dir let a run that died before flushing adopt a
+    // sibling's session. Trace discovery sweeps nested dirs fine.
+    let sessions_dir = reg.sessions_dir().join(&id);
     if let Err(e) = std::fs::create_dir_all(&sessions_dir) {
         reg.finish(
             &id,
@@ -576,6 +657,34 @@ async fn drive_run(
     // follow-up queues one more loop.
     let mut ends_remaining: i64 = 1;
     let mut steer_seq: u64 = 0;
+    // Deliver control messages that arrived while the run was queued —
+    // the API already acknowledged them. A steer landing in the gap
+    // before pi starts streaming surfaces as an error response in the
+    // event feed rather than vanishing.
+    for msg in pending_control.drain(..) {
+        match msg {
+            ControlMsg::Steer(message) => {
+                steer_seq += 1;
+                let cmd = serde_json::json!({
+                    "id": format!("steer-{steer_seq}"),
+                    "type": "steer",
+                    "message": message,
+                });
+                let _ = process.send(&cmd).await;
+            }
+            ControlMsg::FollowUp(message) => {
+                steer_seq += 1;
+                ends_remaining += 1;
+                let cmd = serde_json::json!({
+                    "id": format!("follow-{steer_seq}"),
+                    "type": "follow_up",
+                    "message": message,
+                });
+                let _ = process.send(&cmd).await;
+            }
+            ControlMsg::Abort => {}
+        }
+    }
     let (final_status, final_error) = loop {
         tokio::select! {
             line = process.lines.recv() => {
@@ -640,27 +749,51 @@ async fn drive_run(
 
     // Index the finished session into the §10.3 trace layer so the
     // flywheel sees it without a manual discover.
-    let (session_id, session_path) = {
+    let (session_id, session_path, started_unix_ms) = {
         let run = reg.get(&id);
         (
             run.as_ref().and_then(|r| r.session_id.clone()),
             run.as_ref().and_then(|r| r.session_path.clone()),
+            run.as_ref().and_then(|r| r.started_unix_ms),
         )
     };
     let resolved_path = session_path
         .map(PathBuf::from)
         .filter(|p| p.is_file())
-        .or_else(|| find_session_file(&sessions_dir, session_id.as_deref()));
-    if let Some(path) = resolved_path {
-        let indexed = crate::api::agent_traces::index_session_file(&reg.adapter_dir, &path);
-        reg.update(&id, |run| {
-            run.session_path = Some(path.display().to_string());
-            if let Some(trace) = &indexed {
-                run.session_id = Some(trace.id.clone());
-                run.trace_indexed = true;
-            }
-        });
+        .or_else(|| find_session_file(&sessions_dir, session_id.as_deref(), started_unix_ms));
+    match resolved_path {
+        Some(path) => {
+            let indexed = crate::api::agent_traces::index_session_file(&reg.adapter_dir, &path);
+            reg.update(&id, |run| {
+                run.session_path = Some(path.display().to_string());
+                if let Some(trace) = &indexed {
+                    run.session_id = Some(trace.id.clone());
+                    run.trace_indexed = true;
+                }
+            });
+        }
+        None => {
+            tracing::warn!(run = %id, dir = %sessions_dir.display(), "embedded run session file not found — trace not indexed");
+            reg.push_event(
+                &id,
+                serde_json::json!({
+                    "type": "kiln_note",
+                    "note": "session file not found — trace not indexed",
+                }),
+            );
+        }
     }
+
+    // A run whose last assistant turn ended in an error (observe_line
+    // records it) is not a success, even though pi emitted a normal
+    // agent_end — e.g. the model endpoint 4xx/5xxed on the final turn.
+    let final_status = if final_status == RunStatus::Completed
+        && reg.get(&id).is_some_and(|r| r.error.is_some())
+    {
+        RunStatus::Failed
+    } else {
+        final_status
+    };
 
     reg.finish(&id, final_status, final_error);
 }
@@ -690,8 +823,28 @@ fn observe_line(reg: &AgentRunRegistry, id: &str, value: &serde_json::Value) {
                             .join("\n")
                     })
                     .unwrap_or_default();
+                // An assistant turn can end in an error (stopReason
+                // "error": model endpoint down, 4xx/5xx, ...) while pi
+                // still finishes the loop normally — record it so the
+                // run doesn't report success on a failed turn. A later
+                // successful turn clears it (pi recovered).
+                let turn_errored = message
+                    .and_then(|m| m.get("stopReason"))
+                    .and_then(|s| s.as_str())
+                    == Some("error");
+                let turn_error_message = message
+                    .and_then(|m| m.get("errorMessage"))
+                    .and_then(|s| s.as_str())
+                    .map(str::to_string);
                 reg.update(id, |run| {
                     run.num_turns += 1;
+                    if turn_errored {
+                        run.error = Some(turn_error_message.unwrap_or_else(|| {
+                            "assistant turn ended with an error".to_string()
+                        }));
+                    } else {
+                        run.error = None;
+                    }
                     if !text.is_empty() {
                         let mut t = text;
                         if t.len() > LAST_TEXT_CAP {
@@ -740,10 +893,20 @@ fn observe_line(reg: &AgentRunRegistry, id: &str, value: &serde_json::Value) {
     }
 }
 
-/// Fallback session lookup when get_state never answered: prefer a
-/// file named after the session id anywhere under the sessions dir,
-/// else the most recently modified `.jsonl`.
-fn find_session_file(sessions_dir: &Path, session_id: Option<&str>) -> Option<PathBuf> {
+/// Fallback session lookup when get_state never answered, scoped to
+/// this run's own session dir. With a known session id, only a
+/// matching filename counts — an id that matches nothing means the
+/// session was never flushed, and attaching any other file would be
+/// wrong. Without one, the newest `.jsonl` is accepted only if it was
+/// modified at/after the run started (1s slack for fs granularity).
+fn find_session_file(
+    sessions_dir: &Path,
+    session_id: Option<&str>,
+    started_unix_ms: Option<u64>,
+) -> Option<PathBuf> {
+    let not_before = started_unix_ms.map(|ms| {
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(ms.saturating_sub(1000))
+    });
     let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
     let mut stack = vec![sessions_dir.to_path_buf()];
     let mut depth_guard = 0usize;
@@ -764,11 +927,15 @@ fn find_session_file(sessions_dir: &Path, session_id: Option<&str>) -> Option<Pa
                     if p.file_stem().is_some_and(|stem| stem.to_string_lossy().contains(sid)) {
                         return Some(p);
                     }
+                    continue;
                 }
                 let mtime = entry
                     .metadata()
                     .and_then(|m| m.modified())
                     .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                if not_before.is_some_and(|floor| mtime < floor) {
+                    continue;
+                }
                 if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
                     newest = Some((mtime, p));
                 }
@@ -865,7 +1032,7 @@ for line in sys.stdin:
         let pi_bin = write_fake_pi(adapter_dir.path());
         let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
 
-        let rec = reg.start_run(params(pi_bin, workdir.path().to_path_buf(), "say hi"));
+        let rec = reg.start_run(params(pi_bin, workdir.path().to_path_buf(), "say hi")).unwrap();
         assert_eq!(rec.status, RunStatus::Queued);
 
         let done = wait_terminal(&reg, &rec.id).await;
@@ -877,9 +1044,12 @@ for line in sys.stdin:
         assert!(done.trace_indexed, "session must be merged into agent_traces.json");
 
         // The event feed captured the full trajectory.
-        let (events, status) = reg.events_after(&rec.id, 0).unwrap();
-        assert_eq!(status, RunStatus::Completed);
-        let types: Vec<_> = events
+        let page = reg.events_after(&rec.id, 0).unwrap();
+        assert_eq!(page.status, RunStatus::Completed);
+        assert!(!page.truncated, "nothing was pruned");
+        assert_eq!(page.first_available_seq, Some(0));
+        let types: Vec<_> = page
+            .events
             .iter()
             .map(|(_, v)| v.get("type").and_then(|t| t.as_str()).unwrap_or(""))
             .collect();
@@ -922,8 +1092,8 @@ for line in sys.stdin:
         let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
         reg.apply_config(1, 900);
 
-        let a = reg.start_run(params(slow_pi.clone(), workdir.path().to_path_buf(), "a"));
-        let b = reg.start_run(params(slow_pi, workdir.path().to_path_buf(), "b"));
+        let a = reg.start_run(params(slow_pi.clone(), workdir.path().to_path_buf(), "a")).unwrap();
+        let b = reg.start_run(params(slow_pi, workdir.path().to_path_buf(), "b")).unwrap();
 
         // Give the first driver time to claim the only slot.
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
@@ -950,14 +1120,70 @@ for line in sys.stdin:
         let adapter_dir = tempfile::tempdir().unwrap();
         let workdir = tempfile::tempdir().unwrap();
         let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
-        let rec = reg.start_run(params(
-            PathBuf::from("/nonexistent/pi-binary"),
-            workdir.path().to_path_buf(),
-            "x",
-        ));
+        let rec = reg
+            .start_run(params(
+                PathBuf::from("/nonexistent/pi-binary"),
+                workdir.path().to_path_buf(),
+                "x",
+            ))
+            .unwrap();
         let done = wait_terminal(&reg, &rec.id).await;
         assert_eq!(done.status, RunStatus::Failed);
         assert!(done.error.unwrap().contains("could not start pi"));
+    }
+
+    #[test]
+    fn self_url_brackets_ipv6_and_rewrites_wildcards() {
+        assert_eq!(format_self_url("127.0.0.1", 8420), "http://127.0.0.1:8420");
+        assert_eq!(format_self_url("0.0.0.0", 8420), "http://127.0.0.1:8420");
+        assert_eq!(format_self_url("::", 8420), "http://127.0.0.1:8420");
+        // A bare IPv6 loopback bind passes the runs gate; unbracketed it
+        // produced http://::1:8420, which pi cannot parse.
+        assert_eq!(format_self_url("::1", 8420), "http://[::1]:8420");
+        assert_eq!(format_self_url("[::1]", 8420), "http://[::1]:8420");
+        assert_eq!(format_self_url("office-kiln", 9000), "http://office-kiln:9000");
+    }
+
+    #[tokio::test]
+    async fn start_run_rejects_at_backstop_capacity() {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let workdir = tempfile::tempdir().unwrap();
+        let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
+        reg.apply_config(1, 900);
+        // Fill the registry with queued records via the public path; the
+        // missing binary keeps them from progressing instantly, and
+        // capacity counts queued + running either way.
+        let mut started = Vec::new();
+        for i in 0..ACTIVE_RUNS_BACKSTOP {
+            match reg.start_run(params(
+                PathBuf::from("/nonexistent/pi-binary"),
+                workdir.path().to_path_buf(),
+                &format!("task {i}"),
+            )) {
+                Ok(rec) => started.push(rec.id),
+                Err(StartRunError::AtCapacity(_)) => {
+                    // Drivers may already have failed some runs (terminal
+                    // states free capacity), so reaching the cap is not
+                    // guaranteed — but a rejection here still proves the
+                    // backstop fires.
+                    return;
+                }
+            }
+        }
+        let over = reg.start_run(params(
+            PathBuf::from("/nonexistent/pi-binary"),
+            workdir.path().to_path_buf(),
+            "one too many",
+        ));
+        assert!(
+            matches!(over, Err(StartRunError::AtCapacity(max)) if max == ACTIVE_RUNS_BACKSTOP)
+                // On a fast machine some of the 32 may already be terminal
+                // (missing binary fails immediately), freeing capacity.
+                || over.is_ok(),
+        );
+        // Either way the registry never holds more than the backstop in
+        // non-terminal states.
+        assert!(reg.active_count() <= ACTIVE_RUNS_BACKSTOP);
     }
 
     #[test]

--- a/crates/kiln-server/src/agent_runs.rs
+++ b/crates/kiln-server/src/agent_runs.rs
@@ -1,0 +1,999 @@
+//! Embedded agent runs — kiln drives pi itself.
+//!
+//! Until now pi was external: the user ran it in a terminal, pi wrote
+//! session JSONL to `~/.pi/agent/sessions/`, and kiln indexed those
+//! traces after the fact. This module embeds the agent: the server
+//! spawns `pi --mode rpc` as a child process pointed at its own
+//! OpenAI-compatible endpoint, submits a task, streams the trajectory
+//! live, and auto-indexes the finished session into the §10.3 agent
+//! trace layer — where the §10.6 flywheel (judge_distill /
+//! self_improve) already consumes it.
+//!
+//! That closes the loop: kiln can now *generate* on-policy agentic
+//! rollouts on demand instead of waiting for a human to drive pi.
+//!
+//! Lifecycle of one run:
+//!   queued → (FIFO slot, bounded by `[agent].max_concurrent_runs`)
+//!   running → prompt sent, events streamed into a per-run buffer
+//!   terminal: completed | failed | aborted | timed_out
+//!   → session JSONL indexed into `agent_traces.json` (merge)
+//!
+//! Records persist to `<adapter_dir>/agent_runs/runs.json`; runs that
+//! were active when the server died come back as `interrupted`.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::pi_rpc::{PiRpcLine, PiRpcOptions, PiRpcProcess};
+
+/// pi provider id the `kiln pi-setup` merge registers (cli.rs).
+const PI_PROVIDER_ID: &str = "kiln-local";
+/// Events kept per run for the live feed / replay.
+const EVENT_BUFFER_CAP: usize = 2000;
+/// Terminal run records kept before pruning oldest.
+const TERMINAL_RUNS_CAP: usize = 200;
+/// last_assistant_text is a summary, not a transcript.
+const LAST_TEXT_CAP: usize = 4000;
+
+static SELF_URL: OnceLock<String> = OnceLock::new();
+
+/// Record the URL this server is reachable at locally, for the pi
+/// config merge before each embedded run. A wildcard bind is rewritten
+/// to loopback — the child runs on the same host.
+pub fn set_self_url(host: &str, port: u16) {
+    let host = match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    };
+    let _ = SELF_URL.set(format!("http://{host}:{port}"));
+}
+
+pub fn self_url() -> String {
+    SELF_URL
+        .get()
+        .cloned()
+        .unwrap_or_else(|| "http://127.0.0.1:8420".to_string())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Aborted,
+    TimedOut,
+    /// Was queued/running when the server restarted.
+    Interrupted,
+}
+
+impl RunStatus {
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, RunStatus::Queued | RunStatus::Running)
+    }
+}
+
+impl std::fmt::Display for RunStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            RunStatus::Queued => "queued",
+            RunStatus::Running => "running",
+            RunStatus::Completed => "completed",
+            RunStatus::Failed => "failed",
+            RunStatus::Aborted => "aborted",
+            RunStatus::TimedOut => "timed_out",
+            RunStatus::Interrupted => "interrupted",
+        };
+        f.write_str(s)
+    }
+}
+
+/// One embedded run, as listed by `GET /v1/agent/runs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRunRecord {
+    pub id: String,
+    pub task: String,
+    pub cwd: String,
+    /// Free-form grouping label (e.g. a rollout batch name).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub status: RunStatus,
+    pub created_unix_ms: u64,
+    /// Monotonic submission order — FIFO tie-break for runs created in
+    /// the same millisecond.
+    #[serde(default)]
+    pub queue_seq: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_unix_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_unix_ms: Option<u64>,
+    /// Assistant turns observed (message_end with role=assistant).
+    pub num_turns: usize,
+    /// Tool executions observed (tool_execution_end).
+    pub num_tool_calls: usize,
+    /// pi session id — also the agent-trace id once indexed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_path: Option<String>,
+    /// True once the session JSONL was merged into agent_traces.json.
+    pub trace_indexed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_assistant_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Inputs for one run, validated at the API layer.
+#[derive(Debug, Clone)]
+pub struct NewRunParams {
+    pub task: String,
+    pub cwd: PathBuf,
+    pub label: Option<String>,
+    pub tools: Option<Vec<String>>,
+    pub thinking_level: Option<String>,
+    /// Per-run override of `[agent].run_timeout_secs`.
+    pub timeout_secs: Option<u64>,
+    /// Binary to spawn. The API resolves via `pi_rpc::find_pi()`;
+    /// tests inject a stub.
+    pub pi_bin: PathBuf,
+    /// Model id pi selects under the kiln provider.
+    pub model: String,
+    /// When set, run the same non-destructive `pi-setup` config merge
+    /// the embedded terminal does, pointed at this URL. `None` skips
+    /// the merge (tests; pre-configured environments).
+    pub kiln_url: Option<String>,
+}
+
+#[derive(Debug)]
+enum ControlMsg {
+    Steer(String),
+    FollowUp(String),
+    Abort,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RunSettings {
+    max_concurrent: usize,
+    timeout: std::time::Duration,
+}
+
+impl Default for RunSettings {
+    fn default() -> Self {
+        Self {
+            max_concurrent: 2,
+            timeout: std::time::Duration::from_secs(900),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct EventBuf {
+    next_seq: u64,
+    items: VecDeque<(u64, serde_json::Value)>,
+}
+
+impl EventBuf {
+    fn push(&mut self, value: serde_json::Value) {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.items.push_back((seq, value));
+        while self.items.len() > EVENT_BUFFER_CAP {
+            self.items.pop_front();
+        }
+    }
+
+    fn after(&self, after: u64) -> Vec<(u64, serde_json::Value)> {
+        self.items
+            .iter()
+            .filter(|(seq, _)| *seq >= after)
+            .cloned()
+            .collect()
+    }
+}
+
+pub struct AgentRunRegistry {
+    adapter_dir: PathBuf,
+    runs: std::sync::RwLock<BTreeMap<String, AgentRunRecord>>,
+    events: std::sync::Mutex<HashMap<String, EventBuf>>,
+    control: std::sync::Mutex<HashMap<String, mpsc::Sender<ControlMsg>>>,
+    settings: std::sync::RwLock<RunSettings>,
+    /// Pinged whenever a slot may have freed (run finished/started).
+    slot_notify: tokio::sync::Notify,
+    next_queue_seq: std::sync::atomic::AtomicU64,
+}
+
+impl AgentRunRegistry {
+    pub fn new(adapter_dir: PathBuf) -> Self {
+        let persist_path = runs_json_path(&adapter_dir);
+        let mut runs: BTreeMap<String, AgentRunRecord> = match std::fs::read(&persist_path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "agent_runs/runs.json parse failed");
+                BTreeMap::new()
+            }),
+            Err(_) => BTreeMap::new(),
+        };
+        // Anything non-terminal in the persisted file did not survive
+        // the restart — its driver task is gone.
+        for run in runs.values_mut() {
+            if !run.status.is_terminal() {
+                run.status = RunStatus::Interrupted;
+                run.error
+                    .get_or_insert_with(|| "server restarted while the run was active".into());
+            }
+        }
+        let next_seq = runs.values().map(|r| r.queue_seq + 1).max().unwrap_or(0);
+        Self {
+            adapter_dir,
+            runs: std::sync::RwLock::new(runs),
+            events: std::sync::Mutex::new(HashMap::new()),
+            control: std::sync::Mutex::new(HashMap::new()),
+            settings: std::sync::RwLock::new(RunSettings::default()),
+            slot_notify: tokio::sync::Notify::new(),
+            next_queue_seq: std::sync::atomic::AtomicU64::new(next_seq),
+        }
+    }
+
+    /// Apply `[agent]` config (called from main after state creation).
+    pub fn apply_config(&self, max_concurrent_runs: usize, run_timeout_secs: u64) {
+        let mut s = self.settings.write().unwrap();
+        s.max_concurrent = max_concurrent_runs.max(1);
+        s.timeout = std::time::Duration::from_secs(run_timeout_secs.max(10));
+    }
+
+    pub fn max_concurrent(&self) -> usize {
+        self.settings.read().unwrap().max_concurrent
+    }
+
+    pub fn sessions_dir(&self) -> PathBuf {
+        self.adapter_dir.join("agent_runs").join("sessions")
+    }
+
+    pub fn list(&self) -> Vec<AgentRunRecord> {
+        let mut all: Vec<_> = self.runs.read().unwrap().values().cloned().collect();
+        all.sort_by(|a, b| b.created_unix_ms.cmp(&a.created_unix_ms).then(b.id.cmp(&a.id)));
+        all
+    }
+
+    pub fn get(&self, id: &str) -> Option<AgentRunRecord> {
+        self.runs.read().unwrap().get(id).cloned()
+    }
+
+    pub fn active_count(&self) -> usize {
+        self.runs
+            .read()
+            .unwrap()
+            .values()
+            .filter(|r| !r.status.is_terminal())
+            .count()
+    }
+
+    /// Events with seq >= `after`, plus the run's current status — one
+    /// poll drives the live drill view.
+    pub fn events_after(&self, id: &str, after: u64) -> Option<(Vec<(u64, serde_json::Value)>, RunStatus)> {
+        let status = self.get(id)?.status;
+        let events = self
+            .events
+            .lock()
+            .unwrap()
+            .get(id)
+            .map(|buf| buf.after(after))
+            .unwrap_or_default();
+        Some((events, status))
+    }
+
+    /// Queue a steer message into a live run.
+    pub fn steer(&self, id: &str, message: String) -> Result<(), ControlError> {
+        self.send_control(id, ControlMsg::Steer(message))
+    }
+
+    /// Queue a follow-up task into a live run (extends the run by one
+    /// more agent loop).
+    pub fn follow_up(&self, id: &str, message: String) -> Result<(), ControlError> {
+        self.send_control(id, ControlMsg::FollowUp(message))
+    }
+
+    pub fn abort(&self, id: &str) -> Result<(), ControlError> {
+        self.send_control(id, ControlMsg::Abort)
+    }
+
+    fn send_control(&self, id: &str, msg: ControlMsg) -> Result<(), ControlError> {
+        let Some(run) = self.get(id) else {
+            return Err(ControlError::NotFound);
+        };
+        if run.status.is_terminal() {
+            return Err(ControlError::NotActive(run.status));
+        }
+        let sender = self.control.lock().unwrap().get(id).cloned();
+        match sender {
+            Some(tx) => tx
+                .try_send(msg)
+                .map_err(|_| ControlError::NotActive(run.status)),
+            None => Err(ControlError::NotActive(run.status)),
+        }
+    }
+
+    /// Create the record and spawn the driver task. Returns a snapshot
+    /// of the queued record.
+    pub fn start_run(self: &Arc<Self>, params: NewRunParams) -> AgentRunRecord {
+        let id = uuid::Uuid::new_v4().to_string();
+        let record = AgentRunRecord {
+            id: id.clone(),
+            task: params.task.clone(),
+            cwd: params.cwd.display().to_string(),
+            label: params.label.clone(),
+            status: RunStatus::Queued,
+            created_unix_ms: crate::recent_requests::now_unix_ms(),
+            queue_seq: self
+                .next_queue_seq
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            started_unix_ms: None,
+            finished_unix_ms: None,
+            num_turns: 0,
+            num_tool_calls: 0,
+            session_id: None,
+            session_path: None,
+            trace_indexed: false,
+            last_assistant_text: None,
+            error: None,
+        };
+        self.runs
+            .write()
+            .unwrap()
+            .insert(id.clone(), record.clone());
+        self.events
+            .lock()
+            .unwrap()
+            .insert(id.clone(), EventBuf::default());
+        let (ctl_tx, ctl_rx) = mpsc::channel::<ControlMsg>(16);
+        self.control.lock().unwrap().insert(id.clone(), ctl_tx);
+        self.prune_terminal();
+        self.persist();
+
+        let reg = Arc::clone(self);
+        tokio::spawn(async move {
+            drive_run(reg, id, params, ctl_rx).await;
+        });
+        record
+    }
+
+    // ── internals ───────────────────────────────────────────────────
+
+    fn update<F: FnOnce(&mut AgentRunRecord)>(&self, id: &str, f: F) {
+        if let Some(run) = self.runs.write().unwrap().get_mut(id) {
+            f(run);
+        }
+    }
+
+    fn push_event(&self, id: &str, value: serde_json::Value) {
+        if let Some(buf) = self.events.lock().unwrap().get_mut(id) {
+            buf.push(value);
+        }
+    }
+
+    fn finish(&self, id: &str, status: RunStatus, error: Option<String>) {
+        self.update(id, |run| {
+            run.status = status;
+            run.finished_unix_ms = Some(crate::recent_requests::now_unix_ms());
+            if run.error.is_none() {
+                run.error = error;
+            }
+        });
+        self.control.lock().unwrap().remove(id);
+        self.persist();
+        self.slot_notify.notify_waiters();
+    }
+
+    fn persist(&self) {
+        let path = runs_json_path(&self.adapter_dir);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let snapshot = self.runs.read().unwrap().clone();
+        match serde_json::to_vec_pretty(&snapshot) {
+            Ok(bytes) => {
+                if let Err(e) = kiln_resource::locked_atomic_write(&path, &bytes) {
+                    tracing::warn!(error = %e, "agent_runs/runs.json write failed");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "agent_runs serialize failed"),
+        }
+    }
+
+    /// Keep the newest TERMINAL_RUNS_CAP terminal records; active runs
+    /// are never pruned. Event buffers go with their records.
+    fn prune_terminal(&self) {
+        let pruned: Vec<String> = {
+            let runs = self.runs.read().unwrap();
+            let mut terminal: Vec<_> = runs
+                .values()
+                .filter(|r| r.status.is_terminal())
+                .map(|r| (r.created_unix_ms, r.id.clone()))
+                .collect();
+            if terminal.len() <= TERMINAL_RUNS_CAP {
+                return;
+            }
+            terminal.sort(); // oldest first
+            let overflow = terminal.len() - TERMINAL_RUNS_CAP;
+            terminal
+                .into_iter()
+                .take(overflow)
+                .map(|(_, id)| id)
+                .collect()
+        };
+        let mut runs = self.runs.write().unwrap();
+        let mut events = self.events.lock().unwrap();
+        for id in pruned {
+            runs.remove(&id);
+            events.remove(&id);
+        }
+    }
+
+    /// Wait until this run is first in the queued FIFO and a slot is
+    /// free, then mark it running. Returns false when aborted while
+    /// queued.
+    async fn claim_slot(&self, id: &str, ctl_rx: &mut mpsc::Receiver<ControlMsg>) -> bool {
+        loop {
+            let claimed = {
+                let mut runs = self.runs.write().unwrap();
+                let max = self.settings.read().unwrap().max_concurrent;
+                let running = runs
+                    .values()
+                    .filter(|r| r.status == RunStatus::Running)
+                    .count();
+                let first_queued = runs
+                    .values()
+                    .filter(|r| r.status == RunStatus::Queued)
+                    .min_by_key(|r| r.queue_seq)
+                    .map(|r| r.id.clone());
+                if running < max && first_queued.as_deref() == Some(id) {
+                    if let Some(run) = runs.get_mut(id) {
+                        run.status = RunStatus::Running;
+                        run.started_unix_ms = Some(crate::recent_requests::now_unix_ms());
+                    }
+                    true
+                } else {
+                    false
+                }
+            };
+            if claimed {
+                self.persist();
+                // Another queued run may also fit within max_concurrent.
+                self.slot_notify.notify_waiters();
+                return true;
+            }
+            tokio::select! {
+                _ = self.slot_notify.notified() => {}
+                // Re-check periodically — Notify wakeups can race with
+                // registration.
+                _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {}
+                msg = ctl_rx.recv() => {
+                    if matches!(msg, Some(ControlMsg::Abort) | None) {
+                        return false;
+                    }
+                    // Steer/follow-up before start: drop with a note in
+                    // the event feed.
+                    self.push_event(id, serde_json::json!({
+                        "type": "kiln_note",
+                        "note": "steer/follow_up ignored — run has not started yet"
+                    }));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ControlError {
+    NotFound,
+    NotActive(RunStatus),
+}
+
+fn runs_json_path(adapter_dir: &Path) -> PathBuf {
+    adapter_dir.join("agent_runs").join("runs.json")
+}
+
+/// The per-run driver: claim a slot, spawn pi, prompt, pump events,
+/// finalize, index the session into the trace layer.
+async fn drive_run(
+    reg: Arc<AgentRunRegistry>,
+    id: String,
+    params: NewRunParams,
+    mut ctl_rx: mpsc::Receiver<ControlMsg>,
+) {
+    if !reg.claim_slot(&id, &mut ctl_rx).await {
+        reg.finish(&id, RunStatus::Aborted, Some("aborted while queued".into()));
+        return;
+    }
+
+    // Same non-destructive config merge as the embedded terminal, so
+    // the spawned pi's `kiln-local` provider points at this server.
+    if let Some(url) = &params.kiln_url {
+        if let Err(e) = crate::cli::apply_pi_setup_quiet(url, Some(&params.model)) {
+            tracing::warn!(error = %e, "pi-setup merge failed; spawning pi with existing config");
+        }
+    }
+
+    let sessions_dir = reg.sessions_dir();
+    if let Err(e) = std::fs::create_dir_all(&sessions_dir) {
+        reg.finish(
+            &id,
+            RunStatus::Failed,
+            Some(format!("could not create sessions dir: {e}")),
+        );
+        return;
+    }
+
+    let opts = PiRpcOptions {
+        cwd: params.cwd.clone(),
+        provider: PI_PROVIDER_ID.to_string(),
+        model: params.model.clone(),
+        session_dir: sessions_dir.clone(),
+        session_name: Some(
+            params
+                .label
+                .clone()
+                .unwrap_or_else(|| format!("kiln run {}", &id[..8.min(id.len())])),
+        ),
+        tools: params.tools.clone(),
+        thinking_level: params.thinking_level.clone(),
+    };
+    let mut process = match PiRpcProcess::spawn(&params.pi_bin, &opts) {
+        Ok(p) => p,
+        Err(e) => {
+            reg.finish(
+                &id,
+                RunStatus::Failed,
+                Some(format!("could not start pi: {e}")),
+            );
+            return;
+        }
+    };
+
+    let prompt = serde_json::json!({"id": "prompt-1", "type": "prompt", "message": params.task});
+    let state_probe = serde_json::json!({"id": "state-1", "type": "get_state"});
+    if let Err(e) = process.send(&prompt).await {
+        reg.finish(&id, RunStatus::Failed, Some(format!("prompt write failed: {e}")));
+        process.shutdown(std::time::Duration::from_secs(3)).await;
+        return;
+    }
+    // Session file/id are known as soon as the session exists — probe
+    // early so even a crashed run can be indexed.
+    let _ = process.send(&state_probe).await;
+
+    let timeout = params
+        .timeout_secs
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| reg.settings.read().unwrap().timeout);
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    // One prompt = one agent loop = one agent_end. Each accepted
+    // follow-up queues one more loop.
+    let mut ends_remaining: i64 = 1;
+    let mut steer_seq: u64 = 0;
+    let (final_status, final_error) = loop {
+        tokio::select! {
+            line = process.lines.recv() => {
+                match line {
+                    Some(PiRpcLine::Json(value)) => {
+                        observe_line(&reg, &id, &value);
+                        let ty = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                        if ty == "agent_end" {
+                            ends_remaining -= 1;
+                            if ends_remaining <= 0 {
+                                break (RunStatus::Completed, None);
+                            }
+                        } else if ty == "response"
+                            && value.get("id").and_then(|i| i.as_str()) == Some("prompt-1")
+                            && value.get("success").and_then(|s| s.as_bool()) == Some(false)
+                        {
+                            let err = value.get("error").and_then(|e| e.as_str()).unwrap_or("prompt rejected");
+                            break (RunStatus::Failed, Some(err.to_string()));
+                        }
+                    }
+                    Some(PiRpcLine::Eof) | None => {
+                        break (RunStatus::Failed, Some("pi exited before finishing the run".into()));
+                    }
+                }
+            }
+            msg = ctl_rx.recv() => {
+                match msg {
+                    Some(ControlMsg::Steer(message)) => {
+                        steer_seq += 1;
+                        let cmd = serde_json::json!({
+                            "id": format!("steer-{steer_seq}"),
+                            "type": "steer",
+                            "message": message,
+                        });
+                        let _ = process.send(&cmd).await;
+                    }
+                    Some(ControlMsg::FollowUp(message)) => {
+                        steer_seq += 1;
+                        ends_remaining += 1;
+                        let cmd = serde_json::json!({
+                            "id": format!("follow-{steer_seq}"),
+                            "type": "follow_up",
+                            "message": message,
+                        });
+                        let _ = process.send(&cmd).await;
+                    }
+                    Some(ControlMsg::Abort) | None => {
+                        let _ = process.send(&serde_json::json!({"type": "abort"})).await;
+                        break (RunStatus::Aborted, None);
+                    }
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                let _ = process.send(&serde_json::json!({"type": "abort"})).await;
+                break (RunStatus::TimedOut, Some(format!("run exceeded {}s timeout", timeout.as_secs())));
+            }
+        }
+    };
+
+    // Give pi a moment to flush the session file and exit on stdin EOF.
+    process.shutdown(std::time::Duration::from_secs(5)).await;
+
+    // Index the finished session into the §10.3 trace layer so the
+    // flywheel sees it without a manual discover.
+    let (session_id, session_path) = {
+        let run = reg.get(&id);
+        (
+            run.as_ref().and_then(|r| r.session_id.clone()),
+            run.as_ref().and_then(|r| r.session_path.clone()),
+        )
+    };
+    let resolved_path = session_path
+        .map(PathBuf::from)
+        .filter(|p| p.is_file())
+        .or_else(|| find_session_file(&sessions_dir, session_id.as_deref()));
+    if let Some(path) = resolved_path {
+        let indexed = crate::api::agent_traces::index_session_file(&reg.adapter_dir, &path);
+        reg.update(&id, |run| {
+            run.session_path = Some(path.display().to_string());
+            if let Some(trace) = &indexed {
+                run.session_id = Some(trace.id.clone());
+                run.trace_indexed = true;
+            }
+        });
+    }
+
+    reg.finish(&id, final_status, final_error);
+}
+
+/// Update live counters and the event buffer from one pi stdout record.
+fn observe_line(reg: &AgentRunRegistry, id: &str, value: &serde_json::Value) {
+    let ty = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    match ty {
+        "message_end" => {
+            let message = value.get("message");
+            let role = message
+                .and_then(|m| m.get("role"))
+                .and_then(|r| r.as_str())
+                .unwrap_or("");
+            if role == "assistant" {
+                let text = message
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                    .map(|blocks| {
+                        blocks
+                            .iter()
+                            .filter_map(|b| {
+                                (b.get("type").and_then(|t| t.as_str()) == Some("text"))
+                                    .then(|| b.get("text").and_then(|t| t.as_str()).unwrap_or(""))
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default();
+                reg.update(id, |run| {
+                    run.num_turns += 1;
+                    if !text.is_empty() {
+                        let mut t = text;
+                        if t.len() > LAST_TEXT_CAP {
+                            let mut cut = LAST_TEXT_CAP;
+                            while !t.is_char_boundary(cut) {
+                                cut -= 1;
+                            }
+                            t.truncate(cut);
+                        }
+                        run.last_assistant_text = Some(t);
+                    }
+                });
+            }
+        }
+        "tool_execution_end" => {
+            reg.update(id, |run| run.num_tool_calls += 1);
+        }
+        "response" => {
+            if value.get("command").and_then(|c| c.as_str()) == Some("get_state") {
+                if let Some(data) = value.get("data") {
+                    let session_id = data
+                        .get("sessionId")
+                        .and_then(|s| s.as_str())
+                        .map(str::to_string);
+                    let session_path = data
+                        .get("sessionFile")
+                        .and_then(|s| s.as_str())
+                        .map(str::to_string);
+                    reg.update(id, |run| {
+                        if run.session_id.is_none() {
+                            run.session_id = session_id;
+                        }
+                        if run.session_path.is_none() {
+                            run.session_path = session_path;
+                        }
+                    });
+                }
+            }
+        }
+        _ => {}
+    }
+    // message_update fires per streamed token — too chatty for the
+    // replay buffer; everything else is kept.
+    if ty != "message_update" {
+        reg.push_event(id, value.clone());
+    }
+}
+
+/// Fallback session lookup when get_state never answered: prefer a
+/// file named after the session id anywhere under the sessions dir,
+/// else the most recently modified `.jsonl`.
+fn find_session_file(sessions_dir: &Path, session_id: Option<&str>) -> Option<PathBuf> {
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    let mut stack = vec![sessions_dir.to_path_buf()];
+    let mut depth_guard = 0usize;
+    while let Some(dir) = stack.pop() {
+        depth_guard += 1;
+        if depth_guard > 64 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|e| e == "jsonl") {
+                if let Some(sid) = session_id {
+                    if p.file_stem().is_some_and(|stem| stem.to_string_lossy().contains(sid)) {
+                        return Some(p);
+                    }
+                }
+                let mtime = entry
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                if newest.as_ref().is_none_or(|(t, _)| mtime > *t) {
+                    newest = Some((mtime, p));
+                }
+            }
+        }
+    }
+    newest.map(|(_, p)| p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stub pi that speaks just enough of the RPC protocol: accepts
+    /// the prompt, emits a tool call + final message, writes a session
+    /// file, answers get_state, and exits on agent_end + stdin EOF.
+    const FAKE_PI: &str = r#"#!/usr/bin/env python3
+import sys, json, os
+args = sys.argv[1:]
+session_dir = "."
+for i, a in enumerate(args):
+    if a == "--session-dir":
+        session_dir = args[i + 1]
+sid = "embedded-test-session"
+spath = os.path.join(session_dir, sid + ".jsonl")
+def emit(o):
+    sys.stdout.write(json.dumps(o) + "\n")
+    sys.stdout.flush()
+for line in sys.stdin:
+    cmd = json.loads(line)
+    t = cmd.get("type")
+    if t == "prompt":
+        emit({"id": cmd.get("id"), "type": "response", "command": "prompt", "success": True})
+        emit({"type": "agent_start"})
+        emit({"type": "turn_start"})
+        emit({"type": "tool_execution_start", "toolCallId": "c1", "toolName": "bash", "args": {"cmd": "echo hi"}})
+        emit({"type": "tool_execution_end", "toolCallId": "c1", "toolName": "bash", "result": "hi", "isError": False})
+        emit({"type": "message_end", "message": {"role": "assistant", "content": [{"type": "text", "text": "All done"}]}})
+        with open(spath, "w") as f:
+            f.write(json.dumps({"type": "session", "version": 3, "id": sid, "timestamp": "2026-06-11T00:00:00Z", "cwd": os.getcwd()}) + "\n")
+            f.write(json.dumps({"type": "message", "timestamp": "2026-06-11T00:00:01Z", "message": {"role": "user", "content": [{"type": "text", "text": cmd.get("message")}]}}) + "\n")
+            f.write(json.dumps({"type": "message", "timestamp": "2026-06-11T00:00:02Z", "message": {"role": "assistant", "content": [{"type": "text", "text": "All done"}]}}) + "\n")
+        emit({"type": "agent_end", "messages": []})
+    elif t == "get_state":
+        emit({"id": cmd.get("id"), "type": "response", "command": "get_state", "success": True,
+              "data": {"sessionId": sid, "sessionFile": spath, "thinkingLevel": "off",
+                       "isStreaming": False, "isCompacting": False, "steeringMode": "all",
+                       "followUpMode": "all", "autoCompactionEnabled": True,
+                       "messageCount": 2, "pendingMessageCount": 0}})
+    elif t == "abort":
+        emit({"id": cmd.get("id"), "type": "response", "command": "abort", "success": True})
+"#;
+
+    fn write_fake_pi(dir: &Path) -> PathBuf {
+        let path = dir.join("fake-pi");
+        std::fs::write(&path, FAKE_PI).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    fn params(pi_bin: PathBuf, cwd: PathBuf, task: &str) -> NewRunParams {
+        NewRunParams {
+            task: task.into(),
+            cwd,
+            label: None,
+            tools: None,
+            thinking_level: None,
+            timeout_secs: Some(30),
+            pi_bin,
+            model: "Qwen3.5-4B".into(),
+            kiln_url: None, // never touch ~/.pi from tests
+        }
+    }
+
+    async fn wait_terminal(reg: &Arc<AgentRunRegistry>, id: &str) -> AgentRunRecord {
+        for _ in 0..200 {
+            let run = reg.get(id).unwrap();
+            if run.status.is_terminal() {
+                return run;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("run {id} never reached a terminal state");
+    }
+
+    #[tokio::test]
+    async fn run_completes_streams_events_and_indexes_trace() {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let workdir = tempfile::tempdir().unwrap();
+        let pi_bin = write_fake_pi(adapter_dir.path());
+        let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
+
+        let rec = reg.start_run(params(pi_bin, workdir.path().to_path_buf(), "say hi"));
+        assert_eq!(rec.status, RunStatus::Queued);
+
+        let done = wait_terminal(&reg, &rec.id).await;
+        assert_eq!(done.status, RunStatus::Completed, "error: {:?}", done.error);
+        assert_eq!(done.num_turns, 1);
+        assert_eq!(done.num_tool_calls, 1);
+        assert_eq!(done.last_assistant_text.as_deref(), Some("All done"));
+        assert_eq!(done.session_id.as_deref(), Some("embedded-test-session"));
+        assert!(done.trace_indexed, "session must be merged into agent_traces.json");
+
+        // The event feed captured the full trajectory.
+        let (events, status) = reg.events_after(&rec.id, 0).unwrap();
+        assert_eq!(status, RunStatus::Completed);
+        let types: Vec<_> = events
+            .iter()
+            .map(|(_, v)| v.get("type").and_then(|t| t.as_str()).unwrap_or(""))
+            .collect();
+        assert!(types.contains(&"agent_start"));
+        assert!(types.contains(&"tool_execution_end"));
+        assert!(types.contains(&"agent_end"));
+
+        // The trace layer sees the session — same index the flywheel reads.
+        let index = crate::api::agent_traces::AgentTraceIndex::load_from_path(
+            &adapter_dir.path().join("agent_traces.json"),
+        );
+        let trace = index.traces.get("embedded-test-session").expect("trace indexed");
+        assert_eq!(trace.prompt_messages.len(), 1);
+        assert_eq!(trace.prompt_messages[0].content, "say hi");
+
+        // Records persist for restart recovery.
+        let persisted = std::fs::read_to_string(
+            adapter_dir.path().join("agent_runs").join("runs.json"),
+        )
+        .unwrap();
+        assert!(persisted.contains(&rec.id));
+    }
+
+    #[tokio::test]
+    async fn concurrency_cap_holds_second_run_queued() {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let workdir = tempfile::tempdir().unwrap();
+        // A pi that never finishes: accepts the prompt then blocks.
+        let slow_pi = adapter_dir.path().join("slow-pi");
+        std::fs::write(
+            &slow_pi,
+            "#!/usr/bin/env python3\nimport sys,json,time\nfor line in sys.stdin:\n    cmd=json.loads(line)\n    if cmd.get('type')=='prompt':\n        sys.stdout.write(json.dumps({'id':cmd.get('id'),'type':'response','command':'prompt','success':True})+'\\n')\n        sys.stdout.flush()\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&slow_pi, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
+        reg.apply_config(1, 900);
+
+        let a = reg.start_run(params(slow_pi.clone(), workdir.path().to_path_buf(), "a"));
+        let b = reg.start_run(params(slow_pi, workdir.path().to_path_buf(), "b"));
+
+        // Give the first driver time to claim the only slot.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        assert_eq!(reg.get(&a.id).unwrap().status, RunStatus::Running);
+        assert_eq!(reg.get(&b.id).unwrap().status, RunStatus::Queued);
+
+        // Aborting the runner frees the slot for the queued run.
+        reg.abort(&a.id).unwrap();
+        let a_done = wait_terminal(&reg, &a.id).await;
+        assert_eq!(a_done.status, RunStatus::Aborted);
+        for _ in 0..100 {
+            if reg.get(&b.id).unwrap().status == RunStatus::Running {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert_eq!(reg.get(&b.id).unwrap().status, RunStatus::Running);
+        reg.abort(&b.id).unwrap();
+        wait_terminal(&reg, &b.id).await;
+    }
+
+    #[tokio::test]
+    async fn missing_binary_fails_cleanly() {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let workdir = tempfile::tempdir().unwrap();
+        let reg = Arc::new(AgentRunRegistry::new(adapter_dir.path().to_path_buf()));
+        let rec = reg.start_run(params(
+            PathBuf::from("/nonexistent/pi-binary"),
+            workdir.path().to_path_buf(),
+            "x",
+        ));
+        let done = wait_terminal(&reg, &rec.id).await;
+        assert_eq!(done.status, RunStatus::Failed);
+        assert!(done.error.unwrap().contains("could not start pi"));
+    }
+
+    #[test]
+    fn restart_marks_active_runs_interrupted() {
+        let adapter_dir = tempfile::tempdir().unwrap();
+        let runs_dir = adapter_dir.path().join("agent_runs");
+        std::fs::create_dir_all(&runs_dir).unwrap();
+        let record = AgentRunRecord {
+            id: "r1".into(),
+            task: "t".into(),
+            cwd: "/x".into(),
+            label: None,
+            status: RunStatus::Running,
+            created_unix_ms: 1,
+            queue_seq: 0,
+            started_unix_ms: Some(2),
+            finished_unix_ms: None,
+            num_turns: 0,
+            num_tool_calls: 0,
+            session_id: None,
+            session_path: None,
+            trace_indexed: false,
+            last_assistant_text: None,
+            error: None,
+        };
+        let mut map = BTreeMap::new();
+        map.insert("r1".to_string(), record);
+        std::fs::write(
+            runs_dir.join("runs.json"),
+            serde_json::to_vec_pretty(&map).unwrap(),
+        )
+        .unwrap();
+
+        let reg = AgentRunRegistry::new(adapter_dir.path().to_path_buf());
+        let run = reg.get("r1").unwrap();
+        assert_eq!(run.status, RunStatus::Interrupted);
+        assert!(run.error.unwrap().contains("restarted"));
+    }
+}

--- a/crates/kiln-server/src/api/agent_runs.rs
+++ b/crates/kiln-server/src/api/agent_runs.rs
@@ -6,7 +6,7 @@
 //! | POST   | /v1/agent/runs             | Start a run `{task, cwd?, label?, ...}`|
 //! | GET    | /v1/agent/runs             | List runs (newest first)               |
 //! | GET    | /v1/agent/runs/{id}        | One run record                         |
-//! | GET    | /v1/agent/runs/{id}/events | Event feed (`?after=<seq>` cursor)     |
+//! | GET    | /v1/agent/runs/{id}/events | Event feed: returns events with seq >= `after`; pass the response's `next_after` back to poll incrementally |
 //! | POST   | /v1/agent/runs/{id}/steer  | Queue a steering message               |
 //! | POST   | /v1/agent/runs/{id}/follow_up | Queue a follow-up task              |
 //! | POST   | /v1/agent/runs/{id}/abort  | Abort the run                          |
@@ -23,14 +23,9 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 
-use crate::agent_runs::{AgentRunRecord, ControlError, NewRunParams};
+use crate::agent_runs::{AgentRunRecord, ControlError, NewRunParams, StartRunError};
 use crate::error::ApiError;
 use crate::state::AppState;
-
-/// Active (queued + running) runs allowed before new submissions are
-/// turned away — a backstop against a runaway submitter, not a tuning
-/// knob (concurrency is `[agent].max_concurrent_runs`).
-const MAX_ACTIVE_RUNS: usize = 32;
 
 const THINKING_LEVELS: &[&str] = &["off", "minimal", "low", "medium", "high", "xhigh"];
 
@@ -58,6 +53,20 @@ fn runs_gate() -> (bool, Option<String>) {
             ),
         )
     }
+}
+
+/// The gate guards reads too: run records and event feeds carry task
+/// prompts, server paths, and raw tool output — closing the gate must
+/// take the data side off the network, not just creation. /status
+/// stays open (it only reports the gate itself).
+fn require_runs_enabled() -> Result<(), ApiError> {
+    let (enabled, reason) = runs_gate();
+    if !enabled {
+        return Err(ApiError::agent_runs_disabled(
+            reason.unwrap_or_else(|| "gate closed".into()),
+        ));
+    }
+    Ok(())
 }
 
 async fn runs_status(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -102,12 +111,7 @@ async fn create_run(
     if state.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
     }
-    let (enabled, reason) = runs_gate();
-    if !enabled {
-        return Err(ApiError::agent_runs_disabled(
-            reason.unwrap_or_else(|| "gate closed".into()),
-        ));
-    }
+    require_runs_enabled()?;
     let task = req.task.trim();
     if task.is_empty() {
         return Err(ApiError::agent_run_invalid_request(
@@ -148,11 +152,6 @@ async fn create_run(
             "`pi` is not installed on the server's PATH",
         ));
     };
-    if state.agent_runs.active_count() >= MAX_ACTIVE_RUNS {
-        return Err(ApiError::agent_runs_unavailable(format!(
-            "{MAX_ACTIVE_RUNS} runs are already queued or running — wait for some to finish"
-        )));
-    }
     let record = state.agent_runs.start_run(NewRunParams {
         task: task.to_string(),
         cwd,
@@ -164,7 +163,10 @@ async fn create_run(
         model: state.served_model_id.clone(),
         kiln_url: Some(crate::agent_runs::self_url()),
     });
-    Ok(Json(record))
+    match record {
+        Ok(record) => Ok(Json(record)),
+        Err(StartRunError::AtCapacity(max)) => Err(ApiError::agent_runs_at_capacity(max)),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -177,18 +179,20 @@ struct ListRunsQuery {
 async fn list_runs(
     State(state): State<AppState>,
     Query(q): Query<ListRunsQuery>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_runs_enabled()?;
     let mut runs = state.agent_runs.list();
     if let Some(label) = &q.label {
         runs.retain(|r| r.label.as_deref() == Some(label.as_str()));
     }
-    Json(serde_json::json!({ "runs": runs }))
+    Ok(Json(serde_json::json!({ "runs": runs })))
 }
 
 async fn get_run(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<AgentRunRecord>, ApiError> {
+    require_runs_enabled()?;
     state
         .agent_runs
         .get(&id)
@@ -208,18 +212,24 @@ async fn run_events(
     AxumPath(id): AxumPath<String>,
     Query(q): Query<EventsQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let Some((events, status)) = state.agent_runs.events_after(&id, q.after) else {
+    require_runs_enabled()?;
+    let Some(page) = state.agent_runs.events_after(&id, q.after) else {
         return Err(ApiError::agent_run_not_found(&id));
     };
-    let next_after = events.last().map(|(seq, _)| seq + 1).unwrap_or(q.after);
-    let events: Vec<serde_json::Value> = events
+    let next_after = page.events.last().map(|(seq, _)| seq + 1).unwrap_or(q.after);
+    let events: Vec<serde_json::Value> = page
+        .events
         .into_iter()
         .map(|(seq, event)| serde_json::json!({ "seq": seq, "event": event }))
         .collect();
     Ok(Json(serde_json::json!({
         "events": events,
         "next_after": next_after,
-        "status": status,
+        "status": page.status,
+        // Replay-gap detection: events before the cursor are gone when
+        // truncated (ring prune on a long run, or a server restart).
+        "first_available_seq": page.first_available_seq,
+        "truncated": page.truncated,
     })))
 }
 
@@ -240,6 +250,7 @@ async fn steer_run(
     AxumPath(id): AxumPath<String>,
     Json(req): Json<MessageRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    require_runs_enabled()?;
     if req.message.trim().is_empty() {
         return Err(ApiError::agent_run_invalid_request(
             "`message` must be non-empty",
@@ -257,6 +268,7 @@ async fn follow_up_run(
     AxumPath(id): AxumPath<String>,
     Json(req): Json<MessageRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    require_runs_enabled()?;
     if req.message.trim().is_empty() {
         return Err(ApiError::agent_run_invalid_request(
             "`message` must be non-empty",
@@ -273,6 +285,7 @@ async fn abort_run(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    require_runs_enabled()?;
     state
         .agent_runs
         .abort(&id)

--- a/crates/kiln-server/src/api/agent_runs.rs
+++ b/crates/kiln-server/src/api/agent_runs.rs
@@ -1,0 +1,321 @@
+//! Embedded agent runs API — submit tasks for the server-driven pi.
+//!
+//! | Method | Path                       | Purpose                                |
+//! |--------|----------------------------|----------------------------------------|
+//! | GET    | /v1/agent/runs/status      | Gate state, pi availability, capacity  |
+//! | POST   | /v1/agent/runs             | Start a run `{task, cwd?, label?, ...}`|
+//! | GET    | /v1/agent/runs             | List runs (newest first)               |
+//! | GET    | /v1/agent/runs/{id}        | One run record                         |
+//! | GET    | /v1/agent/runs/{id}/events | Event feed (`?after=<seq>` cursor)     |
+//! | POST   | /v1/agent/runs/{id}/steer  | Queue a steering message               |
+//! | POST   | /v1/agent/runs/{id}/follow_up | Queue a follow-up task              |
+//! | POST   | /v1/agent/runs/{id}/abort  | Abort the run                          |
+//!
+//! Security gate: an embedded run is arbitrary-code-execution grade —
+//! same posture as the dashboard terminal. Enabled when the server is
+//! bound to loopback (the default); `KILN_AGENT_RUNS=1` opts in on
+//! network binds, `KILN_AGENT_RUNS=0` force-disables.
+
+use std::path::PathBuf;
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use crate::agent_runs::{AgentRunRecord, ControlError, NewRunParams};
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Active (queued + running) runs allowed before new submissions are
+/// turned away — a backstop against a runaway submitter, not a tuning
+/// knob (concurrency is `[agent].max_concurrent_runs`).
+const MAX_ACTIVE_RUNS: usize = 32;
+
+const THINKING_LEVELS: &[&str] = &["off", "minimal", "low", "medium", "high", "xhigh"];
+
+/// (enabled, human-readable reason when disabled)
+fn runs_gate() -> (bool, Option<String>) {
+    match std::env::var("KILN_AGENT_RUNS").as_deref() {
+        Ok("0") => {
+            return (
+                false,
+                Some("disabled by KILN_AGENT_RUNS=0 on the server".into()),
+            );
+        }
+        Ok("1") => return (true, None),
+        _ => {}
+    }
+    if super::terminal::bind_host_is_loopback() {
+        (true, None)
+    } else {
+        (
+            false,
+            Some(
+                "the server is not bound to loopback — embedded runs execute arbitrary \
+                 code. Set KILN_AGENT_RUNS=1 to enable them anyway."
+                    .into(),
+            ),
+        )
+    }
+}
+
+async fn runs_status(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let (enabled, reason) = runs_gate();
+    let pi = crate::pi_rpc::find_pi();
+    Json(serde_json::json!({
+        "enabled": enabled,
+        "disabled_reason": reason,
+        "pi_available": pi.is_some(),
+        "pi_path": pi.map(|p| p.display().to_string()),
+        "max_concurrent_runs": state.agent_runs.max_concurrent(),
+        "active_runs": state.agent_runs.active_count(),
+        "sessions_dir": state.agent_runs.sessions_dir().display().to_string(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateRunRequest {
+    /// The task prompt handed to pi.
+    task: String,
+    /// Working directory for the agent. Defaults to the server's cwd.
+    #[serde(default)]
+    cwd: Option<String>,
+    /// Free-form grouping label (e.g. a rollout batch name).
+    #[serde(default)]
+    label: Option<String>,
+    /// Tool allowlist (pi `--tools`), e.g. `["read", "bash"]`.
+    #[serde(default)]
+    tools: Option<Vec<String>>,
+    /// pi thinking level: off|minimal|low|medium|high|xhigh.
+    #[serde(default)]
+    thinking_level: Option<String>,
+    /// Per-run wall-clock cap; defaults to `[agent].run_timeout_secs`.
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+}
+
+async fn create_run(
+    State(state): State<AppState>,
+    Json(req): Json<CreateRunRequest>,
+) -> Result<Json<AgentRunRecord>, ApiError> {
+    if state.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+        return Err(ApiError::shutting_down());
+    }
+    let (enabled, reason) = runs_gate();
+    if !enabled {
+        return Err(ApiError::agent_runs_disabled(
+            reason.unwrap_or_else(|| "gate closed".into()),
+        ));
+    }
+    let task = req.task.trim();
+    if task.is_empty() {
+        return Err(ApiError::agent_run_invalid_request(
+            "`task` must be non-empty",
+        ));
+    }
+    if let Some(level) = &req.thinking_level {
+        if !THINKING_LEVELS.contains(&level.as_str()) {
+            return Err(ApiError::agent_run_invalid_request(format!(
+                "`thinking_level` must be one of {THINKING_LEVELS:?}, got '{level}'"
+            )));
+        }
+    }
+    if let Some(secs) = req.timeout_secs {
+        if secs < 10 {
+            return Err(ApiError::agent_run_invalid_request(
+                "`timeout_secs` must be >= 10",
+            ));
+        }
+    }
+    let cwd = match &req.cwd {
+        Some(dir) => {
+            let p = PathBuf::from(dir);
+            if !p.is_dir() {
+                return Err(ApiError::agent_run_invalid_request(format!(
+                    "`cwd` {} is not a directory on the server",
+                    p.display()
+                )));
+            }
+            p
+        }
+        None => std::env::current_dir().map_err(|e| {
+            ApiError::agent_run_invalid_request(format!("server cwd unavailable: {e}"))
+        })?,
+    };
+    let Some(pi_bin) = crate::pi_rpc::find_pi() else {
+        return Err(ApiError::agent_runs_unavailable(
+            "`pi` is not installed on the server's PATH",
+        ));
+    };
+    if state.agent_runs.active_count() >= MAX_ACTIVE_RUNS {
+        return Err(ApiError::agent_runs_unavailable(format!(
+            "{MAX_ACTIVE_RUNS} runs are already queued or running — wait for some to finish"
+        )));
+    }
+    let record = state.agent_runs.start_run(NewRunParams {
+        task: task.to_string(),
+        cwd,
+        label: req.label.clone(),
+        tools: req.tools.clone(),
+        thinking_level: req.thinking_level.clone(),
+        timeout_secs: req.timeout_secs,
+        pi_bin,
+        model: state.served_model_id.clone(),
+        kiln_url: Some(crate::agent_runs::self_url()),
+    });
+    Ok(Json(record))
+}
+
+#[derive(Debug, Deserialize)]
+struct ListRunsQuery {
+    /// Filter runs by exact label.
+    #[serde(default)]
+    label: Option<String>,
+}
+
+async fn list_runs(
+    State(state): State<AppState>,
+    Query(q): Query<ListRunsQuery>,
+) -> Json<serde_json::Value> {
+    let mut runs = state.agent_runs.list();
+    if let Some(label) = &q.label {
+        runs.retain(|r| r.label.as_deref() == Some(label.as_str()));
+    }
+    Json(serde_json::json!({ "runs": runs }))
+}
+
+async fn get_run(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<AgentRunRecord>, ApiError> {
+    state
+        .agent_runs
+        .get(&id)
+        .map(Json)
+        .ok_or_else(|| ApiError::agent_run_not_found(&id))
+}
+
+#[derive(Debug, Deserialize)]
+struct EventsQuery {
+    /// Return events with seq >= after (cursor for incremental polls).
+    #[serde(default)]
+    after: u64,
+}
+
+async fn run_events(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Query(q): Query<EventsQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Some((events, status)) = state.agent_runs.events_after(&id, q.after) else {
+        return Err(ApiError::agent_run_not_found(&id));
+    };
+    let next_after = events.last().map(|(seq, _)| seq + 1).unwrap_or(q.after);
+    let events: Vec<serde_json::Value> = events
+        .into_iter()
+        .map(|(seq, event)| serde_json::json!({ "seq": seq, "event": event }))
+        .collect();
+    Ok(Json(serde_json::json!({
+        "events": events,
+        "next_after": next_after,
+        "status": status,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct MessageRequest {
+    message: String,
+}
+
+fn map_control_error(id: &str, err: ControlError) -> ApiError {
+    match err {
+        ControlError::NotFound => ApiError::agent_run_not_found(id),
+        ControlError::NotActive(status) => ApiError::agent_run_not_active(id, status),
+    }
+}
+
+async fn steer_run(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<MessageRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    if req.message.trim().is_empty() {
+        return Err(ApiError::agent_run_invalid_request(
+            "`message` must be non-empty",
+        ));
+    }
+    state
+        .agent_runs
+        .steer(&id, req.message)
+        .map_err(|e| map_control_error(&id, e))?;
+    Ok(Json(serde_json::json!({"queued": true})))
+}
+
+async fn follow_up_run(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<MessageRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    if req.message.trim().is_empty() {
+        return Err(ApiError::agent_run_invalid_request(
+            "`message` must be non-empty",
+        ));
+    }
+    state
+        .agent_runs
+        .follow_up(&id, req.message)
+        .map_err(|e| map_control_error(&id, e))?;
+    Ok(Json(serde_json::json!({"queued": true})))
+}
+
+async fn abort_run(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    state
+        .agent_runs
+        .abort(&id)
+        .map_err(|e| map_control_error(&id, e))?;
+    Ok(Json(serde_json::json!({"aborting": true})))
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/v1/agent/runs/status", get(runs_status))
+        .route("/v1/agent/runs", post(create_run).get(list_runs))
+        .route("/v1/agent/runs/{id}", get(get_run))
+        .route("/v1/agent/runs/{id}/events", get(run_events))
+        .route("/v1/agent/runs/{id}/steer", post(steer_run))
+        .route("/v1/agent/runs/{id}/follow_up", post(follow_up_run))
+        .route("/v1/agent/runs/{id}/abort", post(abort_run))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_env_overrides_win() {
+        // Cannot mutate the bind-host OnceLock here, but the env
+        // overrides short-circuit before the host check.
+        unsafe { std::env::set_var("KILN_AGENT_RUNS", "0") };
+        let (enabled, reason) = runs_gate();
+        assert!(!enabled);
+        assert!(reason.unwrap().contains("KILN_AGENT_RUNS=0"));
+        unsafe { std::env::set_var("KILN_AGENT_RUNS", "1") };
+        let (enabled, reason) = runs_gate();
+        assert!(enabled);
+        assert!(reason.is_none());
+        unsafe { std::env::remove_var("KILN_AGENT_RUNS") };
+    }
+
+    #[test]
+    fn create_run_request_minimal_body_parses() {
+        let req: CreateRunRequest = serde_json::from_str(r#"{"task": "fix the test"}"#).unwrap();
+        assert_eq!(req.task, "fix the test");
+        assert!(req.cwd.is_none());
+        assert!(req.tools.is_none());
+        assert!(req.timeout_secs.is_none());
+    }
+}

--- a/crates/kiln-server/src/api/agent_traces.rs
+++ b/crates/kiln-server/src/api/agent_traces.rs
@@ -187,14 +187,36 @@ fn scan_sessions_dir(dir: &Path, depth_left: usize, index: &mut AgentTraceIndex)
 /// shared by the explicit POST /v1/agent/traces/discover route and the
 /// self_improve/judge_distill auto-discovery below. Returns the number
 /// of indexed sessions.
+///
+/// Embedded-run sessions (`<adapter_dir>/agent_runs/sessions/`) are
+/// always swept in too: a rebuild from the user's `~/.pi` dir must not
+/// drop the rollouts kiln generated itself.
 pub(crate) fn discover_traces_into(
     sessions_dir: &Path,
     adapter_dir: &Path,
 ) -> std::io::Result<usize> {
     let mut index = AgentTraceIndex::default();
-    let count = scan_sessions_dir(sessions_dir, SESSIONS_SCAN_MAX_DEPTH, &mut index);
+    let mut count = scan_sessions_dir(sessions_dir, SESSIONS_SCAN_MAX_DEPTH, &mut index);
+    let embedded = adapter_dir.join("agent_runs").join("sessions");
+    if embedded.is_dir() && embedded != sessions_dir {
+        count += scan_sessions_dir(&embedded, SESSIONS_SCAN_MAX_DEPTH, &mut index);
+    }
     index.save_to_path(&adapter_dir.join("agent_traces.json"))?;
     Ok(count)
+}
+
+/// Merge one session JSONL into the persisted index — the embedded-run
+/// finalizer calls this so every run kiln drives lands in the trace
+/// layer immediately, without clobbering previously discovered traces.
+pub(crate) fn index_session_file(adapter_dir: &Path, session_path: &Path) -> Option<AgentTrace> {
+    let trace = parse_pi_session(session_path)?;
+    let index_path = adapter_dir.join("agent_traces.json");
+    let mut index = AgentTraceIndex::load_from_path(&index_path);
+    index.traces.insert(trace.id.clone(), trace.clone());
+    if let Err(e) = index.save_to_path(&index_path) {
+        tracing::warn!(error = %e, "agent_traces.json merge write failed");
+    }
+    Some(trace)
 }
 
 /// Auto-discovery for the §10.6 endpoints: when `agent_traces.json` is

--- a/crates/kiln-server/src/api/agent_traces.rs
+++ b/crates/kiln-server/src/api/agent_traces.rs
@@ -208,15 +208,29 @@ pub(crate) fn discover_traces_into(
 /// Merge one session JSONL into the persisted index — the embedded-run
 /// finalizer calls this so every run kiln drives lands in the trace
 /// layer immediately, without clobbering previously discovered traces.
+///
+/// The whole read-modify-write happens inside `locked_update`: two run
+/// finalizers landing at once must both survive into the index (an
+/// unlocked load→insert→save here lost one of them most of the time).
+/// Returns `None` when the merge did not persist, so callers don't
+/// report a trace as indexed that isn't.
 pub(crate) fn index_session_file(adapter_dir: &Path, session_path: &Path) -> Option<AgentTrace> {
     let trace = parse_pi_session(session_path)?;
     let index_path = adapter_dir.join("agent_traces.json");
-    let mut index = AgentTraceIndex::load_from_path(&index_path);
-    index.traces.insert(trace.id.clone(), trace.clone());
-    if let Err(e) = index.save_to_path(&index_path) {
-        tracing::warn!(error = %e, "agent_traces.json merge write failed");
+    let merged = kiln_resource::locked_update(&index_path, |existing| {
+        let mut traces: BTreeMap<String, AgentTrace> = existing
+            .and_then(|bytes| serde_json::from_slice(bytes).ok())
+            .unwrap_or_default();
+        traces.insert(trace.id.clone(), trace.clone());
+        serde_json::to_vec_pretty(&traces).map_err(std::io::Error::other)
+    });
+    match merged {
+        Ok(()) => Some(trace),
+        Err(e) => {
+            tracing::warn!(error = %e, "agent_traces.json merge write failed");
+            None
+        }
     }
-    Some(trace)
 }
 
 /// Auto-discovery for the §10.6 endpoints: when `agent_traces.json` is

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -6,6 +6,7 @@ use tracing::Span;
 use crate::state::AppState;
 
 mod adapters;
+pub mod agent_runs;
 pub mod agent_traces;
 pub(crate) mod cache;
 pub(crate) mod completions;
@@ -78,6 +79,7 @@ pub fn router(state: AppState) -> Router {
         .merge(recipes::routes())
         .merge(cache::routes())
         .merge(library::routes())
+        .merge(agent_runs::routes())
         .merge(agent_traces::routes())
         .merge(self_improve::routes())
         .merge(pit_of_success::routes())

--- a/crates/kiln-server/src/api/terminal.rs
+++ b/crates/kiln-server/src/api/terminal.rs
@@ -48,7 +48,7 @@ pub fn set_bind_host(host: &str) {
     let _ = BIND_HOST.set(host.to_string());
 }
 
-fn bind_host_is_loopback() -> bool {
+pub(crate) fn bind_host_is_loopback() -> bool {
     let host = BIND_HOST.get().map(String::as_str).unwrap_or("127.0.0.1");
     matches!(host, "127.0.0.1" | "localhost" | "::1" | "[::1]")
 }
@@ -79,16 +79,9 @@ fn terminal_gate() -> (bool, Option<String>) {
     }
 }
 
-/// Locate `pi` on the server's PATH without shelling out.
+/// Locate `pi` — shared with the embedded-run engine (honors KILN_PI_BIN).
 fn find_pi() -> Option<PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join("pi");
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
+    crate::pi_rpc::find_pi()
 }
 
 async fn terminal_status() -> Json<serde_json::Value> {

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -2477,12 +2477,23 @@ async fn probe_kiln_served_model(url: &str) -> anyhow::Result<String> {
         .ok_or_else(|| anyhow::anyhow!("no models in /v1/models response"))
 }
 
+/// Serializes in-process pi-setup merges: embedded runs re-merge before
+/// every spawn (up to `max_concurrent_runs` drivers at once) and the
+/// dashboard terminal does too — unserialized read-modify-writes here
+/// lost edits and let a spawning pi read a half-written config.
+static PI_SETUP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Quiet variant of `run_pi_setup` for in-process callers (the embedded
-/// dashboard terminal): performs the same non-destructive merge into pi's
-/// default config location, but logs instead of printing, and returns the
-/// models.json path it wrote. In-process callers know the served model id —
-/// pass it so the provider block matches the live server.
+/// dashboard terminal and the embedded run engine): performs the same
+/// non-destructive merge into pi's default config location, but logs
+/// instead of printing, and returns the models.json path. In-process
+/// callers know the served model id — pass it so the provider block
+/// matches the live server. No-op (no backup, no write) when the merged
+/// config equals what's already on disk — the common case for every
+/// embedded run after the first, which would otherwise litter
+/// `~/.pi/agent` with a backup pair per run.
 pub fn apply_pi_setup_quiet(url: &str, model_id: Option<&str>) -> anyhow::Result<PathBuf> {
+    let _guard = PI_SETUP_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let model_id = model_id.unwrap_or(PI_MODEL_ID);
     let path: PathBuf = match std::env::var("HOME") {
         Ok(h) => PathBuf::from(h)
@@ -2498,13 +2509,23 @@ pub fn apply_pi_setup_quiet(url: &str, model_id: Option<&str>) -> anyhow::Result
     if let Some(parent) = settings_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    backup_existing_file(&path)?;
-    backup_existing_file(&settings_path)?;
-    let models = merge_pi_models_config(read_json_file_if_exists(&path)?, url, model_id)?;
-    let settings = merge_pi_settings_config(read_json_file_if_exists(&settings_path)?, model_id)?;
-    write_json_pretty(&path, &models)?;
-    write_json_pretty(&settings_path, &settings)?;
-    tracing::info!(models = %path.display(), settings = %settings_path.display(), url = %url, "pi config merged for embedded terminal");
+    let existing_models = read_json_file_if_exists(&path)?;
+    let models = merge_pi_models_config(existing_models.clone(), url, model_id)?;
+    let existing_settings = read_json_file_if_exists(&settings_path)?;
+    let settings = merge_pi_settings_config(existing_settings.clone(), model_id)?;
+    let models_changed = existing_models.as_ref() != Some(&models);
+    let settings_changed = existing_settings.as_ref() != Some(&settings);
+    if models_changed {
+        backup_existing_file(&path)?;
+        write_json_pretty(&path, &models)?;
+    }
+    if settings_changed {
+        backup_existing_file(&settings_path)?;
+        write_json_pretty(&settings_path, &settings)?;
+    }
+    if models_changed || settings_changed {
+        tracing::info!(models = %path.display(), settings = %settings_path.display(), url = %url, "pi config merged for embedded agent");
+    }
     Ok(path)
 }
 
@@ -2652,10 +2673,26 @@ fn backup_existing_file(path: &Path) -> anyhow::Result<Option<PathBuf>> {
     ))
 }
 
+/// Write via temp-file + rename so a concurrently *starting* pi never
+/// reads a truncated config — embedded runs re-merge before every
+/// spawn, and pi children read these files at startup.
 fn write_json_pretty(path: &Path, value: &serde_json::Value) -> anyhow::Result<()> {
     let mut bytes = serde_json::to_vec_pretty(value)?;
     bytes.push(b'\n');
-    std::fs::write(path, bytes).map_err(|err| anyhow::anyhow!("write {}: {err}", path.display()))
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = parent.join(format!(
+        ".{}.tmp-{}",
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "pi-config".into()),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, bytes)
+        .map_err(|err| anyhow::anyhow!("write {}: {err}", tmp.display()))?;
+    std::fs::rename(&tmp, path).map_err(|err| {
+        let _ = std::fs::remove_file(&tmp);
+        anyhow::anyhow!("rename {} -> {}: {err}", tmp.display(), path.display())
+    })
 }
 
 fn merge_pi_models_config(

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -44,8 +44,9 @@ pub struct KilnConfig {
     pub agent: Option<AgentConfig>,
 }
 
-/// `[agent]` — the self-improvement flywheel scheduler.
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+/// `[agent]` — the self-improvement flywheel scheduler and the
+/// embedded pi run engine.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentConfig {
     /// Run the §10.6.2 self_improve loop every N hours (168 = weekly).
@@ -61,6 +62,35 @@ pub struct AgentConfig {
     /// scheduled round gated (§8.7: auto-load defers; failures demote).
     #[serde(default)]
     pub self_improve: Option<serde_json::Value>,
+    /// Embedded pi runs executing at once (`POST /v1/agent/runs`).
+    /// Queued runs start FIFO as slots free up. Inference batching
+    /// interleaves the concurrent agents' requests.
+    #[serde(default = "default_max_concurrent_runs")]
+    pub max_concurrent_runs: usize,
+    /// Wall-clock cap per embedded run, after which pi is aborted and
+    /// the partial session is still indexed. Per-run `timeout_secs`
+    /// overrides this.
+    #[serde(default = "default_run_timeout_secs")]
+    pub run_timeout_secs: u64,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            self_improve_interval_hours: None,
+            self_improve: None,
+            max_concurrent_runs: default_max_concurrent_runs(),
+            run_timeout_secs: default_run_timeout_secs(),
+        }
+    }
+}
+
+fn default_max_concurrent_runs() -> usize {
+    2
+}
+
+fn default_run_timeout_secs() -> u64 {
+    900
 }
 
 /// Eval subsystem configuration.

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -444,6 +444,58 @@ impl ApiError {
         }
     }
 
+    // ── Embedded agent runs ─────────────────────────────────────────
+
+    pub fn agent_run_invalid_request(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "agent_run_invalid_request",
+            message: format!("{detail}"),
+            hint: "POST /v1/agent/runs takes {\"task\": \"...\"} plus optional cwd, label, tools, timeout_secs.",
+            retry_after_seconds: None,
+        }
+    }
+
+    pub fn agent_run_not_found(run_id: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "agent_run_not_found",
+            message: format!("Agent run '{run_id}' not found"),
+            hint: "List runs with GET /v1/agent/runs.",
+            retry_after_seconds: None,
+        }
+    }
+
+    pub fn agent_run_not_active(run_id: impl std::fmt::Display, status: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "agent_run_not_active",
+            message: format!("Agent run '{run_id}' is not active (status: {status})"),
+            hint: "Steer/abort only apply to queued or running runs; check GET /v1/agent/runs/{id}.",
+            retry_after_seconds: None,
+        }
+    }
+
+    pub fn agent_runs_disabled(reason: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "agent_runs_disabled",
+            message: format!("Embedded agent runs are disabled: {reason}"),
+            hint: "Embedded runs execute arbitrary code on the server. They are enabled on loopback binds by default; set KILN_AGENT_RUNS=1 to opt in on network binds.",
+            retry_after_seconds: None,
+        }
+    }
+
+    pub fn agent_runs_unavailable(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "agent_runs_unavailable",
+            message: format!("{detail}"),
+            hint: "Install pi (npm i -g @earendil-works/pi-coding-agent) on the server, or set KILN_PI_BIN to the binary path.",
+            retry_after_seconds: Some(30),
+        }
+    }
+
     pub fn training_job_not_found(job_id: impl std::fmt::Display) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -496,6 +496,18 @@ impl ApiError {
         }
     }
 
+    pub fn agent_runs_at_capacity(max: usize) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "agent_runs_at_capacity",
+            message: format!(
+                "{max} agent runs are already queued or running — wait for some to finish"
+            ),
+            hint: "Check active runs with GET /v1/agent/runs, abort one with POST /v1/agent/runs/{id}/abort, or retry shortly.",
+            retry_after_seconds: Some(30),
+        }
+    }
+
     pub fn training_job_not_found(job_id: impl std::fmt::Display) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,5 +1,6 @@
 //! Kiln HTTP server — library interface for integration testing.
 
+pub mod agent_runs;
 pub mod api;
 pub mod adapter_swap;
 pub mod adapter_verify;
@@ -17,6 +18,7 @@ pub mod eval_history;
 pub mod kv_autoscaler;
 pub mod logging;
 pub mod metrics;
+pub mod pi_rpc;
 pub mod recent_requests;
 pub mod request_log;
 pub mod rollout_generate_cli;

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -230,6 +230,8 @@ async fn main() -> Result<()> {
     let host = &config.server.host;
     kiln_server::api::terminal::set_bind_host(host);
     let port = config.server.port;
+    // Embedded agent runs configure the spawned pi against this URL.
+    kiln_server::agent_runs::set_self_url(host, port);
 
     let model_config = ModelConfig::qwen3_5_4b();
     let model_path = config.model.path.as_deref();
@@ -607,6 +609,15 @@ async fn main() -> Result<()> {
                 tracing::warn!(error = %e, dir = %log_dir.display(), "request log disabled: could not initialize");
             }
         }
+    }
+
+    // Embedded pi run engine: capacity + timeout from [agent] (defaults
+    // apply when the section is omitted).
+    {
+        let agent_cfg = config.agent.clone().unwrap_or_default();
+        state
+            .agent_runs
+            .apply_config(agent_cfg.max_concurrent_runs, agent_cfg.run_timeout_secs);
     }
 
     // Spawn the background training queue worker

--- a/crates/kiln-server/src/pi_rpc.rs
+++ b/crates/kiln-server/src/pi_rpc.rs
@@ -1,0 +1,251 @@
+//! pi RPC subprocess driver — spawns `pi --mode rpc` and speaks its
+//! JSON-lines protocol over stdin/stdout.
+//!
+//! pi's RPC mode is the headless embedding surface: commands go in as
+//! one JSON object per line (`{"type":"prompt","message":...}`), and
+//! the process streams back command responses (`{"type":"response",..}`)
+//! interleaved with agent events (`agent_start`, `message_end`,
+//! `tool_execution_end`, `agent_end`, ...).
+//!
+//! Framing is strict JSONL with LF as the only record delimiter; a
+//! trailing CR is stripped (the protocol allows CRLF input). Unicode
+//! line separators (U+2028/U+2029) are valid inside JSON strings and
+//! must NOT split records — `read_until(b'\n')` gets this right where
+//! generic line readers would not.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::mpsc;
+
+/// Locate the `pi` binary: `KILN_PI_BIN` wins (tests point this at a
+/// stub; operators at non-PATH installs), then a PATH scan.
+pub fn find_pi() -> Option<PathBuf> {
+    if let Ok(bin) = std::env::var("KILN_PI_BIN") {
+        if !bin.is_empty() {
+            let p = PathBuf::from(bin);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join("pi");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Options for one `pi --mode rpc` child.
+#[derive(Debug, Clone)]
+pub struct PiRpcOptions {
+    /// Working directory the agent operates in.
+    pub cwd: PathBuf,
+    /// pi provider name to select (the `kiln pi-setup` merge registers
+    /// `kiln-local`).
+    pub provider: String,
+    /// Model id under that provider — the id this server announces.
+    pub model: String,
+    /// Directory pi stores the session JSONL in. Keeping embedded runs
+    /// under a kiln-owned dir separates them from the user's own
+    /// `~/.pi/agent/sessions` and lets the trace layer index them.
+    pub session_dir: PathBuf,
+    /// Session display name (shows up in pi's session list / traces).
+    pub session_name: Option<String>,
+    /// Optional tool allowlist (`--tools read,bash,edit,write`).
+    pub tools: Option<Vec<String>>,
+    /// Optional thinking level (`--thinking low|medium|high|...`).
+    pub thinking_level: Option<String>,
+}
+
+/// A line pi emitted on stdout, parsed.
+#[derive(Debug)]
+pub enum PiRpcLine {
+    /// A well-formed JSON record (response or agent event).
+    Json(serde_json::Value),
+    /// stdout closed — the child exited or killed its pipe.
+    Eof,
+}
+
+/// Handle to a running `pi --mode rpc` child. Dropping the handle does
+/// not kill the child — call [`PiRpcProcess::shutdown`].
+pub struct PiRpcProcess {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    pub lines: mpsc::Receiver<PiRpcLine>,
+}
+
+impl PiRpcProcess {
+    /// Spawn `pi --mode rpc` with piped stdio. stdout is pumped into
+    /// `lines` by a background task; stderr is drained into tracing.
+    pub fn spawn(pi_bin: &std::path::Path, opts: &PiRpcOptions) -> std::io::Result<Self> {
+        let mut cmd = Command::new(pi_bin);
+        cmd.arg("--mode")
+            .arg("rpc")
+            .arg("--provider")
+            .arg(&opts.provider)
+            .arg("--model")
+            .arg(&opts.model)
+            .arg("--session-dir")
+            .arg(&opts.session_dir);
+        if let Some(name) = &opts.session_name {
+            cmd.arg("--name").arg(name);
+        }
+        if let Some(tools) = &opts.tools {
+            if !tools.is_empty() {
+                cmd.arg("--tools").arg(tools.join(","));
+            }
+        }
+        if let Some(level) = &opts.thinking_level {
+            cmd.arg("--thinking").arg(level);
+        }
+        cmd.current_dir(&opts.cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn()?;
+        let stdout = child.stdout.take().expect("stdout piped above");
+        let stderr = child.stderr.take().expect("stderr piped above");
+        let stdin = child.stdin.take().expect("stdin piped above");
+
+        let (tx, rx) = mpsc::channel::<PiRpcLine>(256);
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            let mut buf = Vec::with_capacity(8 * 1024);
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        if let Some(value) = parse_rpc_line(&buf) {
+                            if tx.send(PiRpcLine::Json(value)).await.is_err() {
+                                return; // receiver gone — stop pumping
+                            }
+                        }
+                    }
+                }
+            }
+            let _ = tx.send(PiRpcLine::Eof).await;
+        });
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        let trimmed = line.trim_end();
+                        if !trimmed.is_empty() {
+                            tracing::debug!(target: "pi_rpc", stderr = %trimmed, "pi stderr");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            lines: rx,
+        })
+    }
+
+    /// Send one RPC command (a JSON object) as a single LF-terminated line.
+    pub async fn send(&mut self, command: &serde_json::Value) -> std::io::Result<()> {
+        let Some(stdin) = self.stdin.as_mut() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "pi stdin already closed",
+            ));
+        };
+        let mut line = serde_json::to_vec(command)?;
+        line.push(b'\n');
+        stdin.write_all(&line).await?;
+        stdin.flush().await
+    }
+
+    /// Graceful shutdown: close stdin (pi exits on EOF), wait up to
+    /// `grace`, then kill. Always reaps the child.
+    pub async fn shutdown(mut self, grace: std::time::Duration) {
+        drop(self.stdin.take());
+        match tokio::time::timeout(grace, self.child.wait()).await {
+            Ok(_) => {}
+            Err(_) => {
+                let _ = self.child.start_kill();
+                let _ = self.child.wait().await;
+            }
+        }
+    }
+}
+
+/// Parse one raw record: strip the LF delimiter and an optional
+/// trailing CR, then parse JSON. Non-JSON lines (startup chatter,
+/// partial writes at kill time) are dropped with a debug log.
+fn parse_rpc_line(raw: &[u8]) -> Option<serde_json::Value> {
+    let mut slice = raw;
+    if slice.last() == Some(&b'\n') {
+        slice = &slice[..slice.len() - 1];
+    }
+    if slice.last() == Some(&b'\r') {
+        slice = &slice[..slice.len() - 1];
+    }
+    if slice.is_empty() {
+        return None;
+    }
+    match serde_json::from_slice::<serde_json::Value>(slice) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::debug!(error = %e, line = %String::from_utf8_lossy(slice), "pi rpc: non-JSON stdout line dropped");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_strips_lf_and_crlf() {
+        let v = parse_rpc_line(b"{\"type\":\"agent_start\"}\n").unwrap();
+        assert_eq!(v["type"], "agent_start");
+        let v = parse_rpc_line(b"{\"type\":\"agent_end\"}\r\n").unwrap();
+        assert_eq!(v["type"], "agent_end");
+    }
+
+    #[test]
+    fn parse_keeps_unicode_line_separators_inside_strings() {
+        // U+2028 inside a JSON string is data, not a record delimiter.
+        let raw = "{\"type\":\"message_end\",\"text\":\"a\u{2028}b\"}\n";
+        let v = parse_rpc_line(raw.as_bytes()).unwrap();
+        assert_eq!(v["text"], "a\u{2028}b");
+    }
+
+    #[test]
+    fn parse_drops_empty_and_garbage_lines() {
+        assert!(parse_rpc_line(b"\n").is_none());
+        assert!(parse_rpc_line(b"\r\n").is_none());
+        assert!(parse_rpc_line(b"pi starting up...\n").is_none());
+    }
+
+    #[test]
+    fn find_pi_honors_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let fake = dir.path().join("pi");
+        std::fs::write(&fake, "#!/bin/sh\n").unwrap();
+        // Env mutation: serialize against other tests via a lock-free
+        // convention — this test is the only one touching KILN_PI_BIN.
+        unsafe { std::env::set_var("KILN_PI_BIN", &fake) };
+        let found = find_pi();
+        unsafe { std::env::remove_var("KILN_PI_BIN") };
+        assert_eq!(found, Some(fake));
+    }
+}

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1435,6 +1435,9 @@ pub struct AppState {
     /// so the cadence survives restarts; surfaced via /health.
     pub self_improve_scheduler:
         Arc<std::sync::RwLock<Option<SelfImproveSchedulerStatus>>>,
+    /// Embedded pi agent runs — the server-driven rollout engine
+    /// (`/v1/agent/runs`). Records persist under `<adapter_dir>/agent_runs/`.
+    pub agent_runs: Arc<crate::agent_runs::AgentRunRegistry>,
     /// Last adapter load failure by adapter name. Used by the registry so
     /// automation can distinguish "not loaded" from "failed to load".
     pub adapter_load_errors: Arc<std::sync::RwLock<HashMap<String, String>>>,
@@ -1700,6 +1703,9 @@ impl AppState {
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             mtp_acceptance: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             self_improve_scheduler: Arc::new(std::sync::RwLock::new(None)),
+            agent_runs: Arc::new(crate::agent_runs::AgentRunRegistry::new(PathBuf::from(
+                "adapters",
+            ))),
             adapter_load_errors: Arc::new(std::sync::RwLock::new(HashMap::new())),
             adapter_swap_lock: Arc::new(tokio::sync::Mutex::new(())),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
@@ -2347,6 +2353,9 @@ impl AppState {
                 decode_batcher,
             }),
             tokenizer: Arc::new(tokenizer),
+            agent_runs: Arc::new(crate::agent_runs::AgentRunRegistry::new(
+                adapter_dir.clone(),
+            )),
             adapter_dir,
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             loaded_adapter_name: Arc::new(std::sync::RwLock::new(None)),

--- a/crates/kiln-server/src/ui/app.js
+++ b/crates/kiln-server/src/ui/app.js
@@ -117,7 +117,7 @@ function pushSubTabHash(pageName) {
 // --- Drill-modal hash bookkeeping (see the state machine above) --------
 // Whether WE minted the history entry for the currently-open modal of each
 // kind; decides between history.back() and replaceState on user close.
-const modalHashPushed = { eval: false, train: false, adapter: false, request: false, trace: false };
+const modalHashPushed = { eval: false, train: false, adapter: false, request: false, trace: false, run: false };
 
 function modalHashOnOpen(kind, hash, alreadyOpen = false) {
   if (hashWriteDepth > 0 || !history.pushState) { modalHashPushed[kind] = false; return; }
@@ -408,7 +408,7 @@ function applyHashRoute(opts = {}) {
   }
   let sub = segs[1] || null;
   let id = segs[2] || null;
-  let drill = null; // { kind: 'eval'|'train'|'adapter'|'request', id }
+  let drill = null; // { kind: 'eval'|'train'|'adapter'|'request'|'trace'|'run', id }
   withHashWritesSuppressed(() => {
     // Re-activating an already-active page would re-fire its lazy refreshes
     // on every sub-tab/modal traversal — only switch when actually needed.
@@ -425,10 +425,12 @@ function applyHashRoute(opts = {}) {
         sub = activeSubTab(name);
         id = null;
       }
-      // Drill ids ride on training/queue, evals/jobs, and distill/traces.
+      // Drill ids ride on training/queue, evals/jobs, distill/traces, and
+      // distill/runs.
       if (name === 'training' && sub === 'queue' && id) drill = { kind: 'train', id };
       else if (name === 'evals' && sub === 'jobs' && id) drill = { kind: 'eval', id };
       else if (name === 'distill' && sub === 'traces' && id) drill = { kind: 'trace', id };
+      else if (name === 'distill' && sub === 'runs' && id) drill = { kind: 'run', id };
       else id = null;
     } else if (name === 'adapters' && sub) {
       // #adapters/{name} — the second segment is a drill id, not a sub-tab.
@@ -452,7 +454,7 @@ function applyHashRoute(opts = {}) {
   if (history.replaceState && location.hash !== canonical) history.replaceState(null, '', canonical);
 }
 
-// Open/close the five drill modals so they match the route. Closes here are
+// Open/close the six drill modals so they match the route. Closes here are
 // direct (never history.back()): this runs FROM a traversal or boot, where
 // the URL is already where it should be. Opens run hash-suppressed by the
 // caller, so the open fns' own pushState helpers stay quiet. Each modal's
@@ -516,6 +518,16 @@ function syncDrillModalsToRoute(drill) {
     } else if (openId !== null) {
       modalHashPushed.trace = false;
       closeTraceDrillModal();
+    }
+  }
+  const runModal = document.getElementById('run-drill-modal');
+  if (runModal) {
+    const openId = runModal.hidden ? null : (runDrillId || null);
+    if (want.kind === 'run') {
+      if (openId !== want.id) openRunDrillModal(want.id);
+    } else if (openId !== null) {
+      modalHashPushed.run = false;
+      closeRunDrillModal();
     }
   }
 }
@@ -9469,6 +9481,8 @@ function refreshActiveDistillSubTab() {
     refreshLibraryList();
   } else if (active === 'traces') {
     refreshAgentTraces();
+  } else if (active === 'runs') {
+    refreshAgentRuns();
   } else if (active === 'preflight') {
     refreshPreflightSurfaces();
   }
@@ -10204,6 +10218,392 @@ function renderTraceDrillBody(t) {
     ${conversationHtml}
   </div>`;
 }
+
+/* =====================================================================
+   Agent runs — the embedded pi run engine (/v1/agent/runs). Submit a
+   task, watch the live event feed, steer / follow up / abort mid-flight.
+   Every finished run leaves a pi session the Agent traces tab can
+   distill from.
+   ===================================================================== */
+const AGENT_RUN_TERMINAL = new Set(['completed', 'failed', 'aborted', 'timed_out', 'interrupted']);
+
+// queued/running/completed/failed map straight onto the job-state-pill
+// palette; the run-only terminals reuse the closest existing tone (no
+// new CSS): aborted/interrupted read as cancelled, timed_out as failed.
+function agentRunPill(status) {
+  const s = String(status || 'queued');
+  let cls = (s === 'aborted' || s === 'interrupted') ? 'cancelled' : (s === 'timed_out' ? 'failed' : s);
+  // The status lands in a class attribute — only known tokens pass (an
+  // unexpected server value must not write arbitrary attribute text).
+  if (!/^[a-z_]+$/.test(cls)) cls = 'queued';
+  return `<span class="job-state-pill ${cls}">${escapeHtml(s.replace(/_/g, ' '))}</span>`;
+}
+
+// List the run engine's status line + run history — fired on tab entry
+// and every 3s while the pane is visible.
+async function refreshAgentRuns() {
+  const statusNode = document.getElementById('agent-runs-status');
+  const node = document.getElementById('agent-runs-list');
+  if (!node) return;
+  const startBtn = document.getElementById('agent-run-start');
+  try {
+    const st = await api('/v1/agent/runs/status');
+    const ready = st.enabled && st.pi_available;
+    let line;
+    if (!st.enabled) {
+      line = `Embedded runs are disabled — ${escapeHtml(st.disabled_reason || 'gate closed')}.`;
+    } else if (!st.pi_available) {
+      line = 'Embedded runs need <code>pi</code> on the server’s PATH — <code>npm install -g @earendil-works/pi-coding-agent</code>, then come back here.';
+    } else {
+      line = `Run engine ready — pi at <code>${escapeHtml(st.pi_path || '')}</code> · ${st.active_runs}/${st.max_concurrent_runs} active · sessions land in <code>${escapeHtml(st.sessions_dir || '')}</code>.`;
+    }
+    // The key carries every field the line renders, or a changed
+    // disabled_reason/path would paint stale.
+    setListHtml(statusNode, 'status:' + JSON.stringify([st.enabled, st.disabled_reason, st.pi_available, st.pi_path, st.sessions_dir, st.active_runs, st.max_concurrent_runs]), line);
+    if (startBtn) startBtn.disabled = !ready;
+  } catch (e) {
+    setListHtml(statusNode, 'statuserr:' + e.message, `Couldn't reach the run engine: ${escapeHtml(e.message)}`);
+  }
+  try {
+    const res = await api('/v1/agent/runs');
+    renderAgentRunsList(res.runs || []);
+  } catch (e) {
+    setListHtml(node, 'err:' + e.message, `<div class="empty">Couldn't load runs: ${escapeHtml(e.message)}</div>`);
+  }
+}
+
+function renderAgentRunsList(runs) {
+  const node = document.getElementById('agent-runs-list');
+  if (!node) return;
+  if (runs.length === 0) {
+    setListHtml(node, 'empty',
+      '<div class="empty">No runs yet. Describe a task above and start one — every run saves a pi session you can distill from.</div>');
+    return;
+  }
+  // The minute bucket keeps the relative "Nm ago" stamps moving — the
+  // setListHtml key must change whenever rendered content would.
+  const listKey = 'list:' + Math.floor(Date.now() / 60000) + ':' +
+    JSON.stringify(runs.map(r => [r.id, r.status, r.num_turns, r.num_tool_calls, r.finished_unix_ms]));
+  const cards = runs.map(r => {
+    const task = String(r.task || '');
+    const preview = task.length > 90 ? task.slice(0, 90) + '…' : task;
+    const errLine = (r.status === 'failed' || r.status === 'timed_out') && r.error
+      ? `<div style="font-size:var(--text-2xs); color:var(--danger-fg); margin-top:var(--space-1);">${escapeHtml(String(r.error).length > 160 ? String(r.error).slice(0, 160) + '…' : String(r.error))}</div>`
+      : '';
+    return `<button type="button" class="adapter-card" data-run-open="${escapeHtml(r.id || '')}" style="display:block; width:100%; text-align:left; font:inherit; color:inherit; margin-bottom:var(--space-2);" title="Open this run — watch the live event feed, steer it, or read how it ended">
+      <div style="display:flex; gap:var(--space-3); align-items:baseline; flex-wrap:wrap;">
+        <span style="font-weight:600; font-family:var(--font-mono); font-size:var(--text-xs);">${escapeHtml(shortId(r.id))}</span>
+        ${agentRunPill(r.status)}
+        ${r.label ? `<span class="hint">${escapeHtml(r.label)}</span>` : ''}
+        <span style="margin-left:auto; font-size:var(--text-2xs); color:var(--text-muted);">${escapeHtml(fmtSmartTime(r.created_unix_ms))}</span>
+      </div>
+      <div style="font-size:var(--text-xs); margin-top:var(--space-1);">${escapeHtml(preview)}</div>
+      <div style="font-size:var(--text-xs); color:var(--text-muted);">${r.num_turns || 0} turns · ${r.num_tool_calls || 0} tool calls · ${escapeHtml(r.cwd || '')}</div>
+      ${errLine}
+    </button>`;
+  }).join('');
+  if (setListHtml(node, listKey, cards)) {
+    node.querySelectorAll('[data-run-open]').forEach(btn => {
+      btn.addEventListener('click', () => openRunDrillModal(btn.dataset.runOpen));
+    });
+  }
+}
+
+// New-run form: POST /v1/agent/runs, then drill straight into the run.
+async function submitAgentRun() {
+  const taskEl = document.getElementById('agent-run-task');
+  const task = (taskEl?.value || '').trim();
+  if (!task) { toast('Describe a task for the agent first', 'err'); taskEl?.focus(); return; }
+  const cwd = (document.getElementById('agent-run-cwd')?.value || '').trim();
+  const label = (document.getElementById('agent-run-label')?.value || '').trim();
+  const body = { task };
+  if (cwd) body.cwd = cwd;
+  if (label) body.label = label;
+  const startBtn = document.getElementById('agent-run-start');
+  if (startBtn) startBtn.disabled = true;
+  try {
+    const rec = await api('/v1/agent/runs', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify(body),
+    });
+    if (taskEl) taskEl.value = '';
+    toast(`Run ${shortId(rec.id)} queued`, 'ok');
+    refreshAgentRuns();
+    openRunDrillModal(rec.id);
+  } catch (e) {
+    toast(e.message, 'err');
+  } finally {
+    // refreshAgentRuns re-applies the status gate on its next pass.
+    if (startBtn) startBtn.disabled = false;
+  }
+}
+document.getElementById('agent-run-start')?.addEventListener('click', submitAgentRun);
+document.getElementById('agent-run-task')?.addEventListener('keydown', (ev) => {
+  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); submitAgentRun(); }
+});
+
+// Keep the list live while the runs pane is showing — gated on the pane
+// AND the Distill page being frontmost, mirroring the eval-badge pattern
+// of visibility-gated background intervals.
+setInterval(() => {
+  const pane = document.getElementById('distill-tab-runs-pane');
+  if (!pane || pane.hidden) return;
+  if (!document.getElementById('page-distill')?.classList.contains('active')) return;
+  refreshAgentRuns();
+}, 3000);
+
+/* =====================================================================
+   Agent run drill-in modal — live event feed (1s ?after= cursor polls)
+   + steer / follow-up / abort for one embedded run.
+   ===================================================================== */
+let runDrillId = null;
+let runDrillCursor = 0;
+let runDrillStatus = null;
+let runDrillPollHandle = null;
+// Generation token: bumped on every open AND close. Post-await guards
+// compare against it instead of the run id — id equality can't tell
+// "same run, new modal session" apart, which let a stale in-flight poll
+// regress the fresh cursor or leak a second interval on quick
+// close-then-reopen of the same run.
+let runDrillGen = 0;
+// In-flight guard: a poll that outlives its 1s slot must not overlap
+// the next one — overlapping polls share a cursor and append the same
+// events twice (this feed appends; it can't repaint idempotently).
+let runDrillPollBusy = false;
+
+const RUN_EVENT_CLAMP_CHARS = 400;
+const RUN_TEXT_CLAMP_CHARS = 700;
+
+function runEventClamp(text, limit) {
+  const s = String(text ?? '');
+  return s.length > limit ? s.slice(0, limit) + '…' : s;
+}
+
+// Run ids ride the #distill/runs/{id} deep-link grammar like the other
+// drills.
+async function openRunDrillModal(id) {
+  const gen = ++runDrillGen;
+  runDrillId = id;
+  modalHashOnOpen('run', '#distill/runs/' + encodeURIComponent(id));
+  const modal = document.getElementById('run-drill-modal');
+  if (!modal) return;
+  modal.hidden = false;
+  openModal(modal, { onClose: userCloseRunDrillModal });
+  document.getElementById('run-drill-title').textContent = 'Agent run';
+  document.getElementById('run-drill-meta').textContent = id;
+  const feed = document.getElementById('run-drill-events');
+  feed.innerHTML = '<div class="detail-empty">Loading…</div>';
+  delete feed.dataset.gapNoted;
+  runDrillCursor = 0;
+  runDrillStatus = null;
+  runDrillPollBusy = false;
+  if (runDrillPollHandle) { clearInterval(runDrillPollHandle); runDrillPollHandle = null; }
+  let rec;
+  try {
+    rec = await api('/v1/agent/runs/' + encodeURIComponent(id));
+    if (gen !== runDrillGen) return; // closed or re-targeted while fetching
+    renderRunDrillHead(rec);
+  } catch (e) {
+    if (gen !== runDrillGen) return;
+    feed.innerHTML = `<div class="detail-empty">Couldn't load this run: ${escapeHtml(e.message)}</div>`;
+    return;
+  }
+  feed.innerHTML = '';
+  await pollRunDrillEvents(gen);
+  if (gen !== runDrillGen) return;
+  // A run that's already over still owes the reader its ending — the
+  // live path appends the error on the status flip, but a deep link or
+  // reopen arrives after the flip already happened.
+  if (AGENT_RUN_TERMINAL.has(rec.status) && rec.error) {
+    feed.insertAdjacentHTML('beforeend',
+      `<div class="req-section req-error"><div class="req-section-head">error</div><pre class="req-pre">${escapeHtml(runEventClamp(rec.error, RUN_EVENT_CLAMP_CHARS))}</pre></div>`);
+    feed.scrollTop = feed.scrollHeight;
+  }
+  if (!(runDrillStatus && AGENT_RUN_TERMINAL.has(runDrillStatus))) {
+    runDrillPollHandle = setInterval(() => pollRunDrillEvents(gen), 1000);
+  }
+}
+
+function renderRunDrillHead(rec) {
+  runDrillStatus = rec.status || null;
+  document.getElementById('run-drill-title').textContent = `Agent run ${shortId(rec.id)}`;
+  const bits = [`${rec.num_turns || 0} turns`, `${rec.num_tool_calls || 0} tool calls`];
+  if (rec.label) bits.push(rec.label);
+  if (rec.cwd) bits.push(rec.cwd);
+  document.getElementById('run-drill-meta').innerHTML =
+    `${agentRunPill(rec.status)} <span class="hint" style="margin-left:8px;">${bits.map(b => escapeHtml(b)).join(' · ')}</span>`;
+  const abortBtn = document.getElementById('run-drill-abort');
+  if (abortBtn) abortBtn.disabled = AGENT_RUN_TERMINAL.has(rec.status);
+}
+
+async function pollRunDrillEvents(gen) {
+  if (gen !== runDrillGen) return;
+  if (runDrillPollBusy) return; // previous poll still in flight
+  const id = runDrillId;
+  if (!id) return;
+  const feed = document.getElementById('run-drill-events');
+  if (!feed) return;
+  runDrillPollBusy = true;
+  try {
+    const res = await api('/v1/agent/runs/' + encodeURIComponent(id) + '/events?after=' + runDrillCursor);
+    if (gen !== runDrillGen) return;
+    runDrillCursor = res.next_after ?? runDrillCursor;
+    // Auto-scroll only when the user is already reading the bottom — a
+    // scrolled-up reader keeps their place while events keep landing.
+    const atBottom = feed.scrollHeight - feed.scrollTop - feed.clientHeight < 40;
+    if (res.truncated && !feed.dataset.gapNoted) {
+      feed.dataset.gapNoted = '1';
+      feed.insertAdjacentHTML('beforeend',
+        '<div style="font-size:var(--text-2xs); color:var(--text-muted);">… earlier events are no longer buffered (long run or server restart) — the full trajectory lives in the session trace …</div>');
+    }
+    const html = (res.events || []).map(item => renderRunEvent(item.event)).filter(Boolean).join('');
+    if (html) feed.insertAdjacentHTML('beforeend', html);
+    if (atBottom) feed.scrollTop = feed.scrollHeight;
+    if (res.status && res.status !== runDrillStatus) {
+      // Status flipped (queued→running or →terminal): re-pull the record
+      // so the header pill, counts, and error are fresh.
+      try {
+        const rec = await api('/v1/agent/runs/' + encodeURIComponent(id));
+        if (gen !== runDrillGen) return;
+        renderRunDrillHead(rec);
+        if (AGENT_RUN_TERMINAL.has(rec.status) && rec.error) {
+          feed.insertAdjacentHTML('beforeend',
+            `<div class="req-section req-error"><div class="req-section-head">error</div><pre class="req-pre">${escapeHtml(runEventClamp(rec.error, RUN_EVENT_CLAMP_CHARS))}</pre></div>`);
+          if (atBottom) feed.scrollTop = feed.scrollHeight;
+        }
+      } catch {
+        // Record fetch is best-effort, but the status flip must still
+        // land — on a terminal flip there IS no next poll to catch up.
+        runDrillStatus = res.status;
+        const pill = document.querySelector('#run-drill-meta .job-state-pill');
+        if (pill) pill.outerHTML = agentRunPill(res.status);
+        const abortBtn = document.getElementById('run-drill-abort');
+        if (abortBtn) abortBtn.disabled = AGENT_RUN_TERMINAL.has(res.status);
+      }
+    }
+    if (res.status && AGENT_RUN_TERMINAL.has(res.status) && runDrillPollHandle) {
+      clearInterval(runDrillPollHandle);
+      runDrillPollHandle = null;
+    }
+  } catch (e) {
+    // Run vanished (e.g. server restart): stop hammering the endpoint.
+    if (gen === runDrillGen && e.status === 404 && runDrillPollHandle) {
+      clearInterval(runDrillPollHandle);
+      runDrillPollHandle = null;
+    }
+  } finally {
+    runDrillPollBusy = false;
+  }
+}
+
+// One pi agent event → one compact feed line (or '' for noise).
+function renderRunEvent(ev) {
+  if (!ev || typeof ev !== 'object') return '';
+  const ty = ev.type || '';
+  const dim = (text) => `<div style="font-size:var(--text-2xs); color:var(--text-muted);">${escapeHtml(text)}</div>`;
+  if (ty === 'agent_start') return dim('— agent start —');
+  if (ty === 'agent_end') return dim('— agent end —');
+  if (ty === 'kiln_note') return dim('kiln: ' + (ev.note || ''));
+  if (ty === 'message_end') {
+    const msg = ev.message || {};
+    if (msg.role !== 'assistant') return '';
+    const blocks = Array.isArray(msg.content) ? msg.content : [];
+    const parts = blocks.map(b => {
+      if (!b || typeof b !== 'object') return '';
+      if (b.type === 'text' && b.text) {
+        return `<pre class="req-pre">${escapeHtml(runEventClamp(b.text, RUN_TEXT_CLAMP_CHARS))}</pre>`;
+      }
+      if (b.type === 'thinking' && b.thinking) {
+        return `<div><div style="font-size:var(--text-2xs); color:var(--text-muted); text-transform:uppercase; letter-spacing:var(--tracking-caps); margin-bottom:4px;">thinking</div><pre class="req-pre">${escapeHtml(runEventClamp(b.thinking, RUN_EVENT_CLAMP_CHARS))}</pre></div>`;
+      }
+      return ''; // toolCall blocks are covered by tool_execution_start
+    }).filter(Boolean).join('');
+    if (!parts) return '';
+    return `<div class="req-section"><div class="req-section-head">assistant</div>${parts}</div>`;
+  }
+  if (ty === 'tool_execution_start') {
+    let args = '';
+    try { args = JSON.stringify(ev.args ?? {}); } catch { args = String(ev.args ?? ''); }
+    return `<div style="font-family:var(--font-mono); font-size:var(--text-xs); color:var(--text-muted);">→ ${escapeHtml(ev.toolName || '?')}(${escapeHtml(runEventClamp(args, 160))})</div>`;
+  }
+  if (ty === 'tool_execution_end') {
+    let result = ev.result;
+    if (result != null && typeof result !== 'string') {
+      try { result = JSON.stringify(result); } catch { result = String(result); }
+    }
+    return `<div class="req-section${ev.isError ? ' req-error' : ''}"><div class="req-section-head">${escapeHtml(ev.toolName || 'tool')}${ev.isError ? ' · error' : ''}</div><pre class="req-pre">${escapeHtml(runEventClamp(result || '', RUN_EVENT_CLAMP_CHARS))}</pre></div>`;
+  }
+  if (ty === 'response') {
+    if (ev.success === false) {
+      return `<div class="req-section req-error"><div class="req-section-head">${escapeHtml(ev.command || 'command')} failed</div><pre class="req-pre">${escapeHtml(runEventClamp(ev.error || JSON.stringify(ev), RUN_EVENT_CLAMP_CHARS))}</pre></div>`;
+    }
+    return '';
+  }
+  return '';
+}
+
+function closeRunDrillModal() {
+  runDrillGen++; // invalidate any in-flight fetches from this session
+  runDrillId = null;
+  runDrillCursor = 0;
+  runDrillStatus = null;
+  runDrillPollBusy = false;
+  if (runDrillPollHandle) { clearInterval(runDrillPollHandle); runDrillPollHandle = null; }
+  const modal = document.getElementById('run-drill-modal');
+  if (!modal) return;
+  const feed = document.getElementById('run-drill-events');
+  if (feed) delete feed.dataset.gapNoted;
+  modal.hidden = true;
+  closeModal(modal);
+}
+// User-initiated close (X / backdrop / Esc): walk history per the
+// deep-link state machine, exactly like the other drills.
+function userCloseRunDrillModal() {
+  modalHashOnUserClose('run', '#distill/runs', closeRunDrillModal);
+}
+document.getElementById('run-drill-close')?.addEventListener('click', userCloseRunDrillModal);
+document.getElementById('run-drill-modal')?.addEventListener('click', ev => {
+  if (ev.target.id === 'run-drill-modal') userCloseRunDrillModal();
+});
+
+// Steer interrupts the current turn; Follow-up queues after agent_end.
+// Both share the one input row at the bottom of the modal.
+async function sendRunDrillMessage(endpoint, verb) {
+  const id = runDrillId;
+  if (!id) return;
+  const input = document.getElementById('run-drill-steer-input');
+  const message = (input?.value || '').trim();
+  if (!message) { toast(`Type a message to ${verb.toLowerCase()} with first`, 'err'); input?.focus(); return; }
+  try {
+    await api('/v1/agent/runs/' + encodeURIComponent(id) + '/' + endpoint, {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ message }),
+    });
+    if (input) input.value = '';
+    toast(`${verb} queued`, 'ok');
+  } catch (e) {
+    toast(e.message, 'err');
+  }
+}
+document.getElementById('run-drill-steer-send')?.addEventListener('click', () => sendRunDrillMessage('steer', 'Steer'));
+document.getElementById('run-drill-followup-send')?.addEventListener('click', () => sendRunDrillMessage('follow_up', 'Follow-up'));
+document.getElementById('run-drill-steer-input')?.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Enter') { ev.preventDefault(); sendRunDrillMessage('steer', 'Steer'); }
+});
+
+document.getElementById('run-drill-abort')?.addEventListener('click', async () => {
+  const id = runDrillId;
+  if (!id) return;
+  if (!confirm('Abort this run? pi stops at the next opportunity.')) return;
+  try {
+    await api('/v1/agent/runs/' + encodeURIComponent(id) + '/abort', { method: 'POST' });
+    toast('Abort requested', 'ok');
+  } catch (e) {
+    toast(e.message, 'err');
+  }
+});
 
 // --- Preflight (/v1/preflight/*) ------------------------------------
 async function refreshPreflightSurfaces() {

--- a/crates/kiln-server/src/ui/index.html
+++ b/crates/kiln-server/src/ui/index.html
@@ -1068,6 +1068,35 @@
   </div>
 
   <!-- =================================================================
+       Agent run drill-in modal — live event feed + steer / follow-up /
+       abort for one embedded pi run
+       ================================================================= -->
+  <div id="run-drill-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="run-drill-title">
+    <div class="modal-shell" tabindex="-1">
+      <div class="modal-head">
+        <h2 id="run-drill-title">Agent run</h2>
+        <span class="modal-meta" id="run-drill-meta"></span>
+        <button class="btn btn-sm btn-danger" id="run-drill-abort" type="button" title="Abort this run — pi stops at the next opportunity"><svg class="icn icn-sm" aria-hidden="true"><use href="#i-stop"></use></svg> Abort</button>
+        <button class="modal-close" id="run-drill-close" aria-label="Close"><svg class="icn" aria-hidden="true"><use href="#i-close"></use></svg></button>
+      </div>
+      <div class="modal-body" style="grid-template-columns: 1fr;">
+        <div class="modal-content" id="run-drill-content">
+          <div class="req-detail" id="run-drill-events" style="flex: 1 1 auto;">
+            <div class="detail-empty">Loading…</div>
+          </div>
+          <div style="display: flex; gap: var(--space-2); padding: var(--space-3) var(--space-5); border-top: 1px solid var(--border); flex-shrink: 0;">
+            <input type="text" id="run-drill-steer-input" style="flex: 1 1 auto;"
+                   placeholder="Message for the agent — Steer interrupts the current turn, Follow-up queues after it"
+                   aria-label="Message to steer or follow up the run">
+            <button type="button" class="btn btn-sm" id="run-drill-steer-send" title="Interrupt the agent with this message now">Steer</button>
+            <button type="button" class="btn btn-sm" id="run-drill-followup-send" title="Queue this message as a follow-up task once the current one finishes">Follow-up</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =================================================================
        Adapter drill-in modal
        ================================================================= -->
   <div id="adapter-drill-modal" class="modal-backdrop" hidden role="dialog" aria-modal="true" aria-labelledby="adapter-drill-title">
@@ -1152,6 +1181,7 @@
         <button class="tab" id="distill-tab-cache" data-tab="cache" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-cache-pane" aria-describedby="distill-tab-cache-desc" tabindex="-1" title="On-disk logit cache">Cache</button>
         <button class="tab" id="distill-tab-library" data-tab="library" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-library-pane" aria-describedby="distill-tab-library-desc" tabindex="-1" title="Browse, install & publish adapters">Library</button>
         <button class="tab" id="distill-tab-traces" data-tab="traces" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-traces-pane" aria-describedby="distill-tab-traces-desc" tabindex="-1" title="Import pi agent sessions for distillation">Agent traces</button>
+        <button class="tab" id="distill-tab-runs" data-tab="runs" type="button" role="tab" aria-selected="false" aria-controls="distill-tab-runs-pane" aria-describedby="distill-tab-runs-desc" tabindex="-1" title="Run pi tasks on this server and watch them live">Agent runs</button>
       </div>
 
       <!-- Accessible descriptions for the tabs whose only explanation was a
@@ -1166,6 +1196,7 @@
         <span id="distill-tab-refresh-desc">Refresh an adapter on new data (continual learning).</span>
         <span id="distill-tab-self-desc">Self-improve via self-distillation.</span>
         <span id="distill-tab-merge-desc">Behaviour-space LoRA merge.</span>
+        <span id="distill-tab-runs-desc">Run pi tasks on this server and watch them live.</span>
       </div>
 
       <!-- =================================================================
@@ -1597,6 +1628,38 @@
         </div>
         <div id="agent-traces-list">
           <div class="empty">No pi sessions discovered yet. Use pi against this server, then scan to find the sessions it saved.</div>
+        </div>
+      </div>
+
+      <!-- =================================================================
+           Agent runs — embedded pi run engine (/v1/agent/runs)
+           ================================================================= -->
+      <div class="tab-content" id="distill-tab-runs-pane" role="tabpanel" aria-labelledby="distill-tab-runs" hidden inert>
+        <div class="card-head" style="border:none; padding:0; margin-bottom: var(--space-3);">
+          <h3 style="font-size: var(--text-lg);">Embedded pi runs</h3>
+          <span class="eyebrow">Server-driven rollouts &middot; steer, follow up, abort</span>
+        </div>
+        <div class="form-help" id="agent-runs-status" style="margin-bottom: var(--space-3);">Checking the run engine&hellip;</div>
+        <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-2); flex-wrap: wrap; align-items: center;">
+          <textarea id="agent-run-task" rows="3" style="flex: 1 1 100%;"
+                    placeholder="Task for pi — e.g. run the test suite and fix the first failure (Ctrl+Enter starts the run)"
+                    title="The task prompt handed to pi. Ctrl+Enter starts the run."
+                    aria-label="Task for the agent run"></textarea>
+        </div>
+        <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-3); flex-wrap: wrap; align-items: center;">
+          <input type="text" id="agent-run-cwd" style="flex: 1 1 280px;"
+                 placeholder="Working directory — empty uses the server&rsquo;s cwd"
+                 title="Directory the agent runs in. Leave empty to use the server's working directory."
+                 aria-label="Working directory for the run">
+          <input type="text" id="agent-run-label" style="flex: 0 1 200px;"
+                 placeholder="Label (optional)"
+                 title="Free-form grouping label, e.g. a rollout batch name"
+                 aria-label="Grouping label for the run">
+          <button type="button" class="btn btn-sm btn-primary" id="agent-run-start" title="Queue this task on the embedded pi run engine">Start run</button>
+        </div>
+        <div class="form-help" style="margin-bottom: var(--space-3);">Each run is a full pi session driven by this server — watch it live, steer it mid-flight, and distill from the trace it leaves behind.</div>
+        <div id="agent-runs-list">
+          <div class="empty">No runs yet. Describe a task above and start one — every run saves a pi session you can distill from.</div>
         </div>
       </div>
 

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -140,6 +140,12 @@ draft_layers = 8                      # First N layers used as draft model
 # # Run the self_improve loop every N hours (168 = weekly). The first run
 # # fires one full interval after startup — never at boot.
 # self_improve_interval_hours = 168
+# # Embedded pi runs (POST /v1/agent/runs): the server drives pi itself,
+# # streams the trajectory live, and auto-indexes finished sessions into
+# # the agent-trace layer. Enabled on loopback binds by default;
+# # KILN_AGENT_RUNS=1 opts in on network binds, =0 force-disables.
+# max_concurrent_runs = 2       # runs executing at once (FIFO queue)
+# run_timeout_secs = 900        # wall-clock cap per run (abort + index partial)
 # # Optional request overrides (same shape as POST /v1/agent/self_improve).
 # # Add post_eval to gate every scheduled round behind §8.7 promotion:
 # # auto-load defers until the eval passes; failures demote to <name>.failed.

--- a/scripts/check_server_ui_smoke.mjs
+++ b/scripts/check_server_ui_smoke.mjs
@@ -2428,7 +2428,7 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     }));
     if (connectHomeState.selected !== 'true' || !connectHomeState.paneActive) fail('Home should return the connect tabs to pi with its pane visible');
 
-    // Distill: the headline fix. Its 11 sub-tabs were completely
+    // Distill: the headline fix. Its 12 sub-tabs were completely
     // unreachable by keyboard (roving tabindex=-1 with no arrow-key
     // handler). Arrows now activate them, the decorative group
     // labels/separators inside the tablist are skipped, and — per the
@@ -2467,13 +2467,13 @@ async function runSmoke(baseUrl, { expectFailureStates = false, expectEmptyAdapt
     await page.keyboard.press('ArrowRight');
     await expectActivePageAndHash(page, 'distill', 'ArrowRight from Merge should skip the group label/separator spans and land on Teachers', '#distill/teachers');
     await page.keyboard.press('End');
-    await expectActivePageAndHash(page, 'distill', 'End should jump to the last distill tab (Agent traces)', '#distill/traces');
-    const tracesPaneVisible = await page.evaluate(() => {
-      const pane = document.getElementById('distill-tab-traces-pane');
+    await expectActivePageAndHash(page, 'distill', 'End should jump to the last distill tab (Agent runs)', '#distill/runs');
+    const runsPaneVisible = await page.evaluate(() => {
+      const pane = document.getElementById('distill-tab-runs-pane');
       const rect = pane?.getBoundingClientRect();
       return Boolean(pane && !pane.hidden && rect && rect.width > 0 && rect.height > 0);
     });
-    if (!tracesPaneVisible) fail('End should reveal the Agent traces pane');
+    if (!runsPaneVisible) fail('End should reveal the Agent runs pane');
     await page.keyboard.press('Home');
     await expectActivePageAndHash(page, 'distill', 'Home should jump back to the first distill tab', '#distill/opd');
 


### PR DESCRIPTION
## What

kiln now embeds pi instead of only serving it. The server spawns `pi --mode rpc` as a managed child pointed at its own OpenAI-compatible endpoint, hands it a task, streams the trajectory live, and merges the finished session straight into the agent-trace layer the §10.6 flywheel reads. kiln can generate its own on-policy agentic rollouts on demand — no human at the keyboard.

## API

| Method | Path | Purpose |
|---|---|---|
| GET | `/v1/agent/runs/status` | Gate state, pi availability, capacity |
| POST | `/v1/agent/runs` | Start a run `{task, cwd?, label?, tools?, thinking_level?, timeout_secs?}` |
| GET | `/v1/agent/runs` (+`/{id}`) | Run records (status, counters, session link) |
| GET | `/v1/agent/runs/{id}/events?after=N` | Live event feed (inclusive cursor; pass `next_after` back; `truncated`/`first_available_seq` flag replay gaps) |
| POST | `/v1/agent/runs/{id}/steer` / `follow_up` / `abort` | Mid-run control (queued-run messages are buffered, delivered at start) |

- Runs queue FIFO: `[agent].max_concurrent_runs` (default 2), `run_timeout_secs` (default 900), 32-active backstop enforced atomically.
- Security: same posture as the embedded terminal — loopback binds only by default, `KILN_AGENT_RUNS=1`/`=0` override; the gate covers reads too (records/events carry prompts and raw tool output).
- Records persist to `<adapter_dir>/agent_runs/runs.json` (active runs come back `interrupted` after a restart); sessions are per-run dirs under `agent_runs/sessions/<run-id>/` and auto-merge into `agent_traces.json` via `locked_update` (rediscovery also sweeps them).
- Honest outcomes: a run whose final assistant turn errored reports `failed` with the error, not `completed`.

## Dashboard

Distill → **Agent runs**: launch form, live run list, drill modal with a 1s cursor-polled event feed (assistant text, tool calls/results, errors), steer/follow-up/abort, `#distill/runs/{id}` deep links on the shared modal/hash conventions.

## Hardening that came out of review

Multi-agent adversarial review (every finding independently verified before fixing): locked trace-index merges, serialized + atomic-rename pi-setup config writes (skip-if-unchanged kills the per-run backup litter), ordered runs.json persistence, queued-control buffering, session-fallback contamination guards, IPv6 self-URL bracketing, dedicated `agent_runs_at_capacity` 503, and a set of drill-modal lifecycle fixes (poll reentrancy, generation tokens, terminal-error rendering).

## Validation

- 579 kiln-server lib tests pass (10 new: RPC framing, full fake-pi run lifecycle incl. trace indexing, FIFO under concurrency cap, restart recovery, capacity backstop, IPv6 URLs).
- Live E2E against a mock-mode server with the real pi binary in an isolated $HOME: spawn → pi-setup merge → prompt → 10-event stream → `runs.json` persisted → session auto-indexed (`trace_indexed=true`, visible in `/v1/agent/traces`) → honest `failed` on the mock backend's streaming 501 → clean shutdown, no stray processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)