### PR TITLE
Restore multi-turn prefix caching on ROCm and the non-batched serve path

### DIFF
--- a/crates/kiln-model/src/backend/capability.rs
+++ b/crates/kiln-model/src/backend/capability.rs
@@ -344,10 +344,7 @@ impl MatmulRequest {
             self.rhs_shape[rank - 1],
             self.rhs_layout,
         );
-        Some((
-            [lhs.0, lhs.1],
-            [rhs.0, rhs.1],
-        ))
+        Some(([lhs.0, lhs.1], [rhs.0, rhs.1]))
     }
 
     pub fn rank(&self) -> Option<usize> {
@@ -377,7 +374,6 @@ impl MatmulRequest {
         }
         self.batch == MatmulBatchPolicy::from_leading_shape(&self.lhs_shape[..rank - 2])
     }
-
 }
 
 /// Attention operation family being queried.
@@ -1788,7 +1784,16 @@ impl DecodeBatcherPolicy {
                 direct_paged_decode_attention_env_gate: DecodeAttentionEnvGate::EnabledUnlessOff(
                     "KILN_ROCM_PAGED_DECODE",
                 ),
-                allow_prefix_cache_split_snapshot: false,
+                // Must stay true on every backend that serves chat traffic:
+                // without the prefill-split snapshot no block-aligned prefix
+                // entry ever registers, and RealPrefixCache strict-prefix
+                // lookups (entry len % block_size == 0) can never hit — every
+                // multi-turn agent request re-prefills its full history.
+                // 002af558 set this false while optimizing ROCm long-context
+                // prefill, trading one extra forward boundary + one ~27 MiB
+                // linear-state snapshot per request for a full re-prefill
+                // (40s+ at 16K tokens) on EVERY turn of every conversation.
+                allow_prefix_cache_split_snapshot: true,
                 paged_decode_requires_contiguous_kv_chunks: true,
                 use_greedy_token_decode: false,
                 use_native_sampled_contiguous_decode: false,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -19,8 +19,8 @@ use kiln_core::token::TokenId;
 use kiln_core::tokenizer::KilnTokenizer;
 
 use crate::backend::{
-    self, BackendIdentity, BackendRuntime, LinearBackend, ReplayBackend,
-    ResidencyBackend, SamplingBackend, StartupBackend, TrainingLossBackend,
+    self, BackendIdentity, BackendRuntime, LinearBackend, ReplayBackend, ResidencyBackend,
+    SamplingBackend, StartupBackend, TrainingLossBackend,
     capability::{
         BackendCapabilities, BackendCapabilityQueries, DecodeBatcherPolicy, ReplayNativePrimitive,
         ReplayRequest, Support, decode_hot_path_fallback_policy_for_backend,
@@ -2694,8 +2694,14 @@ impl ModelRunner {
                 &self.weights.embed_tokens.device(),
                 prefill_tokens.len(),
             );
-        let split_pos =
-            strict_prompt_prefix_split_pos(prompt_tokens.len(), cached_tokens, block_size);
+        // Same capability gate as the batching-engine path: the split
+        // snapshot is what makes multi-turn strict-prefix lookups possible
+        // (RealPrefixCache only serves longer prompts from block-aligned
+        // entries), so a backend opting out here opts out of multi-turn
+        // prefix caching entirely.
+        let split_pos = prefix_cache_split_snapshot_allowed(self.backend.as_ref())
+            .then(|| strict_prompt_prefix_split_pos(prompt_tokens.len(), cached_tokens, block_size))
+            .flatten();
         let mut prefill_split_snapshot: Option<RollingPrefixSnapshot> = None;
         let prefill_start = std::time::Instant::now();
         let prefill_source = {
@@ -2762,10 +2768,15 @@ impl ModelRunner {
                     PrefillSampleSource::Logits(logits)
                 }
             } else if use_greedy_prefill_token {
-                PrefillSampleSource::GreedyToken(
-                    model_forward_paged_last_token_greedy(
+                if let Some(split_pos) = split_pos {
+                    // Split the prefill at the last block boundary so the
+                    // linear-attention state can be snapshotted at the
+                    // cross-turn-safe position (mirrors the batching-engine
+                    // path). The head pass's logits are discarded.
+                    let head_tokens = &prompt_tokens[cached_tokens..split_pos];
+                    let _ = model_forward_paged_last_token(
                         &*self.backend,
-                        prefill_tokens,
+                        head_tokens,
                         &self.weights,
                         &self.config,
                         pc_guard,
@@ -2775,8 +2786,97 @@ impl ModelRunner {
                         self.active_lora.as_ref(),
                         None,
                     )
-                    .context("greedy prefill forward pass (paged prefix cache) failed")?,
+                    .context("greedy prefill forward pass (paged prefix cache, head) failed")?;
+                    prefill_split_snapshot = Some(RollingPrefixSnapshot {
+                        position: split_pos,
+                        linear_state: linear_state
+                            .snapshot()
+                            .context("snapshot linear state at greedy prefill split")?,
+                    });
+
+                    let tail_tokens = &prompt_tokens[split_pos..];
+                    let pc_guard = lock_paged_cache(paged_cache)?;
+                    PrefillSampleSource::GreedyToken(
+                        model_forward_paged_last_token_greedy(
+                            &*self.backend,
+                            tail_tokens,
+                            &self.weights,
+                            &self.config,
+                            pc_guard,
+                            block_table,
+                            split_pos,
+                            Some(&mut linear_state),
+                            self.active_lora.as_ref(),
+                            None,
+                        )
+                        .context("greedy prefill forward pass (paged prefix cache, tail) failed")?,
+                    )
+                } else {
+                    PrefillSampleSource::GreedyToken(
+                        model_forward_paged_last_token_greedy(
+                            &*self.backend,
+                            prefill_tokens,
+                            &self.weights,
+                            &self.config,
+                            pc_guard,
+                            block_table,
+                            cached_tokens,
+                            Some(&mut linear_state),
+                            self.active_lora.as_ref(),
+                            None,
+                        )
+                        .context("greedy prefill forward pass (paged prefix cache) failed")?,
+                    )
+                }
+            } else if let Some(split_pos) = split_pos {
+                // Split the prefill at the last block boundary so the
+                // linear-attention state can be snapshotted at the
+                // cross-turn-safe position (mirrors the batching-engine
+                // path). The head pass's logits are discarded.
+                let head_tokens = &prompt_tokens[cached_tokens..split_pos];
+                let _ = model_forward_paged_last_token(
+                    &*self.backend,
+                    head_tokens,
+                    &self.weights,
+                    &self.config,
+                    pc_guard,
+                    block_table,
+                    cached_tokens,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
                 )
+                .context("prefill forward pass (paged prefix cache, head) failed")?;
+                prefill_split_snapshot = Some(RollingPrefixSnapshot {
+                    position: split_pos,
+                    linear_state: linear_state
+                        .snapshot()
+                        .context("snapshot linear state at prefill split")?,
+                });
+                if let Some(cancel) = cancel {
+                    cancel.report_prefill_tokens_completed(head_tokens.len() as u64);
+                }
+
+                let tail_tokens = &prompt_tokens[split_pos..];
+                let pc_guard = lock_paged_cache(paged_cache)?;
+                let logits = model_forward_paged_last_token(
+                    &*self.backend,
+                    tail_tokens,
+                    &self.weights,
+                    &self.config,
+                    pc_guard,
+                    block_table,
+                    split_pos,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged prefix cache, tail) failed")?;
+                if let Some(cancel) = cancel {
+                    cancel.report_prefill_tokens_completed(prefill_tokens.len() as u64);
+                }
+                // (#1082) kt-native logits — sampler is kt now; no candle bridge.
+                PrefillSampleSource::Logits(logits)
             } else {
                 let logits = model_forward_paged_last_token(
                     &*self.backend,
@@ -3280,7 +3380,9 @@ impl ModelRunner {
             };
             match result {
                 Ok(tokens) => sampled = Some(tokens),
-                Err(err) if !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) => {
+                Err(err)
+                    if !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) =>
+                {
                     return Err(err).context(decode_hot_path_fallback_disabled_context(
                         &*self.backend,
                         "contiguous-batched decode declined",
@@ -3489,7 +3591,11 @@ impl ModelRunner {
                         .context("sample Vulkan resident multi-row hidden batch")?;
                         sampled = Some(tokens);
                     }
-                    Err(err) if !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) => {
+                    Err(err)
+                        if !decode_hot_path_generic_fallback_enabled_for_backend(
+                            &*self.backend,
+                        ) =>
+                    {
                         return Err(err).context(decode_hot_path_fallback_disabled_context(
                             &*self.backend,
                             "resident batched hidden decode declined",
@@ -3548,7 +3654,9 @@ impl ModelRunner {
             match sample_result {
                 Ok(Some(tokens)) => sampled = Some(tokens),
                 Ok(None) => {}
-                Err(err) if !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) => {
+                Err(err)
+                    if !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) =>
+                {
                     return Err(err).context(decode_hot_path_fallback_disabled_context(
                         &*self.backend,
                         "Metal sampled decode declined",
@@ -3562,7 +3670,9 @@ impl ModelRunner {
                     );
                 }
             }
-            if sampled.is_none() && !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend) {
+            if sampled.is_none()
+                && !decode_hot_path_generic_fallback_enabled_for_backend(&*self.backend)
+            {
                 anyhow::bail!(
                     "{}",
                     decode_hot_path_fallback_disabled_context(
@@ -8961,7 +9071,10 @@ mod tests {
                 name: backend_name,
                 device,
             };
-            assert_eq!(decode_hot_path_fallback_policy_for_backend(&backend), expected);
+            assert_eq!(
+                decode_hot_path_fallback_policy_for_backend(&backend),
+                expected
+            );
         }
 
         let vulkan_cpu_sentinel = NamedTestBackend {

--- a/crates/kiln-model/tests/backend_capability_contract.rs
+++ b/crates/kiln-model/tests/backend_capability_contract.rs
@@ -4225,7 +4225,8 @@ fn runtime_policy_call_sites_consume_focused_capability_surfaces() {
     assert!(
         direct_paged_decode_attention_helper.contains("fn native_decode_attention_required(")
             && direct_paged_decode_attention_helper.contains("require_native_decode_attention")
-            && forward_source.contains("decode_hot_path_debug_fallback_enabled_for_backend(backend)")
+            && forward_source
+                .contains("decode_hot_path_debug_fallback_enabled_for_backend(backend)")
             && forward_source.contains("decode_hot_path_debug_fallback_env_for_backend(backend)"),
         "decode attention native-required routing should combine DecodeBatcherPolicy with BackendFallbackCapabilities"
     );
@@ -6962,10 +6963,9 @@ fn generated_capability_report_tracks_migration_phase_status() {
 
 #[test]
 fn cuda_graph_replay_hidden_routes_through_replay_plan_contract() {
-    let cuda_graph_source = fs::read_to_string(
-        workspace_root().join("crates/kiln-model/src/cuda_graph.rs"),
-    )
-    .expect("cuda_graph.rs should be readable");
+    let cuda_graph_source =
+        fs::read_to_string(workspace_root().join("crates/kiln-model/src/cuda_graph.rs"))
+            .expect("cuda_graph.rs should be readable");
     let replay_section = source_between(
         &cuda_graph_source,
         "if let Some(captured) = self.captured.get(&cache_key)",
@@ -7006,10 +7006,9 @@ fn cuda_graph_replay_hidden_routes_through_replay_plan_contract() {
 
 #[test]
 fn rocm_graph_replay_hidden_routes_through_replay_plan_contract() {
-    let rocm_graph_source = fs::read_to_string(
-        workspace_root().join("crates/kiln-model/src/rocm_graph.rs"),
-    )
-    .expect("rocm_graph.rs should be readable");
+    let rocm_graph_source =
+        fs::read_to_string(workspace_root().join("crates/kiln-model/src/rocm_graph.rs"))
+            .expect("rocm_graph.rs should be readable");
     let replay_hidden_section = source_between(
         &rocm_graph_source,
         "fn replay_hidden(",
@@ -7083,10 +7082,9 @@ fn metal_graph_icb_replay_routes_through_replay_plan_contract() {
 
 #[test]
 fn vulkan_resident_decode_routes_command_batch_through_replay_plan_contract() {
-    let vk_source = fs::read_to_string(
-        workspace_root().join("crates/kiln-model/src/vk_decode_resident.rs"),
-    )
-    .expect("vk_decode_resident.rs should be readable");
+    let vk_source =
+        fs::read_to_string(workspace_root().join("crates/kiln-model/src/vk_decode_resident.rs"))
+            .expect("vk_decode_resident.rs should be readable");
     let production = production_source_before_tests(&vk_source);
     let replay_plan_impl = source_between(
         production,
@@ -7224,10 +7222,7 @@ fn replay_plan_cpu_mock_parity_gate_runs_in_unification_contract() -> GraphContr
     };
 
     plan.validate_inputs(ReplayInputs::new(&key, &resources))?;
-    let outputs = kiln_graph::ReplayPlan::replay(
-        &mut plan,
-        ReplayInputs::new(&key, &resources),
-    )?;
+    let outputs = kiln_graph::ReplayPlan::replay(&mut plan, ReplayInputs::new(&key, &resources))?;
     assert_eq!(outputs.replay_count, 1);
     assert_eq!(outputs.resources, resources);
     let replayed = plan
@@ -7355,7 +7350,11 @@ fn generated_capability_report_check_mode_is_non_mutating_and_enforced() {
             "capability report generator should keep check-mode contract: {required}"
         );
     }
-    for forbidden in ["GITHUB_HEAD_REF", "GITHUB_REF_NAME", "branch\", \"--show-current"] {
+    for forbidden in [
+        "GITHUB_HEAD_REF",
+        "GITHUB_REF_NAME",
+        "branch\", \"--show-current",
+    ] {
         assert!(
             !script_source.contains(forbidden),
             "capability report generator should not depend on branch-specific metadata: {forbidden}"
@@ -7390,4 +7389,40 @@ fn generated_capability_report_check_mode_is_non_mutating_and_enforced() {
         evidence_present.contains(&"scripts/check_unification_gates.sh"),
         "generated dashboard gate should cite the local unification gate"
     );
+}
+
+/// Every backend must keep the prefix-cache split snapshot enabled.
+///
+/// The prefill-split snapshot is the ONLY producer of block-aligned
+/// strict-prefix cache entries, and `RealPrefixCache` can only serve a
+/// longer next-turn prompt from a block-aligned entry. A backend arm that
+/// sets `allow_prefix_cache_split_snapshot: false` therefore silently
+/// disables multi-turn prefix caching wholesale: every agent turn
+/// re-prefills its entire conversation history from scratch (40s+ per turn
+/// at 16K tokens on Strix Halo). Commit 002af558 did exactly that to ROCm
+/// while optimizing long-context prefill, and nothing caught it.
+///
+/// If a backend ever genuinely cannot capture a mid-prefill
+/// `LinearAttentionState` snapshot, gate it behind an env override with a
+/// startup warning — never a silent policy `false`.
+#[test]
+fn every_backend_allows_prefix_cache_split_snapshot() {
+    use kiln_model::backend::capability::DecodeBatcherPolicy;
+
+    let arms = [
+        ("cuda", kiln_tensor::Device::Cuda(0)),
+        ("rocm", kiln_tensor::Device::Rocm(0)),
+        ("metal", kiln_tensor::Device::Metal(0)),
+        ("vulkan", kiln_tensor::Device::Vulkan(0)),
+        ("cpu", kiln_tensor::Device::Cpu),
+    ];
+    for (name, device) in arms {
+        let policy = DecodeBatcherPolicy::for_backend(name, device);
+        assert!(
+            policy.allow_prefix_cache_split_snapshot,
+            "backend `{name}` disables the prefix-cache split snapshot, which kills \
+             multi-turn prefix caching (every turn fully re-prefills its history); \
+             see the field comment on allow_prefix_cache_split_snapshot"
+        );
+    }
 }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1129,6 +1129,16 @@ impl RealPrefixCache {
             .iter()
             .filter(|block_id| !self.block_refcounts.contains_key(block_id))
             .count();
+        if needed_new_blocks > self.max_blocks {
+            // This entry can never fit, even into an empty cache. Bail
+            // before the eviction loop below, which would otherwise evict
+            // every resident entry chasing an impossible target and still
+            // register nothing — destroying the whole cache for no gain.
+            return RealPrefixCacheRegisterOutcome {
+                retained_blocks: Vec::new(),
+                evicted_blocks: Vec::new(),
+            };
+        }
         while self.cached_blocks() + needed_new_blocks > self.max_blocks
             || self.entries.len() >= self.max_entries
         {
@@ -1406,7 +1416,6 @@ pub struct SelfImproveSchedulerStatus {
     pub next_run_unix_ms: u64,
 }
 
-
 #[derive(Clone)]
 pub struct AppState {
     pub model_config: ModelConfig,
@@ -1428,13 +1437,11 @@ pub struct AppState {
     /// serve path after each MTP generation; surfaced via /v1/stats so
     /// the draft head's alpha is measurable per adapter without the
     /// KILN_C1_ATTR_PATH CSV.
-    pub mtp_acceptance:
-        Arc<std::sync::Mutex<std::collections::HashMap<String, (u64, u64)>>>,
+    pub mtp_acceptance: Arc<std::sync::Mutex<std::collections::HashMap<String, (u64, u64)>>>,
     /// [agent] self_improve scheduler status — None when the scheduler
     /// isn't armed. Persisted to `<adapter_dir>/.self_improve_scheduler.json`
     /// so the cadence survives restarts; surfaced via /health.
-    pub self_improve_scheduler:
-        Arc<std::sync::RwLock<Option<SelfImproveSchedulerStatus>>>,
+    pub self_improve_scheduler: Arc<std::sync::RwLock<Option<SelfImproveSchedulerStatus>>>,
     /// Embedded pi agent runs — the server-driven rollout engine
     /// (`/v1/agent/runs`). Records persist under `<adapter_dir>/agent_runs/`.
     pub agent_runs: Arc<crate::agent_runs::AgentRunRegistry>,
@@ -1744,8 +1751,8 @@ impl AppState {
                 RECENT_REQUESTS_CAPACITY,
             ))),
             request_log: None,
-            request_log_max_capture_bytes:
-                crate::request_log::RequestLogConfig::default().max_capture_bytes,
+            request_log_max_capture_bytes: crate::request_log::RequestLogConfig::default()
+                .max_capture_bytes,
             completion_cache: Arc::new(std::sync::Mutex::new(DeterministicCompletionCache::new(
                 DETERMINISTIC_COMPLETION_CACHE_CAPACITY,
             ))),
@@ -2400,8 +2407,8 @@ impl AppState {
                 RECENT_REQUESTS_CAPACITY,
             ))),
             request_log: None,
-            request_log_max_capture_bytes:
-                crate::request_log::RequestLogConfig::default().max_capture_bytes,
+            request_log_max_capture_bytes: crate::request_log::RequestLogConfig::default()
+                .max_capture_bytes,
             completion_cache: Arc::new(std::sync::Mutex::new(DeterministicCompletionCache::new(
                 DETERMINISTIC_COMPLETION_CACHE_CAPACITY,
             ))),
@@ -3312,6 +3319,55 @@ mod tests {
             hit.cached_tokens, 8,
             "extended entry covers 8 tokens (prompt + decoded); prompt-only would only cover 5 \
              and additionally fails strict-prefix because 5 % 4 != 0"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn real_prefix_cache_unfittable_registration_does_not_evict_resident_entries()
+    -> anyhow::Result<()> {
+        // A registration that cannot fit even into an EMPTY cache (more new
+        // blocks than max_blocks) must bail before the eviction loop. The
+        // old behavior evicted every resident entry chasing the impossible
+        // target and still registered nothing — one oversized conversation
+        // wiped the cache for every other session.
+        let config = tiny_linear_config();
+        let device = cpu_device!();
+        let mut cache = RealPrefixCache::new(true, 4, 4, 8, 1024);
+
+        let resident_tokens = vec![10u32, 11, 12, 13, 14, 15, 16, 17];
+        let resident = PagedPrefixRegistration {
+            prompt_tokens: resident_tokens.clone(),
+            block_ids: vec![100, 101],
+            linear_state: LinearAttentionState::new(&config, &device)?,
+            next_token: None,
+        };
+        let outcome = cache.register(None, resident);
+        assert_eq!(outcome.retained_blocks, vec![100, 101]);
+
+        // 8 new blocks needed > max_blocks of 4: can never fit.
+        let oversized = PagedPrefixRegistration {
+            prompt_tokens: (0..32u32).collect(),
+            block_ids: (200..208u32).collect(),
+            linear_state: LinearAttentionState::new(&config, &device)?,
+            next_token: None,
+        };
+        let outcome = cache.register(None, oversized);
+        assert!(
+            outcome.retained_blocks.is_empty() && outcome.evicted_blocks.is_empty(),
+            "unfittable registration must be a no-op"
+        );
+
+        let stats = cache.stats();
+        assert_eq!(
+            stats.cached_entries, 1,
+            "resident entry must survive an unfittable registration attempt"
+        );
+        assert!(
+            cache
+                .lookup(&None, &[10u32, 11, 12, 13, 14, 15, 16, 17, 50, 51])?
+                .is_some(),
+            "resident entry must still be hittable after the unfittable attempt"
         );
         Ok(())
     }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -936,8 +936,7 @@ fn tiny_gdn_weights_bf16(config: &ModelConfig, device: &Device) -> GpuWeights {
     let head_dim = config.head_dim;
 
     let bf16 = |t: &Tensor| kiln_tensor::ops::cast(t, DType::BF16).expect("cast bf16");
-    let rnd =
-        |shape: &[usize]| bf16(&Tensor::randn(0.0_f32, 0.02, shape, device).unwrap());
+    let rnd = |shape: &[usize]| bf16(&Tensor::randn(0.0_f32, 0.02, shape, device).unwrap());
     let rnd_t = |shape: &[usize]| {
         let w = Tensor::randn(0.0_f32, 0.02, shape, device).unwrap();
         let wt = w.t().unwrap().contiguous().unwrap();
@@ -1310,7 +1309,10 @@ fn test_real_model_grpo_metal() {
     assert_adapter_written(&out);
 
     let losses = losses.lock().unwrap();
-    assert!(!losses.is_empty(), "GRPO progress callback recorded no losses");
+    assert!(
+        !losses.is_empty(),
+        "GRPO progress callback recorded no losses"
+    );
     assert!(
         losses.iter().all(|l| l.is_finite()),
         "all GRPO training losses must be finite, got {losses:?}"
@@ -1456,7 +1458,10 @@ fn test_real_model_opd_metal() {
             // (adapter written + finite losses + grads flowed).
             assert_adapter_written(&out);
             let losses = losses.lock().unwrap();
-            assert!(!losses.is_empty(), "OPD progress callback recorded no losses");
+            assert!(
+                !losses.is_empty(),
+                "OPD progress callback recorded no losses"
+            );
             assert!(
                 losses.iter().all(|l| l.is_finite()),
                 "all OPD training losses must be finite, got {losses:?}"
@@ -1485,4 +1490,387 @@ fn test_real_model_opd_metal() {
             );
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-turn prefix-cache reuse with a REAL ModelRunner (CPU).
+//
+// These are the regression tests for the 002af558 class of bug: the prefix
+// cache "worked" (entries registered, exact replays hit) while multi-turn
+// reuse — the entire point of the cache for agent traffic — was structurally
+// impossible because no block-aligned strict-prefix entry ever registered.
+// One test drives the batching-engine forward (CUDA/Vulkan/ROCm/CPU serve
+// path), one drives the non-batched generate path (Metal's default serve
+// path); both run on the CPU backend so they execute on every CI runner.
+// ---------------------------------------------------------------------------
+
+use std::sync::{Arc, Mutex, RwLock};
+
+use kiln_core::block::BlockManager;
+use kiln_core::sampling::SamplingParams;
+use kiln_core::token::TokenId;
+use kiln_model::{CancelHandle, FinishReason, PagedKvCacheKt, PagedPrefixReuse};
+use kiln_server::batching_engine::{DecodeForward, EngineRequest, RealDecodeForward};
+use kiln_server::state::RealPrefixCache;
+use uuid::Uuid;
+
+const PREFIX_TEST_BLOCK_SIZE: usize = 16;
+const PREFIX_TEST_NUM_BLOCKS: usize = 64;
+
+/// Tiny HYBRID config (one GDN layer + one full-attention layer) in FP32 for
+/// CPU prefix-cache tests. The GDN layer matters: prefix-cache resume must
+/// restore the linear-attention state snapshot exactly, and a full-attn-only
+/// model would never exercise that path.
+fn tiny_gdn_config_f32() -> ModelConfig {
+    ModelConfig {
+        hidden_size: 8,
+        num_layers: 2,
+        num_attention_heads: 2,
+        num_kv_heads: 1,
+        head_dim: 4,
+        intermediate_size: 16,
+        vocab_size: 32,
+        max_position_embeddings: 256,
+        rms_norm_eps: 1e-6,
+        rope_theta: 10_000.0,
+        dtype: kiln_core::config::DType::FP32,
+        // Layer 0 -> linear (GDN), layer 1 -> full attention.
+        num_full_attention_layers: 1,
+        full_attention_interval: 2,
+        attn_output_gate: false,
+        linear_num_key_heads: 1,
+        linear_key_head_dim: 4,
+        linear_num_value_heads: 1,
+        linear_value_head_dim: 4,
+        linear_conv_kernel_dim: 4,
+        partial_rotary_factor: 1.0,
+    }
+}
+
+/// FP32 GpuWeights for [`tiny_gdn_config_f32`]: layer 0 GDN, layer 1 full
+/// attention. Same literal as `tiny_gdn_weights_bf16` minus the BF16 casts.
+fn tiny_gdn_weights_f32(config: &ModelConfig, device: &Device) -> GpuWeights {
+    let h = config.hidden_size;
+    let inter = config.intermediate_size;
+    let vocab = config.vocab_size;
+    let num_heads = config.num_attention_heads;
+    let num_kv_heads = config.num_kv_heads;
+    let head_dim = config.head_dim;
+
+    let rnd = |shape: &[usize]| Tensor::randn(0.0_f32, 0.02, shape, device).unwrap();
+    let rnd_t = |shape: &[usize]| {
+        let w = Tensor::randn(0.0_f32, 0.02, shape, device).unwrap();
+        let wt = w.t().unwrap().contiguous().unwrap();
+        (w, wt)
+    };
+
+    let embed = Tensor::randn(0.0_f32, 0.02, (vocab, h), device).unwrap();
+    let embed_t = embed.t().unwrap().contiguous().unwrap();
+    let final_norm = Tensor::zeros((h,), DType::F32, device).unwrap();
+
+    let mk_mlp = || {
+        let (gate_proj, gate_proj_t) = rnd_t(&[inter, h]);
+        let (up_proj, up_proj_t) = rnd_t(&[inter, h]);
+        let (down_proj, down_proj_t) = rnd_t(&[h, inter]);
+        GpuFfnWeights {
+            gate_proj,
+            up_proj,
+            down_proj,
+            gate_proj_t,
+            up_proj_t,
+            down_proj_t,
+            gate_up_proj_t: None,
+            gate_up_proj_w8: None,
+            gate_proj_marlin: None,
+            up_proj_marlin: None,
+            down_proj_marlin: None,
+            down_proj_w8: None,
+        }
+    };
+
+    // --- Layer 0: GDN (linear attention). ---
+    let qkv_dim = config.linear_qkv_dim();
+    let v_dim = config.linear_v_dim();
+    let nv = config.linear_num_value_heads;
+    let (in_proj_qkv, in_proj_qkv_t) = rnd_t(&[qkv_dim, h]);
+    let (in_proj_z, in_proj_z_t) = rnd_t(&[v_dim, h]);
+    let (out_proj, out_proj_t) = rnd_t(&[h, v_dim]);
+    let (in_proj_a, in_proj_a_t) = rnd_t(&[nv, h]);
+    let (in_proj_b, in_proj_b_t) = rnd_t(&[nv, h]);
+    let a_log = Tensor::randn(0.0_f32, 0.5, (nv,), device).unwrap();
+    let gdn_layer = GpuLayerWeights {
+        input_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
+        post_attention_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
+        attention: GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
+            in_proj_qkv,
+            in_proj_z,
+            out_proj,
+            in_proj_a,
+            in_proj_b,
+            conv1d: rnd(&[qkv_dim, 1, config.linear_conv_kernel_dim]),
+            norm: Tensor::ones((config.linear_value_head_dim,), DType::F32, device).unwrap(),
+            a_log: a_log.clone(),
+            a_log_gates: a_log,
+            dt_bias: Tensor::zeros((nv,), DType::F32, device).unwrap(),
+            in_proj_qkv_t,
+            in_proj_z_t,
+            in_proj_a_t,
+            in_proj_b_t,
+            in_proj_ab_t: None,
+            out_proj_t,
+            out_proj_marlin: None,
+            in_proj_qkvzab_w8: None,
+        }),
+        mlp: mk_mlp(),
+    };
+
+    // --- Layer 1: full attention. ---
+    let (q_proj, q_proj_t) = rnd_t(&[num_heads * head_dim, h]);
+    let (k_proj, k_proj_t) = rnd_t(&[num_kv_heads * head_dim, h]);
+    let (v_proj, v_proj_t) = rnd_t(&[num_kv_heads * head_dim, h]);
+    let (o_proj, o_proj_t) = rnd_t(&[h, num_heads * head_dim]);
+    let full_layer = GpuLayerWeights {
+        input_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
+        post_attention_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
+        attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm: Tensor::zeros((head_dim,), DType::F32, device).unwrap(),
+            k_norm: Tensor::zeros((head_dim,), DType::F32, device).unwrap(),
+            q_proj_t,
+            k_proj_t,
+            v_proj_t,
+            qkv_proj_t: None,
+            qkv_proj_w8: None,
+            o_proj_t,
+            q_proj_marlin: None,
+            o_proj_w8: None,
+        }),
+        mlp: mk_mlp(),
+    };
+
+    let rotary_inv_freq = kiln_model::forward::compute_rotary_inv_freq(
+        config.rotary_dim(),
+        config.rope_theta,
+        device,
+    )
+    .unwrap();
+
+    GpuWeights {
+        embed_tokens: embed,
+        embed_tokens_t: embed_t,
+        layers: vec![gdn_layer, full_layer],
+        final_norm,
+        rotary_inv_freq,
+        mtp: None,
+        lm_head_w8: None,
+    }
+}
+
+fn prefix_test_paged_cache(config: &ModelConfig) -> PagedKvCacheKt {
+    PagedKvCacheKt::new(
+        config.num_full_attention_layers,
+        PREFIX_TEST_NUM_BLOCKS,
+        PREFIX_TEST_BLOCK_SIZE,
+        config.num_kv_heads,
+        config.head_dim,
+        DType::F32,
+        Device::Cpu,
+    )
+    .expect("paged KV cache")
+}
+
+/// 81 deterministic prompt tokens: long enough that the prefill-split entry
+/// (floor((81-1)/16)*16 = 80 tokens) clears the production-style
+/// min_register_tokens=64 gate, and non-block-aligned (81 % 16 != 0) like
+/// every real chat-template rendering.
+fn prefix_test_turn1_prompt() -> Vec<TokenId> {
+    (0..81u32).map(|i| (i % 17) + 1).collect()
+}
+
+/// Batching-engine serve path (CUDA / Vulkan / ROCm / CPU default): turn 1
+/// must register a block-aligned strict-prefix entry, and turn 2 (a superset
+/// prompt, as every multi-turn agent request is) must HIT it instead of
+/// re-prefilling the whole conversation.
+#[test]
+fn prefix_cache_multi_turn_hit_through_batching_engine_forward() {
+    let config = tiny_config();
+    let weights = tiny_weights(&config, &Device::Cpu);
+    let runner = ModelRunner::new(weights, test_tokenizer(), config.clone());
+
+    let prefix_cache = Arc::new(Mutex::new(RealPrefixCache::new_with_min_register_tokens(
+        true,
+        PREFIX_TEST_BLOCK_SIZE,
+        32,   // max_blocks
+        8,    // max_entries
+        1024, // state_bytes_per_entry (accounting only)
+        64,   // production REAL_PREFIX_CACHE_MIN_REGISTER_TOKENS
+    )));
+    let forward = RealDecodeForward::new(
+        Arc::new(RwLock::new(runner)),
+        Arc::new(Mutex::new(BlockManager::new(
+            PREFIX_TEST_NUM_BLOCKS,
+            PREFIX_TEST_BLOCK_SIZE,
+        ))),
+        Arc::new(prefix_test_paged_cache(&config)),
+        prefix_cache.clone(),
+        Arc::new(RwLock::new(())),
+    );
+
+    let sampling = SamplingParams {
+        max_tokens: 4,
+        ..SamplingParams::greedy()
+    };
+    let turn1 = prefix_test_turn1_prompt();
+    let req1 = EngineRequest {
+        request_id: Uuid::new_v4(),
+        prompt_tokens: turn1.clone(),
+        sampling: sampling.clone(),
+        adapter: None,
+        cancel: CancelHandle::new(),
+    };
+    let slot1 = forward.prepare_request(&req1).expect("turn-1 prepare");
+    forward
+        .finish_request(slot1, FinishReason::MaxTokens)
+        .expect("turn-1 finish");
+
+    let stats = prefix_cache.lock().unwrap().stats();
+    assert_eq!(stats.lookup_hits, 0);
+    assert_eq!(stats.lookup_misses, 1, "turn-1 lookup must miss (cold)");
+    assert!(
+        stats.cached_entries >= 2,
+        "turn-1 must register the prompt entry AND the block-aligned \
+         prefill-split entry; got {} entries — if this is 1, the split \
+         snapshot was not captured (the 002af558 regression)",
+        stats.cached_entries
+    );
+
+    // Turn 2: the conversation grew (assistant reply + new user message).
+    let mut turn2 = turn1.clone();
+    turn2.extend((0..9u32).map(|i| (i % 7) + 2));
+    let req2 = EngineRequest {
+        request_id: Uuid::new_v4(),
+        prompt_tokens: turn2,
+        sampling,
+        adapter: None,
+        cancel: CancelHandle::new(),
+    };
+    let slot2 = forward.prepare_request(&req2).expect("turn-2 prepare");
+    let stats = prefix_cache.lock().unwrap().stats();
+    assert_eq!(
+        stats.lookup_hits, 1,
+        "turn-2 must hit the block-aligned strict-prefix entry"
+    );
+    assert_eq!(
+        stats.hit_tokens, 80,
+        "the hit must cover the full split position (floor((81-1)/16)*16)"
+    );
+    forward
+        .finish_request(slot2, FinishReason::MaxTokens)
+        .expect("turn-2 finish");
+}
+
+/// Non-batched serve path (Metal's default): the non-streaming CPU prefill
+/// must register a block-aligned strict-prefix entry (the branch 002af558-era
+/// code only covered under streaming prefill), and resuming generation from
+/// that entry — paged KV blocks + the GDN linear-attention state snapshot —
+/// must produce tokens IDENTICAL to an uncached full prefill. Token
+/// equivalence on a hybrid GDN model is the correctness proof that the
+/// linear-state snapshot/restore is exact, not just that plumbing connects.
+#[test]
+fn prefix_cache_nonbatched_path_split_entry_replays_token_identical() {
+    let config = tiny_gdn_config_f32();
+    let weights = tiny_gdn_weights_f32(&config, &Device::Cpu);
+    let runner = ModelRunner::new(weights, test_tokenizer(), config.clone());
+
+    let sampling = SamplingParams {
+        max_tokens: 4,
+        ..SamplingParams::greedy()
+    };
+    let turn1 = prefix_test_turn1_prompt();
+
+    let block_manager = Mutex::new(BlockManager::new(
+        PREFIX_TEST_NUM_BLOCKS,
+        PREFIX_TEST_BLOCK_SIZE,
+    ));
+    let paged_cache = prefix_test_paged_cache(&config);
+    let out1 = runner
+        .generate_paged_shared_tokens_with_prefix_cache(
+            &turn1,
+            &sampling,
+            &block_manager,
+            &paged_cache,
+            None,
+            None,
+        )
+        .expect("turn-1 generation");
+
+    let split_reg = out1
+        .extra_registrations
+        .iter()
+        .find(|reg| {
+            reg.prompt_tokens.len() % PREFIX_TEST_BLOCK_SIZE == 0
+                && turn1.starts_with(&reg.prompt_tokens)
+        })
+        .expect(
+            "non-streaming CPU prefill must register a block-aligned strict-prefix \
+             entry — its absence means the non-batched path lost the split snapshot",
+        );
+    assert_eq!(split_reg.prompt_tokens.len(), 80);
+
+    // Turn 2 extends the transcript: turn-1 prompt + emitted tokens + new input.
+    let mut turn2 = turn1.clone();
+    turn2.extend(out1.output.token_ids.iter().copied());
+    turn2.extend([3u32, 5, 7, 2, 4]);
+
+    // Control: full prefill on a fresh KV pool, no cache involvement.
+    let control_bm = Mutex::new(BlockManager::new(
+        PREFIX_TEST_NUM_BLOCKS,
+        PREFIX_TEST_BLOCK_SIZE,
+    ));
+    let control_pc = prefix_test_paged_cache(&config);
+    let control = runner
+        .generate_paged_shared_tokens_with_prefix_cache(
+            &turn2,
+            &sampling,
+            &control_bm,
+            &control_pc,
+            None,
+            None,
+        )
+        .expect("control generation");
+
+    // Cached: resume from the split entry's KV blocks + linear-state snapshot
+    // (turn-1's blocks are still resident in `paged_cache`; nothing freed them).
+    let reuse = PagedPrefixReuse {
+        cached_tokens: split_reg.prompt_tokens.len(),
+        block_ids: split_reg.block_ids.clone(),
+        linear_state: split_reg
+            .linear_state
+            .snapshot()
+            .expect("snapshot registered linear state"),
+        next_token: None,
+    };
+    let cached = runner
+        .generate_paged_shared_tokens_with_prefix_cache(
+            &turn2,
+            &sampling,
+            &block_manager,
+            &paged_cache,
+            Some(reuse),
+            None,
+        )
+        .expect("cached generation");
+
+    assert!(
+        !control.output.token_ids.is_empty(),
+        "control run must generate at least one token for the equivalence check"
+    );
+    assert_eq!(
+        cached.output.token_ids, control.output.token_ids,
+        "generation resumed from the prefix-cache entry (KV blocks + GDN linear \
+         state) must be token-identical to an uncached full prefill"
+    );
 }


### PR DESCRIPTION
## Problem

Every pi / terminal turn was re-prefilling its **entire conversation history** — 40-55s per turn at 16-18K tokens on Strix Halo. Live counters told the story: `lookup_hits=0, lookup_misses=9` across a whole pi session while 13 entries sat in the cache at 96% block utilization, structurally unable to ever match.

Root cause chain (verified by code trace + live timing probes + a jinja simulation against the real chat template):

1. `RealPrefixCache` can only serve a *longer* next-turn prompt from a **block-aligned** entry (`entry.prompt_tokens.len() % block_size == 0`, `state.rs`) — a hard requirement, since hybrid linear-attention state can only resume at exact snapshot boundaries.
2. The only producer of block-aligned strict-prefix entries is the **prefill-split snapshot** (added in `31a21948` precisely to fix this symptom).
3. `002af558` ("Speed up ROCm long-context inference") disabled that snapshot on ROCm — preserved by the capabilities refactor as `allow_prefix_cache_split_snapshot: false`, the **only** false arm. The empty commit body never mentioned it reverted the multi-turn fix, and no real-backend test asserted a turn-2 hit, so nothing caught it.

## Fix

- **capability.rs** — ROCm `allow_prefix_cache_split_snapshot` back to `true`, with a comment stating the invariant. Cost of the split: one extra forward boundary + one ~27MB linear-state snapshot per prefill. Cost of `false`: full history re-prefill on every turn of every conversation.
- **generate.rs (non-batched path, Metal's default)** — capture the split snapshot in the non-streaming and greedy prefill branches too; previously only the streaming-prefill branch captured it, so sub-threshold prompts on that path had the same disease. `split_pos` now consults the same backend capability as the batched path.
- **state.rs** — `register()` bails before the eviction loop when an entry can never fit (`needed blocks > max_blocks`); it used to evict every resident entry chasing an impossible target and still register nothing.

## Confidence across engines

| Engine | Coverage |
|---|---|
| ROCm | **Live-validated on Strix Halo (gfx1151)**: turn-2/3 each hit (3,264 of ~3,285 tokens cached), 1.85s vs 6.4s predicted full re-prefill; residual is decode time |
| CPU | Two new real-`ModelRunner` integration tests (run on every CI runner): batched-path turn-2 strict-prefix HIT, and non-batched-path **token-identical replay** from the split entry on a hybrid GDN model — proving linear-state snapshot/restore exactness |
| CUDA / Metal / Vulkan | Same shared code paths + new contract test pinning `allow_prefix_cache_split_snapshot == true` for **every** backend arm (a backend that genuinely can't snapshot must use an env gate, never a silent policy false) |

Caveat, stated plainly: Vulkan could not be live-validated — hybrid-GDN Vulkan inference on main is broken before any prefix-cache code runs (`DeviceOp2 "add": inputs on different devices`, even on a 13-token no-split prompt; the pre-existing vk-cpu-sentinel gap that `feat/vk-inference-fix` addresses). Prefix caching there rides the same code validated on ROCm/CPU once that lands.

Follow-up candidates (intentionally out of scope): rolling prompt+generated extras never match on Qwen3.5 thinking templates (LRU pollution, ~27MB each); `docs/backend-capability-report.json` did not change (policy values aren't serialized there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)