### PR TITLE
Expose core Kiln guides in documentation

### DIFF
--- a/docs/site/docs-manifest.json
+++ b/docs/site/docs-manifest.json
@@ -11,6 +11,16 @@
         "description": "Install Kiln, start a model, and send the first request."
       },
       {
+        "title": "GRPO Guide",
+        "href": "../grpo.html",
+        "description": "Generate, score, train, and hot-swap LoRA adapters over HTTP."
+      },
+      {
+        "title": "Evals Guide",
+        "href": "../evals.html",
+        "description": "Grade, compare, replay, and turn local judgments back into training."
+      },
+      {
         "title": "API Reference",
         "href": "../api.html",
         "description": "Serving, training, eval, adapter, and diagnostics endpoints."
@@ -19,6 +29,11 @@
         "title": "CLI Reference",
         "href": "../cli.html",
         "description": "Terminal workflows for serving, training, evals, and adapters."
+      },
+      {
+        "title": "Architecture",
+        "href": "../architecture.html",
+        "description": "Trace request flow, backends, scheduling, training, and adapter hot-swap."
       },
       {
         "title": "Troubleshooting",

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -100,6 +100,8 @@ const generatedDocsPages = [
     h1: 'Complete Kiln documentation',
     terms: [
       'Configuration Reference',
+      'GRPO Guide',
+      'Evals Guide',
       'Configuration Schema',
       'HTTP API Contract',
       'Observability API Schema',
@@ -3101,6 +3103,22 @@ function validateGeneratedDocsArtifacts() {
   }
   if (!Array.isArray(searchIndex) || searchIndex.length === 0) {
     fail('generated documentation search index must contain published documents');
+  }
+  const expectedProductGuideOrder = [
+    'Quickstart',
+    'GRPO Guide',
+    'Evals Guide',
+    'API Reference',
+    'CLI Reference',
+    'Architecture',
+    'Troubleshooting',
+    'Demo',
+  ];
+  const productGuideOrder = searchIndex
+    .filter((entry) => entry?.kind === 'product_guide')
+    .map((entry) => entry.title);
+  if (JSON.stringify(productGuideOrder) !== JSON.stringify(expectedProductGuideOrder)) {
+    fail(`generated documentation search index has the wrong product-guide order: ${productGuideOrder.join(', ')}`);
   }
   for (const expected of generatedDocsPages.filter((page) => page.label !== 'Documentation hub')) {
     const slug = expected.path.split('/').filter(Boolean).at(-2);


### PR DESCRIPTION
## Summary
- add GRPO, Evals, and Architecture to the generated documentation directory, sidebar, and search index
- order all eight product guides around the visitor journey from setup through learning, reference, operations, and demos
- enforce the product-guide inventory and ordering in the Pages smoke contract

## Verification
- `npm test --prefix scripts/docs-site` (10/10)
- `node scripts/docs-site/build.mjs --out _site` (54 documents)
- `KILN_DOCS_SITE_ROOT=_site KILN_DOCS_REQUIRE_GENERATED=true node scripts/check_docs_site_smoke.mjs`
- mobile and desktop visual checks of the rebuilt documentation directory