### PR TITLE
Generate agent-readable Kiln documentation index

### DIFF
--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -3088,6 +3088,7 @@ function validateGeneratedDocsArtifacts() {
     publishedPath('css/docs.css'),
     publishedPath('js/docs.js'),
     publishedPath('sitemap.xml'),
+    publishedPath('llms.txt'),
   ];
   const missing = requiredPaths.filter((path) => !existsSync(resolve(repoRoot, path)));
   if (missing.length > 0) {
@@ -3166,6 +3167,28 @@ function validateGeneratedDocsArtifacts() {
     if (!sitemap.includes(`<loc>${url}</loc>`)) {
       fail(`generated sitemap is missing ${url}`);
     }
+  }
+
+  const llms = readFileSync(resolve(siteRoot, 'llms.txt'), 'utf8');
+  const requiredLlmsTerms = [
+    '# Kiln',
+    '> Kiln is a pure-Rust, single-GPU server for Qwen3.5-4B',
+    '## Product guides',
+    '[Quickstart](https://ericflo.github.io/kiln/quickstart.html)',
+    '[GRPO Guide](https://ericflo.github.io/kiln/grpo.html)',
+    '[Evals Guide](https://ericflo.github.io/kiln/evals.html)',
+    '## Core documentation',
+    'https://raw.githubusercontent.com/ericflo/kiln/refs/heads/main/README.md',
+    'https://raw.githubusercontent.com/ericflo/kiln/refs/heads/main/docs/GRPO_GUIDE.md',
+    'https://raw.githubusercontent.com/ericflo/kiln/refs/heads/main/docs/EVAL_GUIDE.md',
+    '## Machine-readable contracts',
+    'https://raw.githubusercontent.com/ericflo/kiln/refs/heads/main/contracts/kiln-http-api-v1.openapi.json',
+    '## Optional',
+    '[Documentation search index](https://ericflo.github.io/kiln/docs/search-index.json)',
+  ];
+  const missingLlmsTerms = requiredLlmsTerms.filter((term) => !llms.includes(term));
+  if (missingLlmsTerms.length > 0) {
+    fail(`generated llms.txt is missing agent-discovery terms: ${missingLlmsTerms.join(', ')}`);
   }
   return true;
 }

--- a/scripts/docs-site/lib.mjs
+++ b/scripts/docs-site/lib.mjs
@@ -955,6 +955,101 @@ async function writeSitemap(outDir) {
   );
 }
 
+function escapeMarkdownLabel(value) {
+  return String(value)
+    .replaceAll('\\', '\\\\')
+    .replaceAll('[', '\\[')
+    .replaceAll(']', '\\]');
+}
+
+function rawRepositorySourceUrl(manifest, source) {
+  const repository = new URL(manifest.site.repository_url);
+  const repositoryPath = repository.pathname
+    .replace(/^\/+/, '')
+    .replace(/\.git$/, '');
+  if (repository.hostname !== 'github.com' || repositoryPath.split('/').length !== 2) {
+    return `${manifest.site.repository_url}/blob/main/${encodeRepoPath(source)}`;
+  }
+  return `https://raw.githubusercontent.com/${repositoryPath}/refs/heads/main/${encodeRepoPath(source)}`;
+}
+
+function llmsFileEntry(title, url, description) {
+  return `- [${escapeMarkdownLabel(title)}](${url}): ${normalizeWhitespace(description)}`;
+}
+
+async function writeLlmsTxt(outDir, manifest) {
+  const documentBySlug = new Map(manifest.documents.map((document) => [document.slug, document]));
+  const documentsFor = (slugs) => slugs
+    .map((slug) => documentBySlug.get(slug))
+    .filter(Boolean)
+    .map((document) => llmsFileEntry(
+      document.title,
+      rawRepositorySourceUrl(manifest, document.source),
+      document.description,
+    ));
+  const productGuides = manifest.site.product_guides.map((guide) => llmsFileEntry(
+    guide.title,
+    new URL(guide.href, `${manifest.site.base_url}/docs/`).href,
+    guide.description,
+  ));
+  const coreDocumentation = documentsFor([
+    'overview',
+    'quickstart-reference',
+    'configuration',
+    'architecture-reference',
+    'grpo',
+    'evals',
+    'benchmarks',
+  ]);
+  const machineReadableContracts = documentsFor([
+    'http-api',
+    'configuration-schema',
+    'inference-schema',
+    'observability-schema',
+    'eval-api-schema',
+    'control-plane-api-schema',
+  ]);
+  const projectDocumentation = documentsFor([
+    'security',
+    'changelog',
+    'contributing',
+  ]);
+  const sections = [
+    '# Kiln',
+    '',
+    '> Kiln is a pure-Rust, single-GPU server for Qwen3.5-4B that combines OpenAI-compatible inference, live LoRA training, local evals, and strict replay in one process.',
+    '',
+    'Kiln deliberately targets one model family and one local improvement loop. The server owns inference, SFT, GRPO, OPD, adapter lifecycle, evaluation, receipts, and the dashboard. CUDA, ROCm, Metal, and Vulkan are supported; performance claims are bounded by the published benchmark receipts.',
+    '',
+    'Prefer the source documents and machine-readable contracts below for implementation details. Use the product guides for task-oriented orientation.',
+    '',
+    '## Product guides',
+    '',
+    ...productGuides,
+  ];
+  if (coreDocumentation.length > 0) {
+    sections.push('', '## Core documentation', '', ...coreDocumentation);
+  }
+  if (machineReadableContracts.length > 0) {
+    sections.push('', '## Machine-readable contracts', '', ...machineReadableContracts);
+  }
+  if (projectDocumentation.length > 0) {
+    sections.push('', '## Project and operations', '', ...projectDocumentation);
+  }
+  sections.push(
+    '',
+    '## Optional',
+    '',
+    llmsFileEntry('Complete documentation directory', `${manifest.site.base_url}/docs/`, 'Searchable HTML reference for every published Kiln document and contract.'),
+    llmsFileEntry('Documentation search index', `${manifest.site.base_url}/docs/search-index.json`, 'Structured titles, descriptions, headings, and searchable text for all published references.'),
+    llmsFileEntry('Sitemap', `${manifest.site.base_url}/sitemap.xml`, 'Complete canonical URL inventory.'),
+    llmsFileEntry('Source repository', manifest.site.repository_url, 'Canonical source, issues, releases, and development history.'),
+    llmsFileEntry('Latest release', `${manifest.site.repository_url}/releases/latest`, 'Current signed Kiln release and platform artifacts.'),
+    '',
+  );
+  await writeFile(resolve(outDir, 'llms.txt'), `${sections.join('\n')}\n`);
+}
+
 async function validateGeneratedHtml(outDir) {
   const errors = [];
   const htmlFiles = await listFiles(outDir, (path) => extname(path).toLowerCase() === '.html');
@@ -1226,6 +1321,7 @@ export async function buildDocsSite({
     }
 
     await writeSitemap(buildOut);
+    await writeLlmsTxt(buildOut, manifest);
     await validateGeneratedHtml(buildOut);
     await writeFile(resolve(buildOut, OUTPUT_MARKER), 'kiln-docs-site-output-v1\n');
     if ((await pathKind(resolvedOut)) === 'directory') {

--- a/scripts/docs-site/test/build.test.mjs
+++ b/scripts/docs-site/test/build.test.mjs
@@ -236,6 +236,11 @@ test('build copies the static site and emits complete deterministic docs', async
   const sitemap = await readFile(resolve(first, 'sitemap.xml'), 'utf8');
   assert.match(sitemap, /https:\/\/example\.test\/kiln\//);
   assert.match(sitemap, /https:\/\/example\.test\/kiln\/docs\/configuration\//);
+  const llms = await readFile(resolve(first, 'llms.txt'), 'utf8');
+  assert.match(llms, /^# Kiln\n\n> Kiln is a pure-Rust, single-GPU server/m);
+  assert.match(llms, /\[Product\]\(https:\/\/example\.test\/kiln\/index\.html\): Product guide\./);
+  assert.match(llms, /\[Configuration\]\(https:\/\/raw\.githubusercontent\.com\/example\/kiln\/refs\/heads\/main\/docs\/CONFIGURATION\.md\): Complete configuration reference\./);
+  assert.match(llms, /\[Documentation search index\]\(https:\/\/example\.test\/kiln\/docs\/search-index\.json\)/);
   assert.deepEqual(await treeDigest(first), await treeDigest(second));
 });
 


### PR DESCRIPTION
## Summary
- generate a concise `/llms.txt` from the canonical docs manifest during every Pages build
- orient agents to Kiln’s scope, task guides, raw source documents, machine-readable contracts, and bounded benchmark claims
- link directly to authoritative `main` sources instead of duplicating documentation into a hand-maintained artifact
- validate required agent-discovery terms and deterministic output in the docs test/smoke contracts

## Verification
- `npm test --prefix scripts/docs-site` (10/10)
- `node scripts/docs-site/build.mjs --out _site` (54 documents)
- `KILN_DOCS_SITE_ROOT=_site KILN_DOCS_REQUIRE_GENERATED=true node scripts/check_docs_site_smoke.mjs`
- 29/29 generated manifest links return HTTP 200
- format check: one H1, blockquote summary, five sections, 6,276 bytes

This follows the emerging `/llms.txt` convention recognized by Chrome Lighthouse’s agentic-browsing guidance while remaining explicitly optional and source-bound.