### PR TITLE
Clarify release provenance and verification

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -344,9 +344,9 @@
           <span class="eyebrow eyebrow--accent">Run it locally</span>
           <h2>One binary.<br>One model path.<br>One endpoint.</h2>
           <p>
-            Signed releases are available for Linux CUDA, ROCm, and Vulkan; Apple Silicon
-            Metal; and Windows CUDA. The full quickstart covers drivers, Docker, Desktop,
-            and every backend.
+            Provenance-attested release archives are available for Linux CUDA, ROCm, and
+            Vulkan; Apple Silicon Metal; and Windows CUDA. The macOS binary is also signed
+            and notarized. The full quickstart covers drivers, Docker, Desktop, and every backend.
           </p>
           <div class="install-actions">
             <a class="btn btn-primary btn-lg" href="quickstart.html">Choose your platform</a>
@@ -360,7 +360,7 @@
             <span class="code-title">linux · cuda 12.4</span>
             <button class="copy-btn" type="button" data-target="home-install-code" aria-label="Copy install commands">copy</button>
           </div>
-<pre id="home-install-code" tabindex="0" aria-label="Kiln installation commands"><code># Resolve the newest signed server release
+<pre id="home-install-code" tabindex="0" aria-label="Kiln installation commands"><code># Resolve the newest provenance-attested server release
 KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest \
   | sed -n 's/.*"tag_name": "kiln-v\([^"]*\)".*/\1/p')
 

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -203,6 +203,24 @@
       font-weight: 500;
     }
     .install-alternatives .install-grid { padding: 1rem; }
+    .release-verification {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: minmax(0, 0.85fr) minmax(22rem, 1.15fr);
+      gap: 1.25rem;
+      align-items: center;
+      border-color: rgba(74, 222, 128, 0.24);
+      background:
+        linear-gradient(135deg, rgba(74, 222, 128, 0.055), transparent 48%),
+        var(--bg-soft-2);
+    }
+    .release-verification p { color: var(--fg-dim); }
+    .release-verification pre { margin: 0; }
+    .release-verification > *,
+    .release-verification .copy-code-shell {
+      min-width: 0;
+      max-width: 100%;
+    }
     .quickstart-path {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -338,6 +356,7 @@
     }
     @media (max-width: 760px) {
       .install-card-recommended { grid-template-columns: 1fr; }
+      .release-verification { grid-template-columns: 1fr; }
       .quickstart-path { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     }
   </style>
@@ -503,6 +522,24 @@ tar -xzf kiln-macos.tar.gz</code></pre>
 curl.exe -L -o kiln-windows.zip `
   "https://github.com/ericflo/kiln/releases/download/kiln-v$KilnVersion/kiln-$KilnVersion-x86_64-pc-windows-msvc-cuda124.zip"
 Expand-Archive .\kiln-windows.zip -DestinationPath .\kiln</code></pre>
+        </div>
+        <div class="install-card release-verification">
+          <div>
+            <p class="label mb-2">Release integrity</p>
+            <h3 class="font-semibold mb-2">Verify provenance before extraction</h3>
+            <p class="text-sm">
+              Every server archive has a SHA-256 file and a Sigstore-backed GitHub build-provenance
+              attestation from the release workflow. The macOS binary is also code-signed and
+              notarized; Linux and Windows archives are intentionally not platform code-signed.
+            </p>
+            <p class="text-sm mt-3">
+              Install the <a href="https://cli.github.com/manual/gh_attestation_verify">GitHub CLI</a>,
+              then replace the example filename with the archive you downloaded.
+            </p>
+          </div>
+<pre class="text-sm" tabindex="0" aria-label="Verify Kiln release provenance"><code>gh attestation verify kiln-linux-cuda.tar.gz \
+  --repo ericflo/kiln \
+  --signer-workflow ericflo/kiln/.github/workflows/server-release.yml</code></pre>
         </div>
           </div>
         </details>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -2192,7 +2192,10 @@ function validateGrpoDemoPayloadCue() {
 function validateLandingDesktopVersionSplitCue() {
   const index = readFileSync(resolve(repoRoot, 'docs/site/index.html'), 'utf8');
   const requiredTerms = [
-    'Signed releases are available',
+    'Provenance-attested release archives are available',
+    'macOS binary is also signed',
+    'notarized',
+    'newest provenance-attested server release',
     'Linux CUDA',
     'ROCm',
     'Vulkan',
@@ -2203,6 +2206,9 @@ function validateLandingDesktopVersionSplitCue() {
   ];
   for (const term of requiredTerms) {
     assertIncludes(index, term, 'docs/site/index.html: release-platform cue');
+  }
+  if (index.includes('Signed releases are available')) {
+    fail('docs/site/index.html: release copy must distinguish provenance attestation from platform code signing');
   }
 }
 
@@ -2238,6 +2244,19 @@ function validateQuickstartDesktopVersionSplitCue() {
     assertIncludes(quickstart, assetLink, 'docs/site/quickstart.html: direct Desktop installer link');
   }
   assertIncludes(quickstart, 'class="install-alternatives"', 'docs/site/quickstart.html: advanced installer disclosure');
+  const releaseIntegrityTerms = [
+    'Release integrity',
+    'Verify provenance before extraction',
+    'Sigstore-backed GitHub build-provenance',
+    'macOS binary is also code-signed',
+    'Linux and Windows archives are intentionally not platform code-signed',
+    'gh attestation verify kiln-linux-cuda.tar.gz',
+    '--repo ericflo/kiln',
+    '--signer-workflow ericflo/kiln/.github/workflows/server-release.yml',
+  ];
+  for (const term of releaseIntegrityTerms) {
+    assertIncludes(quickstart, term, 'docs/site/quickstart.html: server release integrity cue');
+  }
   assertIncludes(quickstart, 'Four checkpoints. One working endpoint.', 'docs/site/quickstart.html: first-success path');
 }
 


### PR DESCRIPTION
## Summary
- replace the ambiguous “signed releases” claim with the exact release guarantee: Sigstore-backed GitHub provenance attestations on every archive, plus code signing/notarization on macOS
- state clearly that Linux and Windows archives are intentionally not platform code-signed
- add a tested `gh attestation verify` recipe bound to Kiln’s exact release workflow
- keep the verification guidance inside the terminal-first installer disclosure so the five-minute recommended path stays concise
- enforce the distinction and verification command in the Pages smoke contract

## Verification
- `npm test --prefix scripts/docs-site` (10/10)
- `node scripts/docs-site/build.mjs --out _site` (54 documents)
- `KILN_DOCS_SITE_ROOT=_site KILN_DOCS_REQUIRE_GENERATED=true node scripts/check_docs_site_smoke.mjs`
- current Vulkan 0.5.0 archive SHA-256 matches its published checksum
- `gh attestation verify ... --signer-workflow ericflo/kiln/.github/workflows/server-release.yml` succeeds and returns the archive’s exact subject digest
- expanded Desktop/mobile visual checks; zero overflow, and the long command is keyboard-scrollable