### PR TITLE
Stabilize product navigation before first paint

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/css/kiln.css
+++ b/docs/site/css/kiln.css
@@ -1748,6 +1748,23 @@ pre code { background: transparent; border: 0; padding: 0; color: inherit; font-
   scroll-padding-top: calc(var(--topbar-h) + 18px);
 }
 
+/* Product pages set product-page-enhanced synchronously in <head>. Keep the
+   unenhanced navigation from occupying multiple rows before site.js condenses
+   it; without JavaScript, the class is never set and the full nav stays usable. */
+@media (max-width: 980px) {
+  .product-page-enhanced .site-nav-bar {
+    min-height: var(--topbar-h);
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    flex-direction: row !important;
+    align-items: center !important;
+  }
+
+  .product-page-enhanced .site-nav {
+    display: none;
+  }
+}
+
 .product-page-shell .product-topbar {
   position: sticky;
   top: 0;

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="../css/utilities.css">
   <link rel="stylesheet" href="../css/fonts.css">
   <link rel="stylesheet" href="../css/kiln.css">

--- a/docs/site/evals.html
+++ b/docs/site/evals.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/js/docs.js
+++ b/docs/site/js/docs.js
@@ -7,7 +7,7 @@
     if (!menuButton) return;
     body.classList.remove('docs-nav-open');
     menuButton.setAttribute('aria-expanded', 'false');
-    menuButton.setAttribute('aria-label', 'Open documentation navigation');
+    menuButton.setAttribute('aria-label', 'Menu, open documentation navigation');
     menuButton.title = 'Open navigation';
     if (restoreFocus) menuButton.focus();
   }
@@ -17,7 +17,7 @@
       const opening = !body.classList.contains('docs-nav-open');
       body.classList.toggle('docs-nav-open', opening);
       menuButton.setAttribute('aria-expanded', String(opening));
-      menuButton.setAttribute('aria-label', opening ? 'Close documentation navigation' : 'Open documentation navigation');
+      menuButton.setAttribute('aria-label', opening ? 'Menu, close documentation navigation' : 'Menu, open documentation navigation');
       menuButton.title = opening ? 'Close navigation' : 'Open navigation';
     });
 

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -29,6 +29,7 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/og-image-v3.png">
   <meta name="twitter:image:alt" content="Kiln — Serve it. Teach it. Watch it get better. OpenAI-compatible inference, live LoRA training, and local evals in one server.">
 
+  <script>document.documentElement.classList.add('product-page-enhanced');</script>
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/fonts.css">
   <link rel="stylesheet" href="css/kiln.css">

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -2289,6 +2289,11 @@ function validateSelfHostedProductPageAssets() {
       `src="${prefix}js/site.js"`,
       `docs/site/${relativePath}: shared product-page shell`,
     );
+    assertIncludes(
+      html,
+      "<script>document.documentElement.classList.add('product-page-enhanced');</script>",
+      `docs/site/${relativePath}: pre-render product-page shell`,
+    );
     const externalRuntimeAssets = Array.from(
       html.matchAll(/\b(?:src|href)="(https?:\/\/[^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gi),
       (match) => match[1],

--- a/scripts/docs-site/lib.mjs
+++ b/scripts/docs-site/lib.mjs
@@ -775,7 +775,7 @@ function renderTopbar(manifest, depth) {
         <input id="docs-search-${depth}" type="search" placeholder="Search documentation" autocomplete="off" spellcheck="false">
         <div class="docs-search-results" data-docs-search-results hidden></div>
       </div>
-      <button class="docs-menu-button" type="button" data-docs-menu aria-controls="docs-sidebar" aria-expanded="false" aria-label="Open documentation navigation" title="Open navigation">Menu</button>
+      <button class="docs-menu-button" type="button" data-docs-menu aria-controls="docs-sidebar" aria-expanded="false" aria-label="Menu, open documentation navigation" title="Open navigation">Menu</button>
     </header>`;
 }
 


### PR DESCRIPTION
## Summary
- mark product pages for progressive navigation enhancement before CSS renders
- reserve the final mobile shell geometry before `site.js` condenses the navigation
- preserve the complete navigation when JavaScript is disabled
- make the generated docs menu accessible name include its visible “Menu” label

## Impact
- Demo CLS: 0.921 → 0.011 locally
- Quickstart CLS: 0.093 → 0.005 locally
- generated docs label/content-name mismatch: resolved

## Validation
- `npm test --prefix scripts/docs-site`
- generated-site build
- full generated-site smoke test across all product pages at mobile and desktop viewports
- JavaScript-disabled mobile audit: all 9 navigation links visible, zero horizontal overflow on Quickstart and Demo
- local Lighthouse across Demo, Quickstart, and Docs: accessibility 100, best practices 100, SEO 100
- `git diff --check`